### PR TITLE
UN-2997 Fix for race condition in async http request handler.

### DIFF
--- a/neuro_san/http_sidecar/handlers/streaming_chat_handler.py
+++ b/neuro_san/http_sidecar/handlers/streaming_chat_handler.py
@@ -15,8 +15,6 @@ See class comment for details
 from typing import Any, Dict, Generator
 import json
 
-import asyncio
-
 from google.protobuf.json_format import MessageToDict
 from google.protobuf.json_format import Parse
 


### PR DESCRIPTION
This PR is a simple fix for what seems to be a race condition
between async GRPC generator providing stream of chat responses
and async request handler closing http connection.
Idea is to factor out generator loop into separate function
and explicitly "await" it to finish before proceeding to close this request.
 