### PR TITLE
Put in a delay to help force output buffer flush.

### DIFF
--- a/neuro_san/http_sidecar/handlers/base_request_handler.py
+++ b/neuro_san/http_sidecar/handlers/base_request_handler.py
@@ -20,9 +20,9 @@ from typing import Tuple
 
 import json
 import os
+import asyncio
 
 import grpc
-import asyncio
 
 import tornado
 from tornado.web import RequestHandler

--- a/neuro_san/http_sidecar/handlers/base_request_handler.py
+++ b/neuro_san/http_sidecar/handlers/base_request_handler.py
@@ -22,6 +22,7 @@ import json
 import os
 
 import grpc
+import asyncio
 
 import tornado
 from tornado.web import RequestHandler
@@ -191,6 +192,7 @@ class BaseRequestHandler(RequestHandler):
         """
         try:
             await self.flush()
+            await asyncio.sleep(0.3)
             return True
         except tornado.iostream.StreamClosedError:
             self.logger.warning(self.get_metadata(), "Flush: client closed connection unexpectedly.")

--- a/neuro_san/http_sidecar/handlers/base_request_handler.py
+++ b/neuro_san/http_sidecar/handlers/base_request_handler.py
@@ -192,6 +192,18 @@ class BaseRequestHandler(RequestHandler):
         """
         try:
             await self.flush()
+            # What happens here: we have finished writing out one data item in our output stream,
+            # and we have flushed Tornado output.
+            # BUT: this does not guarantee in general that underlying TCP/IP transport
+            # will flush its own buffers, so low-level buffering is still possible.
+            # Result would be that several chat responses will be bunched together
+            # and received by a client as one data piece.
+            # If client is not ready for this, there will be problems.
+            # SO: this real wall clock delay here helps to encourage underlying transport
+            # to flush its own buffers - and we are good.
+            # Duration of delay is speculative and maybe could be adjusted.
+            # But best solution and reliable one: make client accept multiple data items
+            # in one "get" request - as it should when dealing with streaming service.
             await asyncio.sleep(0.3)
             return True
         except tornado.iostream.StreamClosedError:


### PR DESCRIPTION
This is basically a hack to help Tornado async streaming force out output http buffers
and ensure that client will get "one response per http chunk".
That seems to work, at least until UI client knows how to handle "multiple responses per chunk",
which would be much more reliable.
In case of emergency: play with delay duration.

Tested with MAA UI against local neuro-san server:
music-nerd-pro, esp-assistant, web-search. 
No amnesia noted.

BTW: putting in time.sleep(0) doesn't seem to help.


