### PR TITLE
UN-2913 Change default HTTP service port to 8080.

### DIFF
--- a/neuro_san/interfaces/agent_session.py
+++ b/neuro_san/interfaces/agent_session.py
@@ -26,7 +26,7 @@ class AgentSession:
 
     # Default port for the Agent HTTP Service
     # This port number will also be mentioned in its Dockerfile
-    DEFAULT_HTTP_PORT: int = 80
+    DEFAULT_HTTP_PORT: int = 8080
 
     # Some constants
     FOUND: int = 1


### PR DESCRIPTION
So we'll avoid Linux-land problems with port numbers < 1024 (or something like that)
available to super-users only.
