### PR TITLE
UN-2927 Remove half-baked service prefix

### DIFF
--- a/neuro_san/deploy/Dockerfile
+++ b/neuro_san/deploy/Dockerfile
@@ -143,10 +143,6 @@ ENV AGENT_SERVER_NAME="neuro-san.Agent"
 # Name of the service as seen in logs
 ENV AGENT_SERVER_NAME_FOR_LOGS="Agent Server"
 
-# An extra string to add for more fine-grained request routing.
-# Routes are of the form /{serivce_prefix}.{agent_name}.AgentService/{neuro_sanAPI_call}
-ENV AGENT_SERVICE_PREFIX=""
-
 # A space-delimited list of http metadata request keys to forward to logs/other requests
 # You can see how these are used in the AGENT_SERVICE_LOG_JSON file (see above) and
 # customize this and the AGENT_SERVER_LOG_JSON file to your needs.

--- a/neuro_san/deploy/internal/Dockerfile
+++ b/neuro_san/deploy/internal/Dockerfile
@@ -167,10 +167,6 @@ ENV AGENT_SERVER_NAME="neuro-san.Agent"
 # Name of the service as seen in logs
 ENV AGENT_SERVER_NAME_FOR_LOGS="Agent Server"
 
-# An extra string to add for more fine-grained request routing.
-# Routes are of the form /{serivce_prefix}.{agent_name}.AgentService/{neuro_sanAPI_call}
-ENV AGENT_SERVICE_PREFIX=""
-
 # A space-delimited list of http metadata request keys to forward to logs/other requests
 ENV AGENT_FORWARDED_REQUEST_METADATA="request_id user_id"
 

--- a/neuro_san/internals/run_context/utils/external_agent_parsing.py
+++ b/neuro_san/internals/run_context/utils/external_agent_parsing.py
@@ -79,8 +79,6 @@ class ExternalAgentParsing:
             "host": host,
             "port": port,
             "agent_name": agent_name,
-            # DEF: At some point, get this from the parsing and/or config/defaults.
-            "service_prefix": None
         }
         return return_dict
 

--- a/neuro_san/service/agent_main_loop.py
+++ b/neuro_san/service/agent_main_loop.py
@@ -36,7 +36,6 @@ from neuro_san.service.agent_server import DEFAULT_MAX_CONCURRENT_REQUESTS
 from neuro_san.service.agent_server import DEFAULT_REQUEST_LIMIT
 from neuro_san.service.agent_server import DEFAULT_FORWARDED_REQUEST_METADATA
 from neuro_san.service.agent_service import AgentService
-from neuro_san.session.agent_service_stub import DEFAULT_SERVICE_PREFIX
 from neuro_san.session.chat_session_map import ChatSessionMap
 from neuro_san.http_sidecar.http_sidecar import HttpSidecar
 
@@ -54,14 +53,9 @@ class AgentMainLoop(ServerLoopCallbacks):
     This class handles the service main loop.
     """
 
-    def __init__(self, service_prefix: str = DEFAULT_SERVICE_PREFIX):
+    def __init__(self):
         """
         Constructor
-
-        :param service_prefix: An optional prefix that gets prepended to all gRPC request/response
-                        handling for this instance of the server. Note that this can be
-                        passed in by argument (as opposed to env var) because this is the
-                        one configurable item that is likely to be shared with other code.
         """
         self.port: int = 0
         self.http_port: int = 0
@@ -80,7 +74,6 @@ class AgentMainLoop(ServerLoopCallbacks):
         self.max_concurrent_requests: int = DEFAULT_MAX_CONCURRENT_REQUESTS
         self.request_limit: int = DEFAULT_REQUEST_LIMIT
         self.forwarded_request_metadata: int = DEFAULT_FORWARDED_REQUEST_METADATA
-        self.service_prefix: str = service_prefix
         self.server: AgentServer = None
 
     def parse_args(self):
@@ -102,11 +95,6 @@ class AgentMainLoop(ServerLoopCallbacks):
         arg_parser.add_argument("--server_name_for_logs", type=str,
                                 default=str(os.environ.get("AGENT_SERVER_NAME_FOR_LOGS", self.server_name_for_logs)),
                                 help="Name of the service as seen in logs")
-        arg_parser.add_argument("--service_prefix", type=str,
-                                default=str(os.environ.get("AGENT_SERVICE_PREFIX", self.service_prefix)),
-                                help="An extra string to add for more fine-grained request routing. "
-                                     "Routes are of the form: "
-                                     "/{serivce_prefix}.{agent_name}.AgentService/{neuro_sanAPI_call}")
         arg_parser.add_argument("--max_concurrent_requests", type=int,
                                 default=int(os.environ.get("AGENT_MAX_CONCURRENT_REQUESTS",
                                                            self.max_concurrent_requests)),
@@ -129,7 +117,6 @@ class AgentMainLoop(ServerLoopCallbacks):
         self.http_port = args.http_port
         self.server_name = args.server_name
         self.server_name_for_logs = args.server_name_for_logs
-        self.service_prefix = args.service_prefix
         self.max_concurrent_requests = args.max_concurrent_requests
         self.request_limit = args.request_limit
         self.forwarded_request_metadata = args.forwarded_request_metadata
@@ -157,7 +144,6 @@ class AgentMainLoop(ServerLoopCallbacks):
                                   server_name_for_logs=self.server_name_for_logs,
                                   max_concurrent_requests=self.max_concurrent_requests,
                                   request_limit=self.request_limit,
-                                  service_prefix=self.service_prefix,
                                   forwarded_request_metadata=self.forwarded_request_metadata)
 
         # Start HTTP server side-car:

--- a/neuro_san/service/agent_server.py
+++ b/neuro_san/service/agent_server.py
@@ -58,7 +58,6 @@ class AgentServer:
                  server_name_for_logs: str = DEFAULT_SERVER_NAME_FOR_LOGS,
                  max_concurrent_requests: int = DEFAULT_MAX_CONCURRENT_REQUESTS,
                  request_limit: int = DEFAULT_REQUEST_LIMIT,
-                 service_prefix: str = None,
                  forwarded_request_metadata: str = DEFAULT_FORWARDED_REQUEST_METADATA):
         """
         Constructor
@@ -77,7 +76,6 @@ class AgentServer:
         :param request_limit: The number of requests to service before shutting down.
                         This is useful to be sure production environments can handle
                         a service occasionally going down.
-        :param service_prefix: A prefix for grpc routing.
         :param forwarded_request_metadata: A space-delimited list of http metadata request keys
                         to forward to logs/other requests
         """
@@ -106,7 +104,6 @@ class AgentServer:
         self.server_name_for_logs: str = server_name_for_logs
         self.max_concurrent_requests: int = max_concurrent_requests
         self.request_limit: int = request_limit
-        self.service_prefix: str = service_prefix
         self.forwarded_request_metadata: List[str] = forwarded_request_metadata.split(" ")
 
         self.services: List[AgentService] = []
@@ -150,8 +147,7 @@ class AgentServer:
                                    self.forwarded_request_metadata)
             self.services.append(service)
 
-            servicer_to_server = AgentServicerToServer(service, agent_name=agent_name,
-                                                       service_prefix=self.service_prefix)
+            servicer_to_server = AgentServicerToServer(service, agent_name=agent_name)
             servicer_to_server.add_rpc_handlers(server)
 
         server_lifetime.run()

--- a/neuro_san/service/agent_servicer_to_server.py
+++ b/neuro_san/service/agent_servicer_to_server.py
@@ -32,14 +32,12 @@ class AgentServicerToServer:
     """
 
     def __init__(self, servicer: AgentServiceServicer,
-                 agent_name: str = "",
-                 service_prefix: str = None):
+                 agent_name: str = ""):
         """
         Constructor
         """
         self.servicer: AgentServiceServicer = servicer
         self.agent_name: str = agent_name
-        self.service_prefix: str = service_prefix
 
     def add_rpc_handlers(self, server: Server):
         """
@@ -87,7 +85,7 @@ class AgentServicerToServer:
         }
 
         # Prepare the service name on a per-agent basis
-        service_name: str = AgentServiceStub.prepare_service_name(self.agent_name, self.service_prefix)
+        service_name: str = AgentServiceStub.prepare_service_name(self.agent_name)
 
         generic_handler: GenericRpcHandler = method_handlers_generic_handler(service_name,
                                                                              rpc_method_handlers)

--- a/neuro_san/session/agent_service_stub.py
+++ b/neuro_san/session/agent_service_stub.py
@@ -10,8 +10,6 @@
 #
 # END COPYRIGHT
 
-import os
-
 from grpc import Channel
 from grpc import UnaryUnaryMultiCallable
 from grpc import UnaryStreamMultiCallable
@@ -19,25 +17,17 @@ from grpc import UnaryStreamMultiCallable
 import neuro_san.api.grpc.agent_pb2 as agent__pb2
 
 
-# Effectively no service prefix for the default
-DEFAULT_SERVICE_PREFIX: str = ""
-
-
 # pylint: disable=too-many-instance-attributes
 class AgentServiceStub:
     """
     The service comprises all the exchanges to the backend in support of agent services.
-    Note that as of 3/21/24, this is *not* a RESTful service due to constraints
-    with OpenAI service used behind the scenes.
     """
 
-    def __init__(self, agent_name: str = "",
-                 service_prefix: str = None):
+    def __init__(self, agent_name: str = ""):
         """
         Constructor.
         """
         self._agent_name: str = agent_name
-        self._service_prefix: str = service_prefix
 
         # Stub methods. These all happen to be the same kind of method, but
         # note that thare are more defined on grpc.Channel if needed (see the source).
@@ -74,7 +64,7 @@ class AgentServiceStub:
         """
 
         # Prepare the service name given the agent name
-        service_name: str = self.prepare_service_name(self._agent_name, self._service_prefix)
+        service_name: str = self.prepare_service_name(self._agent_name)
 
         # Below comes from generated _grpc.py code for the Stub,
         # with the modification of the service name going into the args.
@@ -116,22 +106,15 @@ class AgentServiceStub:
         return self
 
     @staticmethod
-    def prepare_service_name(agent_name: str, service_prefix: str = None) -> str:
+    def prepare_service_name(agent_name: str) -> str:
         """
         Prepares the full grpc service name given the name of the agent
         :param agent_name: The string agent name
-        :param service_prefix: The service prefix.
-                    This is often the same as the package name in the grpc file.
         :return: A service name that specifies the agent name as part of the routing.
         """
 
-        if service_prefix is None:
-            service_prefix = os.environ.get("AGENT_SERVICE_PREFIX", DEFAULT_SERVICE_PREFIX)
-
         # Prepare the service name on a per-agent basis
         service_name: str = ""
-        if service_prefix is not None and len(service_prefix) > 0:
-            service_name = f"{service_prefix}"
 
         # The agent name adds the voodoo to handle the request routing for each
         # agent on the same server.

--- a/neuro_san/session/async_grpc_service_agent_session.py
+++ b/neuro_san/session/async_grpc_service_agent_session.py
@@ -38,8 +38,7 @@ class AsyncGrpcServiceAgentSession(AsyncAbstractServiceSession, AsyncAgentSessio
                  security_cfg: Dict[str, Any] = None,
                  umbrella_timeout: Timeout = None,
                  streaming_timeout_in_seconds: int = None,
-                 agent_name: str = DEFAULT_AGENT_NAME,
-                 service_prefix: str = None):
+                 agent_name: str = DEFAULT_AGENT_NAME):
         """
         Creates an AsyncAgentSession that connects to the
         Agent Service and delegates its implementations to the service.
@@ -63,8 +62,6 @@ class AsyncGrpcServiceAgentSession(AsyncAbstractServiceSession, AsyncAgentSessio
                         the service. Default is None, indicating connection should
                         stay open until the (last) result is yielded.
         :param agent_name: The name of the agent to talk to
-        :param service_prefix: The service prefix to use. Default is None,
-                        implying the policy in AgentServiceStub takes over.
         """
         use_host: str = "localhost"
         if host is not None:
@@ -77,7 +74,7 @@ class AsyncGrpcServiceAgentSession(AsyncAbstractServiceSession, AsyncAgentSessio
         # Normally we pass around the service_stub like a class,
         # but AgentServiceStub has a __call__() method to intercept
         # constructor-like behavior.
-        service_stub = AgentServiceStub(agent_name, service_prefix)
+        service_stub = AgentServiceStub(agent_name)
         AsyncAbstractServiceSession.__init__(self, "Agent Server",
                                              service_stub,
                                              use_host, use_port,

--- a/neuro_san/session/external_agent_session_factory.py
+++ b/neuro_san/session/external_agent_session_factory.py
@@ -69,7 +69,6 @@ class ExternalAgentSessionFactory(AsyncAgentSessionFactory):
         host = agent_location.get("host")
         port = agent_location.get("port")
         agent_name = agent_location.get("agent_name")
-        service_prefix = agent_location.get("service_prefix")
 
         # Note: It's possible we might want some filtering/translation of
         #       metadata keys not unlike what we are doing for sly_data.
@@ -93,7 +92,6 @@ class ExternalAgentSessionFactory(AsyncAgentSessionFactory):
 
         if session is None:
             session = AsyncGrpcServiceAgentSession(host, port, agent_name=agent_name,
-                                                   service_prefix=service_prefix,
                                                    metadata=metadata)
 
         # Quiet any logging from leaf-common grpc stuff.

--- a/neuro_san/session/grpc_service_agent_session.py
+++ b/neuro_san/session/grpc_service_agent_session.py
@@ -38,8 +38,7 @@ class GrpcServiceAgentSession(AbstractServiceSession, AgentSession):
                  security_cfg: Dict[str, Any] = None,
                  umbrella_timeout: Timeout = None,
                  streaming_timeout_in_seconds: int = None,
-                 agent_name: str = DEFAULT_AGENT_NAME,
-                 service_prefix: str = None):
+                 agent_name: str = DEFAULT_AGENT_NAME):
         """
         Creates a AgentSession that connects to the
         Agent Service and delegates its implementations to the service.
@@ -63,8 +62,6 @@ class GrpcServiceAgentSession(AbstractServiceSession, AgentSession):
                         the service. Default is None, indicating connection should
                         stay open until the (last) result is yielded.
         :param agent_name: The name of the agent to talk to
-        :param service_prefix: The service prefix to use. Default is None,
-                        implying the policy in AgentServiceStub takes over.
         """
         use_host: str = "localhost"
         if host is not None:
@@ -77,7 +74,7 @@ class GrpcServiceAgentSession(AbstractServiceSession, AgentSession):
         # Normally we pass around the service_stub like a class,
         # but AgentServiceStub has a __call__() method to intercept
         # constructor-like behavior.
-        service_stub = AgentServiceStub(agent_name, service_prefix)
+        service_stub = AgentServiceStub(agent_name)
         AbstractServiceSession.__init__(self, "Agent Server",
                                         service_stub,
                                         use_host, use_port,

--- a/neuro_san/session/http_service_agent_session.py
+++ b/neuro_san/session/http_service_agent_session.py
@@ -38,8 +38,7 @@ class HttpServiceAgentSession(AgentSession):
                  security_cfg: Dict[str, Any] = None,
                  umbrella_timeout: Timeout = None,
                  streaming_timeout_in_seconds: int = None,
-                 agent_name: str = DEFAULT_AGENT_NAME,
-                 service_prefix: str = None):
+                 agent_name: str = DEFAULT_AGENT_NAME):
         """
         Creates a AgentSession that connects to the
         Agent Service and delegates its implementations to the service.
@@ -63,14 +62,11 @@ class HttpServiceAgentSession(AgentSession):
                         the service. Default is None, indicating connection should
                         stay open until the (last) result is yielded.
         :param agent_name: The name of the agent to talk to
-        :param service_prefix: The service prefix to use. Default is None,
-                        implying the policy in AgentServiceStub takes over.
         """
         _ = umbrella_timeout
         _ = streaming_timeout_in_seconds
 
         self.security_cfg: Dict[str, Any] = security_cfg
-        self.service_prefix: str = service_prefix
         self.use_host: str = "localhost"
         if host is not None:
             self.use_host = host
@@ -88,9 +84,7 @@ class HttpServiceAgentSession(AgentSession):
         if self.security_cfg is not None:
             scheme = "https"
 
-        if self.service_prefix is None or len(self.service_prefix) == 0:
-            return f"{scheme}://{self.use_host}:{self.use_port}/api/v1/{self.agent_name}/{function}"
-        return f"{scheme}://{self.use_host}:{self.use_port}/api/v1/{self.service_prefix}/{self.agent_name}/{function}"
+        return f"{scheme}://{self.use_host}:{self.use_port}/api/v1/{self.agent_name}/{function}"
 
     def help_message(self, path: str) -> str:
         """


### PR DESCRIPTION
Remove the half-baked idea of a service prefix for routes.
The idea got out ahead of its skis in maybe trying to make ALB routing easier, but no one is using it and
with the http side-car it became confusing.

Methodology: search for service_prefix and SERVICE_PREFIX and remove

Tested: grpc and http chicken scenario