### PR TITLE
UN-3019 Repair chat_context use in client DirectAgentSessions

### DIFF
--- a/neuro_san/client/streaming_input_processor.py
+++ b/neuro_san/client/streaming_input_processor.py
@@ -20,6 +20,7 @@ from neuro_san.interfaces.agent_session import AgentSession
 from neuro_san.internals.messages.chat_message_type import ChatMessageType
 from neuro_san.internals.messages.origination import Origination
 from neuro_san.message_processing.basic_message_processor import BasicMessageProcessor
+from neuro_san.session.direct_agent_session import DirectAgentSession
 
 
 class StreamingInputProcessor:
@@ -66,7 +67,7 @@ class StreamingInputProcessor:
         # the conversation.
         chat_request: Dict[str, Any] = self.formulate_chat_request(user_input, sly_data,
                                                                    chat_context, chat_filter)
-        self.processor.reset()
+        self.reset()
 
         return_state: Dict[str, Any] = copy(state)
         chat_responses: Generator[Dict[str, Any], None, None] = self.session.streaming_chat(chat_request)
@@ -125,3 +126,15 @@ class StreamingInputProcessor:
             chat_request["chat_filter"] = chat_filter
 
         return chat_request
+
+    def reset(self):
+        """
+        Reset for a new exchange
+        """
+        # Reset the message processor to recieve a new answer
+        self.processor.reset()
+
+        if isinstance(self.session, DirectAgentSession):
+            # Direct sessions need their Origination reset otherwise chat_context
+            # origins do not match up.
+            self.session.reset()

--- a/neuro_san/internals/messages/origination.py
+++ b/neuro_san/internals/messages/origination.py
@@ -120,3 +120,9 @@ class Origination:
         full_path = full_path.replace("./", "/")
 
         return full_path
+
+    def reset(self):
+        """
+        Resets the origination tracking
+        """
+        self.tool_to_index_map = {}

--- a/neuro_san/session/async_direct_agent_session.py
+++ b/neuro_san/session/async_direct_agent_session.py
@@ -174,6 +174,12 @@ class AsyncDirectAgentSession(AsyncAgentSession):
                 response_dict["response"] = message
                 yield response_dict
 
+    def reset(self):
+        """
+        Allows for re-use of the same instance for clients
+        """
+        self.invocation_context.reset()
+
     def close(self):
         """
         Tears down resources created

--- a/neuro_san/session/direct_agent_session.py
+++ b/neuro_san/session/direct_agent_session.py
@@ -181,6 +181,12 @@ class DirectAgentSession(AgentSession):
                 response_dict["response"] = message
                 yield response_dict
 
+    def reset(self):
+        """
+        Allows for re-use of the same instance for clients
+        """
+        self.invocation_context.reset()
+
     def close(self):
         """
         Tears down resources created

--- a/neuro_san/session/session_invocation_context.py
+++ b/neuro_san/session/session_invocation_context.py
@@ -130,3 +130,13 @@ class SessionInvocationContext(InvocationContext):
         :return: The ContextTypeLlmFactory instance for the session
         """
         return self.llm_factory
+
+    def reset(self):
+        """
+        Resets the instance for a subsequent use for another exchange with the agent network.
+        """
+        # Origination needs to be reset so that origin information can match up
+        # with what is in the chat_context. If we do not reset this, then library calls
+        # to DirectAgentSession do not properly carry forward any memory of the conversation
+        # in subsequent interactions with the same network.
+        self.origination.reset()


### PR DESCRIPTION
@ofrancon had found that in direct sessions, the chat_context seemed to be ignored.
Turns out it wasn't ignored at all, but the real problem was a mismatch between the origins provided in that chat_context and the new agents coming up in the subsequent conversation.  So now we reset that on the client side if we are using a direct session.  The server side effectively does this for every request already which is why the problem was localized to DirectAgentSessions only and not http or grpc sessions