### PR TITLE
UN-3208 Add azure gpt-4.1 model to default_llm_info

### DIFF
--- a/neuro_san/internals/run_context/langchain/llms/default_llm_info.hocon
+++ b/neuro_san/internals/run_context/langchain/llms/default_llm_info.hocon
@@ -259,19 +259,21 @@
         "class": "azure-openai",
         "use_model_name": "gpt-4-0613",
         "model_info_url": "https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models?tabs=global-standard%2Cstandard-chat-completions#gpt-4-and-gpt-4-turbo-models"
-
     },
     "azure-gpt-4o-mini": {
         "class": "azure-openai",
         "use_model_name": "gpt-4o-mini-2024-07-18"
         "model_info_url": "https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models?tabs=global-standard%2Cstandard-chat-completions#gpt-4-and-gpt-4-turbo-models"
-
     },
     "azure-gpt-4o": {
         "class": "azure-openai",
         "use_model_name": "gpt-4o-2024-08-06",
         "model_info_url": "https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models?tabs=global-standard%2Cstandard-chat-completions#gpt-4-and-gpt-4-turbo-models"
-
+    },
+    "azure-gpt-4.1": {
+        "class": "azure-openai",
+        "use_model_name": "gpt-4.1-2025-04-14",
+        "model_info_url": "https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models?tabs=global-standard%2Cstandard-chat-completions#gpt-4-and-gpt-4-turbo-models"
     },
     "azure-o1": {
         "class": "azure-openai",

--- a/neuro_san/internals/run_context/langchain/llms/default_llm_info.hocon
+++ b/neuro_san/internals/run_context/langchain/llms/default_llm_info.hocon
@@ -64,7 +64,21 @@
         "max_output_tokens": 32768,
         "knowledge_cutoff": "09/30/2023",
     },
-
+    "gpt-4.1": {
+        "use_model_name": "gpt-4.1-2025-04-14",
+    },
+    "gpt-4.1-2025-04-14": {
+        "class": "openai",
+        "model_info_url": "https://platform.openai.com/docs/models/gpt-4.1",
+        "modalities": {
+            "input": [ "text", "image" ],
+            "output": [ "text" ],
+        },
+        "capabilities": [ "tools" ],
+        "context_window_size": 1047576,
+        "max_output_tokens": 32768,
+        "knowledge_cutoff": "05/31/2024",
+    },
     "gpt-4o": {
         "use_model_name": "gpt-4o-2024-08-06",
     },


### PR DESCRIPTION
### Changes
- Add key `gpt-4.1-2025-04-14` in `default_llm_info.hocon`
- Add key `gpt-4.1` which points to `gpt-4.1-2025-04-14` in `default_llm_info.hocon`
- Add key `azure-gpt-4.1` which points to `gpt-4.1-2025-04-14` in `default_llm_info.hocon`

### Tests
- Run `google_serper` with `gpt-4.1-2025-04-14` and `gpt-4.1`