### PR TITLE
UN-3120 no key messaging

### DIFF
--- a/neuro_san/internals/run_context/langchain/api_key_error_check.py
+++ b/neuro_san/internals/run_context/langchain/api_key_error_check.py
@@ -16,7 +16,8 @@ from typing import List
 
 # Dictionary with provider key env var -> strings to look for
 API_KEY_EXCEPTIONS: Dict[str, List] = {
-    "OPENAI_API_KEY": ["OPENAI_API_KEY", "Incorrect API key provided"]
+    "OPENAI_API_KEY": ["OPENAI_API_KEY", "Incorrect API key provided"],
+    "ANTHROPIC_API_KEY": ["ANTHROPIC_API_KEY", "anthropic_api_key", "invalid x-api-key", "credit balance"],
 }
 
 
@@ -54,7 +55,9 @@ server or run-time enviroment in order to use this agent network.
 Some things to try:
 1) Double check that your value for {api_key} is set correctly
 2) If you do not have a value for {api_key}, visit the LLM provider's website to get one.
-3) Sometimes these errors happen because of firewall blockages to the site that hosts the LLM.
+3) It's possible that your credit balance on your account with the LLM provider is too low
+   to make the request.  Check that.
+4) Sometimes these errors happen because of firewall blockages to the site that hosts the LLM.
    Try checking that you can reach the regular UI for the LLM from a web browser
    on the same machine making this request.
 """

--- a/neuro_san/internals/run_context/langchain/api_key_error_check.py
+++ b/neuro_san/internals/run_context/langchain/api_key_error_check.py
@@ -1,0 +1,62 @@
+
+# Copyright (C) 2023-2025 Cognizant Digital Business, Evolutionary AI.
+# All Rights Reserved.
+# Issued under the Academic Public License.
+#
+# You can be released from the terms, and requirements of the Academic Public
+# License by purchasing a commercial license.
+# Purchase of a commercial license is mandatory for any use of the
+# neuro-san SDK Software in commercial settings.
+#
+# END COPYRIGHT
+
+from typing import Dict
+from typing import List
+
+
+# Dictionary with provider key env var -> strings to look for
+API_KEY_EXCEPTIONS: Dict[str, List] = {
+    "OPENAI_API_KEY": ["OPENAI_API_KEY", "Incorrect API key provided"]
+}
+
+
+class ApiKeyErrorCheck:
+    """
+    Class for common policy when checking for API key errors for various LLM providers.
+    """
+
+    @staticmethod
+    def check_for_api_key_exception(exception: Exception) -> str:
+        """
+        :param exception: An exception to check
+        :return: A more helpful exception message if it relates to an API key or None
+                if it does not pertain to an API key.
+        """
+
+        exception_message: str = str(exception)
+        print(f"message={exception_message}")
+
+        # Search for strings in the exception message
+        found = False
+        for api_key, string_list in API_KEY_EXCEPTIONS.items():
+            for find_string in string_list:
+                if find_string in exception_message:
+                    found = True
+                    break
+            if found:
+                break
+
+        if found:
+            return f"""
+A value for the {api_key} environment variable must be correctly set in the neuro-san
+server or run-time enviroment in order to use this agent network.
+
+Some things to try:
+1) Double check that your value for {api_key} is set correctly
+2) If you do not have a value for {api_key}, visit the LLM provider's website to get one.
+3) Sometimes these errors happen because of firewall blockages to the site that hosts the LLM.
+   Try checking that you can reach the regular UI for the LLM from a web browser
+   on the same machine making this request.
+"""
+
+        return None

--- a/neuro_san/internals/run_context/langchain/default_llm_factory.py
+++ b/neuro_san/internals/run_context/langchain/default_llm_factory.py
@@ -17,6 +17,8 @@ from typing import Type
 
 import os
 
+from openai import OpenAIError
+
 from langchain_core.callbacks.base import BaseCallbackHandler
 from langchain_core.language_models.base import BaseLanguageModel
 
@@ -25,6 +27,7 @@ from leaf_common.config.resolver import Resolver
 from leaf_common.parsers.dictionary_extractor import DictionaryExtractor
 
 from neuro_san.internals.interfaces.context_type_llm_factory import ContextTypeLlmFactory
+from neuro_san.internals.run_context.langchain.api_key_error_check import ApiKeyErrorCheck
 from neuro_san.internals.run_context.langchain.langchain_llm_factory import LangChainLlmFactory
 from neuro_san.internals.run_context.langchain.llm_info_restorer import LlmInfoRestorer
 from neuro_san.internals.run_context.langchain.standard_langchain_llm_factory import StandardLangChainLlmFactory
@@ -251,9 +254,21 @@ class DefaultLlmFactory(ContextTypeLlmFactory, LangChainLlmFactory):
                     # We found what we were looking for
                     found_exception = None
                     break
+
             except ValueError as exception:
                 # Let the next model have a crack
                 found_exception = exception
+
+            # Catch some common wrong or missing API key errors in a single place
+            # with some verbose error messaging.
+            except OpenAIError as exception:
+                # Will re-raise but with the right exception text it will
+                # also provide some more helpful failure text.
+                message: str = ApiKeyErrorCheck.check_for_api_key_exception(exception)
+                if message is not None:
+                    raise ValueError(message) from exception
+                else:
+                    raise exception
 
         if found_exception is not None:
             raise found_exception


### PR DESCRIPTION
There were a couple of modes of failure that could happen when OPENAI_API_KEY or ANTHROPIC_API_KEY were not defined that were reasonably described as cryptic.

This PR consolidates the error detection and reporting for those cases so as to put out the same bit of helpful error text when those situations do arise.

It's likely I haven't gotten all cases, so if you come across a situation where the new messaging should be applied, give me a holler.