### PR TITLE
UN-2770 Better error messages when external functions do not have proper functions defined

### DIFF
--- a/neuro_san/internals/graph/registry/agent_tool_registry.py
+++ b/neuro_san/internals/graph/registry/agent_tool_registry.py
@@ -219,7 +219,7 @@ class AgentToolRegistry(AgentToolFactory):
         # The primary way to identify a front-man is that its function has no parameters.
         for name, agent_spec in self.agent_spec_map.items():
             function: Dict[str, Any] = agent_spec.get("function")
-            if function.get("parameters") is None:
+            if function is not None and function.get("parameters") is None:
                 front_men.append(name)
 
         if len(front_men) == 0:


### PR DESCRIPTION
Provide some details as to why a particular function_json is not up to snuff when creating a FunctionTool to call the agent from another. 