### PR TITLE
UN-3225 Add library version(s) to health-check

### DIFF
--- a/neuro_san/http_sidecar/handlers/health_check_handler.py
+++ b/neuro_san/http_sidecar/handlers/health_check_handler.py
@@ -11,9 +11,15 @@
 """
 See class comment for details
 """
+from typing import Any
+from typing import Dict
+from typing import List
+
 import http
 import os
-from typing import Any, Dict, List
+
+from importlib.metadata import version as library_version
+from importlib.metadata import PackageNotFoundError
 
 from tornado.web import RequestHandler
 from neuro_san.http_sidecar.logging.http_logger import HttpLogger
@@ -42,10 +48,26 @@ class HealthCheckHandler(RequestHandler):
         Implementation of GET request handler for API health check.
         """
 
+        # Allow for a list of libraries to report versioning.
+        # For now we simply report one, but we might want to allow extension here
+        # at some point.
+        versioned_libs: List[str] = ["neuro-san"]
+        versions: Dict[str, Any] = {}
+
+        for lib in versioned_libs:
+            version: str = None
+            try:
+                version = str(library_version(lib))
+            except PackageNotFoundError:
+                version = "unknown"
+            versions[lib] = version
+
         try:
-            result_dict: Dict[str, Any] = \
-                {"service": "neuro-san agents",
-                 "status": "healthy"}
+            result_dict: Dict[str, Any] = {
+                "service": "neuro-san agents",
+                "status": "healthy",
+                "versions": versions
+            }
             self.set_header("Content-Type", "application/json")
             self.write(result_dict)
         except Exception:  # pylint: disable=broad-exception-caught


### PR DESCRIPTION
With this change the health-check would now return:
```
{
    "service": "neuro-san agents",
    "status": "healthy",
    "versions": {
        "neuro-san": "0.5.36"
    }
}
```

An open question is do we want to report more than just the neuro-san version?
Can go there if there is demand.