### PR TITLE
UN-3273 Fix 'Filename too long' by using uuids as filenames when that occurs

### DIFF
--- a/neuro_san/client/thinking_file_message_processor.py
+++ b/neuro_san/client/thinking_file_message_processor.py
@@ -15,6 +15,7 @@ from typing import Dict
 from typing import List
 
 import json
+import uuid
 
 from pathlib import Path
 
@@ -89,31 +90,57 @@ class ThinkingFileMessageProcessor(MessageProcessor):
             # There is no real text, but there is a structure. JSON-ify it.
             text = json.dumps(structure, indent=4, sort_keys=True)
 
+        use_origin: str = self._determine_origin_reporting(response, origin_str)
+
+        try:
+            self._write_to_file(origin_str, origin_str, message_type_str, use_origin, text)
+        except OSError as os_error:
+            # For very deep networks we can sometimes get a "File name too long",
+            # which is Error code 63.
+            if os_error.errno == 63:
+                # Retry with a uuid as file name.
+                # If this fails, there's no helping ya.
+                new_uuid: str = str(uuid.uuid4())
+                self._write_to_file(new_uuid, origin_str, message_type_str, use_origin, text)
+            else:
+                raise os_error
+
+    def _write_to_file(self, origin_filename: str, origin_str: str,
+                       message_type_str: str, use_origin: str, text: str):
+
         filename: Path = self.thinking_file
         if self.thinking_dir:
-            if origin_str is None or len(origin_str) == 0:
+            if origin_filename is None or len(origin_filename) == 0:
                 return
-            filename = Path(self.thinking_dir, origin_str)
+            filename = Path(self.thinking_dir, origin_filename)
 
         how_to_open_file: str = "a"
         if not filename.exists():
             how_to_open_file = "w"
 
         with filename.open(mode=how_to_open_file, encoding="utf-8") as thinking:
-            use_origin: str = ""
-
-            # Maybe add some context to where message is coming from if not using thinking_dir
-            if not self.thinking_dir:
-                use_origin += f" from {origin_str}"
-
-            # Maybe add some context as to where the tool result came from if we have info for that.
-            tool_result_origin: List[Dict[str, Any]] = response.get("tool_result_origin")
-            if tool_result_origin is not None:
-                last_origin_only: List[Dict[str, Any]] = [tool_result_origin[-1]]
-                origin_str = Origination.get_full_name_from_origin(last_origin_only)
-                use_origin += f" (result from {origin_str})"
+            if how_to_open_file == "w":
+                # New file, preface it with an origin log.
+                thinking.write(f"Agent: {origin_str}\n")
 
             # Write the message out
             thinking.write(f"\n[{message_type_str}{use_origin}]:\n")
             thinking.write(text)
             thinking.write("\n")
+
+    def _determine_origin_reporting(self, response: Dict[str, Any], origin_str: str) -> str:
+
+        use_origin: str = ""
+
+        # Maybe add some context to where message is coming from if not using thinking_dir
+        if not self.thinking_dir:
+            use_origin += f" from {origin_str}"
+
+        # Maybe add some context as to where the tool result came from if we have info for that.
+        tool_result_origin: List[Dict[str, Any]] = response.get("tool_result_origin")
+        if tool_result_origin is not None:
+            last_origin_only: List[Dict[str, Any]] = [tool_result_origin[-1]]
+            origin_str = Origination.get_full_name_from_origin(last_origin_only)
+            use_origin += f" (result from {origin_str})"
+
+        return use_origin

--- a/neuro_san/client/thinking_file_message_processor.py
+++ b/neuro_san/client/thinking_file_message_processor.py
@@ -93,6 +93,7 @@ class ThinkingFileMessageProcessor(MessageProcessor):
             # There is no real text, but there is a structure. JSON-ify it.
             text = json.dumps(structure, indent=4, sort_keys=True)
 
+        # Figure out how we are going to report the origin given the message.
         use_origin: str = self._determine_origin_reporting(response, origin_str)
 
         # Determine the filename to use given the origin_str.


### PR DESCRIPTION
@babakatwork is the primary reviewer

* When we get an OSError which is a "Filename too long" error, try again to write the filename as a uuid.
* Since it's possible for filenames to now not match the agent's full origin string they belong to, we add this as a preface to any newly created file.