### PR TITLE
Add a first prompt file as a text fixture commonly used for esp_decision_assistant

### DIFF
--- a/tests/fixtures/chicken.txt
+++ b/tests/fixtures/chicken.txt
@@ -1,0 +1,9 @@
+Should I cross the road?
+
+There is a traffic light and it is yellow.
+The traffic is very busy.
+The is a designated crosswalk. I am standing there now.
+It is a rainy afternoon. Visibility is poor. A 3 out of 10.
+It is urgent that I cross.
+
+If you have all the information you need, there is no need to confirm the context attributes.


### PR DESCRIPTION
This file has  helped me run/debug the esp_decision_assistant agent over time. It is used with the command line:

python -m neuro_san.client.agent_cli --agent esp_decision_assistant --first_prompt_file file

Maybe at some point when we develop automated test infrastructure for agents, it can become part of the test cases.
One thing is for sure, it is not doing anyone any favors sitting in my /tmp directory.