### PR TITLE
UN-3235 Allow DirectAgentSession Timeout

### DIFF
--- a/neuro_san/client/agent_cli.py
+++ b/neuro_san/client/agent_cli.py
@@ -109,13 +109,7 @@ class AgentCli:
                 not bool(self.args.chat_filter):
             chat_filter["chat_filter_type"] = "MINIMAL"
 
-        empty: Dict[str, Any] = {}
-        try:
-            response: Dict[str, Any] = self.session.function(empty)
-        except RpcError as exception:
-            # pylint: disable=no-member
-            if exception.code() is StatusCode.UNIMPLEMENTED:
-                message = f"""
+        message = f"""
 The agent "{self.args.agent}" is not implemented on the server.
 
 Some suggestions:
@@ -124,7 +118,17 @@ Some suggestions:
 3. Is the value for the agent name key in the server manifest.hocon file set to true?
 4. Servers will skip manifest entries that have errors. They will also print out which
    agents they are actually serving.  Check your server output for each of these.
+5. Is the server itself actually running?
 """
+
+        empty: Dict[str, Any] = {}
+        try:
+            response: Dict[str, Any] = self.session.function(empty)
+            if response is None:
+                raise ValueError(message)
+        except RpcError as exception:
+            # pylint: disable=no-member
+            if exception.code() is StatusCode.UNIMPLEMENTED:
                 raise ValueError(message) from exception
 
             # If not an RpcException, then I dunno what it is.

--- a/neuro_san/client/agent_session_factory.py
+++ b/neuro_san/client/agent_session_factory.py
@@ -49,18 +49,19 @@ class AgentSessionFactory:
         """
         session: AgentSession = None
 
+        umbrella_timeout: Timeout = None
+        if connect_timeout_in_seconds is not None:
+            umbrella_timeout = Timeout()
+            umbrella_timeout.set_limit_in_seconds(connect_timeout_in_seconds)
+
         # Incorrectly flagged as destination of Trust Boundary Violation 1
         #   Reason: This is the place where the session_type enforced-string argument is
         #           actually checked for positive use.
         if session_type == "direct":
             factory = DirectAgentSessionFactory()
             session = factory.create_session(agent_name, use_direct=use_direct,
-                                             metadata=metadata)
+                                             metadata=metadata, umbrella_timeout=umbrella_timeout)
         elif session_type in ("service", "grpc"):
-            umbrella_timeout: Timeout = None
-            if connect_timeout_in_seconds is not None:
-                umbrella_timeout = Timeout()
-                umbrella_timeout.set_limit_in_seconds(connect_timeout_in_seconds)
             session = GrpcServiceAgentSession(host=hostname, port=port, agent_name=agent_name,
                                               metadata=metadata, umbrella_timeout=umbrella_timeout)
         elif session_type in ("http", "https"):

--- a/neuro_san/client/direct_agent_session_factory.py
+++ b/neuro_san/client/direct_agent_session_factory.py
@@ -79,7 +79,8 @@ class DirectAgentSessionFactory:
         invocation_context.start()
         session: DirectAgentSession = DirectAgentSession(tool_registry=tool_registry,
                                                          invocation_context=invocation_context,
-                                                         metadata=metadata, umbrella_timeout=umbrella_timeout)
+                                                         metadata=metadata,
+                                                         umbrella_timeout=umbrella_timeout)
         return session
 
     def get_agent_tool_registry(self, agent_name: str) -> AgentToolRegistry:

--- a/neuro_san/client/direct_agent_session_factory.py
+++ b/neuro_san/client/direct_agent_session_factory.py
@@ -11,6 +11,8 @@
 # END COPYRIGHT
 from typing import Dict
 
+from leaf_common.time.timeout import Timeout
+
 from neuro_san.interfaces.agent_session import AgentSession
 from neuro_san.internals.interfaces.context_type_toolbox_factory import ContextTypeToolboxFactory
 from neuro_san.internals.graph.registry.agent_tool_registry import AgentToolRegistry
@@ -48,7 +50,7 @@ class DirectAgentSessionFactory:
             tool_factory.add_agent_tool_registry(agent_name, tool_registry)
 
     def create_session(self, agent_name: str, use_direct: bool = False,
-                       metadata: Dict[str, str] = None) -> AgentSession:
+                       metadata: Dict[str, str] = None, umbrella_timeout: Timeout = None) -> AgentSession:
         """
         :param agent_name: The name of the agent to use for the session.
                 This name can be something in the manifest file (with no file suffix)
@@ -58,6 +60,8 @@ class DirectAgentSessionFactory:
         :param metadata: A grpc metadata of key/value pairs to be inserted into
                          the header. Default is None. Preferred format is a
                          dictionary of string keys to string values.
+        :param umbrella_timeout: A Timeout object to periodically check in loops.
+                        Default is None (no timeout).
         """
 
         tool_registry: AgentToolRegistry = self.get_agent_tool_registry(agent_name)
@@ -75,7 +79,7 @@ class DirectAgentSessionFactory:
         invocation_context.start()
         session: DirectAgentSession = DirectAgentSession(tool_registry=tool_registry,
                                                          invocation_context=invocation_context,
-                                                         metadata=metadata)
+                                                         metadata=metadata, umbrella_timeout=umbrella_timeout)
         return session
 
     def get_agent_tool_registry(self, agent_name: str) -> AgentToolRegistry:

--- a/neuro_san/session/async_grpc_service_agent_session.py
+++ b/neuro_san/session/async_grpc_service_agent_session.py
@@ -97,7 +97,8 @@ class AsyncGrpcServiceAgentSession(AsyncAbstractServiceSession, AsyncAgentSessio
             request_dict,
             service_messages.FunctionRequest())
 
-        self.umbrella_timeout.check_timeout()
+        if self.umbrella_timeout is not None:
+            self.umbrella_timeout.check_timeout()
         return response_dict
 
     async def connectivity(self, request_dict: Dict[str, Any]) -> Dict[str, Any]:
@@ -118,7 +119,8 @@ class AsyncGrpcServiceAgentSession(AsyncAbstractServiceSession, AsyncAgentSessio
             request_dict,
             service_messages.ConnectivityRequest())
 
-        self.umbrella_timeout.check_timeout()
+        if self.umbrella_timeout is not None:
+            self.umbrella_timeout.check_timeout()
         return response_dict
 
     async def streaming_chat(self, request_dict: Dict[str, Any]) -> AsyncGenerator[Dict[str, Any], None]:

--- a/neuro_san/session/async_grpc_service_agent_session.py
+++ b/neuro_san/session/async_grpc_service_agent_session.py
@@ -97,8 +97,7 @@ class AsyncGrpcServiceAgentSession(AsyncAbstractServiceSession, AsyncAgentSessio
             request_dict,
             service_messages.FunctionRequest())
 
-        if self.umbrella_timeout is not None:
-            self.umbrella_timeout.check_timeout()
+        Timeout.check_if_not_none(self.umbrella_timeout)
         return response_dict
 
     async def connectivity(self, request_dict: Dict[str, Any]) -> Dict[str, Any]:
@@ -119,8 +118,7 @@ class AsyncGrpcServiceAgentSession(AsyncAbstractServiceSession, AsyncAgentSessio
             request_dict,
             service_messages.ConnectivityRequest())
 
-        if self.umbrella_timeout is not None:
-            self.umbrella_timeout.check_timeout()
+        Timeout.check_if_not_none(self.umbrella_timeout)
         return response_dict
 
     async def streaming_chat(self, request_dict: Dict[str, Any]) -> AsyncGenerator[Dict[str, Any], None]:

--- a/neuro_san/session/grpc_service_agent_session.py
+++ b/neuro_san/session/grpc_service_agent_session.py
@@ -98,7 +98,8 @@ class GrpcServiceAgentSession(AbstractServiceSession, AgentSession):
             request_dict,
             service_messages.FunctionRequest())
 
-        self.umbrella_timeout.check_timeout()
+        if self.umbrella_timeout is not None:
+            self.umbrella_timeout.check_timeout()
         return response
 
     def connectivity(self, request_dict: Dict[str, Any]) -> Dict[str, Any]:
@@ -119,7 +120,8 @@ class GrpcServiceAgentSession(AbstractServiceSession, AgentSession):
             request_dict,
             service_messages.ConnectivityRequest())
 
-        self.umbrella_timeout.check_timeout()
+        if self.umbrella_timeout is not None:
+            self.umbrella_timeout.check_timeout()
         return response
 
     def streaming_chat(self, request_dict: Dict[str, Any]) -> Generator[Dict[str, Any], None, None]:

--- a/neuro_san/session/grpc_service_agent_session.py
+++ b/neuro_san/session/grpc_service_agent_session.py
@@ -98,8 +98,7 @@ class GrpcServiceAgentSession(AbstractServiceSession, AgentSession):
             request_dict,
             service_messages.FunctionRequest())
 
-        if self.umbrella_timeout is not None:
-            self.umbrella_timeout.check_timeout()
+        Timeout.check_if_not_none(self.umbrella_timeout)
         return response
 
     def connectivity(self, request_dict: Dict[str, Any]) -> Dict[str, Any]:
@@ -120,8 +119,7 @@ class GrpcServiceAgentSession(AbstractServiceSession, AgentSession):
             request_dict,
             service_messages.ConnectivityRequest())
 
-        if self.umbrella_timeout is not None:
-            self.umbrella_timeout.check_timeout()
+        Timeout.check_if_not_none(self.umbrella_timeout)
         return response
 
     def streaming_chat(self, request_dict: Dict[str, Any]) -> Generator[Dict[str, Any], None, None]:

--- a/neuro_san/test/driver/data_driven_agent_test_driver.py
+++ b/neuro_san/test/driver/data_driven_agent_test_driver.py
@@ -301,4 +301,4 @@ Need at least {num_need_success} to consider {hocon_file} test to be successful.
         :param timeouts: A list of timeout objects to check
         """
         for one_timeout in timeouts:
-            one_timeout.check_timeout()
+            Timeout.check_if_not_none(one_timeout)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@
 
 # In-house dependencies
 leaf-common==1.2.23
-leaf-server-common==0.1.19
+leaf-server-common==0.1.20
 
 # These are needed for generating code from .proto files
 grpcio>=1.62.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 # requirements-build.txt
 
 # In-house dependencies
-leaf-common==1.2.22
+leaf-common==1.2.23
 leaf-server-common==0.1.19
 
 # These are needed for generating code from .proto files

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,8 +6,8 @@
 # requirements-build.txt
 
 # In-house dependencies
-leaf-common==1.2.23
-leaf-server-common==0.1.20
+leaf-common>=1.2.23
+leaf-server-common>=0.1.20
 
 # These are needed for generating code from .proto files
 grpcio>=1.62.0


### PR DESCRIPTION
* Use Timeout.check_if_not_none() to avoid an error
* Pass umbrella_timeout down to DirectSession and use it.
* Use latest leaf-server-common and leaf-common
* Catch case of timeout failure w/ DirectAgentSession that @vince-leaf found and print out nice message.