### PR TITLE
UN-3191 Fix esp_decision_assist gist test prompt to accommodate for intermittent failures.

### DIFF
--- a/docs/test_case_hocon_reference.md
+++ b/docs/test_case_hocon_reference.md
@@ -100,6 +100,10 @@ By default this value is "1/1" indicating that the test case will only run once,
 and that single test sample *must* pass in order to "pass".  This is in keeping with
 standard expectations w/ non-statistically-oriented tests.
 
+Keep in mind that when using the success_ratio to define test success for an agent test,
+sometimes the failures can actually be due to the test criteria ([gist/not_gist](#gistnot_gist) prompting) and
+not the agent itself.
+
 ### use_direct
 
 Boolean value that describes how an external agent is called.

--- a/tests/fixtures/esp_decision_assistant/fallbacks_and_commondef_values.hocon
+++ b/tests/fixtures/esp_decision_assistant/fallbacks_and_commondef_values.hocon
@@ -19,7 +19,9 @@
 
     # Timeout for the entire test.
     # It's also possible to have a timeout_in_seconds on a per-interaction basis.
-    "timeout_in_seconds": 45,
+    # "timeout_in_seconds": 45,
+
+    "success_ratio": "20/20",
 
     # Interactions are a series of dictionaries with request elements paired with
     # descriptions of response checks.
@@ -47,7 +49,9 @@ If you have all the information you need, there is no need to confirm the contex
                     # Gist says we are going to ask an LLM about how the response
                     # matches up to our description of acceptance criteria.
                     # Each component of the list needs to pass muster in order to pass.
-                    "gist": ["The text sample should generally reflect a negative sentiment about crossing the road."]
+                    "gist": ["""
+The text sample should generally reflect a negative sentiment about crossing the road in the immediate future.
+                             """"]
                 }
             }
         }

--- a/tests/fixtures/esp_decision_assistant/fallbacks_and_commondef_values.hocon
+++ b/tests/fixtures/esp_decision_assistant/fallbacks_and_commondef_values.hocon
@@ -19,9 +19,12 @@
 
     # Timeout for the entire test.
     # It's also possible to have a timeout_in_seconds on a per-interaction basis.
-    # "timeout_in_seconds": 45,
+    "timeout_in_seconds": 45,
 
-    "success_ratio": "20/20",
+    # success_ratio is useful for passing to the assessor to find out why
+    # a test is intermitently failing. Sometimes it's the agent prompt, but
+    # sometimes it's the test itself.
+    # "success_ratio": "20/20",
 
     # Interactions are a series of dictionaries with request elements paired with
     # descriptions of response checks.


### PR DESCRIPTION
Using the assessor, I was able to deduce that the problem was in the test and not the agent.