### PR TITLE
UN-3071 Switch to using HTTP for external agents from gRPC

### DIFF
--- a/build_scripts/run_pylint.sh
+++ b/build_scripts/run_pylint.sh
@@ -5,7 +5,7 @@
 RCFILE=./.pylintrc
 UP_TO_SNUFF_DIRS=$(ls -1)
 DEPENDENCY_DIRS=""
-IGNORE="${DEPENDENCY_DIRS} build build_scripts dist neuro_san.egg-info venv"
+IGNORE="${DEPENDENCY_DIRS} build build_scripts dist docs neuro_san.egg-info venv"
 
 dirs=$1
 if [ "${dirs}" == "" ]

--- a/neuro_san/interfaces/agent_session.py
+++ b/neuro_san/interfaces/agent_session.py
@@ -14,19 +14,13 @@ from typing import Any
 from typing import Dict
 from typing import Generator
 
+from neuro_san.interfaces.agent_session_constants import AgentSessionConstants
 
-class AgentSession:
+
+class AgentSession(AgentSessionConstants):
     """
     Interface for the initiation and continuity of a single Agent session.
     """
-
-    # Default port for the Agent Service
-    # This port number will also be mentioned in its Dockerfile
-    DEFAULT_PORT: int = 30011
-
-    # Default port for the Agent HTTP Service
-    # This port number will also be mentioned in its Dockerfile
-    DEFAULT_HTTP_PORT: int = 8080
 
     def function(self, request_dict: Dict[str, Any]) -> Dict[str, Any]:
         """

--- a/neuro_san/interfaces/agent_session_constants.py
+++ b/neuro_san/interfaces/agent_session_constants.py
@@ -16,9 +16,12 @@ class AgentSessionConstants:
     Interface for shared constants between AgentSession and AsyncAgentSession
     """
 
-    # Default port for the Agent Service
+    # Default gRPC port for the Agent Service
     # This port number will also be mentioned in its Dockerfile
-    DEFAULT_PORT: int = 30011
+    DEFAULT_GRPC_PORT: int = 30011
+
+    # For backwards compatibility
+    DEFAULT_PORT: int = DEFAULT_GRPC_PORT
 
     # Default port for the Agent HTTP Service
     # This port number will also be mentioned in its Dockerfile

--- a/neuro_san/interfaces/agent_session_constants.py
+++ b/neuro_san/interfaces/agent_session_constants.py
@@ -1,0 +1,25 @@
+
+# Copyright (C) 2023-2025 Cognizant Digital Business, Evolutionary AI.
+# All Rights Reserved.
+# Issued under the Academic Public License.
+#
+# You can be released from the terms, and requirements of the Academic Public
+# License by purchasing a commercial license.
+# Purchase of a commercial license is mandatory for any use of the
+# neuro-san SDK Software in commercial settings.
+#
+# END COPYRIGHT
+
+
+class AgentSessionConstants:
+    """
+    Interface for shared constants between AgentSession and AsyncAgentSession
+    """
+
+    # Default port for the Agent Service
+    # This port number will also be mentioned in its Dockerfile
+    DEFAULT_PORT: int = 30011
+
+    # Default port for the Agent HTTP Service
+    # This port number will also be mentioned in its Dockerfile
+    DEFAULT_HTTP_PORT: int = 8080

--- a/neuro_san/interfaces/async_agent_session.py
+++ b/neuro_san/interfaces/async_agent_session.py
@@ -26,6 +26,10 @@ class AsyncAgentSession:
     # This port number will also be mentioned in its Dockerfile
     DEFAULT_PORT: int = AgentSession.DEFAULT_PORT
 
+    # Default port for the Agent HTTP Service
+    # This port number will also be mentioned in its Dockerfile
+    DEFAULT_HTTP_PORT: int = AgentSession.DEFAULT_HTTP_PORT
+
     async def function(self, request_dict: Dict[str, Any]) -> Dict[str, Any]:
         """
         :param request_dict: A dictionary version of the FunctionRequest

--- a/neuro_san/interfaces/async_agent_session.py
+++ b/neuro_san/interfaces/async_agent_session.py
@@ -14,21 +14,13 @@ from typing import Any
 from typing import Dict
 from typing import Generator
 
-from neuro_san.interfaces.agent_session import AgentSession
+from neuro_san.interfaces.agent_session_constants import AgentSessionConstants
 
 
-class AsyncAgentSession:
+class AsyncAgentSession(AgentSessionConstants):
     """
     Asynchronous interface for the initiation and continuity of a single Agent session.
     """
-
-    # Default port for the Agent Service
-    # This port number will also be mentioned in its Dockerfile
-    DEFAULT_PORT: int = AgentSession.DEFAULT_PORT
-
-    # Default port for the Agent HTTP Service
-    # This port number will also be mentioned in its Dockerfile
-    DEFAULT_HTTP_PORT: int = AgentSession.DEFAULT_HTTP_PORT
 
     async def function(self, request_dict: Dict[str, Any]) -> Dict[str, Any]:
         """

--- a/neuro_san/session/abstract_http_service_agent_session.py
+++ b/neuro_san/session/abstract_http_service_agent_session.py
@@ -1,0 +1,127 @@
+
+# Copyright (C) 2023-2025 Cognizant Digital Business, Evolutionary AI.
+# All Rights Reserved.
+# Issued under the Academic Public License.
+#
+# You can be released from the terms, and requirements of the Academic Public
+# License by purchasing a commercial license.
+# Purchase of a commercial license is mandatory for any use of the
+# neuro-san SDK Software in commercial settings.
+#
+# END COPYRIGHT
+
+from typing import Any
+from typing import Dict
+
+from leaf_common.time.timeout import Timeout
+
+from neuro_san.interfaces.agent_session_constants import AgentSessionConstants
+
+
+class AbstractHttpServiceAgentSession(AgentSessionConstants):
+    """
+    Abstract base class for sync and async version for http service agent sessions.
+    """
+
+    # pylint: disable=too-many-arguments,too-many-positional-arguments
+    def __init__(self, host: str = None,
+                 port: str = None,
+                 timeout_in_seconds: int = 30,
+                 metadata: Dict[str, str] = None,
+                 security_cfg: Dict[str, Any] = None,
+                 umbrella_timeout: Timeout = None,
+                 streaming_timeout_in_seconds: int = None,
+                 agent_name: str = None):
+        """
+        Creates a AsyncAgentSession that asynchronously connects to the
+        Agent Service and delegates its implementations to the service.
+
+        :param host: the service host to connect to
+                        If None, will use a default
+        :param port: the service port
+                        If None, will use a default
+        :param timeout_in_seconds: timeout to use when communicating
+                        with the service
+        :param metadata: A grpc metadata of key/value pairs to be inserted into
+                         the header. Default is None. Preferred format is a
+                         dictionary of string keys to string values.
+        :param security_cfg: An optional dictionary of parameters used to
+                        secure the TLS and the authentication of the gRPC
+                        connection.  Supplying this implies use of a secure
+                        GRPC Channel.  Default is None, uses insecure channel.
+        :param umbrella_timeout: A Timeout object under which the length of all
+                        looping and retries should be considered
+        :param streaming_timeout_in_seconds: timeout to use when streaming to/from
+                        the service. Default is None, indicating connection should
+                        stay open until the (last) result is yielded.
+        :param agent_name: The name of the agent to talk to
+        """
+        _ = umbrella_timeout
+        _ = streaming_timeout_in_seconds
+
+        self.security_cfg: Dict[str, Any] = security_cfg
+        self.use_host: str = "localhost"
+        if host is not None:
+            self.use_host = host
+
+        self.use_port: str = str(self.DEFAULT_HTTP_PORT)
+        if port is not None:
+            self.use_port = port
+
+        if agent_name is None:
+            raise ValueError("agent_name is None")
+        self.agent_name: str = agent_name
+
+        self.timeout_in_seconds = timeout_in_seconds
+        self.metadata: Dict[str, str] = metadata
+
+    def get_request_path(self, method: str) -> str:
+        """
+        :param method: The method endpoint we wish to reach
+        :return: The full URL for accessing the method, given the host, port and agent_name.
+        """
+        scheme: str = "http"
+        if self.security_cfg is not None:
+            scheme = "https"
+
+        return f"{scheme}://{self.use_host}:{self.use_port}/api/v1/{self.agent_name}/{method}"
+
+    def get_headers(self) -> Dict[str, Any]:
+        """
+        Get headers for any outgoing request
+        """
+        headers: Dict[str, Any] = self.metadata
+        if headers is None:
+            headers = {}
+        return headers
+
+    def help_message(self, path: str) -> str:
+        """
+        Method returning general help message for http connectivity problems.
+        :param path: url path of a request
+        :return: help message
+        """
+        message = f"""
+        Some basic suggestions to help debug connectivity issues:
+        1. Ensure the server is running and reachable:
+           ping <server_address>
+           curl -v <server_url>
+        2. Check network issues:
+           traceroute <server_address>  # Linux/macOS
+           tracert <server_address>  # Windows
+        3. Ensure you are using correct protocol (http/https) and port number;
+        4. Run service health check:
+           curl <server_url:server_port>
+        5. Try testing with increased timeout;
+        6. Did you misspell the agent and/or method name in your {path} request path?
+        7. If working with a local docker container:
+           7.1 Does your http port EXPOSEd in the Dockerfile match your value for AGENT_HTTP_PORT?
+           7.2 Did you add a -p <server_port>:<server_port> to your docker run command line to map container port(s)
+               to your local ones?
+        8. Is the agent turned on in your manifest.hocon?
+        9. If you are attempting to use https, know that the default server configurations do not
+           provide any of the necessary certificates for this to work and any certs used will
+           need to be well known.  If you're unfamiliar with this process, it's a big deal.
+           Try regular http instead.
+        """
+        return message

--- a/neuro_san/session/async_grpc_service_agent_session.py
+++ b/neuro_san/session/async_grpc_service_agent_session.py
@@ -27,9 +27,6 @@ class AsyncGrpcServiceAgentSession(AsyncAbstractServiceSession, AsyncAgentSessio
     Implementation of AsyncAgentSession that talks to a gRPC service asynchronously.
     """
 
-    DEFAULT_PORT: int = AsyncAgentSession.DEFAULT_PORT
-    DEFAULT_AGENT_NAME: str = "esp_decision_assistant"
-
     # pylint: disable=too-many-arguments,too-many-positional-arguments
     def __init__(self, host: str = None,
                  port: str = None,
@@ -38,7 +35,7 @@ class AsyncGrpcServiceAgentSession(AsyncAbstractServiceSession, AsyncAgentSessio
                  security_cfg: Dict[str, Any] = None,
                  umbrella_timeout: Timeout = None,
                  streaming_timeout_in_seconds: int = None,
-                 agent_name: str = DEFAULT_AGENT_NAME):
+                 agent_name: str = None):
         """
         Creates an AsyncAgentSession that connects to the
         Agent Service and delegates its implementations to the service.
@@ -74,6 +71,8 @@ class AsyncGrpcServiceAgentSession(AsyncAbstractServiceSession, AsyncAgentSessio
         # Normally we pass around the service_stub like a class,
         # but AgentServiceStub has a __call__() method to intercept
         # constructor-like behavior.
+        if agent_name is None:
+            raise ValueError("agent_name is None")
         service_stub = AgentServiceStub(agent_name)
         AsyncAbstractServiceSession.__init__(self, "Agent Server",
                                              service_stub,

--- a/neuro_san/session/async_http_service_agent_session.py
+++ b/neuro_san/session/async_http_service_agent_session.py
@@ -28,8 +28,6 @@ class AsyncHttpServiceAgentSession(AsyncAgentSession):
     Implementation of AsyncAgentSession that talks to an HTTP service.
     """
 
-    DEFAULT_AGENT_NAME: str = "esp_decision_assistant"
-
     # pylint: disable=too-many-arguments,too-many-positional-arguments
     def __init__(self, host: str = None,
                  port: str = None,
@@ -38,7 +36,7 @@ class AsyncHttpServiceAgentSession(AsyncAgentSession):
                  security_cfg: Dict[str, Any] = None,
                  umbrella_timeout: Timeout = None,
                  streaming_timeout_in_seconds: int = None,
-                 agent_name: str = DEFAULT_AGENT_NAME):
+                 agent_name: str = None):
         """
         Creates a AsyncAgentSession that asynchronously connects to the
         Agent Service and delegates its implementations to the service.
@@ -75,7 +73,10 @@ class AsyncHttpServiceAgentSession(AsyncAgentSession):
         if port is not None:
             self.use_port = port
 
+        if agent_name is None:
+            raise ValueError("agent_name is None")
         self.agent_name: str = agent_name
+
         self.timeout_in_seconds = timeout_in_seconds
         self.metadata: Dict[str, str] = metadata
 

--- a/neuro_san/session/async_http_service_agent_session.py
+++ b/neuro_san/session/async_http_service_agent_session.py
@@ -1,0 +1,206 @@
+
+# Copyright (C) 2023-2025 Cognizant Digital Business, Evolutionary AI.
+# All Rights Reserved.
+# Issued under the Academic Public License.
+#
+# You can be released from the terms, and requirements of the Academic Public
+# License by purchasing a commercial license.
+# Purchase of a commercial license is mandatory for any use of the
+# neuro-san SDK Software in commercial settings.
+#
+# END COPYRIGHT
+
+from typing import Any
+from typing import Dict
+from typing import Generator
+
+import json
+
+from aiohttp import ClientSession
+
+from leaf_common.time.timeout import Timeout
+
+from neuro_san.interfaces.async_agent_session import AsyncAgentSession
+
+
+class AsyncHttpServiceAgentSession(AsyncAgentSession):
+    """
+    Implementation of AsyncAgentSession that talks to an HTTP service.
+    """
+
+    DEFAULT_AGENT_NAME: str = "esp_decision_assistant"
+
+    # pylint: disable=too-many-arguments,too-many-positional-arguments
+    def __init__(self, host: str = None,
+                 port: str = None,
+                 timeout_in_seconds: int = 30,
+                 metadata: Dict[str, str] = None,
+                 security_cfg: Dict[str, Any] = None,
+                 umbrella_timeout: Timeout = None,
+                 streaming_timeout_in_seconds: int = None,
+                 agent_name: str = DEFAULT_AGENT_NAME):
+        """
+        Creates a AsyncAgentSession that asynchronously connects to the
+        Agent Service and delegates its implementations to the service.
+
+        :param host: the service host to connect to
+                        If None, will use a default
+        :param port: the service port
+                        If None, will use a default
+        :param timeout_in_seconds: timeout to use when communicating
+                        with the service
+        :param metadata: A grpc metadata of key/value pairs to be inserted into
+                         the header. Default is None. Preferred format is a
+                         dictionary of string keys to string values.
+        :param security_cfg: An optional dictionary of parameters used to
+                        secure the TLS and the authentication of the gRPC
+                        connection.  Supplying this implies use of a secure
+                        GRPC Channel.  Default is None, uses insecure channel.
+        :param umbrella_timeout: A Timeout object under which the length of all
+                        looping and retries should be considered
+        :param streaming_timeout_in_seconds: timeout to use when streaming to/from
+                        the service. Default is None, indicating connection should
+                        stay open until the (last) result is yielded.
+        :param agent_name: The name of the agent to talk to
+        """
+        _ = umbrella_timeout
+        _ = streaming_timeout_in_seconds
+
+        self.security_cfg: Dict[str, Any] = security_cfg
+        self.use_host: str = "localhost"
+        if host is not None:
+            self.use_host = host
+
+        self.use_port: str = str(self.DEFAULT_HTTP_PORT)
+        if port is not None:
+            self.use_port = port
+
+        self.agent_name: str = agent_name
+        self.timeout_in_seconds = timeout_in_seconds
+        self.metadata: Dict[str, str] = metadata
+
+    def _get_request_path(self, function: str):
+        scheme: str = "http"
+        if self.security_cfg is not None:
+            scheme = "https"
+
+        return f"{scheme}://{self.use_host}:{self.use_port}/api/v1/{self.agent_name}/{function}"
+
+    def _get_headers(self) -> Dict[str, Any]:
+        """
+        Get headers for any outgoing request
+        """
+        headers: Dict[str, Any] = self.metadata
+        if headers is None:
+            headers = {}
+        return headers
+
+    def help_message(self, path: str) -> str:
+        """
+        Method returning general help message for http connectivity problems.
+        :param path: url path of a request
+        :return: help message
+        """
+        message = f"""
+        Some basic suggestions to help debug connectivity issues:
+        1. Ensure the server is running and reachable:
+           ping <server_address>
+           curl -v <server_url>
+        2. Check network issues:
+           traceroute <server_address>  # Linux/macOS
+           tracert <server_address>  # Windows
+        3. Ensure you are using correct protocol (http/https) and port number;
+        4. Run service health check:
+           curl <server_url:server_port>
+        5. Try testing with increased timeout;
+        6. Did you misspell the agent and/or method name in your {path} request path?
+        7. If working with a local docker container:
+           7.1 Does your http port EXPOSEd in the Dockerfile match your value for AGENT_HTTP_PORT?
+           7.2 Did you add a -p <server_port>:<server_port> to your docker run command line to map container port(s)
+               to your local ones?
+        8. Is the agent turned on in your manifest.hocon?
+        9. If you are attempting to use https, know that the default server configurations do not
+           provide any of the necessary certificates for this to work and any certs used will
+           need to be well known.  If you're unfamiliar with this process, it's a big deal.
+           Try regular http instead.
+        """
+        return message
+
+    async def function(self, request_dict: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        :param request_dict: A dictionary version of the FunctionRequest
+                    protobufs structure. Has the following keys:
+                        <None>
+        :return: A dictionary version of the FunctionResponse
+                    protobufs structure. Has the following keys:
+                "function" - the dictionary description of the function
+        """
+        path: str = self._get_request_path("function")
+        result_dict: Dict[str, Any] = None
+        try:
+            async with ClientSession(headers=self._get_headers(),
+                                     conn_timeout=self.timeout_in_seconds,
+                                     read_timeout=self.timeout_in_seconds,
+                                     ) as session:
+                async with session.get(path, json=request_dict) as response:
+                    result_dict = await response.json()
+                    return result_dict
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            raise ValueError(self.help_message(path)) from exc
+
+    async def connectivity(self, request_dict: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        :param request_dict: A dictionary version of the ConnectivityRequest
+                    protobufs structure. Has the following keys:
+                        <None>
+        :return: A dictionary version of the ConnectivityResponse
+                    protobufs structure. Has the following keys:
+                "connectivity_info" - the list of connectivity descriptions for
+                                    each node in the agent network the service
+                                    wants the client ot know about.
+        """
+        path: str = self._get_request_path("connectivity")
+        result_dict: Dict[str, Any] = None
+        try:
+            async with ClientSession(headers=self._get_headers(),
+                                     conn_timeout=self.timeout_in_seconds,
+                                     read_timeout=self.timeout_in_seconds,
+                                     ) as session:
+                async with session.get(path, json=request_dict) as response:
+                    result_dict = await response.json()
+                    return result_dict
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            raise ValueError(self.help_message(path)) from exc
+
+    async def streaming_chat(self, request_dict: Dict[str, Any]) -> Generator[Dict[str, Any], None, None]:
+        """
+        :param request_dict: A dictionary version of the ChatRequest
+                    protobufs structure. Has the following keys:
+            "user_message" - A ChatMessage dict representing the user input to the chat stream
+            "chat_context" - A ChatContext dict representing the state of the previous conversation
+                            (if any)
+        :return: An iterator of dictionary versions of the ChatResponse
+                    protobufs structure. Has the following keys:
+            "response"      - An optional ChatMessage dictionary.  See chat.proto for details.
+
+            Note that responses to the chat input might be numerous and will come as they
+            are produced until the system decides there are no more messages to be sent.
+        """
+        path: str = self._get_request_path("streaming_chat")
+        try:
+            async with ClientSession(headers=self._get_headers(),
+                                     conn_timeout=self.timeout_in_seconds,
+                                     read_timeout=self.timeout_in_seconds,
+                                     ) as session:
+                async with session.post(path, json=request_dict) as response:
+                    # Check for successful response status
+                    response.raise_for_status()
+
+                    # Iterate over the content stream line by line
+                    async for line in response.content:
+                        unicode_line = line.decode('utf-8')
+                        if unicode_line.strip():    # Skip empty lines
+                            result_dict = json.loads(unicode_line)
+                            yield result_dict
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            raise ValueError(self.help_message(path)) from exc

--- a/neuro_san/session/async_http_service_agent_session.py
+++ b/neuro_san/session/async_http_service_agent_session.py
@@ -18,114 +18,14 @@ import json
 
 from aiohttp import ClientSession
 
-from leaf_common.time.timeout import Timeout
-
 from neuro_san.interfaces.async_agent_session import AsyncAgentSession
+from neuro_san.session.abstract_http_service_agent_session import AbstractHttpServiceAgentSession
 
 
-class AsyncHttpServiceAgentSession(AsyncAgentSession):
+class AsyncHttpServiceAgentSession(AbstractHttpServiceAgentSession, AsyncAgentSession):
     """
     Implementation of AsyncAgentSession that talks to an HTTP service.
     """
-
-    # pylint: disable=too-many-arguments,too-many-positional-arguments
-    def __init__(self, host: str = None,
-                 port: str = None,
-                 timeout_in_seconds: int = 30,
-                 metadata: Dict[str, str] = None,
-                 security_cfg: Dict[str, Any] = None,
-                 umbrella_timeout: Timeout = None,
-                 streaming_timeout_in_seconds: int = None,
-                 agent_name: str = None):
-        """
-        Creates a AsyncAgentSession that asynchronously connects to the
-        Agent Service and delegates its implementations to the service.
-
-        :param host: the service host to connect to
-                        If None, will use a default
-        :param port: the service port
-                        If None, will use a default
-        :param timeout_in_seconds: timeout to use when communicating
-                        with the service
-        :param metadata: A grpc metadata of key/value pairs to be inserted into
-                         the header. Default is None. Preferred format is a
-                         dictionary of string keys to string values.
-        :param security_cfg: An optional dictionary of parameters used to
-                        secure the TLS and the authentication of the gRPC
-                        connection.  Supplying this implies use of a secure
-                        GRPC Channel.  Default is None, uses insecure channel.
-        :param umbrella_timeout: A Timeout object under which the length of all
-                        looping and retries should be considered
-        :param streaming_timeout_in_seconds: timeout to use when streaming to/from
-                        the service. Default is None, indicating connection should
-                        stay open until the (last) result is yielded.
-        :param agent_name: The name of the agent to talk to
-        """
-        _ = umbrella_timeout
-        _ = streaming_timeout_in_seconds
-
-        self.security_cfg: Dict[str, Any] = security_cfg
-        self.use_host: str = "localhost"
-        if host is not None:
-            self.use_host = host
-
-        self.use_port: str = str(self.DEFAULT_HTTP_PORT)
-        if port is not None:
-            self.use_port = port
-
-        if agent_name is None:
-            raise ValueError("agent_name is None")
-        self.agent_name: str = agent_name
-
-        self.timeout_in_seconds = timeout_in_seconds
-        self.metadata: Dict[str, str] = metadata
-
-    def _get_request_path(self, function: str):
-        scheme: str = "http"
-        if self.security_cfg is not None:
-            scheme = "https"
-
-        return f"{scheme}://{self.use_host}:{self.use_port}/api/v1/{self.agent_name}/{function}"
-
-    def _get_headers(self) -> Dict[str, Any]:
-        """
-        Get headers for any outgoing request
-        """
-        headers: Dict[str, Any] = self.metadata
-        if headers is None:
-            headers = {}
-        return headers
-
-    def help_message(self, path: str) -> str:
-        """
-        Method returning general help message for http connectivity problems.
-        :param path: url path of a request
-        :return: help message
-        """
-        message = f"""
-        Some basic suggestions to help debug connectivity issues:
-        1. Ensure the server is running and reachable:
-           ping <server_address>
-           curl -v <server_url>
-        2. Check network issues:
-           traceroute <server_address>  # Linux/macOS
-           tracert <server_address>  # Windows
-        3. Ensure you are using correct protocol (http/https) and port number;
-        4. Run service health check:
-           curl <server_url:server_port>
-        5. Try testing with increased timeout;
-        6. Did you misspell the agent and/or method name in your {path} request path?
-        7. If working with a local docker container:
-           7.1 Does your http port EXPOSEd in the Dockerfile match your value for AGENT_HTTP_PORT?
-           7.2 Did you add a -p <server_port>:<server_port> to your docker run command line to map container port(s)
-               to your local ones?
-        8. Is the agent turned on in your manifest.hocon?
-        9. If you are attempting to use https, know that the default server configurations do not
-           provide any of the necessary certificates for this to work and any certs used will
-           need to be well known.  If you're unfamiliar with this process, it's a big deal.
-           Try regular http instead.
-        """
-        return message
 
     async def function(self, request_dict: Dict[str, Any]) -> Dict[str, Any]:
         """
@@ -136,10 +36,10 @@ class AsyncHttpServiceAgentSession(AsyncAgentSession):
                     protobufs structure. Has the following keys:
                 "function" - the dictionary description of the function
         """
-        path: str = self._get_request_path("function")
+        path: str = self.get_request_path("function")
         result_dict: Dict[str, Any] = None
         try:
-            async with ClientSession(headers=self._get_headers(),
+            async with ClientSession(headers=self.get_headers(),
                                      conn_timeout=self.timeout_in_seconds,
                                      read_timeout=self.timeout_in_seconds,
                                      ) as session:
@@ -160,10 +60,10 @@ class AsyncHttpServiceAgentSession(AsyncAgentSession):
                                     each node in the agent network the service
                                     wants the client ot know about.
         """
-        path: str = self._get_request_path("connectivity")
+        path: str = self.get_request_path("connectivity")
         result_dict: Dict[str, Any] = None
         try:
-            async with ClientSession(headers=self._get_headers(),
+            async with ClientSession(headers=self.get_headers(),
                                      conn_timeout=self.timeout_in_seconds,
                                      read_timeout=self.timeout_in_seconds,
                                      ) as session:
@@ -187,9 +87,9 @@ class AsyncHttpServiceAgentSession(AsyncAgentSession):
             Note that responses to the chat input might be numerous and will come as they
             are produced until the system decides there are no more messages to be sent.
         """
-        path: str = self._get_request_path("streaming_chat")
+        path: str = self.get_request_path("streaming_chat")
         try:
-            async with ClientSession(headers=self._get_headers(),
+            async with ClientSession(headers=self.get_headers(),
                                      conn_timeout=self.timeout_in_seconds,
                                      read_timeout=self.timeout_in_seconds,
                                      ) as session:

--- a/neuro_san/session/external_agent_session_factory.py
+++ b/neuro_san/session/external_agent_session_factory.py
@@ -23,7 +23,7 @@ from neuro_san.internals.interfaces.agent_tool_factory_provider import AgentTool
 from neuro_san.internals.interfaces.invocation_context import InvocationContext
 from neuro_san.internals.run_context.utils.external_agent_parsing import ExternalAgentParsing
 from neuro_san.session.async_direct_agent_session import AsyncDirectAgentSession
-from neuro_san.session.async_grpc_service_agent_session import AsyncGrpcServiceAgentSession
+from neuro_san.session.async_http_service_agent_session import AsyncHttpServiceAgentSession
 
 
 class ExternalAgentSessionFactory(AsyncAgentSessionFactory):
@@ -90,7 +90,7 @@ class ExternalAgentSessionFactory(AsyncAgentSessionFactory):
             session = AsyncDirectAgentSession(tool_registry, invocation_context, metadata=metadata)
 
         if session is None:
-            session = AsyncGrpcServiceAgentSession(host, port, agent_name=agent_name,
+            session = AsyncHttpServiceAgentSession(host, port, agent_name=agent_name,
                                                    metadata=metadata)
 
         # Quiet any logging from leaf-common grpc stuff.

--- a/neuro_san/session/grpc_service_agent_session.py
+++ b/neuro_san/session/grpc_service_agent_session.py
@@ -28,8 +28,6 @@ class GrpcServiceAgentSession(AbstractServiceSession, AgentSession):
     gRPC service.  This is largely only used by command-line tests.
     """
 
-    DEFAULT_AGENT_NAME: str = "esp_decision_assistant"
-
     # pylint: disable=too-many-arguments,too-many-positional-arguments
     def __init__(self, host: str = None,
                  port: str = None,
@@ -38,7 +36,7 @@ class GrpcServiceAgentSession(AbstractServiceSession, AgentSession):
                  security_cfg: Dict[str, Any] = None,
                  umbrella_timeout: Timeout = None,
                  streaming_timeout_in_seconds: int = None,
-                 agent_name: str = DEFAULT_AGENT_NAME):
+                 agent_name: str = None):
         """
         Creates a AgentSession that connects to the
         Agent Service and delegates its implementations to the service.
@@ -74,6 +72,8 @@ class GrpcServiceAgentSession(AbstractServiceSession, AgentSession):
         # Normally we pass around the service_stub like a class,
         # but AgentServiceStub has a __call__() method to intercept
         # constructor-like behavior.
+        if agent_name is None:
+            raise ValueError("agent_name is None")
         service_stub = AgentServiceStub(agent_name)
         AbstractServiceSession.__init__(self, "Agent Server",
                                         service_stub,

--- a/neuro_san/session/http_service_agent_session.py
+++ b/neuro_san/session/http_service_agent_session.py
@@ -28,8 +28,6 @@ class HttpServiceAgentSession(AgentSession):
     This is largely only used by command-line tests.
     """
 
-    DEFAULT_AGENT_NAME: str = "esp_decision_assistant"
-
     # pylint: disable=too-many-arguments,too-many-positional-arguments
     def __init__(self, host: str = None,
                  port: str = None,
@@ -38,7 +36,7 @@ class HttpServiceAgentSession(AgentSession):
                  security_cfg: Dict[str, Any] = None,
                  umbrella_timeout: Timeout = None,
                  streaming_timeout_in_seconds: int = None,
-                 agent_name: str = DEFAULT_AGENT_NAME):
+                 agent_name: str = None):
         """
         Creates a AgentSession that connects to the
         Agent Service and delegates its implementations to the service.
@@ -75,7 +73,10 @@ class HttpServiceAgentSession(AgentSession):
         if port is not None:
             self.use_port = port
 
+        if agent_name is None:
+            raise ValueError("agent_name is None")
         self.agent_name: str = agent_name
+
         self.timeout_in_seconds = timeout_in_seconds
         self.metadata: Dict[str, str] = metadata
 

--- a/neuro_san/session/http_service_agent_session.py
+++ b/neuro_san/session/http_service_agent_session.py
@@ -13,119 +13,19 @@
 from typing import Any
 from typing import Dict
 from typing import Generator
+
 import json
 import requests
 
-
-from leaf_common.time.timeout import Timeout
-
 from neuro_san.interfaces.agent_session import AgentSession
+from neuro_san.session.abstract_http_service_agent_session import AbstractHttpServiceAgentSession
 
 
-class HttpServiceAgentSession(AgentSession):
+class HttpServiceAgentSession(AbstractHttpServiceAgentSession, AgentSession):
     """
     Implementation of AgentSession that talks to an HTTP service.
     This is largely only used by command-line tests.
     """
-
-    # pylint: disable=too-many-arguments,too-many-positional-arguments
-    def __init__(self, host: str = None,
-                 port: str = None,
-                 timeout_in_seconds: int = 30,
-                 metadata: Dict[str, str] = None,
-                 security_cfg: Dict[str, Any] = None,
-                 umbrella_timeout: Timeout = None,
-                 streaming_timeout_in_seconds: int = None,
-                 agent_name: str = None):
-        """
-        Creates a AgentSession that connects to the
-        Agent Service and delegates its implementations to the service.
-
-        :param host: the service host to connect to
-                        If None, will use a default
-        :param port: the service port
-                        If None, will use a default
-        :param timeout_in_seconds: timeout to use when communicating
-                        with the service
-        :param metadata: A grpc metadata of key/value pairs to be inserted into
-                         the header. Default is None. Preferred format is a
-                         dictionary of string keys to string values.
-        :param security_cfg: An optional dictionary of parameters used to
-                        secure the TLS and the authentication of the gRPC
-                        connection.  Supplying this implies use of a secure
-                        GRPC Channel.  Default is None, uses insecure channel.
-        :param umbrella_timeout: A Timeout object under which the length of all
-                        looping and retries should be considered
-        :param streaming_timeout_in_seconds: timeout to use when streaming to/from
-                        the service. Default is None, indicating connection should
-                        stay open until the (last) result is yielded.
-        :param agent_name: The name of the agent to talk to
-        """
-        _ = umbrella_timeout
-        _ = streaming_timeout_in_seconds
-
-        self.security_cfg: Dict[str, Any] = security_cfg
-        self.use_host: str = "localhost"
-        if host is not None:
-            self.use_host = host
-
-        self.use_port: str = str(self.DEFAULT_HTTP_PORT)
-        if port is not None:
-            self.use_port = port
-
-        if agent_name is None:
-            raise ValueError("agent_name is None")
-        self.agent_name: str = agent_name
-
-        self.timeout_in_seconds = timeout_in_seconds
-        self.metadata: Dict[str, str] = metadata
-
-    def _get_request_path(self, function: str):
-        scheme: str = "http"
-        if self.security_cfg is not None:
-            scheme = "https"
-
-        return f"{scheme}://{self.use_host}:{self.use_port}/api/v1/{self.agent_name}/{function}"
-
-    def _get_headers(self) -> Dict[str, Any]:
-        """
-        Get headers for any outgoing request
-        """
-        headers: Dict[str, Any] = self.metadata
-        if headers is None:
-            headers = {}
-        return headers
-
-    def help_message(self, path: str) -> str:
-        """
-        Method returning general help message for http connectivity problems.
-        :param path: url path of a request
-        :return: help message
-        """
-        message = f"""
-        Some basic suggestions to help debug connectivity issues:
-        1. Ensure the server is running and reachable:
-           ping <server_address>
-           curl -v <server_url>
-        2. Check network issues:
-           traceroute <server_address>  # Linux/macOS
-           tracert <server_address>  # Windows
-        3. Ensure you are using correct protocol (http/https) and port number;
-        4. Run service health check:
-           curl <server_url:server_port>
-        5. Try testing with increased timeout;
-        6. Did you misspell the agent and/or method name in your {path} request path?
-        7. If working with a local docker container:
-           7.1 Does your http port EXPOSEd in the Dockerfile match your value for AGENT_HTTP_PORT?
-           7.2 Did you add a -p <server_port>:<server_port> to your docker run command line to map container port(s)
-               to your local ones?
-        8. Is the agent turned on in your manifest.hocon?
-        9. If you are attempting to use https, know that the default server configurations do not
-           provide any of the necessary certificates for this to work and any certs used will
-           need to be well known.  If you're unfamiliar with this process, it's a big deal.
-           Try regular http instead.
-        """
-        return message
 
     def function(self, request_dict: Dict[str, Any]) -> Dict[str, Any]:
         """
@@ -136,9 +36,9 @@ class HttpServiceAgentSession(AgentSession):
                     protobufs structure. Has the following keys:
                 "function" - the dictionary description of the function
         """
-        path: str = self._get_request_path("function")
+        path: str = self.get_request_path("function")
         try:
-            response = requests.get(path, json=request_dict, headers=self._get_headers(),
+            response = requests.get(path, json=request_dict, headers=self.get_headers(),
                                     timeout=self.timeout_in_seconds)
             result_dict = json.loads(response.text)
             return result_dict
@@ -156,9 +56,9 @@ class HttpServiceAgentSession(AgentSession):
                                     each node in the agent network the service
                                     wants the client ot know about.
         """
-        path: str = self._get_request_path("connectivity")
+        path: str = self.get_request_path("connectivity")
         try:
-            response = requests.get(path, json=request_dict, headers=self._get_headers(),
+            response = requests.get(path, json=request_dict, headers=self.get_headers(),
                                     timeout=self.timeout_in_seconds)
             result_dict = json.loads(response.text)
             return result_dict
@@ -179,9 +79,9 @@ class HttpServiceAgentSession(AgentSession):
             Note that responses to the chat input might be numerous and will come as they
             are produced until the system decides there are no more messages to be sent.
         """
-        path: str = self._get_request_path("streaming_chat")
+        path: str = self.get_request_path("streaming_chat")
         try:
-            with requests.post(path, json=request_dict, headers=self._get_headers(),
+            with requests.post(path, json=request_dict, headers=self.get_headers(),
                                stream=True,
                                timeout=self.timeout_in_seconds) as response:
                 response.raise_for_status()

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,7 @@ idna>=3.6
 # but latest 2.0 versions have an incompatibility with the requests library
 # See UN-1190.
 urllib3>=1.26.18,<2.0
+aiohttp>=3.10.5,<4.0
 
 # These are transient dependencies needed by leaf-common
 ruamel.yaml>=0.18.6


### PR DESCRIPTION
Some refactoring, some new capability:

* Move common constants to new AgentSessionConstants interface
* Remove use of DEFAULT_AGENT_NAME constant.  Throw an exception if agent_name is not set in sessions now.
* Create an AsyncHttpServiceAgentSession class.  This is based on aiohttp which seems most similar to requests lib.
* Consolidate common code of sync and asynchronous versions into AbstractHttpServiceAgentSession
* Move default communication for external agents to use the new AsyncHttpServiceAgentSession class as opposed to its gRPC counterpart.

Tested: math_guy_passthrough on http and grpc via agent_cli.

@andreidenissov-cog is primary