### PR TITLE
UN-3192 More graph-level interface refactors

### DIFF
--- a/neuro_san/internals/chat/data_driven_chat_session.py
+++ b/neuro_san/internals/chat/data_driven_chat_session.py
@@ -78,7 +78,7 @@ class DataDrivenChatSession:
 
         self.front_man = self.registry.create_front_man(self.sly_data, run_context)
 
-        await self.front_man.create_resources()
+        await self.front_man.create_any_resources()
 
     async def chat(self, user_input: str,
                    invocation_context: InvocationContext,
@@ -199,7 +199,7 @@ class DataDrivenChatSession:
         Frees up any service-side resources.
         """
         if self.front_man is not None:
-            await self.front_man.delete_resources(None)
+            await self.front_man.delete_any_resources()
             self.front_man = None
 
     def prepare_chat_context(self, chat_message_history: List[Dict[str, Any]]) -> Dict[str, Any]:

--- a/neuro_san/internals/chat/data_driven_chat_session.py
+++ b/neuro_san/internals/chat/data_driven_chat_session.py
@@ -22,8 +22,8 @@ from openai import BadRequestError
 from neuro_san.internals.chat.async_collating_queue import AsyncCollatingQueue
 from neuro_san.internals.chat.chat_history_message_processor import ChatHistoryMessageProcessor
 from neuro_san.internals.graph.registry.agent_tool_registry import AgentToolRegistry
-from neuro_san.internals.graph.activations.front_man import FrontMan
 from neuro_san.internals.graph.activations.sly_data_redactor import SlyDataRedactor
+from neuro_san.internals.interfaces.front_man import FrontMan
 from neuro_san.internals.interfaces.invocation_context import InvocationContext
 from neuro_san.internals.journals.journal import Journal
 from neuro_san.internals.messages.agent_framework_message import AgentFrameworkMessage

--- a/neuro_san/internals/graph/activations/calling_activation.py
+++ b/neuro_san/internals/graph/activations/calling_activation.py
@@ -36,7 +36,7 @@ class CallingActivation(AbstractCallableActivation, ToolCaller):
 
     Worth noting that this is used as a base implementation for:
         * BranchActivation - which can both call other tools and be called as a tool
-        * FrontMan - which can only call other tools but has other specialized
+        * FrontManActivation - which can only call other tools but has other specialized
             logic for interacting with user input, it being the root node of a tool graph.
     """
 

--- a/neuro_san/internals/graph/activations/front_man_activation.py
+++ b/neuro_san/internals/graph/activations/front_man_activation.py
@@ -13,11 +13,12 @@ from typing import Any
 from typing import List
 
 from neuro_san.internals.graph.activations.calling_activation import CallingActivation
+from neuro_san.internals.interfaces.front_man import FrontMan
 from neuro_san.internals.interfaces.invocation_context import InvocationContext
 from neuro_san.internals.run_context.interfaces.run import Run
 
 
-class FrontMan(CallingActivation):
+class FrontManActivation(CallingActivation, FrontMan):
     """
     A CallingActivation implementation which is the root of the call graph.
     """

--- a/neuro_san/internals/graph/activations/front_man_activation.py
+++ b/neuro_san/internals/graph/activations/front_man_activation.py
@@ -23,6 +23,12 @@ class FrontManActivation(CallingActivation, FrontMan):
     A CallingActivation implementation which is the root of the call graph.
     """
 
+    async def create_any_resources(self):
+        """
+        Creates resources that will be used throughout the lifetime of the component.
+        """
+        await self.create_resources()
+
     async def submit_message(self, user_input: str) -> List[Any]:
         """
         Entry-point method for callers of the root of the Activation tree.
@@ -73,4 +79,13 @@ class FrontManActivation(CallingActivation, FrontMan):
 
         :return: A List of messages produced during this process.
         """
+        # This is never called for a FrontMan, but is needed to satisfy the
+        # class heirarchy stemming from CallableActivation.
+        # A FrontMan is not Callable.
         raise NotImplementedError
+
+    async def delete_any_resources(self):
+        """
+        Cleans up after any allocated resources
+        """
+        await self.delete_resources(None)

--- a/neuro_san/internals/graph/registry/activation_factory.py
+++ b/neuro_san/internals/graph/registry/activation_factory.py
@@ -22,12 +22,13 @@ from leaf_common.parsers.dictionary_extractor import DictionaryExtractor
 from neuro_san.internals.graph.activations.branch_activation import BranchActivation
 from neuro_san.internals.graph.activations.class_activation import ClassActivation
 from neuro_san.internals.graph.activations.external_activation import ExternalActivation
-from neuro_san.internals.graph.activations.front_man import FrontMan
+from neuro_san.internals.graph.activations.front_man_activation import FrontManActivation
 from neuro_san.internals.graph.activations.sly_data_redactor import SlyDataRedactor
 from neuro_san.internals.graph.activations.toolbox_activation import ToolboxActivation
 from neuro_san.internals.graph.interfaces.agent_tool_factory import AgentToolFactory
 from neuro_san.internals.graph.interfaces.callable_activation import CallableActivation
 from neuro_san.internals.graph.registry.agent_network import AgentNetwork
+from neuro_san.internals.interfaces.front_man import FrontMan
 from neuro_san.internals.run_context.interfaces.run_context import RunContext
 from neuro_san.internals.run_context.utils.external_agent_parsing import ExternalAgentParsing
 from neuro_san.internals.utils.file_of_class import FileOfClass
@@ -176,7 +177,7 @@ Check to be sure your value for PYTHONPATH includes where you expect where your 
                 agent_activation = BranchActivation(parent_run_context, factory, use_args, agent_tool_spec, sly_data)
         else:
             # Get the tool to call from the spec.
-            agent_activation = FrontMan(parent_run_context, factory, agent_tool_spec, sly_data)
+            agent_activation = FrontManActivation(parent_run_context, factory, agent_tool_spec, sly_data)
 
         return agent_activation
 
@@ -193,7 +194,7 @@ Check to be sure your value for PYTHONPATH includes where you expect where your 
         front_man_name: str = self.agent_network.find_front_man()
 
         agent_tool_spec: Dict[str, Any] = self.agent_network.get_agent_tool_spec(front_man_name)
-        front_man = FrontMan(parent_run_context, factory, agent_tool_spec, sly_data)
+        front_man = FrontManActivation(parent_run_context, factory, agent_tool_spec, sly_data)
         return front_man
 
     def get_config(self) -> Dict[str, Any]:

--- a/neuro_san/internals/graph/registry/activation_factory.py
+++ b/neuro_san/internals/graph/registry/activation_factory.py
@@ -187,6 +187,12 @@ Check to be sure your value for PYTHONPATH includes where you expect where your 
                          factory: AgentToolFactory = None) -> FrontMan:
         """
         Find and create the FrontMan for chat
+
+        :param sly_data: A mapping whose keys might be referenceable by agents, but whose
+                 values should not appear in agent chat text. Can be an empty dictionary.
+        :param parent_run_context: A RunContext instance
+        :param factory: An optional extra parameter at this ActivationFactory level to provide
+                    the correct object reference for factory scope/lifetime issues.
         """
         if factory is None:
             factory = self

--- a/neuro_san/internals/graph/registry/agent_tool_registry.py
+++ b/neuro_san/internals/graph/registry/agent_tool_registry.py
@@ -12,11 +12,11 @@
 from typing import Any
 from typing import Dict
 
-from neuro_san.internals.graph.activations.front_man import FrontMan
 from neuro_san.internals.graph.interfaces.agent_tool_factory import AgentToolFactory
 from neuro_san.internals.graph.interfaces.callable_activation import CallableActivation
 from neuro_san.internals.graph.registry.activation_factory import ActivationFactory
 from neuro_san.internals.graph.registry.agent_network import AgentNetwork
+from neuro_san.internals.interfaces.front_man import FrontMan
 from neuro_san.internals.run_context.interfaces.agent_network_inspector import AgentNetworkInspector
 from neuro_san.internals.run_context.interfaces.run_context import RunContext
 

--- a/neuro_san/internals/graph/registry/agent_tool_registry.py
+++ b/neuro_san/internals/graph/registry/agent_tool_registry.py
@@ -16,12 +16,13 @@ from neuro_san.internals.graph.interfaces.agent_tool_factory import AgentToolFac
 from neuro_san.internals.graph.interfaces.callable_activation import CallableActivation
 from neuro_san.internals.graph.registry.activation_factory import ActivationFactory
 from neuro_san.internals.graph.registry.agent_network import AgentNetwork
+from neuro_san.internals.interfaces.agent_registry import AgentRegistry
 from neuro_san.internals.interfaces.front_man import FrontMan
 from neuro_san.internals.run_context.interfaces.agent_network_inspector import AgentNetworkInspector
 from neuro_san.internals.run_context.interfaces.run_context import RunContext
 
 
-class AgentToolRegistry(AgentNetworkInspector, AgentToolFactory):
+class AgentToolRegistry(AgentRegistry, AgentNetworkInspector, AgentToolFactory):
     """
     Puts together an AgentNetwork data-only spec with an ActivationFactory
     so that a single entity can handle both interfaces.
@@ -62,6 +63,10 @@ class AgentToolRegistry(AgentNetworkInspector, AgentToolFactory):
                          parent_run_context: RunContext = None) -> FrontMan:
         """
         Find and create the FrontMan for chat
+
+        :param sly_data: A mapping whose keys might be referenceable by agents, but whose
+                 values should not appear in agent chat text. Can be an empty dictionary.
+        :param parent_run_context: A RunContext instance
         """
         return self.factory.create_front_man(sly_data, parent_run_context, self)
 

--- a/neuro_san/internals/interfaces/agent_registry.py
+++ b/neuro_san/internals/interfaces/agent_registry.py
@@ -1,0 +1,46 @@
+# Copyright (C) 2023-2025 Cognizant Digital Business, Evolutionary AI.
+# All Rights Reserved.
+# Issued under the Academic Public License.
+#
+# You can be released from the terms, and requirements of the Academic Public
+# License by purchasing a commercial license.
+# Purchase of a commercial license is mandatory for any use of the
+# neuro-san SDK Software in commercial settings.
+#
+# END COPYRIGHT
+from typing import Any
+from typing import Dict
+
+from neuro_san.internals.interfaces.front_man import FrontMan
+
+
+class AgentRegistry:
+    """
+    Interface that describes how the session-level of the system interacts with
+    a registry of agents.
+    """
+
+    def create_front_man(self, sly_data: Dict[str, Any], parent_run_context: object = None) -> FrontMan:
+        """
+        Find and create the FrontMan for chat
+
+        :param sly_data: A mapping whose keys might be referenceable by agents, but whose
+                 values should not appear in agent chat text. Can be an empty dictionary.
+        :param parent_run_context: A RunContext instance
+        """
+        raise NotImplementedError
+
+    def find_front_man(self) -> str:
+        """
+        :return: A single tool name to use as the root of the chat agent.
+                 This guy will be user facing.  If there are none or > 1,
+                 an exception will be raised.
+        """
+        raise NotImplementedError
+
+    def get_agent_tool_spec(self, name: str) -> Dict[str, Any]:
+        """
+        :param name: The name of the agent tool to get out of the registry
+        :return: The dictionary representing the spec registered agent
+        """
+        raise NotImplementedError

--- a/neuro_san/internals/interfaces/front_man.py
+++ b/neuro_san/internals/interfaces/front_man.py
@@ -20,17 +20,9 @@ class FrontMan:
     Interface that describes how a chat interface can interact with a FrontMan
     """
 
-    async def create_resources(self, component_name: str = None,
-                               instructions: str = None,
-                               assignments: str = ""):
+    async def create_any_resources(self):
         """
         Creates resources that will be used throughout the lifetime of the component.
-        :param component_name: Optional string for labelling the component.
-                        Defaults to the agent name if not set.
-        :param instructions: Optional string for setting more fine-grained instructions.
-                        Defaults to agent instructions if not set.
-        :param assignments: Optional string for assigning agent functional arguments.
-                        Defaults to an empty string if not set.
         """
         raise NotImplementedError
 
@@ -67,11 +59,8 @@ class FrontMan:
         """
         raise NotImplementedError
 
-    async def delete_resources(self, parent_run_context: object):
+    async def delete_any_resources(self):
         """
-        Cleans up after any allocated resources on their server side.
-        :param parent_run_context: The RunContext which contains the scope
-                    of operation of this CallableActivation.
-                    Can be None in the case of the FrontMan
+        Cleans up after any allocated resources
         """
         raise NotImplementedError

--- a/neuro_san/internals/interfaces/front_man.py
+++ b/neuro_san/internals/interfaces/front_man.py
@@ -1,0 +1,77 @@
+# Copyright (C) 2023-2025 Cognizant Digital Business, Evolutionary AI.
+# All Rights Reserved.
+# Issued under the Academic Public License.
+#
+# You can be released from the terms, and requirements of the Academic Public
+# License by purchasing a commercial license.
+# Purchase of a commercial license is mandatory for any use of the
+# neuro-san SDK Software in commercial settings.
+#
+# END COPYRIGHT
+from typing import Any
+from typing import Dict
+from typing import List
+
+from neuro_san.internals.interfaces.invocation_context import InvocationContext
+
+
+class FrontMan:
+    """
+    Interface that describes how a chat interface can interact with a FrontMan
+    """
+
+    async def create_resources(self, component_name: str = None,
+                               instructions: str = None,
+                               assignments: str = ""):
+        """
+        Creates resources that will be used throughout the lifetime of the component.
+        :param component_name: Optional string for labelling the component.
+                        Defaults to the agent name if not set.
+        :param instructions: Optional string for setting more fine-grained instructions.
+                        Defaults to agent instructions if not set.
+        :param assignments: Optional string for assigning agent functional arguments.
+                        Defaults to an empty string if not set.
+        """
+        raise NotImplementedError
+
+    def update_invocation_context(self, invocation_context: InvocationContext):
+        """
+        Update internal state based on the InvocationContext instance passed in.
+        :param invocation_context: The context policy container that pertains to the invocation
+        """
+        raise NotImplementedError
+
+    def get_origin(self) -> List[Dict[str, Any]]:
+        """
+        :return: A List of origin dictionaries indicating the origin of the run.
+                The origin can be considered a path to the original call to the front-man.
+                Origin dictionaries themselves each have the following keys:
+                    "tool"                  The string name of the tool in the spec
+                    "instantiation_index"   An integer indicating which incarnation
+                                            of the tool is being dealt with.
+        """
+        raise NotImplementedError
+
+    def get_agent_tool_spec(self) -> Dict[str, Any]:
+        """
+        :return: the dictionary describing the data-driven agent
+        """
+        raise NotImplementedError
+
+    async def submit_message(self, user_input: str) -> List[Any]:
+        """
+        Entry-point method for callers of the root of the Activation tree.
+
+        :param user_input: An input string from the user.
+        :return: A list of response messages for the run
+        """
+        raise NotImplementedError
+
+    async def delete_resources(self, parent_run_context: object):
+        """
+        Cleans up after any allocated resources on their server side.
+        :param parent_run_context: The RunContext which contains the scope
+                    of operation of this CallableActivation.
+                    Can be None in the case of the FrontMan
+        """
+        raise NotImplementedError

--- a/neuro_san/session/async_direct_agent_session.py
+++ b/neuro_san/session/async_direct_agent_session.py
@@ -26,7 +26,6 @@ from neuro_san.internals.chat.connectivity_reporter import ConnectivityReporter
 from neuro_san.internals.chat.data_driven_chat_session import DataDrivenChatSession
 from neuro_san.internals.filters.message_filter import MessageFilter
 from neuro_san.internals.filters.message_filter_factory import MessageFilterFactory
-from neuro_san.internals.graph.activations.front_man import FrontMan
 from neuro_san.internals.graph.registry.agent_tool_registry import AgentToolRegistry
 from neuro_san.session.session_invocation_context import SessionInvocationContext
 
@@ -78,9 +77,9 @@ class AsyncDirectAgentSession(AsyncAgentSession):
         response_dict: Dict[str, Any] = {
         }
 
-        front_man: FrontMan = self.tool_registry.create_front_man()
+        front_man: str = self.tool_registry.find_front_man()
         if front_man is not None:
-            spec: Dict[str, Any] = front_man.get_agent_tool_spec()
+            spec: Dict[str, Any] = self.tool_registry.get_agent_tool_spec(front_man)
             empty: Dict[str, Any] = {}
             function: Dict[str, Any] = spec.get("function", empty)
             response_dict = {

--- a/neuro_san/session/direct_agent_session.py
+++ b/neuro_san/session/direct_agent_session.py
@@ -27,7 +27,6 @@ from neuro_san.internals.chat.connectivity_reporter import ConnectivityReporter
 from neuro_san.internals.chat.data_driven_chat_session import DataDrivenChatSession
 from neuro_san.internals.filters.message_filter import MessageFilter
 from neuro_san.internals.filters.message_filter_factory import MessageFilterFactory
-from neuro_san.internals.graph.activations.front_man import FrontMan
 from neuro_san.internals.graph.registry.agent_tool_registry import AgentToolRegistry
 from neuro_san.session.session_invocation_context import SessionInvocationContext
 
@@ -80,9 +79,9 @@ class DirectAgentSession(AgentSession):
         response_dict: Dict[str, Any] = {
         }
 
-        front_man: FrontMan = self.tool_registry.create_front_man()
+        front_man: str = self.tool_registry.find_front_man()
         if front_man is not None:
-            spec: Dict[str, Any] = front_man.get_agent_tool_spec()
+            spec: Dict[str, Any] = self.tool_registry.get_agent_tool_spec(front_man)
             empty: Dict[str, Any] = {}
             function: Dict[str, Any] = spec.get("function", empty)
             response_dict = {


### PR DESCRIPTION
* Use the inspector aspect for function() instead of having to fully create a FrontMan instance. Cleaner.
* Break out an interface for FrontMan that DataDrivenChat uses.
* Old FrontMan class renamed to FrontManActivation like its brethren.