### PR TITLE
UN-3253 Default infinite timeout for streaming_chat() over HTTP

### DIFF
--- a/neuro_san/session/abstract_http_service_agent_session.py
+++ b/neuro_san/session/abstract_http_service_agent_session.py
@@ -57,7 +57,6 @@ class AbstractHttpServiceAgentSession(AgentSessionConstants):
         :param agent_name: The name of the agent to talk to
         """
         _ = umbrella_timeout
-        _ = streaming_timeout_in_seconds
 
         self.security_cfg: Dict[str, Any] = security_cfg
         self.use_host: str = "localhost"
@@ -72,7 +71,8 @@ class AbstractHttpServiceAgentSession(AgentSessionConstants):
             raise ValueError("agent_name is None")
         self.agent_name: str = agent_name
 
-        self.timeout_in_seconds = timeout_in_seconds
+        self.timeout_in_seconds: int = timeout_in_seconds
+        self.streaming_timeout_in_seconds: int = streaming_timeout_in_seconds
         self.metadata: Dict[str, str] = metadata
 
     def get_request_path(self, method: str) -> str:

--- a/neuro_san/session/async_http_service_agent_session.py
+++ b/neuro_san/session/async_http_service_agent_session.py
@@ -17,6 +17,7 @@ from typing import Generator
 import json
 
 from aiohttp import ClientSession
+from aiohttp import ClientTimeout
 
 from neuro_san.interfaces.async_agent_session import AsyncAgentSession
 from neuro_san.session.abstract_http_service_agent_session import AbstractHttpServiceAgentSession
@@ -39,8 +40,12 @@ class AsyncHttpServiceAgentSession(AbstractHttpServiceAgentSession, AsyncAgentSe
         path: str = self.get_request_path("function")
         result_dict: Dict[str, Any] = None
         try:
+            timeout: ClientTimeout = None
+            if self.timeout_in_seconds is not None:
+                timeout = ClientTimeout(self.timeout_in_seconds)
+
             async with ClientSession(headers=self.get_headers(),
-                                     timeout=self.timeout_in_seconds
+                                     timeout=timeout
                                      ) as session:
                 async with session.get(path, json=request_dict) as response:
                     result_dict = await response.json()
@@ -62,8 +67,11 @@ class AsyncHttpServiceAgentSession(AbstractHttpServiceAgentSession, AsyncAgentSe
         path: str = self.get_request_path("connectivity")
         result_dict: Dict[str, Any] = None
         try:
+            timeout: ClientTimeout = None
+            if self.timeout_in_seconds is not None:
+                timeout = ClientTimeout(self.timeout_in_seconds)
             async with ClientSession(headers=self.get_headers(),
-                                     timeout=self.timeout_in_seconds
+                                     timeout=timeout
                                      ) as session:
                 async with session.get(path, json=request_dict) as response:
                     result_dict = await response.json()
@@ -87,8 +95,11 @@ class AsyncHttpServiceAgentSession(AbstractHttpServiceAgentSession, AsyncAgentSe
         """
         path: str = self.get_request_path("streaming_chat")
         try:
+            timeout: ClientTimeout = None
+            if self.streaming_timeout_in_seconds is not None:
+                timeout = ClientTimeout(self.streaming_timeout_in_seconds)
             async with ClientSession(headers=self.get_headers(),
-                                     timeout=self.streaming_timeout_in_seconds
+                                     timeout=timeout
                                      ) as session:
                 async with session.post(path, json=request_dict) as response:
                     # Check for successful response status

--- a/neuro_san/session/async_http_service_agent_session.py
+++ b/neuro_san/session/async_http_service_agent_session.py
@@ -40,8 +40,7 @@ class AsyncHttpServiceAgentSession(AbstractHttpServiceAgentSession, AsyncAgentSe
         result_dict: Dict[str, Any] = None
         try:
             async with ClientSession(headers=self.get_headers(),
-                                     conn_timeout=self.timeout_in_seconds,
-                                     read_timeout=self.timeout_in_seconds,
+                                     timeout=self.timeout_in_seconds
                                      ) as session:
                 async with session.get(path, json=request_dict) as response:
                     result_dict = await response.json()
@@ -64,8 +63,7 @@ class AsyncHttpServiceAgentSession(AbstractHttpServiceAgentSession, AsyncAgentSe
         result_dict: Dict[str, Any] = None
         try:
             async with ClientSession(headers=self.get_headers(),
-                                     conn_timeout=self.timeout_in_seconds,
-                                     read_timeout=self.timeout_in_seconds,
+                                     timeout=self.timeout_in_seconds
                                      ) as session:
                 async with session.get(path, json=request_dict) as response:
                     result_dict = await response.json()
@@ -90,8 +88,7 @@ class AsyncHttpServiceAgentSession(AbstractHttpServiceAgentSession, AsyncAgentSe
         path: str = self.get_request_path("streaming_chat")
         try:
             async with ClientSession(headers=self.get_headers(),
-                                     conn_timeout=self.timeout_in_seconds,
-                                     read_timeout=self.timeout_in_seconds,
+                                     timeout=self.streaming_timeout_in_seconds
                                      ) as session:
                 async with session.post(path, json=request_dict) as response:
                     # Check for successful response status

--- a/neuro_san/session/http_service_agent_session.py
+++ b/neuro_san/session/http_service_agent_session.py
@@ -83,7 +83,7 @@ class HttpServiceAgentSession(AbstractHttpServiceAgentSession, AgentSession):
         try:
             with requests.post(path, json=request_dict, headers=self.get_headers(),
                                stream=True,
-                               timeout=self.timeout_in_seconds) as response:
+                               timeout=self.streaming_timeout_in_seconds) as response:
                 response.raise_for_status()
 
                 for line in response.iter_lines(decode_unicode=True):


### PR DESCRIPTION
@Noravee was reporting that using http sessions for external agents was timing out and causing agent failures.
This is different behavior than what we had seen with gRPC sessions.

I was able to chase it down to the grpc bowels of hell to see that in grpc-land we had specifically been passing in a None timeout (meaning infinite) by default for streaming_chat() for the gRPC case.

This was not the case for the HTTP session. This PR should make that parity now.