### PR TITLE
UN-3237 Fix dynamic manifest updating for http service path.

### DIFF
--- a/neuro_san/http_sidecar/http_sidecar.py
+++ b/neuro_san/http_sidecar/http_sidecar.py
@@ -160,7 +160,8 @@ class HttpSidecar(AgentAuthorizer, AgentsUpdater):
                 if self.allowed_agents.get(agent_name, None) is None:
                     self.add_agent(agent_name)
             # All other agents are disabled:
-            for agent_name, _ in self.allowed_agents.items():
+            allowed_set = set(self.allowed_agents.keys())
+            for agent_name in allowed_set:
                 if agent_name not in agents:
                     self.remove_agent(agent_name)
 

--- a/neuro_san/internals/tool_factories/service_tool_factory_provider.py
+++ b/neuro_san/internals/tool_factories/service_tool_factory_provider.py
@@ -84,17 +84,32 @@ class ServiceToolFactoryProvider(ToolFactoryProvider):
         Replace agents registries with "registries" collection.
         Previous state could be empty.
         """
-        prev_agents: Dict[str, AgentToolFactory] = {}
-        with self.lock:
-            prev_agents = self.agents_table
-            self.agents_table = {}
-        # Notify listeners that previous set of agents is removed
-        for agent_name, _ in prev_agents.items():
-            for listener in self.listeners:
-                listener.agent_removed(agent_name)
-        # Add the new agent+registry pairs
-        for agent_name, tool_registry in registries.items():
-            self.add_agent_tool_registry(agent_name, tool_registry)
+        current_agents = set(self.agents_table.keys())
+        new_agents = set(registries.keys())
+        # Remove agents which are not in the new collection:
+        agents_to_remove = current_agents - new_agents
+        for agent_name in agents_to_remove:
+            self.remove_agent_tool_registry(agent_name)
+        # Now add (or possibly replace) agents from new collection:
+        for agent_name in new_agents:
+            self.add_agent_tool_registry(agent_name, registries[agent_name])
+
+    # def setup_tool_registries(self, registries: Dict[str, AgentToolFactory]):
+    #     """
+    #     Replace agents registries with "registries" collection.
+    #     Previous state could be empty.
+    #     """
+    #     prev_agents: Dict[str, AgentToolFactory] = {}
+    #     with self.lock:
+    #         prev_agents = self.agents_table
+    #         self.agents_table = {}
+    #     # Notify listeners that previous set of agents is removed
+    #     for agent_name, _ in prev_agents.items():
+    #         for listener in self.listeners:
+    #             listener.agent_removed(agent_name)
+    #     # Add the new agent+registry pairs
+    #     for agent_name, tool_registry in registries.items():
+    #         self.add_agent_tool_registry(agent_name, tool_registry)
 
     def remove_agent_tool_registry(self, agent_name: str):
         """

--- a/neuro_san/internals/tool_factories/service_tool_factory_provider.py
+++ b/neuro_san/internals/tool_factories/service_tool_factory_provider.py
@@ -94,23 +94,6 @@ class ServiceToolFactoryProvider(ToolFactoryProvider):
         for agent_name in new_agents:
             self.add_agent_tool_registry(agent_name, registries[agent_name])
 
-    # def setup_tool_registries(self, registries: Dict[str, AgentToolFactory]):
-    #     """
-    #     Replace agents registries with "registries" collection.
-    #     Previous state could be empty.
-    #     """
-    #     prev_agents: Dict[str, AgentToolFactory] = {}
-    #     with self.lock:
-    #         prev_agents = self.agents_table
-    #         self.agents_table = {}
-    #     # Notify listeners that previous set of agents is removed
-    #     for agent_name, _ in prev_agents.items():
-    #         for listener in self.listeners:
-    #             listener.agent_removed(agent_name)
-    #     # Add the new agent+registry pairs
-    #     for agent_name, tool_registry in registries.items():
-    #         self.add_agent_tool_registry(agent_name, tool_registry)
-
     def remove_agent_tool_registry(self, agent_name: str):
         """
         Remove agent name and its AgentToolFactory from service scope,


### PR DESCRIPTION
This PR fixes a problem with dynamic manifest/agent .hocon files updates
when using http service stack.
Problem surfaced now because previously we were always going through gRPC service, which works.
Now direct http route ran into this issue.

Fix tested by: modifying hello_world.hocon file for "function" request,
enabling/disabling hello_world + music_nerd agents in manifest.hocon
and observing results from CLI client requests.
gRPC route continues to work.
