### PR TITLE
UN-2850 Split instructions and assignments into 2 different System Messages

### DIFF
--- a/neuro_san/internals/graph/tools/calling_tool.py
+++ b/neuro_san/internals/graph/tools/calling_tool.py
@@ -150,24 +150,27 @@ context with which it will proces input, essentially telling it what to do.
         return self.run_context.get_origin()
 
     async def create_resources(self, component_name: str = None,
-                               specific_instructions: str = None):
+                               instructions: str = None,
+                               assignments: str = ""):
         """
         Creates resources that will be used throughout the lifetime of the component.
         :param component_name: Optional string for labelling the component.
                         Defaults to the agent name if not set.
-        :param specific_instructions: Optional string for setting
-                        more fine-grained instructions. Defaults to agent instructions.
+        :param instructions: Optional string for setting more fine-grained instructions.
+                        Defaults to agent instructions if not set.
+        :param assignments: Optional string for assigning agent functional arguments.
+                        Defaults to an empty string if not set.
         """
         name = component_name
         if name is None:
             name = self.get_name()
 
-        instructions = specific_instructions
+        use_instructions = instructions
         if instructions is None:
-            instructions = self.get_instructions()
+            use_instructions = self.get_instructions()
 
         tool_names: List[str] = self.get_callable_tool_names(self.agent_tool_spec)
-        await self.run_context.create_resources(name, instructions, tool_names=tool_names)
+        await self.run_context.create_resources(name, use_instructions, assignments, tool_names=tool_names)
 
     @staticmethod
     def get_callable_tool_names(agent_tool_spec: Dict[str, Any]) -> List[str]:

--- a/neuro_san/internals/run_context/interfaces/run_context.py
+++ b/neuro_san/internals/run_context/interfaces/run_context.py
@@ -30,12 +30,14 @@ class RunContext(AgentSpecProvider):
 
     async def create_resources(self, assistant_name: str,
                                instructions: str,
+                               assignments: str,
                                tool_names: List[str] = None):
         """
         Creates resources to be used during a run of an assistant.
         The result is stored as a member in this instance for future use.
         :param assistant_name: String name of the assistant.
         :param instructions: string instructions that are used to create the assistant
+        :param assignments: string assignments of function parameters that are used as input
         :param tool_names: The list of registered tool names to use.
                     Default is None implying no tool is to be called.
         """

--- a/neuro_san/internals/run_context/langchain/langchain_run_context.py
+++ b/neuro_san/internals/run_context/langchain/langchain_run_context.py
@@ -12,6 +12,7 @@
 from typing import Any
 from typing import Dict
 from typing import List
+from typing import Tuple
 
 import json
 import uuid
@@ -106,6 +107,7 @@ class LangChainRunContext(RunContext):
 
     async def create_resources(self, assistant_name: str,
                                instructions: str,
+                               assignments: str,
                                tool_names: List[str] = None):
         """
         Creates resources for later use within the RunContext instance.
@@ -117,6 +119,7 @@ class LangChainRunContext(RunContext):
         :param assistant_name: String name of the assistant
         :param instructions: string instructions that are used
                     to create the assistant/agent
+        :param assignments: string assignments of function parameters that are used as input
         :param tool_names: The list of registered tool names to use.
                     Default is None implying no tool is to be called.
         """
@@ -142,7 +145,7 @@ class LangChainRunContext(RunContext):
                 if tool is not None:
                     self.tools.append(tool)
 
-        prompt_template: ChatPromptTemplate = await self._create_prompt_template(instructions)
+        prompt_template: ChatPromptTemplate = await self._create_prompt_template(instructions, assignments)
 
         if len(self.tools) > 0:
             self.agent = create_tool_calling_agent(llm, self.tools, prompt_template)
@@ -199,21 +202,33 @@ class LangChainRunContext(RunContext):
                                                                                  self.tool_caller)
         return function_tool
 
-    async def _create_prompt_template(self, instructions: str) -> ChatPromptTemplate:
+    async def _create_prompt_template(self, instructions: str, assignments: str) -> ChatPromptTemplate:
         """
         Creates a ChatPromptTemplate given the generic instructions
         """
+        # Assemble the prompt message list
+        message_list: List[Tuple[str, str]] = []
+
         # Add to our own chat history which is updated in write_message()
         system_message = SystemMessage(instructions)
         await self.journal.write_message(system_message)
+        message_list.append(("system", instructions))
 
-        # Make a prompt per the docs for create_tooling_agent()
-        message_list = [
-            ("system", instructions),
+        # If we have assignments, add them
+        if assignments is not None and len(assignments) > 0:
+            system_message = SystemMessage(assignments)
+            await self.journal.write_message(system_message)
+            message_list.append(("system", assignments))
+
+        # Fill out the rest of the prompt per the docs for create_tooling_agent()
+        # Note we are not write_message()-ing the chat history because that is redundant
+        # Unclear if we should somehow/someplace write_message() the agent_scratchpad at all.
+        message_list.extend([
             ("placeholder", "{chat_history}"),
             ("human", "{input}"),
             ("placeholder", "{agent_scratchpad}"),
-        ]
+        ])
+
         prompt: ChatPromptTemplate = ChatPromptTemplate.from_messages(message_list)
 
         return prompt

--- a/neuro_san/internals/run_context/openai/openai_run_context.py
+++ b/neuro_san/internals/run_context/openai/openai_run_context.py
@@ -74,8 +74,10 @@ class OpenAIRunContext(RunContext):
         self.assistant_id: str = None
         self.invocation_context: InvocationContext = invocation_context
 
+    # pylint: disable=too-many-locals
     async def create_resources(self, assistant_name: str,
                                instructions: str,
+                               assignments: str,
                                tool_names: List[str] = None):
         """
         Creates the thread resource on the OpenAI service side.
@@ -83,6 +85,7 @@ class OpenAIRunContext(RunContext):
         :param assistant_name: String name of the assistant that can show up in the
                     OpenAI web API.
         :param instructions: string instructions that are used to create the OpenAI assistant
+        :param assignments: string assignments of function parameters that are used as input
         :param tool_names: The list of registered tool names to use.
                     Default is None implying no tool is to be called.
                     Note that this implementation can only handle the 1st tool in the list
@@ -105,10 +108,14 @@ class OpenAIRunContext(RunContext):
 
         model_name: str = self.llm_config.get("model_name")
 
+        use_instructions: str = instructions
+        if assignments is not None:
+            use_instructions = use_instructions + assignments
+
         # Create the assistant
         assistant = await self.openai_client.create_assistant(
             name=assistant_name,
-            instructions=instructions,
+            instructions=use_instructions,
             model=model_name,
         )
         self.assistant_id = assistant.id


### PR DESCRIPTION
* I investigated the viablitily of sending ToolMessages for the results of tools.  Did not work out so well.
  OpenAI models expect very specific things when ToolMessages are in the chat history, so I add a comment and
  keep to telling the chat history that the tool results were all the LLM's idea to make it feel nice.
* Separate the assignments of arguments into a separate System message than the instructions go into.
   Later on, this will allow me to conditionally keep the instructions from the agent private when I figure out how I
   want to "allow" that.


Tested: esp_decision_assistant chicken scenario