### PR TITLE
UN-3045  Sanitize llm config keys (No LLM entry for model llama3.1)

### DIFF
--- a/neuro_san/internals/run_context/langchain/default_llm_factory.py
+++ b/neuro_san/internals/run_context/langchain/default_llm_factory.py
@@ -79,7 +79,7 @@ class DefaultLlmFactory(ContextTypeLlmFactory, LangChainLlmFactory):
         if llm_info_file is not None and len(llm_info_file) > 0:
             extra_llm_infos: Dict[str, Any] = restorer.restore(file_reference=llm_info_file)
             self.llm_infos = self.overlayer.overlay(self.llm_infos, extra_llm_infos)
-            
+
         # sanitize the llm_infos keys
         self.llm_infos = self.sanitize_keys(self.llm_infos)
 


### PR DESCRIPTION
Sanitize llm config keys
Introduce utility methods to clean up LLM configuration dictionaries parsed from HOCON files. Specifically:
- `strip_outer_quotes`: Removes surrounding double quotes from string keys.
- `sanitize_keys`: Applies the above method to all top-level keys in a given dictionary.

To address an issue where model names like "llama3.1" are incorrectly parsed with quotes '"llama3.1"', causing lookup failures in DefaultLlmFactory.

Note: Not sure if this is going to add a significant amount of latency.