### PR TITLE
Un-3137 Use AsyncAgentService for http service stack.

### DIFF
--- a/neuro_san/http_sidecar/handlers/base_request_handler.py
+++ b/neuro_san/http_sidecar/handlers/base_request_handler.py
@@ -29,8 +29,6 @@ from tornado.web import RequestHandler
 from neuro_san.http_sidecar.logging.http_logger import HttpLogger
 from neuro_san.http_sidecar.interfaces.agent_authorizer import AgentAuthorizer
 from neuro_san.http_sidecar.interfaces.agents_updater import AgentsUpdater
-from neuro_san.interfaces.async_agent_session import AsyncAgentSession
-from neuro_san.session.async_grpc_service_agent_session import AsyncGrpcServiceAgentSession
 
 
 class BaseRequestHandler(RequestHandler):
@@ -103,21 +101,6 @@ class BaseRequestHandler(RequestHandler):
             else:
                 result[item_name] = "None"
         return result
-
-    def get_agent_grpc_session(self,
-                               metadata: Dict[str, Any],
-                               agent_name: str) -> AsyncAgentSession:
-        """
-        Build gRPC session to talk to "main" service
-        :return: AgentSession to use
-        """
-        grpc_session: AsyncAgentSession = \
-            AsyncGrpcServiceAgentSession(
-                host="localhost",
-                port=self.port,
-                metadata=metadata,
-                agent_name=agent_name)
-        return grpc_session
 
     async def update_agents(self, metadata: Dict[str, Any]) -> bool:
         """

--- a/neuro_san/http_sidecar/handlers/connectivity_handler.py
+++ b/neuro_san/http_sidecar/handlers/connectivity_handler.py
@@ -16,6 +16,7 @@ from typing import Any, Dict
 
 from neuro_san.http_sidecar.handlers.base_request_handler import BaseRequestHandler
 from neuro_san.interfaces.async_agent_session import AsyncAgentSession
+from neuro_san.service.async_agent_service import AsyncAgentService
 
 
 class ConnectivityHandler(BaseRequestHandler):
@@ -32,7 +33,8 @@ class ConnectivityHandler(BaseRequestHandler):
         if not update_done:
             return
 
-        if not self.agent_policy.allow(agent_name):
+        service: AsyncAgentService = self.agent_policy.allow(agent_name)
+        if service is None:
             self.set_status(404)
             self.logger.error({}, "error: Invalid request path %s", self.request.path)
             self.do_finish()
@@ -41,8 +43,7 @@ class ConnectivityHandler(BaseRequestHandler):
         self.logger.info(metadata, "Start GET %s/connectivity", agent_name)
         try:
             data: Dict[str, Any] = {}
-            grpc_session: AsyncAgentSession = self.get_agent_grpc_session(metadata, agent_name)
-            result_dict: Dict[str, Any] = await grpc_session.connectivity(data)
+            result_dict: Dict[str, Any] = await service.connectivity(data, metadata)
 
             # Return gRPC response to the HTTP client
             self.set_header("Content-Type", "application/json")

--- a/neuro_san/http_sidecar/handlers/connectivity_handler.py
+++ b/neuro_san/http_sidecar/handlers/connectivity_handler.py
@@ -15,7 +15,6 @@ See class comment for details
 from typing import Any, Dict
 
 from neuro_san.http_sidecar.handlers.base_request_handler import BaseRequestHandler
-from neuro_san.interfaces.async_agent_session import AsyncAgentSession
 from neuro_san.service.async_agent_service import AsyncAgentService
 
 

--- a/neuro_san/http_sidecar/handlers/function_handler.py
+++ b/neuro_san/http_sidecar/handlers/function_handler.py
@@ -15,7 +15,6 @@ See class comment for details
 from typing import Any, Dict
 
 from neuro_san.http_sidecar.handlers.base_request_handler import BaseRequestHandler
-from neuro_san.interfaces.async_agent_session import AsyncAgentSession
 from neuro_san.service.async_agent_service import AsyncAgentService
 
 

--- a/neuro_san/http_sidecar/handlers/function_handler.py
+++ b/neuro_san/http_sidecar/handlers/function_handler.py
@@ -16,6 +16,7 @@ from typing import Any, Dict
 
 from neuro_san.http_sidecar.handlers.base_request_handler import BaseRequestHandler
 from neuro_san.interfaces.async_agent_session import AsyncAgentSession
+from neuro_san.service.async_agent_service import AsyncAgentService
 
 
 class FunctionHandler(BaseRequestHandler):
@@ -32,7 +33,8 @@ class FunctionHandler(BaseRequestHandler):
         if not update_done:
             return
 
-        if not self.agent_policy.allow(agent_name):
+        service: AsyncAgentService = self.agent_policy.allow(agent_name)
+        if service is None:
             self.set_status(404)
             self.logger.error({}, "error: Invalid request path %s", self.request.path)
             self.do_finish()
@@ -41,11 +43,9 @@ class FunctionHandler(BaseRequestHandler):
         self.logger.info(metadata, "Start GET %s/function", agent_name)
         try:
             data: Dict[str, Any] = {}
-            grpc_session: AsyncAgentSession =\
-                self.get_agent_grpc_session(metadata, agent_name)
-            result_dict: Dict[str, Any] = await grpc_session.function(data)
+            result_dict: Dict[str, Any] = await service.function(data, metadata)
 
-            # Return gRPC response to the HTTP client
+            # Return service response to the HTTP client
             self.set_header("Content-Type", "application/json")
             self.write(result_dict)
 

--- a/neuro_san/http_sidecar/http_sidecar.py
+++ b/neuro_san/http_sidecar/http_sidecar.py
@@ -23,6 +23,10 @@ from neuro_san.session.direct_concierge_session import DirectConciergeSession
 from neuro_san.service.agent_server import DEFAULT_FORWARDED_REQUEST_METADATA
 from neuro_san.http_sidecar.logging.http_logger import HttpLogger
 from neuro_san.http_sidecar.http_server_app import HttpServerApp
+from neuro_san.service.async_agent_service import AsyncAgentService
+from neuro_san.service.agent_server_logging import AgentServerLogging
+from neuro_san.internals.tool_factories.service_tool_factory_provider import ServiceToolFactoryProvider
+from neuro_san.internals.tool_factories.single_agent_tool_factory_provider import SingleAgentToolFactoryProvider
 
 from neuro_san.http_sidecar.interfaces.agent_authorizer import AgentAuthorizer
 from neuro_san.http_sidecar.interfaces.agents_updater import AgentsUpdater
@@ -113,8 +117,8 @@ class HttpSidecar(AgentAuthorizer, AgentsUpdater):
 
         return HttpServerApp(handlers)
 
-    def allow(self, agent_name) -> bool:
-        return self.allowed_agents.get(agent_name, False)
+    def allow(self, agent_name) -> AsyncAgentService:
+        return self.allowed_agents.get(agent_name, None)
 
     def update_agents(self, metadata: Dict[str, Any]):
         """
@@ -132,11 +136,34 @@ class HttpSidecar(AgentAuthorizer, AgentsUpdater):
         with self.lock:
             # We assume all agents from "agents" list are enabled:
             for agent_name in agents:
-                self.allowed_agents[agent_name] = True
+                if self.allowed_agents.get(agent_name, None) is None:
+                    self.add_agent(agent_name)
             # All other agents are disabled:
             for agent_name, _ in self.allowed_agents.items():
                 if agent_name not in agents:
-                    self.allowed_agents[agent_name] = False
+                    self.remove_agent(agent_name)
+
+    def add_agent(self, agent_name: str):
+        """
+        Add agent to the map of known agents
+        :param agent_name: name of an agent
+        """
+        agent_tool_factory_provider: SingleAgentToolFactoryProvider =\
+            ServiceToolFactoryProvider.get_instance().get_agent_tool_factory_provider(agent_name)
+        # Convert back to a single string as required by constructor
+        request_metadata_str: str = " ".join(self.forwarded_request_metadata)
+        agent_server_logging: AgentServerLogging =\
+            AgentServerLogging(self.server_name_for_logs, request_metadata_str)
+        agent_service: AsyncAgentService =\
+            AsyncAgentService(self.logger, None, agent_name, agent_tool_factory_provider, agent_server_logging)
+        self.allowed_agents[agent_name] = agent_service
+
+    def remove_agent(self, agent_name: str):
+        """
+        Remove agent from the map of known agents
+        :param agent_name: name of an agent
+        """
+        self.allowed_agents.pop(agent_name, None)
 
     def build_request_data(self) -> Dict[str, Any]:
         """

--- a/neuro_san/http_sidecar/http_sidecar.py
+++ b/neuro_san/http_sidecar/http_sidecar.py
@@ -68,7 +68,7 @@ class HttpSidecar(AgentAuthorizer, AgentsUpdater):
         self.logger = None
         self.openapi_service_spec_path: str = openapi_service_spec_path
         self.forwarded_request_metadata: List[str] = forwarded_request_metadata.split(" ")
-        self.allowed_agents: Dict[str, bool] = {}
+        self.allowed_agents: Dict[str, AsyncAgentService] = {}
         self.lock = None
 
     def __call__(self):

--- a/neuro_san/http_sidecar/interfaces/agent_authorizer.py
+++ b/neuro_san/http_sidecar/interfaces/agent_authorizer.py
@@ -12,7 +12,7 @@
 """
 See class comment for details
 """
-
+from neuro_san.service.async_agent_service import AsyncAgentService
 
 class AgentAuthorizer:
     """
@@ -20,10 +20,10 @@ class AgentAuthorizer:
     of allowing to route incoming requests to an agent.
     """
 
-    def allow(self, agent_name) -> bool:
+    def allow(self, agent_name) -> AsyncAgentService:
         """
         :param agent_name: name of an agent
-        :return: True if routing requests is allowed for this agent;
-                 False otherwise
+        :return: instance of AsyncAgentService if routing requests is allowed for this agent;
+                 None otherwise
         """
         raise NotImplementedError

--- a/neuro_san/http_sidecar/interfaces/agent_authorizer.py
+++ b/neuro_san/http_sidecar/interfaces/agent_authorizer.py
@@ -14,6 +14,7 @@ See class comment for details
 """
 from neuro_san.service.async_agent_service import AsyncAgentService
 
+
 class AgentAuthorizer:
     """
     Abstract interface implementing some policy

--- a/neuro_san/internals/messages/chat_message_type.py
+++ b/neuro_san/internals/messages/chat_message_type.py
@@ -67,6 +67,9 @@ class ChatMessageType(IntEnum):
         if isinstance(response_type, ChatMessageType):
             return response_type
 
+        if isinstance(response_type, int):
+            return ChatMessageType(response_type)
+
         try:
             # Normal case: We have a 1:1 mapping of ChatMessageType to what is in grpc def
             message_type = ChatMessageType[response_type]


### PR DESCRIPTION
This PR finally switches from gRPC sessions to asynchronous agent service for executing neuro-san requests.
AsyncAgentService has been added to codebase in previous PR.
Tested: by stability test.
