### PR TITLE
Fix Path Traversal and some references to DECISION_ASSISTANT env vars

### DIFF
--- a/neuro_san/client/agent_cli.py
+++ b/neuro_san/client/agent_cli.py
@@ -119,7 +119,7 @@ class AgentCli:
         arg_parser.add_argument("--sly_data", type=str,
                                 help="JSON string containing data that is out-of-band to the chat stream, "
                                      "but is still essential to agent function")
-        arg_parser.add_argument("--connection", default="service",
+        arg_parser.add_argument("--connection", default="direct",
                                 choices=["service", "direct"],
                                 help="""
 The type of connection to initiate. Choices are to connect to:

--- a/neuro_san/service/agent_server.py
+++ b/neuro_san/service/agent_server.py
@@ -66,8 +66,8 @@ class AgentServer:
         current_dir = os.path.dirname(os.path.abspath(__file__))
 
         setup_logging(SERVER_NAME_FOR_LOGS, current_dir,
-                      'DECISION_ASSISTANT_SERVICE_LOG_JSON',
-                      'DECISION_ASSISTANT_SERVICE_LOG_LEVEL')
+                      'AGENT_SERVICE_LOG_JSON',
+                      'AGENT_SERVICE_LOG_LEVEL')
         # This module within openai library can be quite chatty w/rt http requests
         logging.getLogger("httpx").setLevel(logging.WARNING)
 


### PR DESCRIPTION
* Address a Checkmarx PathTraversal problem from service command line args
* Change the default of the agent_cli to use direct connections
* Change DECISION_ASSISTANT_* env var names to be AGENT_*