### PR TITLE
Fix health check request handler.

### DIFF
--- a/neuro_san/http_sidecar/http_sidecar.py
+++ b/neuro_san/http_sidecar/http_sidecar.py
@@ -97,8 +97,11 @@ class HttpSidecar(AgentAuthorizer, AgentsUpdater):
         Construct tornado HTTP "application" to run.
         """
         request_data: Dict[str, Any] = self.build_request_data()
+        health_request_data: Dict[str, Any] = {
+            "forwarded_request_metadata": self.forwarded_request_metadata
+        }
         handlers = []
-        handlers.append(("/", HealthCheckHandler))
+        handlers.append(("/", HealthCheckHandler, health_request_data))
         handlers.append(("/api/v1/list", ConciergeHandler, request_data))
         handlers.append(("/api/v1/docs", OpenApiPublishHandler, request_data))
 


### PR DESCRIPTION
This PR fixes health check request handler.
Since we are defining our custom "default" Tornado request logger,
several things have to be added to any request handler,
namely self.logger and self.get_metadata() method.
