### PR TITLE
UN-3218 restore missing agent error in a few places

### DIFF
--- a/neuro_san/client/direct_agent_session_factory.py
+++ b/neuro_san/client/direct_agent_session_factory.py
@@ -23,6 +23,7 @@ from neuro_san.internals.interfaces.agent_network_provider import AgentNetworkPr
 from neuro_san.internals.network_providers.service_agent_network_storage import ServiceAgentNetworkStorage
 from neuro_san.session.direct_agent_session import DirectAgentSession
 from neuro_san.session.external_agent_session_factory import ExternalAgentSessionFactory
+from neuro_san.session.missing_agent_check import MissingAgentCheck
 from neuro_san.session.session_invocation_context import SessionInvocationContext
 
 
@@ -100,5 +101,8 @@ class DirectAgentSessionFactory:
             agent_network_provider: AgentNetworkProvider =\
                 network_storage.get_agent_network_provider(agent_name)
             agent_network = agent_network_provider.get_agent_network()
+
+        # Common place for nice error messages when networks are not found
+        MissingAgentCheck.check_agent_network(agent_network, agent_name)
 
         return agent_network

--- a/neuro_san/internals/run_context/langchain/core/langchain_run_context.py
+++ b/neuro_san/internals/run_context/langchain/core/langchain_run_context.py
@@ -311,9 +311,10 @@ class LangChainRunContext(RunContext):
             adapter = ExternalToolAdapter(session_factory, name)
             try:
                 function_json = await adapter.get_function_json(self.invocation_context)
-            except ValueError:
+            except ValueError as exception:
                 # Could not reach the server for the external agent, so tell about it
-                message: str = f"Agent/tool {name} was unreachable. Not including it as a tool."
+                message: str = f"Agent/tool {name} was unreachable. Not including it as a tool.\n"
+                message += str(exception)
                 agent_message = AgentMessage(content=message)
                 await self.journal.write_message(agent_message)
                 self.logger.info(message)

--- a/neuro_san/internals/run_context/utils/external_tool_adapter.py
+++ b/neuro_san/internals/run_context/utils/external_tool_adapter.py
@@ -55,9 +55,9 @@ class ExternalToolAdapter:
             try:
                 function_response: Dict[str, Any] = await session.function(request_dict)
                 self.function_json = function_response.get("function")
-            except AioRpcError as exception:
+            except (AioRpcError, ValueError) as exception:
                 message: str = f"Problem accessing external agent {self.agent_url}.\n"
-                if exception.code() == StatusCode.UNIMPLEMENTED:
+                if not isinstance(exception, AioRpcError) or exception.code() == StatusCode.UNIMPLEMENTED:
                     message += """
 The server (which could be your own localhost) is currently not serving up
 an agent network by that name. Try these hints:

--- a/neuro_san/session/external_agent_session_factory.py
+++ b/neuro_san/session/external_agent_session_factory.py
@@ -97,33 +97,3 @@ class ExternalAgentSessionFactory(AsyncAgentSessionFactory):
         quiet_please.setLevel(logging.WARNING)
 
         return session
-
-    @staticmethod
-    def get_agent_network(agent_name: str,
-                          manifest_tool_registries: Dict[str, AgentNetwork]) -> AgentNetwork:
-        """
-        :param agent_name: The name of the agent to use for the session.
-        :param manifest_tool_registries: Dictionary of AgentNetworks from the manifest
-        :return: The AgentNetwork corresponding to the agent_name
-        """
-
-        tool_registry: AgentNetwork = manifest_tool_registries.get(agent_name)
-        if tool_registry is None:
-            message = f"""
-Agent named "{agent_name}" not found in manifest file: {environ.get("AGENT_MANIFEST_FILE")}.
-
-Some things to check:
-1. If the manifest file named above is None, know that the default points
-   to the one provided with the neuro-san library for a smoother out-of-box
-   experience.  If the agent you wanted is not part of that standard distribution,
-   you need to set the AGENT_MANIFEST_FILE environment variable to point to a
-   manifest.hocon file associated with your own project(s).
-2. Check that the environment variable AGENT_MANIFEST_FILE is pointing to
-   the manifest.hocon file that you expect and has no typos.
-3. Does your manifest.hocon file contain a key for the agent specified?
-4. Does the value for the key in the manifest file have a value of 'true'?
-5. Does your agent name have a typo either in the hocon file or on the command line?
-"""
-            raise ValueError(message)
-
-        return tool_registry

--- a/neuro_san/session/external_agent_session_factory.py
+++ b/neuro_san/session/external_agent_session_factory.py
@@ -11,8 +11,6 @@
 # END COPYRIGHT
 from typing import Dict
 
-from os import environ
-
 import logging
 
 from neuro_san.interfaces.async_agent_session import AsyncAgentSession

--- a/neuro_san/session/missing_agent_check.py
+++ b/neuro_san/session/missing_agent_check.py
@@ -1,0 +1,49 @@
+
+# Copyright (C) 2023-2025 Cognizant Digital Business, Evolutionary AI.
+# All Rights Reserved.
+# Issued under the Academic Public License.
+#
+# You can be released from the terms, and requirements of the Academic Public
+# License by purchasing a commercial license.
+# Purchase of a commercial license is mandatory for any use of the
+# neuro-san SDK Software in commercial settings.
+#
+# END COPYRIGHT
+
+from os import environ
+
+from neuro_san.internals.graph.registry.agent_network import AgentNetwork
+
+
+class MissingAgentCheck:
+    """
+    Convience and consolidation for checks against missing/misnamed agents.
+    """
+
+    @staticmethod
+    def check_agent_network(agent_network: AgentNetwork, agent_name: str) -> AgentNetwork:
+        """
+        :param agent_network: The AgentNetwork to check
+        :param agent_name: The name of the agent to use for the session.
+        :return: The AgentNetwork corresponding to the agent_name
+        """
+
+        if agent_network is None:
+            message = f"""
+Agent named "{agent_name}" not found in manifest file: {environ.get("AGENT_MANIFEST_FILE")}.
+
+Some things to check:
+1. If the manifest file named above is None, know that the default points
+   to the one provided with the neuro-san library for a smoother out-of-box
+   experience.  If the agent you wanted is not part of that standard distribution,
+   you need to set the AGENT_MANIFEST_FILE environment variable to point to a
+   manifest.hocon file associated with your own project(s).
+2. Check that the environment variable AGENT_MANIFEST_FILE is pointing to
+   the manifest.hocon file that you expect and has no typos.
+3. Does your manifest.hocon file contain a key for the agent specified?
+4. Does the value for the key in the manifest file have a value of 'true'?
+5. Does your agent name have a typo either in the hocon file or on the command line?
+"""
+            raise ValueError(message)
+
+        return agent_network


### PR DESCRIPTION
I noticed in the previous PR that a nice error message was no longer in place when there was a problem with the agent name on the user side.  Reinstate that and some similar missing external agent messaging that fell by the wayside when I switched to http from grpc.

Tested:
Agent exist vs not for direct, grpc, http
External agent exist vs not for direct, grpc, http