### PR TITLE
UN-3017 Convert outgoing chat messages to expected format.

### DIFF
--- a/neuro_san/service/agent_service.py
+++ b/neuro_san/service/agent_service.py
@@ -33,6 +33,7 @@ from neuro_san.service.agent_server_logging import AgentServerLogging
 from neuro_san.session.direct_agent_session import DirectAgentSession
 from neuro_san.session.external_agent_session_factory import ExternalAgentSessionFactory
 from neuro_san.session.session_invocation_context import SessionInvocationContext
+from neuro_san.service.chat_message_converter import ChatMessageConverter
 
 # A list of methods to not log requests for
 # Some of these can be way too chatty
@@ -234,6 +235,8 @@ class AgentService:
         chat_filter_type: str = chat_filter_dict.get("chat_filter_type", "MINIMAL")
 
         for response_dict in response_dict_iterator:
+            # Prepare chat message for output:
+            ChatMessageConverter.convert(response_dict)
             # Do not return the request when the filter is MINIMAL
             if chat_filter_type != "MINIMAL":
                 response_dict["request"] = request_dict

--- a/neuro_san/service/agent_service.py
+++ b/neuro_san/service/agent_service.py
@@ -236,7 +236,7 @@ class AgentService:
 
         for response_dict in response_dict_iterator:
             # Prepare chat message for output:
-            ChatMessageConverter.convert(response_dict)
+            response_dict = ChatMessageConverter().to_dict(response_dict)
             # Do not return the request when the filter is MINIMAL
             if chat_filter_type != "MINIMAL":
                 response_dict["request"] = request_dict

--- a/neuro_san/service/async_agent_service.py
+++ b/neuro_san/service/async_agent_service.py
@@ -32,6 +32,7 @@ from neuro_san.service.agent_server_logging import AgentServerLogging
 from neuro_san.session.async_direct_agent_session import AsyncDirectAgentSession
 from neuro_san.session.external_agent_session_factory import ExternalAgentSessionFactory
 from neuro_san.session.session_invocation_context import SessionInvocationContext
+from neuro_san.service.chat_message_converter import ChatMessageConverter
 
 # A list of methods to not log requests for
 # Some of these can be way too chatty
@@ -230,6 +231,8 @@ class AsyncAgentService:
         chat_filter_type: str = chat_filter_dict.get("chat_filter_type", "MINIMAL")
 
         async for response_dict in response_dict_generator:
+            # Prepare chat message for output:
+            ChatMessageConverter.convert(response_dict)
             # Do not return the request when the filter is MINIMAL
             if chat_filter_type != "MINIMAL":
                 response_dict["request"] = request_dict

--- a/neuro_san/service/async_agent_service.py
+++ b/neuro_san/service/async_agent_service.py
@@ -232,7 +232,7 @@ class AsyncAgentService:
 
         async for response_dict in response_dict_generator:
             # Prepare chat message for output:
-            ChatMessageConverter.convert(response_dict)
+            response_dict = ChatMessageConverter().to_dict(response_dict)
             # Do not return the request when the filter is MINIMAL
             if chat_filter_type != "MINIMAL":
                 response_dict["request"] = request_dict

--- a/neuro_san/service/chat_message_converter.py
+++ b/neuro_san/service/chat_message_converter.py
@@ -1,0 +1,49 @@
+
+# Copyright (C) 2023-2025 Cognizant Digital Business, Evolutionary AI.
+# All Rights Reserved.
+# Issued under the Academic Public License.
+#
+# You can be released from the terms, and requirements of the Academic Public
+# License by purchasing a commercial license.
+# Purchase of a commercial license is mandatory for any use of the
+# neuro-san SDK Software in commercial settings.
+#
+# END COPYRIGHT
+from typing import Any
+from typing import Dict
+from neuro_san.internals.messages.chat_message_type import ChatMessageType
+
+
+class ChatMessageConverter:
+    """
+    Helper class to prepare chat response messages
+    for external clients consumption.
+    """
+
+    @classmethod
+    def convert(cls, response_dict: Dict[str, Any]):
+        """
+        Convert chat response message to a format expected by external clients:
+        :param response_dict: chat response message to be sent out
+        """
+        # Ensure that we return ChatMessageType as a string in output json
+        message_dict: Dict[str, Any] = response_dict.get('response', None)
+        if message_dict is not None:
+            ChatMessageConverter.convert_message(message_dict)
+
+    @classmethod
+    def convert_message(cls, message_dict: Dict[str, Any]):
+        """
+        Convert chat message to a format expected by external clients:
+        :param message_dict: chat message to process
+        """
+        # Ensure that we return ChatMessageType as a string in output json
+        response_type = message_dict.get('type', None)
+        if response_type is not None:
+            message_dict['type'] =\
+                ChatMessageType.from_response_type(response_type).name
+        chat_context: Dict[str, Any] = message_dict.get('chat_context', None)
+        if chat_context is not None:
+            for chat_history in chat_context.get("chat_histories", []):
+                for chat_message in chat_history.get("messages", []):
+                    ChatMessageConverter.convert_message(chat_message)

--- a/neuro_san/service/chat_message_converter.py
+++ b/neuro_san/service/chat_message_converter.py
@@ -55,3 +55,13 @@ class ChatMessageConverter(DictionaryConverter):
             for chat_history in chat_context.get("chat_histories", []):
                 for chat_message in chat_history.get("messages", []):
                     self.convert_message(chat_message)
+
+    def from_dict(self, obj_dict: Dict[str, object]) -> object:
+        """
+        :param obj_dict: The data-only dictionary to be converted into an object
+        :return: An object instance created from the given dictionary.
+                If obj_dict is None, the returned object should also be None.
+                If obj_dict is not the correct type, it is also reasonable
+                to return None.
+        """
+        raise NotImplementedError

--- a/neuro_san/service/chat_message_converter.py
+++ b/neuro_san/service/chat_message_converter.py
@@ -9,19 +9,28 @@
 # neuro-san SDK Software in commercial settings.
 #
 # END COPYRIGHT
+import copy
 from typing import Any
 from typing import Dict
+from leaf_common.serialization.interface.dictionary_converter import DictionaryConverter
 from neuro_san.internals.messages.chat_message_type import ChatMessageType
 
 
-class ChatMessageConverter:
+class ChatMessageConverter(DictionaryConverter):
     """
     Helper class to prepare chat response messages
     for external clients consumption.
     """
+    def to_dict(self, obj: object) -> Dict[str, object]:
+        """
+        :param obj: The object (chat response) to be converted into a dictionary
+        :return: chat response dictionary in format expected by clients
+        """
+        response_dict = copy.deepcopy(obj)
+        self.convert(response_dict)
+        return response_dict
 
-    @classmethod
-    def convert(cls, response_dict: Dict[str, Any]):
+    def convert(self, response_dict: Dict[str, Any]):
         """
         Convert chat response message to a format expected by external clients:
         :param response_dict: chat response message to be sent out
@@ -29,10 +38,9 @@ class ChatMessageConverter:
         # Ensure that we return ChatMessageType as a string in output json
         message_dict: Dict[str, Any] = response_dict.get('response', None)
         if message_dict is not None:
-            ChatMessageConverter.convert_message(message_dict)
+            self.convert_message(message_dict)
 
-    @classmethod
-    def convert_message(cls, message_dict: Dict[str, Any]):
+    def convert_message(self, message_dict: Dict[str, Any]):
         """
         Convert chat message to a format expected by external clients:
         :param message_dict: chat message to process
@@ -46,4 +54,4 @@ class ChatMessageConverter:
         if chat_context is not None:
             for chat_history in chat_context.get("chat_histories", []):
                 for chat_message in chat_history.get("messages", []):
-                    ChatMessageConverter.convert_message(chat_message)
+                    self.convert_message(chat_message)


### PR DESCRIPTION
This PR converts all ChatMessageType enum values in outgoing chat responses to strings
as expected by UI clients.
Will work also for agent_cli client, though it can already handle ChatMessageType int values if they do come from a server.
Tested by observing chat response messages being sent to output
with ChatMessageType values represented as strings.
