### PR TITLE
UN-3171 Add sly_data_schema to FunctionResponse

### DIFF
--- a/docs/agent_hocon_reference.md
+++ b/docs/agent_hocon_reference.md
@@ -358,7 +358,7 @@ specific information the agent needs as input arguments over the private sly_dat
 channel when it is called.  The sly_data itself is generally considered to be private information
 that does not belong in the chat stream, for example: credential information.
 
-The sly_data schema specification here has the same format as the [parameters](#parameters)
+The sly_data_schema specification here has the same format as the [parameters](#parameters)
 schema definition above.  Ideally there should be one [properties](#properties) entry per
 sly_data dictionary input key, and any absolutely necessary keys should be listed in the [required](#required)
 list.
@@ -370,7 +370,7 @@ information before sending any chat input.
 The front-man is the only agent node that ever needs to specify this aspect of the [function](#function)
 definition, as sly_data itself is already visible to all other internal agents of the network.
 
-Example networks that advertise their sly_data schema:
+Example networks that advertise their sly_data_schema:
 - [math_guy.hocon](../neuro_san/registries/math_guy.hocon)
 
 

--- a/docs/agent_hocon_reference.md
+++ b/docs/agent_hocon_reference.md
@@ -40,6 +40,7 @@ Sub-keys to those dictionaries will be described in the next-level down heading 
       - [type](#type)
       - [properties](#properties)
       - [required](#required)
+    - [sly_data](#sly_data)
   - [instructions](#instructions)
   - [command](#command)
   - [tools (agents)](#tools-agents)
@@ -51,11 +52,11 @@ Sub-keys to those dictionaries will be described in the next-level down heading 
   - [allow](#allow)
     - [connectivity](#connectivity)
     - [to_downstream](#to_downstream)
-      - [sly_data](#sly_data)
-    - [from_downstream](#from_downstream)
       - [sly_data](#sly_data-1)
-    - [to_upstream](#to_upstream)
+    - [from_downstream](#from_downstream)
       - [sly_data](#sly_data-2)
+    - [to_upstream](#to_upstream)
+      - [sly_data](#sly_data-3)
   - [display_as](#display_as)
   - [max_message_history](#max_message_history)
   - [error_formatter](#error_formatter-1)
@@ -350,6 +351,29 @@ This is an optional list of string keys in the [properties](#properties) diction
 to be required whenever an upstream agent calls the one being described.
 Note that it's possible to specify a default value for any property that is not listed as required.
 
+#### sly_data
+
+The optional [JSON Schema](https://json-schema.org) dictionary describing what
+specific information the agent needs as input arguments over the private sly_data dictionary
+channel when it is called.  The sly_data itself is generally considered to be private information
+that does not belong in the chat stream, i.e. credential information.
+
+The sly_data schema specification here has the same format as the [parameters](#parameters)
+schema definition above.  Ideally there should be one [properties](#properties) entry per
+sly_data dictionary key, and any absolutely necessary keys should be listed in the [required](#required)
+list.
+
+Note that it is not strictly necessary to advertise to the outside world the sly_data that
+your agent network requires, but doing so does allow generic clients to prompt for this extra
+information before sending any chat input.
+
+The front-man is the only agent node that ever needs to specify this aspect of the [function](#function)
+definition, as sly_data is already visible to all other internal agents of the network.
+
+Example networks that advertise their sly_data schema:
+- [math_guy.hocon](../neuro_san/registries/math_guy.hocon)
+
+
 ### instructions
 
 When included, the single (often very long) string value here tells an LLM-enabled agent
@@ -530,7 +554,7 @@ Boolean values for each key tell whether or not that data from any external agen
 is allowed to be accepted and merged into this agent's sly_data.
 A string value in the dictionary represents a translation to a new key.
 
-The same dictionary/list specification described in [to_downstream](#sly_data) also applies here.
+The same dictionary/list specification described in [to_downstream](#sly_data-1) also applies here.
 
 #### to_upstream
 
@@ -549,7 +573,7 @@ Boolean values for each key tell whether or not that data internal to the agent 
 is allowed to go back to the client in the final message.
 A string value in the dictionary represents a translation to a new key.
 
-The same dictionary/list specification described in [to_downstream](#sly_data) also applies here.
+The same dictionary/list specification described in [to_downstream](#sly_data-1) also applies here.
 
 ### display_as
 

--- a/docs/agent_hocon_reference.md
+++ b/docs/agent_hocon_reference.md
@@ -356,7 +356,7 @@ Note that it's possible to specify a default value for any property that is not 
 The optional [JSON Schema](https://json-schema.org) dictionary describing what
 specific information the agent needs as input arguments over the private sly_data dictionary
 channel when it is called.  The sly_data itself is generally considered to be private information
-that does not belong in the chat stream, i.e. credential information.
+that does not belong in the chat stream, for example: credential information.
 
 The sly_data schema specification here has the same format as the [parameters](#parameters)
 schema definition above.  Ideally there should be one [properties](#properties) entry per

--- a/docs/agent_hocon_reference.md
+++ b/docs/agent_hocon_reference.md
@@ -40,7 +40,7 @@ Sub-keys to those dictionaries will be described in the next-level down heading 
       - [type](#type)
       - [properties](#properties)
       - [required](#required)
-    - [sly_data](#sly_data)
+    - [sly_data_schema](#sly_data_schema)
   - [instructions](#instructions)
   - [command](#command)
   - [tools (agents)](#tools-agents)
@@ -52,11 +52,11 @@ Sub-keys to those dictionaries will be described in the next-level down heading 
   - [allow](#allow)
     - [connectivity](#connectivity)
     - [to_downstream](#to_downstream)
-      - [sly_data](#sly_data-1)
+      - [sly_data](#sly_data)
     - [from_downstream](#from_downstream)
-      - [sly_data](#sly_data-2)
+      - [sly_data](#sly_data-1)
     - [to_upstream](#to_upstream)
-      - [sly_data](#sly_data-3)
+      - [sly_data](#sly_data-2)
   - [display_as](#display_as)
   - [max_message_history](#max_message_history)
   - [error_formatter](#error_formatter-1)
@@ -351,7 +351,7 @@ This is an optional list of string keys in the [properties](#properties) diction
 to be required whenever an upstream agent calls the one being described.
 Note that it's possible to specify a default value for any property that is not listed as required.
 
-#### sly_data
+#### sly_data_schema
 
 The optional [JSON Schema](https://json-schema.org) dictionary describing what
 specific information the agent needs as input arguments over the private sly_data dictionary
@@ -360,15 +360,15 @@ that does not belong in the chat stream, for example: credential information.
 
 The sly_data schema specification here has the same format as the [parameters](#parameters)
 schema definition above.  Ideally there should be one [properties](#properties) entry per
-sly_data dictionary key, and any absolutely necessary keys should be listed in the [required](#required)
+sly_data dictionary input key, and any absolutely necessary keys should be listed in the [required](#required)
 list.
 
-Note that it is not strictly necessary to advertise to the outside world the sly_data that
+Note that it is not strictly necessary to advertise to the outside world the sly_data_schema that
 your agent network requires, but doing so does allow generic clients to prompt for this extra
 information before sending any chat input.
 
 The front-man is the only agent node that ever needs to specify this aspect of the [function](#function)
-definition, as sly_data is already visible to all other internal agents of the network.
+definition, as sly_data itself is already visible to all other internal agents of the network.
 
 Example networks that advertise their sly_data schema:
 - [math_guy.hocon](../neuro_san/registries/math_guy.hocon)
@@ -554,7 +554,7 @@ Boolean values for each key tell whether or not that data from any external agen
 is allowed to be accepted and merged into this agent's sly_data.
 A string value in the dictionary represents a translation to a new key.
 
-The same dictionary/list specification described in [to_downstream](#sly_data-1) also applies here.
+The same dictionary/list specification described in [to_downstream](#sly_data) also applies here.
 
 #### to_upstream
 
@@ -573,7 +573,7 @@ Boolean values for each key tell whether or not that data internal to the agent 
 is allowed to go back to the client in the final message.
 A string value in the dictionary represents a translation to a new key.
 
-The same dictionary/list specification described in [to_downstream](#sly_data-1) also applies here.
+The same dictionary/list specification described in [to_downstream](#sly_data) also applies here.
 
 ### display_as
 

--- a/neuro_san/api/grpc/agent.proto
+++ b/neuro_san/api/grpc/agent.proto
@@ -74,7 +74,7 @@ message Function {
     // Outward-facing description of what the agent does.
     string description = 1 [json_name="description"];
 
-    // Optional map of parameters passed in via the natural-language chat channel
+    // Optional map of parameters passed in via the natural-language chat text channel
     // that the agent needs in order to work.
     // This is really a pydantic/OpenAI function description, which is
     // a bit too complex to specify directly in protobuf.

--- a/neuro_san/api/grpc/agent.proto
+++ b/neuro_san/api/grpc/agent.proto
@@ -81,10 +81,10 @@ message Function {
     google.protobuf.Struct parameters = 2 [json_name="parameters"];
 
     // Optional map of parameters passed in via the sly_data dictionary private data channel
-    // that the agent needs in order to work.
-    // This is really a pydantic/OpenAI function description, which is
+    // that the agent needs in order to work.  Just like the parameters above,
+    // this is really a pydantic/OpenAI function description, which is
     // a bit too complex to specify directly in protobuf.
-    google.protobuf.Struct sly_data = 3 [json_name="sly_data"];
+    google.protobuf.Struct sly_data_schema = 3 [json_name="sly_data_schema"];
 }
 
 // Response structure for Function gRPC method

--- a/neuro_san/api/grpc/agent.proto
+++ b/neuro_san/api/grpc/agent.proto
@@ -74,10 +74,17 @@ message Function {
     // Outward-facing description of what the agent does.
     string description = 1 [json_name="description"];
 
-    // Optional map of parameters that the agent needs in order to work.
+    // Optional map of parameters passed in via the natural-language chat channel
+    // that the agent needs in order to work.
     // This is really a pydantic/OpenAI function description, which is
     // a bit too complex to specify directly in protobuf.
     google.protobuf.Struct parameters = 2 [json_name="parameters"];
+
+    // Optional map of parameters passed in via the sly_data dictionary private data channel
+    // that the agent needs in order to work.
+    // This is really a pydantic/OpenAI function description, which is
+    // a bit too complex to specify directly in protobuf.
+    google.protobuf.Struct sly_data = 3 [json_name="sly_data"];
 }
 
 // Response structure for Function gRPC method

--- a/neuro_san/api/grpc/agent_pb2.py
+++ b/neuro_san/api/grpc/agent_pb2.py
@@ -28,7 +28,7 @@ from google.api import annotations_pb2 as google_dot_api_dot_annotations__pb2
 from neuro_san.api.grpc import chat_pb2 as neuro__san_dot_api_dot_grpc_dot_chat__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x1eneuro_san/api/grpc/agent.proto\x12)dev.cognizant_ai.neuro_san.api.grpc.agent\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1cgoogle/api/annotations.proto\x1a\x1dneuro_san/api/grpc/chat.proto\"\x11\n\x0f\x46unctionRequest\"\x9a\x01\n\x08\x46unction\x12 \n\x0b\x64\x65scription\x18\x01 \x01(\tR\x0b\x64\x65scription\x12\x37\n\nparameters\x18\x02 \x01(\x0b\x32\x17.google.protobuf.StructR\nparameters\x12\x33\n\x08sly_data\x18\x03 \x01(\x0b\x32\x17.google.protobuf.StructR\x08sly_data\"c\n\x10\x46unctionResponse\x12O\n\x08\x66unction\x18\x01 \x01(\x0b\x32\x33.dev.cognizant_ai.neuro_san.api.grpc.agent.FunctionR\x08\x66unction\"s\n\nChatFilter\x12\x65\n\x10\x63hat_filter_type\x18\x01 \x01(\x0e\x32\x39.dev.cognizant_ai.neuro_san.api.grpc.agent.ChatFilterTypeR\x10\x63hat_filter_type\"\xd1\x02\n\x0b\x43hatRequest\x12\x33\n\x08sly_data\x18\x03 \x01(\x0b\x32\x17.google.protobuf.StructR\x08sly_data\x12Y\n\x0cuser_message\x18\x04 \x01(\x0b\x32\x35.dev.cognizant_ai.neuro_san.api.grpc.chat.ChatMessageR\x0cuser_message\x12Y\n\x0c\x63hat_context\x18\x05 \x01(\x0b\x32\x35.dev.cognizant_ai.neuro_san.api.grpc.chat.ChatContextR\x0c\x63hat_context\x12W\n\x0b\x63hat_filter\x18\x06 \x01(\x0b\x32\x35.dev.cognizant_ai.neuro_san.api.grpc.agent.ChatFilterR\x0b\x63hat_filter\"\xaa\x01\n\x0c\x43hatResponse\x12G\n\x07request\x18\x01 \x01(\x0b\x32\x36.dev.cognizant_ai.neuro_san.api.grpc.agent.ChatRequest\x12Q\n\x08response\x18\x04 \x01(\x0b\x32\x35.dev.cognizant_ai.neuro_san.api.grpc.chat.ChatMessageR\x08response\"\x15\n\x13\x43onnectivityRequest\"`\n\x10\x43onnectivityInfo\x12\x16\n\x06origin\x18\x01 \x01(\tR\x06origin\x12\x14\n\x05tools\x18\x02 \x03(\tR\x05tools\x12\x1e\n\ndisplay_as\x18\x03 \x01(\tR\ndisplay_as\"\x81\x01\n\x14\x43onnectivityResponse\x12i\n\x11\x63onnectivity_info\x18\x01 \x03(\x0b\x32;.dev.cognizant_ai.neuro_san.api.grpc.agent.ConnectivityInfoR\x11\x63onnectivity_info*7\n\x0e\x43hatFilterType\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x0b\n\x07MINIMAL\x10\x01\x12\x0b\n\x07MAXIMAL\x10\x02\x32\xad\x04\n\x0c\x41gentService\x12\xaa\x01\n\x08\x46unction\x12:.dev.cognizant_ai.neuro_san.api.grpc.agent.FunctionRequest\x1a;.dev.cognizant_ai.neuro_san.api.grpc.agent.FunctionResponse\"%\x82\xd3\xe4\x93\x02\x1f\x12\x1d/api/v1/{agent_name}/function\x12\xb2\x01\n\rStreamingChat\x12\x36.dev.cognizant_ai.neuro_san.api.grpc.agent.ChatRequest\x1a\x37.dev.cognizant_ai.neuro_san.api.grpc.agent.ChatResponse\".\x82\xd3\xe4\x93\x02(\"#/api/v1/{agent_name}/streaming_chat:\x01*0\x01\x12\xba\x01\n\x0c\x43onnectivity\x12>.dev.cognizant_ai.neuro_san.api.grpc.agent.ConnectivityRequest\x1a?.dev.cognizant_ai.neuro_san.api.grpc.agent.ConnectivityResponse\")\x82\xd3\xe4\x93\x02#\x12!/api/v1/{agent_name}/connectivityBgZegithub.com/cognizant-ai-lab/neuro_san/internal/gen/dev.cognizant_ai/neuro_san/api/grpc/agent/v1;agentb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x1eneuro_san/api/grpc/agent.proto\x12)dev.cognizant_ai.neuro_san.api.grpc.agent\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1cgoogle/api/annotations.proto\x1a\x1dneuro_san/api/grpc/chat.proto\"\x11\n\x0f\x46unctionRequest\"\xa8\x01\n\x08\x46unction\x12 \n\x0b\x64\x65scription\x18\x01 \x01(\tR\x0b\x64\x65scription\x12\x37\n\nparameters\x18\x02 \x01(\x0b\x32\x17.google.protobuf.StructR\nparameters\x12\x41\n\x0fsly_data_schema\x18\x03 \x01(\x0b\x32\x17.google.protobuf.StructR\x0fsly_data_schema\"c\n\x10\x46unctionResponse\x12O\n\x08\x66unction\x18\x01 \x01(\x0b\x32\x33.dev.cognizant_ai.neuro_san.api.grpc.agent.FunctionR\x08\x66unction\"s\n\nChatFilter\x12\x65\n\x10\x63hat_filter_type\x18\x01 \x01(\x0e\x32\x39.dev.cognizant_ai.neuro_san.api.grpc.agent.ChatFilterTypeR\x10\x63hat_filter_type\"\xd1\x02\n\x0b\x43hatRequest\x12\x33\n\x08sly_data\x18\x03 \x01(\x0b\x32\x17.google.protobuf.StructR\x08sly_data\x12Y\n\x0cuser_message\x18\x04 \x01(\x0b\x32\x35.dev.cognizant_ai.neuro_san.api.grpc.chat.ChatMessageR\x0cuser_message\x12Y\n\x0c\x63hat_context\x18\x05 \x01(\x0b\x32\x35.dev.cognizant_ai.neuro_san.api.grpc.chat.ChatContextR\x0c\x63hat_context\x12W\n\x0b\x63hat_filter\x18\x06 \x01(\x0b\x32\x35.dev.cognizant_ai.neuro_san.api.grpc.agent.ChatFilterR\x0b\x63hat_filter\"\xaa\x01\n\x0c\x43hatResponse\x12G\n\x07request\x18\x01 \x01(\x0b\x32\x36.dev.cognizant_ai.neuro_san.api.grpc.agent.ChatRequest\x12Q\n\x08response\x18\x04 \x01(\x0b\x32\x35.dev.cognizant_ai.neuro_san.api.grpc.chat.ChatMessageR\x08response\"\x15\n\x13\x43onnectivityRequest\"`\n\x10\x43onnectivityInfo\x12\x16\n\x06origin\x18\x01 \x01(\tR\x06origin\x12\x14\n\x05tools\x18\x02 \x03(\tR\x05tools\x12\x1e\n\ndisplay_as\x18\x03 \x01(\tR\ndisplay_as\"\x81\x01\n\x14\x43onnectivityResponse\x12i\n\x11\x63onnectivity_info\x18\x01 \x03(\x0b\x32;.dev.cognizant_ai.neuro_san.api.grpc.agent.ConnectivityInfoR\x11\x63onnectivity_info*7\n\x0e\x43hatFilterType\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x0b\n\x07MINIMAL\x10\x01\x12\x0b\n\x07MAXIMAL\x10\x02\x32\xad\x04\n\x0c\x41gentService\x12\xaa\x01\n\x08\x46unction\x12:.dev.cognizant_ai.neuro_san.api.grpc.agent.FunctionRequest\x1a;.dev.cognizant_ai.neuro_san.api.grpc.agent.FunctionResponse\"%\x82\xd3\xe4\x93\x02\x1f\x12\x1d/api/v1/{agent_name}/function\x12\xb2\x01\n\rStreamingChat\x12\x36.dev.cognizant_ai.neuro_san.api.grpc.agent.ChatRequest\x1a\x37.dev.cognizant_ai.neuro_san.api.grpc.agent.ChatResponse\".\x82\xd3\xe4\x93\x02(\"#/api/v1/{agent_name}/streaming_chat:\x01*0\x01\x12\xba\x01\n\x0c\x43onnectivity\x12>.dev.cognizant_ai.neuro_san.api.grpc.agent.ConnectivityRequest\x1a?.dev.cognizant_ai.neuro_san.api.grpc.agent.ConnectivityResponse\")\x82\xd3\xe4\x93\x02#\x12!/api/v1/{agent_name}/connectivityBgZegithub.com/cognizant-ai-lab/neuro_san/internal/gen/dev.cognizant_ai/neuro_san/api/grpc/agent/v1;agentb\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -42,26 +42,26 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   _globals['_AGENTSERVICE'].methods_by_name['StreamingChat']._serialized_options = b'\202\323\344\223\002(\"#/api/v1/{agent_name}/streaming_chat:\001*'
   _globals['_AGENTSERVICE'].methods_by_name['Connectivity']._options = None
   _globals['_AGENTSERVICE'].methods_by_name['Connectivity']._serialized_options = b'\202\323\344\223\002#\022!/api/v1/{agent_name}/connectivity'
-  _globals['_CHATFILTERTYPE']._serialized_start=1328
-  _globals['_CHATFILTERTYPE']._serialized_end=1383
+  _globals['_CHATFILTERTYPE']._serialized_start=1342
+  _globals['_CHATFILTERTYPE']._serialized_end=1397
   _globals['_FUNCTIONREQUEST']._serialized_start=168
   _globals['_FUNCTIONREQUEST']._serialized_end=185
   _globals['_FUNCTION']._serialized_start=188
-  _globals['_FUNCTION']._serialized_end=342
-  _globals['_FUNCTIONRESPONSE']._serialized_start=344
-  _globals['_FUNCTIONRESPONSE']._serialized_end=443
-  _globals['_CHATFILTER']._serialized_start=445
-  _globals['_CHATFILTER']._serialized_end=560
-  _globals['_CHATREQUEST']._serialized_start=563
-  _globals['_CHATREQUEST']._serialized_end=900
-  _globals['_CHATRESPONSE']._serialized_start=903
-  _globals['_CHATRESPONSE']._serialized_end=1073
-  _globals['_CONNECTIVITYREQUEST']._serialized_start=1075
-  _globals['_CONNECTIVITYREQUEST']._serialized_end=1096
-  _globals['_CONNECTIVITYINFO']._serialized_start=1098
-  _globals['_CONNECTIVITYINFO']._serialized_end=1194
-  _globals['_CONNECTIVITYRESPONSE']._serialized_start=1197
-  _globals['_CONNECTIVITYRESPONSE']._serialized_end=1326
-  _globals['_AGENTSERVICE']._serialized_start=1386
-  _globals['_AGENTSERVICE']._serialized_end=1943
+  _globals['_FUNCTION']._serialized_end=356
+  _globals['_FUNCTIONRESPONSE']._serialized_start=358
+  _globals['_FUNCTIONRESPONSE']._serialized_end=457
+  _globals['_CHATFILTER']._serialized_start=459
+  _globals['_CHATFILTER']._serialized_end=574
+  _globals['_CHATREQUEST']._serialized_start=577
+  _globals['_CHATREQUEST']._serialized_end=914
+  _globals['_CHATRESPONSE']._serialized_start=917
+  _globals['_CHATRESPONSE']._serialized_end=1087
+  _globals['_CONNECTIVITYREQUEST']._serialized_start=1089
+  _globals['_CONNECTIVITYREQUEST']._serialized_end=1110
+  _globals['_CONNECTIVITYINFO']._serialized_start=1112
+  _globals['_CONNECTIVITYINFO']._serialized_end=1208
+  _globals['_CONNECTIVITYRESPONSE']._serialized_start=1211
+  _globals['_CONNECTIVITYRESPONSE']._serialized_end=1340
+  _globals['_AGENTSERVICE']._serialized_start=1400
+  _globals['_AGENTSERVICE']._serialized_end=1957
 # @@protoc_insertion_point(module_scope)

--- a/neuro_san/api/grpc/agent_pb2.py
+++ b/neuro_san/api/grpc/agent_pb2.py
@@ -28,7 +28,7 @@ from google.api import annotations_pb2 as google_dot_api_dot_annotations__pb2
 from neuro_san.api.grpc import chat_pb2 as neuro__san_dot_api_dot_grpc_dot_chat__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x1eneuro_san/api/grpc/agent.proto\x12)dev.cognizant_ai.neuro_san.api.grpc.agent\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1cgoogle/api/annotations.proto\x1a\x1dneuro_san/api/grpc/chat.proto\"\x11\n\x0f\x46unctionRequest\"e\n\x08\x46unction\x12 \n\x0b\x64\x65scription\x18\x01 \x01(\tR\x0b\x64\x65scription\x12\x37\n\nparameters\x18\x02 \x01(\x0b\x32\x17.google.protobuf.StructR\nparameters\"c\n\x10\x46unctionResponse\x12O\n\x08\x66unction\x18\x01 \x01(\x0b\x32\x33.dev.cognizant_ai.neuro_san.api.grpc.agent.FunctionR\x08\x66unction\"s\n\nChatFilter\x12\x65\n\x10\x63hat_filter_type\x18\x01 \x01(\x0e\x32\x39.dev.cognizant_ai.neuro_san.api.grpc.agent.ChatFilterTypeR\x10\x63hat_filter_type\"\xd1\x02\n\x0b\x43hatRequest\x12\x33\n\x08sly_data\x18\x03 \x01(\x0b\x32\x17.google.protobuf.StructR\x08sly_data\x12Y\n\x0cuser_message\x18\x04 \x01(\x0b\x32\x35.dev.cognizant_ai.neuro_san.api.grpc.chat.ChatMessageR\x0cuser_message\x12Y\n\x0c\x63hat_context\x18\x05 \x01(\x0b\x32\x35.dev.cognizant_ai.neuro_san.api.grpc.chat.ChatContextR\x0c\x63hat_context\x12W\n\x0b\x63hat_filter\x18\x06 \x01(\x0b\x32\x35.dev.cognizant_ai.neuro_san.api.grpc.agent.ChatFilterR\x0b\x63hat_filter\"\xaa\x01\n\x0c\x43hatResponse\x12G\n\x07request\x18\x01 \x01(\x0b\x32\x36.dev.cognizant_ai.neuro_san.api.grpc.agent.ChatRequest\x12Q\n\x08response\x18\x04 \x01(\x0b\x32\x35.dev.cognizant_ai.neuro_san.api.grpc.chat.ChatMessageR\x08response\"\x15\n\x13\x43onnectivityRequest\"`\n\x10\x43onnectivityInfo\x12\x16\n\x06origin\x18\x01 \x01(\tR\x06origin\x12\x14\n\x05tools\x18\x02 \x03(\tR\x05tools\x12\x1e\n\ndisplay_as\x18\x03 \x01(\tR\ndisplay_as\"\x81\x01\n\x14\x43onnectivityResponse\x12i\n\x11\x63onnectivity_info\x18\x01 \x03(\x0b\x32;.dev.cognizant_ai.neuro_san.api.grpc.agent.ConnectivityInfoR\x11\x63onnectivity_info*7\n\x0e\x43hatFilterType\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x0b\n\x07MINIMAL\x10\x01\x12\x0b\n\x07MAXIMAL\x10\x02\x32\xad\x04\n\x0c\x41gentService\x12\xaa\x01\n\x08\x46unction\x12:.dev.cognizant_ai.neuro_san.api.grpc.agent.FunctionRequest\x1a;.dev.cognizant_ai.neuro_san.api.grpc.agent.FunctionResponse\"%\x82\xd3\xe4\x93\x02\x1f\x12\x1d/api/v1/{agent_name}/function\x12\xb2\x01\n\rStreamingChat\x12\x36.dev.cognizant_ai.neuro_san.api.grpc.agent.ChatRequest\x1a\x37.dev.cognizant_ai.neuro_san.api.grpc.agent.ChatResponse\".\x82\xd3\xe4\x93\x02(\"#/api/v1/{agent_name}/streaming_chat:\x01*0\x01\x12\xba\x01\n\x0c\x43onnectivity\x12>.dev.cognizant_ai.neuro_san.api.grpc.agent.ConnectivityRequest\x1a?.dev.cognizant_ai.neuro_san.api.grpc.agent.ConnectivityResponse\")\x82\xd3\xe4\x93\x02#\x12!/api/v1/{agent_name}/connectivityBgZegithub.com/cognizant-ai-lab/neuro_san/internal/gen/dev.cognizant_ai/neuro_san/api/grpc/agent/v1;agentb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x1eneuro_san/api/grpc/agent.proto\x12)dev.cognizant_ai.neuro_san.api.grpc.agent\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1cgoogle/api/annotations.proto\x1a\x1dneuro_san/api/grpc/chat.proto\"\x11\n\x0f\x46unctionRequest\"\x9a\x01\n\x08\x46unction\x12 \n\x0b\x64\x65scription\x18\x01 \x01(\tR\x0b\x64\x65scription\x12\x37\n\nparameters\x18\x02 \x01(\x0b\x32\x17.google.protobuf.StructR\nparameters\x12\x33\n\x08sly_data\x18\x03 \x01(\x0b\x32\x17.google.protobuf.StructR\x08sly_data\"c\n\x10\x46unctionResponse\x12O\n\x08\x66unction\x18\x01 \x01(\x0b\x32\x33.dev.cognizant_ai.neuro_san.api.grpc.agent.FunctionR\x08\x66unction\"s\n\nChatFilter\x12\x65\n\x10\x63hat_filter_type\x18\x01 \x01(\x0e\x32\x39.dev.cognizant_ai.neuro_san.api.grpc.agent.ChatFilterTypeR\x10\x63hat_filter_type\"\xd1\x02\n\x0b\x43hatRequest\x12\x33\n\x08sly_data\x18\x03 \x01(\x0b\x32\x17.google.protobuf.StructR\x08sly_data\x12Y\n\x0cuser_message\x18\x04 \x01(\x0b\x32\x35.dev.cognizant_ai.neuro_san.api.grpc.chat.ChatMessageR\x0cuser_message\x12Y\n\x0c\x63hat_context\x18\x05 \x01(\x0b\x32\x35.dev.cognizant_ai.neuro_san.api.grpc.chat.ChatContextR\x0c\x63hat_context\x12W\n\x0b\x63hat_filter\x18\x06 \x01(\x0b\x32\x35.dev.cognizant_ai.neuro_san.api.grpc.agent.ChatFilterR\x0b\x63hat_filter\"\xaa\x01\n\x0c\x43hatResponse\x12G\n\x07request\x18\x01 \x01(\x0b\x32\x36.dev.cognizant_ai.neuro_san.api.grpc.agent.ChatRequest\x12Q\n\x08response\x18\x04 \x01(\x0b\x32\x35.dev.cognizant_ai.neuro_san.api.grpc.chat.ChatMessageR\x08response\"\x15\n\x13\x43onnectivityRequest\"`\n\x10\x43onnectivityInfo\x12\x16\n\x06origin\x18\x01 \x01(\tR\x06origin\x12\x14\n\x05tools\x18\x02 \x03(\tR\x05tools\x12\x1e\n\ndisplay_as\x18\x03 \x01(\tR\ndisplay_as\"\x81\x01\n\x14\x43onnectivityResponse\x12i\n\x11\x63onnectivity_info\x18\x01 \x03(\x0b\x32;.dev.cognizant_ai.neuro_san.api.grpc.agent.ConnectivityInfoR\x11\x63onnectivity_info*7\n\x0e\x43hatFilterType\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x0b\n\x07MINIMAL\x10\x01\x12\x0b\n\x07MAXIMAL\x10\x02\x32\xad\x04\n\x0c\x41gentService\x12\xaa\x01\n\x08\x46unction\x12:.dev.cognizant_ai.neuro_san.api.grpc.agent.FunctionRequest\x1a;.dev.cognizant_ai.neuro_san.api.grpc.agent.FunctionResponse\"%\x82\xd3\xe4\x93\x02\x1f\x12\x1d/api/v1/{agent_name}/function\x12\xb2\x01\n\rStreamingChat\x12\x36.dev.cognizant_ai.neuro_san.api.grpc.agent.ChatRequest\x1a\x37.dev.cognizant_ai.neuro_san.api.grpc.agent.ChatResponse\".\x82\xd3\xe4\x93\x02(\"#/api/v1/{agent_name}/streaming_chat:\x01*0\x01\x12\xba\x01\n\x0c\x43onnectivity\x12>.dev.cognizant_ai.neuro_san.api.grpc.agent.ConnectivityRequest\x1a?.dev.cognizant_ai.neuro_san.api.grpc.agent.ConnectivityResponse\")\x82\xd3\xe4\x93\x02#\x12!/api/v1/{agent_name}/connectivityBgZegithub.com/cognizant-ai-lab/neuro_san/internal/gen/dev.cognizant_ai/neuro_san/api/grpc/agent/v1;agentb\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -42,26 +42,26 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   _globals['_AGENTSERVICE'].methods_by_name['StreamingChat']._serialized_options = b'\202\323\344\223\002(\"#/api/v1/{agent_name}/streaming_chat:\001*'
   _globals['_AGENTSERVICE'].methods_by_name['Connectivity']._options = None
   _globals['_AGENTSERVICE'].methods_by_name['Connectivity']._serialized_options = b'\202\323\344\223\002#\022!/api/v1/{agent_name}/connectivity'
-  _globals['_CHATFILTERTYPE']._serialized_start=1274
-  _globals['_CHATFILTERTYPE']._serialized_end=1329
+  _globals['_CHATFILTERTYPE']._serialized_start=1328
+  _globals['_CHATFILTERTYPE']._serialized_end=1383
   _globals['_FUNCTIONREQUEST']._serialized_start=168
   _globals['_FUNCTIONREQUEST']._serialized_end=185
-  _globals['_FUNCTION']._serialized_start=187
-  _globals['_FUNCTION']._serialized_end=288
-  _globals['_FUNCTIONRESPONSE']._serialized_start=290
-  _globals['_FUNCTIONRESPONSE']._serialized_end=389
-  _globals['_CHATFILTER']._serialized_start=391
-  _globals['_CHATFILTER']._serialized_end=506
-  _globals['_CHATREQUEST']._serialized_start=509
-  _globals['_CHATREQUEST']._serialized_end=846
-  _globals['_CHATRESPONSE']._serialized_start=849
-  _globals['_CHATRESPONSE']._serialized_end=1019
-  _globals['_CONNECTIVITYREQUEST']._serialized_start=1021
-  _globals['_CONNECTIVITYREQUEST']._serialized_end=1042
-  _globals['_CONNECTIVITYINFO']._serialized_start=1044
-  _globals['_CONNECTIVITYINFO']._serialized_end=1140
-  _globals['_CONNECTIVITYRESPONSE']._serialized_start=1143
-  _globals['_CONNECTIVITYRESPONSE']._serialized_end=1272
-  _globals['_AGENTSERVICE']._serialized_start=1332
-  _globals['_AGENTSERVICE']._serialized_end=1889
+  _globals['_FUNCTION']._serialized_start=188
+  _globals['_FUNCTION']._serialized_end=342
+  _globals['_FUNCTIONRESPONSE']._serialized_start=344
+  _globals['_FUNCTIONRESPONSE']._serialized_end=443
+  _globals['_CHATFILTER']._serialized_start=445
+  _globals['_CHATFILTER']._serialized_end=560
+  _globals['_CHATREQUEST']._serialized_start=563
+  _globals['_CHATREQUEST']._serialized_end=900
+  _globals['_CHATRESPONSE']._serialized_start=903
+  _globals['_CHATRESPONSE']._serialized_end=1073
+  _globals['_CONNECTIVITYREQUEST']._serialized_start=1075
+  _globals['_CONNECTIVITYREQUEST']._serialized_end=1096
+  _globals['_CONNECTIVITYINFO']._serialized_start=1098
+  _globals['_CONNECTIVITYINFO']._serialized_end=1194
+  _globals['_CONNECTIVITYRESPONSE']._serialized_start=1197
+  _globals['_CONNECTIVITYRESPONSE']._serialized_end=1326
+  _globals['_AGENTSERVICE']._serialized_start=1386
+  _globals['_AGENTSERVICE']._serialized_end=1943
 # @@protoc_insertion_point(module_scope)

--- a/neuro_san/api/grpc/agent_service.json
+++ b/neuro_san/api/grpc/agent_service.json
@@ -381,9 +381,9 @@
             "type": "object",
             "description": "Optional map of parameters passed in via the natural-language chat text channel that the agent needs in order to work. This is really a pydantic/OpenAI function description, which is a bit too complex to specify directly in protobuf."
           },
-          "sly_data": {
+          "sly_data_schema": {
             "type": "object",
-            "description": "Optional map of parameters passed in via the sly_data dictionary private data channel that the agent needs in order to work. This is really a pydantic/OpenAI function description, which is a bit too complex to specify directly in protobuf."
+            "description": "Optional map of parameters passed in via the sly_data dictionary private data channel that the agent needs in order to work.  Just like the parameters above, this is really a pydantic/OpenAI function description, which is a bit too complex to specify directly in protobuf."
           }
         },
         "description": "Description of an agent's function"

--- a/neuro_san/api/grpc/agent_service.json
+++ b/neuro_san/api/grpc/agent_service.json
@@ -379,7 +379,11 @@
           },
           "parameters": {
             "type": "object",
-            "description": "Optional map of parameters that the agent needs in order to work. This is really a pydantic/OpenAI function description, which is a bit too complex to specify directly in protobuf."
+            "description": "Optional map of parameters passed in via the natural-language chat channel that the agent needs in order to work. This is really a pydantic/OpenAI function description, which is a bit too complex to specify directly in protobuf."
+          },
+          "sly_data": {
+            "type": "object",
+            "description": "Optional map of parameters passed in via the sly_data dictionary private data channel that the agent needs in order to work. This is really a pydantic/OpenAI function description, which is a bit too complex to specify directly in protobuf."
           }
         },
         "description": "Description of an agent's function"

--- a/neuro_san/api/grpc/agent_service.json
+++ b/neuro_san/api/grpc/agent_service.json
@@ -379,7 +379,7 @@
           },
           "parameters": {
             "type": "object",
-            "description": "Optional map of parameters passed in via the natural-language chat channel that the agent needs in order to work. This is really a pydantic/OpenAI function description, which is a bit too complex to specify directly in protobuf."
+            "description": "Optional map of parameters passed in via the natural-language chat text channel that the agent needs in order to work. This is really a pydantic/OpenAI function description, which is a bit too complex to specify directly in protobuf."
           },
           "sly_data": {
             "type": "object",

--- a/neuro_san/registries/math_guy.hocon
+++ b/neuro_san/registries/math_guy.hocon
@@ -54,6 +54,24 @@ on the secret numbers.
                         }
                     },
                     "required": ["operator"]
+                },
+
+                # You can also optionally specify the schema needed for any sly_data.
+                # This is to allow generic clients to prompt for private-data inputs
+                # that do not belong in the chat stream.
+                "sly_data": {
+                    "type": "object",
+                    "properties": {
+                        "x": {
+                            "type": "float",
+                            "description": "The first operand for the arithmetic operation"
+                        },
+                        "y": {
+                            "type": "float",
+                            "description": "The second operand for the arithmetic operation"
+                        }
+                    },
+                    "required": ["x", "y"]
                 }
             },
 

--- a/neuro_san/registries/math_guy.hocon
+++ b/neuro_san/registries/math_guy.hocon
@@ -56,10 +56,10 @@ on the secret numbers.
                     "required": ["operator"]
                 },
 
-                # You can also optionally specify the schema needed for any sly_data.
+                # You can also optionally specify the schema needed for any sly_data input.
                 # This is to allow generic clients to prompt for private-data inputs
                 # that do not belong in the chat stream.
-                "sly_data": {
+                "sly_data_schema": {
                     "type": "object",
                     "properties": {
                         "x": {


### PR DESCRIPTION
Idea from a conversation with Paul, this ended up being a lot easier than I thought it would be.

Allowing for sly_data_schema to be sent in the Function() response means that a generic client like
MAAUI can prompt for user-specific information in a generic way.  This should increase the utility of what other
people can demo for us in that for specific cases we don't have to provide deploy-time environment variables 
for special accounts.

Worth noting that there is no checking for the required fields of the schema on the server side.