### PR TITLE
UN-3137 Switch to Tornado http server in-process as a separate thread.

### DIFF
--- a/neuro_san/http_sidecar/handlers/base_request_handler.py
+++ b/neuro_san/http_sidecar/handlers/base_request_handler.py
@@ -30,9 +30,7 @@ from neuro_san.http_sidecar.logging.http_logger import HttpLogger
 from neuro_san.http_sidecar.interfaces.agent_authorizer import AgentAuthorizer
 from neuro_san.http_sidecar.interfaces.agents_updater import AgentsUpdater
 from neuro_san.interfaces.async_agent_session import AsyncAgentSession
-from neuro_san.interfaces.concierge_session import ConciergeSession
 from neuro_san.session.async_grpc_service_agent_session import AsyncGrpcServiceAgentSession
-from neuro_san.session.grpc_concierge_session import GrpcConciergeSession
 
 
 class BaseRequestHandler(RequestHandler):

--- a/neuro_san/http_sidecar/handlers/base_request_handler.py
+++ b/neuro_san/http_sidecar/handlers/base_request_handler.py
@@ -119,15 +119,16 @@ class BaseRequestHandler(RequestHandler):
                 agent_name=agent_name)
         return grpc_session
 
-    async def update_agents(self) -> bool:
+    async def update_agents(self, metadata: Dict[str, Any]) -> bool:
         """
         Update internal agents table by executing request
         to underlying gRPC service.
+        :param metadata: metadata to be used for logging if necessary.
         :return: True if update was successful
                  False otherwise
         """
         try:
-            self.agents_updater.update_agents()
+            self.agents_updater.update_agents(metadata=metadata)
             return True
         except Exception as exc:  # pylint: disable=broad-exception-caught
             self.process_exception(exc)

--- a/neuro_san/http_sidecar/handlers/base_request_handler.py
+++ b/neuro_san/http_sidecar/handlers/base_request_handler.py
@@ -121,35 +121,15 @@ class BaseRequestHandler(RequestHandler):
                 agent_name=agent_name)
         return grpc_session
 
-    def get_concierge_grpc_session(self, metadata: Dict[str, Any]) -> ConciergeSession:
-        """
-        Build gRPC session to talk to "concierge" service
-        :return: ConciergeSession to use
-        """
-        grpc_session: ConciergeSession = \
-            GrpcConciergeSession(
-                host="localhost",
-                port=self.port,
-                metadata=metadata)
-        return grpc_session
-
-    async def update_agents(self, metadata: Dict[str, Any]) -> bool:
+    async def update_agents(self) -> bool:
         """
         Update internal agents table by executing request
         to underlying gRPC service.
-        :param metadata: metadata for request from caller context.
         :return: True if update was successful
                  False otherwise
         """
         try:
-            data: Dict[str, Any] = {}
-            grpc_session: ConciergeSession = self.get_concierge_grpc_session(metadata)
-            agents_dict: Dict[str, Any] = grpc_session.list(data)
-            agents_list = agents_dict.get("agents", [])
-            agents_names: List[str] = []
-            for agent_dict in agents_list:
-                agents_names.append(agent_dict["agent_name"])
-            self.agents_updater.update_agents(agents_names)
+            self.agents_updater.update_agents()
             return True
         except Exception as exc:  # pylint: disable=broad-exception-caught
             self.process_exception(exc)

--- a/neuro_san/http_sidecar/handlers/concierge_handler.py
+++ b/neuro_san/http_sidecar/handlers/concierge_handler.py
@@ -16,6 +16,7 @@ from typing import Any, Dict
 
 from neuro_san.http_sidecar.handlers.base_request_handler import BaseRequestHandler
 from neuro_san.interfaces.concierge_session import ConciergeSession
+from neuro_san.session.direct_concierge_session import DirectConciergeSession
 
 
 class ConciergeHandler(BaseRequestHandler):
@@ -31,8 +32,8 @@ class ConciergeHandler(BaseRequestHandler):
         self.logger.info(metadata, "Start GET /api/v1/list")
         try:
             data: Dict[str, Any] = {}
-            grpc_session: ConciergeSession = self.get_concierge_grpc_session(metadata)
-            result_dict: Dict[str, Any] = grpc_session.list(data)
+            session: ConciergeSession = DirectConciergeSession(metadata=metadata)
+            result_dict: Dict[str, Any] = session.list(data)
 
             # Return gRPC response to the HTTP client
             self.set_header("Content-Type", "application/json")

--- a/neuro_san/http_sidecar/handlers/connectivity_handler.py
+++ b/neuro_san/http_sidecar/handlers/connectivity_handler.py
@@ -28,7 +28,7 @@ class ConnectivityHandler(BaseRequestHandler):
         Implementation of GET request handler for "connectivity" API call.
         """
         metadata: Dict[str, Any] = self.get_metadata()
-        update_done: bool = await self.update_agents()
+        update_done: bool = await self.update_agents(metadata=metadata)
         if not update_done:
             return
 

--- a/neuro_san/http_sidecar/handlers/connectivity_handler.py
+++ b/neuro_san/http_sidecar/handlers/connectivity_handler.py
@@ -28,7 +28,7 @@ class ConnectivityHandler(BaseRequestHandler):
         Implementation of GET request handler for "connectivity" API call.
         """
         metadata: Dict[str, Any] = self.get_metadata()
-        update_done: bool = await self.update_agents(metadata)
+        update_done: bool = await self.update_agents()
         if not update_done:
             return
 

--- a/neuro_san/http_sidecar/handlers/function_handler.py
+++ b/neuro_san/http_sidecar/handlers/function_handler.py
@@ -28,7 +28,7 @@ class FunctionHandler(BaseRequestHandler):
         Implementation of GET request handler for "function" API call.
         """
         metadata: Dict[str, Any] = self.get_metadata()
-        update_done: bool = await self.update_agents(metadata)
+        update_done: bool = await self.update_agents()
         if not update_done:
             return
 

--- a/neuro_san/http_sidecar/handlers/function_handler.py
+++ b/neuro_san/http_sidecar/handlers/function_handler.py
@@ -28,7 +28,7 @@ class FunctionHandler(BaseRequestHandler):
         Implementation of GET request handler for "function" API call.
         """
         metadata: Dict[str, Any] = self.get_metadata()
-        update_done: bool = await self.update_agents()
+        update_done: bool = await self.update_agents(metadata=metadata)
         if not update_done:
             return
 

--- a/neuro_san/http_sidecar/handlers/streaming_chat_handler.py
+++ b/neuro_san/http_sidecar/handlers/streaming_chat_handler.py
@@ -63,7 +63,7 @@ class StreamingChatHandler(BaseRequestHandler):
         """
 
         metadata: Dict[str, Any] = self.get_metadata()
-        update_done: bool = await self.update_agents(metadata)
+        update_done: bool = await self.update_agents()
         if not update_done:
             return
 

--- a/neuro_san/http_sidecar/handlers/streaming_chat_handler.py
+++ b/neuro_san/http_sidecar/handlers/streaming_chat_handler.py
@@ -63,7 +63,7 @@ class StreamingChatHandler(BaseRequestHandler):
         """
 
         metadata: Dict[str, Any] = self.get_metadata()
-        update_done: bool = await self.update_agents()
+        update_done: bool = await self.update_agents(metadata=metadata)
         if not update_done:
             return
 

--- a/neuro_san/http_sidecar/http_sidecar.py
+++ b/neuro_san/http_sidecar/http_sidecar.py
@@ -13,7 +13,6 @@
 See class comment for details
 """
 
-import copy
 import threading
 from typing import Any, Dict, List
 
@@ -40,11 +39,11 @@ class HttpSidecar(AgentAuthorizer, AgentsUpdater):
     Class provides simple http endpoint for neuro-san API,
     working as a client to neuro-san gRPC service.
     """
+    # pylint: disable=too-many-instance-attributes
+    # pylint: disable=too-many-arguments, too-many-positional-arguments
 
     TIMEOUT_TO_START_SECONDS: int = 10
 
-    # pylint: disable=too-many-arguments, too-many-positional-arguments
-    # pylint: disable=too-many-instance-attributes
     def __init__(self, start_event: threading.Event,
                  port: int, http_port: int,
                  openapi_service_spec_path: str,

--- a/neuro_san/http_sidecar/interfaces/agents_updater.py
+++ b/neuro_san/http_sidecar/interfaces/agents_updater.py
@@ -21,9 +21,9 @@ class AgentsUpdater:
     being served.
     """
 
-    def update_agents(self, agents: List[str]):
+    def update_agents(self):
         """
-        :param agents: list of agents names which should be served currently.
+        Update list of agents for which serving is allowed.
         :return: nothing
         """
         raise NotImplementedError

--- a/neuro_san/http_sidecar/interfaces/agents_updater.py
+++ b/neuro_san/http_sidecar/interfaces/agents_updater.py
@@ -12,7 +12,6 @@
 """
 See class comment for details
 """
-from typing import List
 
 
 class AgentsUpdater:

--- a/neuro_san/http_sidecar/interfaces/agents_updater.py
+++ b/neuro_san/http_sidecar/interfaces/agents_updater.py
@@ -12,6 +12,8 @@
 """
 See class comment for details
 """
+from typing import Any
+from typing import Dict
 
 
 class AgentsUpdater:
@@ -20,9 +22,10 @@ class AgentsUpdater:
     being served.
     """
 
-    def update_agents(self):
+    def update_agents(self, metadata: Dict[str, Any]):
         """
         Update list of agents for which serving is allowed.
+        :param metadata: metadata to be used for logging if necessary.
         :return: nothing
         """
         raise NotImplementedError

--- a/neuro_san/service/agent_server.py
+++ b/neuro_san/service/agent_server.py
@@ -12,6 +12,7 @@
 
 from typing import Dict
 from typing import List
+import threading
 
 import logging
 
@@ -91,16 +92,23 @@ class AgentServer:
         self.server_lifetime = None
         self.security_cfg = None
         self.services: List[GrpcAgentService] = []
-
         self.service_router: DynamicAgentRouter = DynamicAgentRouter()
-
+        # Event to notify that we have started serving
+        self.notify_started: threading.Event = threading.Event()
         self.logger.info("tool_registries found: %s", str(list(self.tool_registries.keys())))
+
 
     def get_services(self) -> List[GrpcAgentService]:
         """
         :return: A list of the AgentServices being served up by this instance
         """
         return self.services
+
+    def get_starting_event(self) -> threading.Event:
+        """
+        Get event signalling that server has started work.
+        """
+        return self.notify_started
 
     def setup_tool_factory_provider(self):
         """
@@ -186,4 +194,5 @@ class AgentServer:
             concierge_service,
             server)
 
+        self.notify_started.set()
         self.server_lifetime.run()

--- a/neuro_san/service/agent_server.py
+++ b/neuro_san/service/agent_server.py
@@ -97,7 +97,6 @@ class AgentServer:
         self.notify_started: threading.Event = threading.Event()
         self.logger.info("tool_registries found: %s", str(list(self.tool_registries.keys())))
 
-
     def get_services(self) -> List[GrpcAgentService]:
         """
         :return: A list of the AgentServices being served up by this instance


### PR DESCRIPTION
This PR moves Tornado http server from separate process to separate thread in main neuro-san process.
The move will allow http service stack to access neuro-san internals directly, without relying on local gRPC endpoint.
Note that switch away from local gRPC is not done in this PR - except for Concierge service query.
Switching chat request to using AsyncAgentService is somewhat tricky and warrants I think a separate PR.
As for simple Function and Connectivity requests - right now it's not worth it to mix/match direct and gRPC sessions.

Tested: stability test running concurrent local clients:
2 grpc + 2 http each doing 20x3 one-shot chats.

