### PR TITLE
UN-3030 fix typo in default_llm_info.hocon

### DIFF
--- a/neuro_san/internals/run_context/langchain/default_llm_info.hocon
+++ b/neuro_san/internals/run_context/langchain/default_llm_info.hocon
@@ -103,7 +103,7 @@
     },
 
     "gpt-4o-mini": {
-        "use_model_name": "gpt-4o-2024-07-18",
+        "use_model_name": "gpt-4o-mini-2024-07-18",
     },
     "gpt-4o-mini-2024-07-18": {
         "class": "openai",


### PR DESCRIPTION
from 
"gpt-4o-mini": {
        "use_model_name": "gpt-4o-2024-07-18",
    }
to
"gpt-4o-mini": {
        "use_model_name": "gpt-4o-mini-2024-07-18",
    }