### PR TITLE
UN-3227 Fix timeout handling for http server start-up.

### DIFF
--- a/neuro_san/http_sidecar/http_sidecar.py
+++ b/neuro_san/http_sidecar/http_sidecar.py
@@ -100,10 +100,10 @@ class HttpSidecar(AgentAuthorizer, AgentsUpdater):
 
         # Wait for "go" signal which will be set by gRPC server and corresponding machinery
         # when everything is ready for servicing.
-        event_set = self.start_event.wait(timeout=self.TIMEOUT_TO_START_SECONDS)
-        if not event_set:
-            self.logger.error({}, "Timeout (%d sec) waiting for HTTP server to start", self.TIMEOUT_TO_START_SECONDS)
-            return
+        while not self.start_event.wait(timeout=self.TIMEOUT_TO_START_SECONDS):
+            self.logger.error({},
+                              "Timeout (%d sec) waiting for signal to HTTP server to start",
+                              self.TIMEOUT_TO_START_SECONDS)
 
         app.listen(self.http_port)
         self.logger.info({}, "HTTP server is running on port %d", self.http_port)


### PR DESCRIPTION
This PR fixes logic flaw in handling http server start-up.
We were relying on a fixed though rather generous timeout for http server
while waiting for gRPC server to do its initialization business and signal http to go ahead.
For some reason, on Ubuntu I see gRPC server taking much more time than could be expected,
so timeout fails.
Instead, now we'll be waiting for startup signal basically indefinitely,
with logging spam to get the message across that http server is failing to start.

