### PR TITLE
UN-3277 Clearer assert on what makes a front-man / comments in hocons

### DIFF
--- a/neuro_san/internals/graph/registry/agent_network.py
+++ b/neuro_san/internals/graph/registry/agent_network.py
@@ -143,7 +143,7 @@ Here are some pre-conditions for an agent in your network to be a potential fron
 
 Disqualifiers. A front man cannot:
 * be a CodedTool with a "class" definition
-* be a tool from a "toolbox" definition
+* be a tool with a "toolbox" definition
 """)
 
         if len(valid_front_men) > 1:

--- a/neuro_san/internals/graph/registry/agent_network.py
+++ b/neuro_san/internals/graph/registry/agent_network.py
@@ -147,7 +147,7 @@ Disqualifiers. A front man cannot:
 """)
 
         if len(valid_front_men) > 1:
-            raise ValueError(f"Found > 1 front man for chat. Possibilities: {front_men}")
+            raise ValueError(f"Found > 1 front man for chat. Possibilities: {valid_front_men}")
 
         front_man: str = front_men[0]
 

--- a/neuro_san/internals/graph/registry/agent_network.py
+++ b/neuro_san/internals/graph/registry/agent_network.py
@@ -13,6 +13,8 @@ from typing import Any
 from typing import Dict
 from typing import List
 
+from copy import copy
+
 from leaf_common.parsers.dictionary_extractor import DictionaryExtractor
 
 from neuro_san.internals.run_context.interfaces.agent_network_inspector import AgentNetworkInspector
@@ -115,17 +117,40 @@ Some things to try:
                 front_men.append(name)
 
         if len(front_men) == 0:
-            # The next way to find a front man is to see which agent was registered first
+            # The best way to find a front man is to see which agent was registered first
             front_men.append(self.first_agent)
 
-        if len(front_men) == 0:
-            raise ValueError("No front man for chat found. "
-                             "One entry's function must not have any parameters defined to be the front man")
+        # Check for validity of our front-man candidates.
+        valid_front_men: List[str] = copy(front_men)
+        for front_man in front_men:
 
-        if len(front_men) > 1:
+            # Check the agent spec of the front man for validity
+            agent_spec: Dict[str, Any] = self.get_agent_tool_spec(front_man)
+
+            if agent_spec.get("class") is not None:
+                # Currently, front man cannot be a coded tool
+                valid_front_men.remove(front_man)
+            elif agent_spec.get("toolbox") is not None:
+                # Currently, front man cannot from a toolbox
+                valid_front_men.remove(front_man)
+
+        if len(valid_front_men) == 0:
+            raise ValueError("""
+No front man found.
+Here are some pre-conditions for an agent in your network to be a potential front man:
+1) The agent's "function" does not have any "parameters" defined OR
+2) The agent is the first listed among the "tools" of your agent hocon file
+
+Disqualifiers. A front man cannot:
+* be a CodedTool with a "class" definition
+* be a tool from a "toolbox" definition
+""")
+
+        if len(valid_front_men) > 1:
             raise ValueError(f"Found > 1 front man for chat. Possibilities: {front_men}")
 
-        front_man = front_men[0]
+        front_man: str = front_men[0]
+
         return front_man
 
     def get_agent_llm_info_file(self) -> str:

--- a/neuro_san/internals/graph/registry/agent_network.py
+++ b/neuro_san/internals/graph/registry/agent_network.py
@@ -149,7 +149,7 @@ Disqualifiers. A front man cannot:
         if len(valid_front_men) > 1:
             raise ValueError(f"Found > 1 front man for chat. Possibilities: {valid_front_men}")
 
-        front_man: str = front_men[0]
+        front_man: str = valid_front_men[0]
 
         return front_man
 

--- a/neuro_san/registries/assess_failure.hocon
+++ b/neuro_san/registries/assess_failure.hocon
@@ -22,17 +22,22 @@
         # How they are linked and call each other is defined within their
         # own specs.  This could be a graph, potentially even with cycles.
 
-        # This first guy is the "Front Man".  He is identified as such because
-        # he is the only one with no parameters in his function definition,
-        # and therefore he needs to talk to the outside world to get things rolling.
+        # This first agent definition is regarded as the "Front Man", which
+        # does all the talking to the outside world/client.
+        # It is identified as such because it is either:
+        #   A) The only one with no parameters in his function definition,
+        #      and therefore he needs to talk to the outside world to get things rolling.
+        #   B) The first agent listed, regardless of function parameters.
+        #
+        # Some disqualifications from being a front man:
+        #   1) Cannot use a CodedTool "class" definition
+        #   2) Cannot use a Tool "toolbox" definition
         {
             "name": "assess_failure",
 
             "function": {
 
-                # When there are no function parameters to the front-man,
-                # its description acts as an initial prompt.
-
+                # The description acts as an initial prompt.
                 "description": """
 Knowing that a given text_sample fails against a given acceptance_criteria,
 this tool will attempt to classify just how the failure relates to which one
@@ -41,7 +46,7 @@ existing entries in the failure_modes list, or if nothing quite right exists
 in that list, this tool will propose a new category.
 """,
                 # This parameters section isn't strictly needed if the agent network
-                # is not expected to be called as a coded tool.
+                # is not expected to be called as an external agent.
                 "parameters": {
                     "type": "object",
                     "properties": {

--- a/neuro_san/registries/bing_search.hocon
+++ b/neuro_san/registries/bing_search.hocon
@@ -22,9 +22,16 @@
         # How they are linked and call each other is defined within their
         # own specs.  This could be a graph, potentially even with cycles.
 
-        # This first guy is the "Front Man".  He is identified as such because
-        # he is the only one with no parameters in his function definition,
-        # and therefore he needs to talk to the outside world to get things rolling.
+        # This first agent definition is regarded as the "Front Man", which
+        # does all the talking to the outside world/client.
+        # It is identified as such because it is either:
+        #   A) The only one with no parameters in his function definition,
+        #      and therefore he needs to talk to the outside world to get things rolling.
+        #   B) The first agent listed, regardless of function parameters.
+        #
+        # Some disqualifications from being a front man:
+        #   1) Cannot use a CodedTool "class" definition
+        #   2) Cannot use a Tool "toolbox" definition
         {
             "name": "searcher",
             "instructions": "Use your tool to respond to the inquiry.",
@@ -65,20 +72,20 @@
             #
             # Langchain Tools
             #
-            #   1️)  "bing_search" - Uses Bing to perform web searches.
-            #   2️)  "tavily_search" - Uses Tavily for search queries.
-            #   3️)  "requests_get" - Makes an HTTP GET request.
-            #   4️)  "requests_post" - Makes an HTTP POST request.
-            #   5️)  "requests_patch" - Makes an HTTP PATCH request.
-            #   6️)  "requests_put" - Makes an HTTP PUT request.
-            #   7️)  "requests_delete" - Makes an HTTP DELETE request.
-            #   8)  "requests_toolkit" - Contains all of the request tools.
+            #   * "bing_search" - Uses Bing to perform web searches.
+            #   * "tavily_search" - Uses Tavily for search queries.
+            #   * "requests_get" - Makes an HTTP GET request.
+            #   * "requests_post" - Makes an HTTP POST request.
+            #   * "requests_patch" - Makes an HTTP PATCH request.
+            #   * "requests_put" - Makes an HTTP PUT request.
+            #   * "requests_delete" - Makes an HTTP DELETE request.
+            #   * "requests_toolkit" - Contains all of the request tools.
             #
             # Coded Tools
             #
-            #   9)  "website_search" - Search internet with DuckduckgoSearch.
-            #   10) "google_serper" - Search internet with Google Serper
-            #   11) "rag_retriever" - Perform retrival-augmented generation on given urls.
+            #   * "website_search" - Search internet with DuckduckgoSearch.
+            #   * "google_serper" - Search internet with Google Serper
+            #   * "rag_retriever" - Perform retrival-augmented generation on given urls.
             #
             # Each of these tools may require specific arguments in the "args" section.
             # Refer to the tool's documentation for more details.

--- a/neuro_san/registries/date_time.hocon
+++ b/neuro_san/registries/date_time.hocon
@@ -22,18 +22,25 @@
         # How they are linked and call each other is defined within their
         # own specs.  This could be a graph, potentially even with cycles.
 
-        # This first guy is the "Front Man".  He is identified as such because
-        # he is the only one with no parameters in his function definition,
-        # and therefore he needs to talk to the outside world to get things rolling.
+        # This first agent definition is regarded as the "Front Man", which
+        # does all the talking to the outside world/client.
+        # It is identified as such because it is either:
+        #   A) The only one with no parameters in his function definition,
+        #      and therefore he needs to talk to the outside world to get things rolling.
+        #   B) The first agent listed, regardless of function parameters.
+        #
+        # Some disqualifications from being a front man:
+        #   1) Cannot use a CodedTool "class" definition
+        #   2) Cannot use a Tool "toolbox" definition
         {
             "name": "date_time_provider",
 
-            # Note that there are no parameters defined for this guy's "function" key,
-            # and there is "instructions".
+            # Note that there are no parameters defined for this guy's "function" key.
             # This is the primary way to identify this tool as a front-man,
             # distinguishing it from the rest of the tools.
 
             "function": {
+                # The description acts as an initial prompt. 
                 "description": "Assist caller with current date and time.",
             },
 

--- a/neuro_san/registries/esp_decision_assistant.hocon
+++ b/neuro_san/registries/esp_decision_assistant.hocon
@@ -60,9 +60,16 @@
         # How they are linked and call each other is defined within their
         # own specs.  This could be a graph, potentially even with cycles.
 
-        # This first guy is the "Front Man".  He is identified as such because
-        # he is the only one with no paramaters in his function definition,
-        # and therefore he needs to talk to the outside world to get things rolling.
+        # This first agent definition is regarded as the "Front Man", which
+        # does all the talking to the outside world/client.
+        # It is identified as such because it is either:
+        #   A) The only one with no parameters in his function definition,
+        #      and therefore he needs to talk to the outside world to get things rolling.
+        #   B) The first agent listed, regardless of function parameters.
+        #
+        # Some disqualifications from being a front man:
+        #   1) Cannot use a CodedTool "class" definition
+        #   2) Cannot use a Tool "toolbox" definition
         {
             "name": "decision_making_assistant",
 
@@ -72,9 +79,7 @@
 
             "function": {
 
-                # When there are no function parameters to the front-man,
-                # its description acts as an initial prompt. 
-
+                # The description acts as an initial prompt. 
                 "description": """
 I can help you with your basic decision making.
 What decision are you trying to make?

--- a/neuro_san/registries/gist.hocon
+++ b/neuro_san/registries/gist.hocon
@@ -22,23 +22,28 @@
         # How they are linked and call each other is defined within their
         # own specs.  This could be a graph, potentially even with cycles.
 
-        # This first guy is the "Front Man".  He is identified as such because
-        # he is the only one with no parameters in his function definition,
-        # and therefore he needs to talk to the outside world to get things rolling.
+        # This first agent definition is regarded as the "Front Man", which
+        # does all the talking to the outside world/client.
+        # It is identified as such because it is either:
+        #   A) The only one with no parameters in his function definition,
+        #      and therefore he needs to talk to the outside world to get things rolling.
+        #   B) The first agent listed, regardless of function parameters.
+        #
+        # Some disqualifications from being a front man:
+        #   1) Cannot use a CodedTool "class" definition
+        #   2) Cannot use a Tool "toolbox" definition
         {
             "name": "gist",
 
             "function": {
 
-                # When there are no function parameters to the front-man,
-                # its description acts as an initial prompt.
-
+                # The description acts as an initial prompt.
                 "description": """
 Will return the single string "pass" if the text sample meets the given acceptance criteria
 or the single string "fail" if the text sample does not meet the given acceptance criteria.
 """,
                 # This parameters section isn't strictly needed if the agent network
-                # is not expected to be called as a coded tool.
+                # is not expected to be called as an external agent.
                 "parameters": {
                     "type": "object",
                     "properties": {

--- a/neuro_san/registries/google_serper.hocon
+++ b/neuro_san/registries/google_serper.hocon
@@ -22,13 +22,21 @@
         # How they are linked and call each other is defined within their
         # own specs.  This could be a graph, potentially even with cycles.
 
-        # This first guy is the "Front Man".  He is identified as such because
-        # he is the only one with no parameters in his function definition,
-        # and therefore he needs to talk to the outside world to get things rolling.
+        # This first agent definition is regarded as the "Front Man", which
+        # does all the talking to the outside world/client.
+        # It is identified as such because it is either:
+        #   A) The only one with no parameters in his function definition,
+        #      and therefore he needs to talk to the outside world to get things rolling.
+        #   B) The first agent listed, regardless of function parameters.
+        #
+        # Some disqualifications from being a front man:
+        #   1) Cannot use a CodedTool "class" definition
+        #   2) Cannot use a Tool "toolbox" definition
         {
             "name": "searcher",
             "instructions": "Use your tool to respond to the inquiry.",
              "function": {
+                # The description acts as an initial prompt.
                 "description": "Assist user with answer from internet."
              }
             "tools": ["search_tool"]

--- a/neuro_san/registries/hello_world.hocon
+++ b/neuro_san/registries/hello_world.hocon
@@ -22,9 +22,16 @@
         # How they are linked and call each other is defined within their
         # own specs.  This could be a graph, potentially even with cycles.
 
-        # This first guy is the "Front Man".  He is identified as such because
-        # he is the only one with no parameters in his function definition,
-        # and therefore he needs to talk to the outside world to get things rolling.
+        # This first agent definition is regarded as the "Front Man", which
+        # does all the talking to the outside world/client.
+        # It is identified as such because it is either:
+        #   A) The only one with no parameters in his function definition,
+        #      and therefore he needs to talk to the outside world to get things rolling.
+        #   B) The first agent listed, regardless of function parameters.
+        #
+        # Some disqualifications from being a front man:
+        #   1) Cannot use a CodedTool "class" definition
+        #   2) Cannot use a Tool "toolbox" definition
         {
             "name": "announcer",
 
@@ -34,9 +41,7 @@
 
             "function": {
 
-                # When there are no function parameters to the front-man,
-                # its description acts as an initial prompt. 
-
+                # The description acts as an initial prompt. 
                 "description": """
 I can help you to make a terse anouncement.
 Tell me what your target audience is, and what sentiment you would like to relate.

--- a/neuro_san/registries/intranet_agents.hocon
+++ b/neuro_san/registries/intranet_agents.hocon
@@ -61,6 +61,17 @@ the inquiry, if any. or if it is being asked to respond to the inquiry.
         },
     }
     "tools": [
+
+        # This first agent definition is regarded as the "Front Man", which
+        # does all the talking to the outside world/client.
+        # It is identified as such because it is either:
+        #   A) The only one with no parameters in his function definition,
+        #      and therefore he needs to talk to the outside world to get things rolling.
+        #   B) The first agent listed, regardless of function parameters.
+        #
+        # Some disqualifications from being a front man:
+        #   1) Cannot use a CodedTool "class" definition
+        #   2) Cannot use a Tool "toolbox" definition
         {
             "name": "main_search_box",
 
@@ -70,9 +81,7 @@ the inquiry, if any. or if it is being asked to respond to the inquiry.
 
             "function": {
 
-                # When there are no function parameters to the front-man,
-                # its description acts as an initial prompt. 
-
+                # The description acts as an initial prompt. 
                 "description": "I can help you with your intranet needs."
             },
             "instructions": """

--- a/neuro_san/registries/math_guy.hocon
+++ b/neuro_san/registries/math_guy.hocon
@@ -22,29 +22,30 @@
         # How they are linked and call each other is defined within their
         # own specs.  This could be a graph, potentially even with cycles.
 
-        # This first guy is the "Front Man".  He is identified as such because
-        # he is the only one with no parameters in his function definition,
-        # and therefore he needs to talk to the outside world to get things rolling.
+        # This first agent definition is regarded as the "Front Man", which
+        # does all the talking to the outside world/client.
+        # It is identified as such because it is either:
+        #   A) The only one with no parameters in his function definition,
+        #      and therefore he needs to talk to the outside world to get things rolling.
+        #   B) The first agent listed, regardless of function parameters.
+        #
+        # Some disqualifications from being a front man:
+        #   1) Cannot use a CodedTool "class" definition
+        #   2) Cannot use a Tool "toolbox" definition
         {
             "name": "math_guy",
 
-            # Note that there are no parameters defined for this guy's "function" key.
-            # This is the primary way to identify this tool as a front-man,
-            # distinguishing it from the rest of the tools.
-
             "function": {
 
-                # When there are no function parameters to the front-man,
-                # its description acts as an initial prompt.
-
+                # The description acts as an initial prompt.
                 "description": """
 I am a test agent network that can do math with values in sly_data.
 Just give me the name of an arithmetic operator and I will do the work
 on the secret numbers.
 """,
                 # This parameters section isn't strictly needed if the agent network
-                # is not expected to be called as a coded tool.  This one is used with
-                # math_guy_passthrough, so we need to add this.
+                # is not expected to be called as an external agent.
+                # This one is used with math_guy_passthrough, so we need to add this.
                 "parameters": {
                     "type": "object",
                     "properties": {

--- a/neuro_san/registries/math_guy_passthrough.hocon
+++ b/neuro_san/registries/math_guy_passthrough.hocon
@@ -22,9 +22,16 @@
         # How they are linked and call each other is defined within their
         # own specs.  This could be a graph, potentially even with cycles.
 
-        # This first guy is the "Front Man".  He is identified as such because
-        # he is the only one with no parameters in his function definition,
-        # and therefore he needs to talk to the outside world to get things rolling.
+        # This first agent definition is regarded as the "Front Man", which
+        # does all the talking to the outside world/client.
+        # It is identified as such because it is either:
+        #   A) The only one with no parameters in his function definition,
+        #      and therefore he needs to talk to the outside world to get things rolling.
+        #   B) The first agent listed, regardless of function parameters.
+        #
+        # Some disqualifications from being a front man:
+        #   1) Cannot use a CodedTool "class" definition
+        #   2) Cannot use a Tool "toolbox" definition
         {
             "name": "passthrough",
 
@@ -34,9 +41,7 @@
 
             "function": {
 
-                # When there are no function parameters to the front-man,
-                # its description acts as an initial prompt.
-
+                # The description acts as an initial prompt.
                 "description": """
 I am a test agent network that can do math with values in sly_data.
 Just give me the name of an arithmetic operator and I will do the work

--- a/neuro_san/registries/music_nerd.hocon
+++ b/neuro_san/registries/music_nerd.hocon
@@ -22,9 +22,16 @@
         # How they are linked and call each other is defined within their
         # own specs.  This could be a graph, potentially even with cycles.
 
-        # This first guy is the "Front Man".  He is identified as such because
-        # he is the only one with no parameters in his function definition,
-        # and therefore he needs to talk to the outside world to get things rolling.
+        # This first agent definition is regarded as the "Front Man", which
+        # does all the talking to the outside world/client.
+        # It is identified as such because it is either:
+        #   A) The only one with no parameters in his function definition,
+        #      and therefore he needs to talk to the outside world to get things rolling.
+        #   B) The first agent listed, regardless of function parameters.
+        #
+        # Some disqualifications from being a front man:
+        #   1) Cannot use a CodedTool "class" definition
+        #   2) Cannot use a Tool "toolbox" definition
         {
             "name": "MusicNerd",
 
@@ -34,9 +41,7 @@
 
             "function": {
 
-                # When there are no function parameters to the front-man,
-                # its description acts as an initial prompt. 
-
+                # The description acts as an initial prompt. 
                 "description": """
 I can help with music-related inquiries.
 """

--- a/neuro_san/registries/music_nerd_pro.hocon
+++ b/neuro_san/registries/music_nerd_pro.hocon
@@ -22,9 +22,16 @@
         # How they are linked and call each other is defined within their
         # own specs.  This could be a graph, potentially even with cycles.
 
-        # This first guy is the "Front Man".  He is identified as such because
-        # he is the only one with no parameters in his function definition,
-        # and therefore he needs to talk to the outside world to get things rolling.
+        # This first agent definition is regarded as the "Front Man", which
+        # does all the talking to the outside world/client.
+        # It is identified as such because it is either:
+        #   A) The only one with no parameters in his function definition,
+        #      and therefore he needs to talk to the outside world to get things rolling.
+        #   B) The first agent listed, regardless of function parameters.
+        #
+        # Some disqualifications from being a front man:
+        #   1) Cannot use a CodedTool "class" definition
+        #   2) Cannot use a Tool "toolbox" definition
         {
             "name": "MusicNerdPro",
 
@@ -34,9 +41,7 @@
 
             "function": {
 
-                # When there are no function parameters to the front-man,
-                # its description acts as an initial prompt. 
-
+                # The description acts as an initial prompt. 
                 "description": """
 I can help with music-related inquiries.
 """

--- a/neuro_san/registries/music_nerd_pro_llm_anthropic.hocon
+++ b/neuro_san/registries/music_nerd_pro_llm_anthropic.hocon
@@ -22,9 +22,16 @@
         # How they are linked and call each other is defined within their
         # own specs.  This could be a graph, potentially even with cycles.
 
-        # This first guy is the "Front Man".  He is identified as such because
-        # he is the only one with no parameters in his function definition,
-        # and therefore he needs to talk to the outside world to get things rolling.
+        # This first agent definition is regarded as the "Front Man", which
+        # does all the talking to the outside world/client.
+        # It is identified as such because it is either:
+        #   A) The only one with no parameters in his function definition,
+        #      and therefore he needs to talk to the outside world to get things rolling.
+        #   B) The first agent listed, regardless of function parameters.
+        #
+        # Some disqualifications from being a front man:
+        #   1) Cannot use a CodedTool "class" definition
+        #   2) Cannot use a Tool "toolbox" definition
         {
             "name": "MusicNerdPro",
 
@@ -34,9 +41,7 @@
 
             "function": {
 
-                # When there are no function parameters to the front-man,
-                # its description acts as an initial prompt. 
-
+                # The description acts as an initial prompt. 
                 "description": """
 I can help with music-related inquiries.
 """

--- a/neuro_san/registries/website_rag.hocon
+++ b/neuro_san/registries/website_rag.hocon
@@ -22,9 +22,16 @@
         # How they are linked and call each other is defined within their
         # own specs.  This could be a graph, potentially even with cycles.
 
-        # This first guy is the "Front Man".  He is identified as such because
-        # he is the only one with no parameters in his function definition,
-        # and therefore he needs to talk to the outside world to get things rolling.
+        # This first agent definition is regarded as the "Front Man", which
+        # does all the talking to the outside world/client.
+        # It is identified as such because it is either:
+        #   A) The only one with no parameters in his function definition,
+        #      and therefore he needs to talk to the outside world to get things rolling.
+        #   B) The first agent listed, regardless of function parameters.
+        #
+        # Some disqualifications from being a front man:
+        #   1) Cannot use a CodedTool "class" definition
+        #   2) Cannot use a Tool "toolbox" definition
         {
             "name": "searcher",
 
@@ -33,6 +40,7 @@
             # distinguishing it from the rest of the tools.
 
             "function": {
+                # The description acts as an initial prompt. 
                 "description": "Assist caller with searching an url.",
             },
 

--- a/neuro_san/registries/website_search.hocon
+++ b/neuro_san/registries/website_search.hocon
@@ -22,17 +22,21 @@
         # How they are linked and call each other is defined within their
         # own specs.  This could be a graph, potentially even with cycles.
 
-        # This first guy is the "Front Man".  He is identified as such because
-        # he is the only one with no parameters in his function definition,
-        # and therefore he needs to talk to the outside world to get things rolling.
+        # This first agent definition is regarded as the "Front Man", which
+        # does all the talking to the outside world/client.
+        # It is identified as such because it is either:
+        #   A) The only one with no parameters in his function definition,
+        #      and therefore he needs to talk to the outside world to get things rolling.
+        #   B) The first agent listed, regardless of function parameters.
+        #
+        # Some disqualifications from being a front man:
+        #   1) Cannot use a CodedTool "class" definition
+        #   2) Cannot use a Tool "toolbox" definition
         {
             "name": "searcher",
 
-            # Note that there are no parameters defined for this guy's "function" key.
-            # This is the primary way to identify this tool as a front-man,
-            # distinguishing it from the rest of the tools.
-
             "function": {
+                # The description acts as an initial prompt. 
                 "description": "Assist caller with searching an url.",
                 "parameters": {
                     "type": "object",

--- a/neuro_san/registries/website_search_usage_example.hocon
+++ b/neuro_san/registries/website_search_usage_example.hocon
@@ -22,17 +22,21 @@
         # How they are linked and call each other is defined within their
         # own specs.  This could be a graph, potentially even with cycles.
 
-        # This first guy is the "Front Man".  He is identified as such because
-        # he is the only one with no parameters in his function definition,
-        # and therefore he needs to talk to the outside world to get things rolling.
+        # This first agent definition is regarded as the "Front Man", which
+        # does all the talking to the outside world/client.
+        # It is identified as such because it is either:
+        #   A) The only one with no parameters in his function definition,
+        #      and therefore he needs to talk to the outside world to get things rolling.
+        #   B) The first agent listed, regardless of function parameters.
+        #
+        # Some disqualifications from being a front man:
+        #   1) Cannot use a CodedTool "class" definition
+        #   2) Cannot use a Tool "toolbox" definition
         {
             "name": "searcher",
 
-            # Note that there are no parameters defined for this guy's "function" key.
-            # This is the primary way to identify this tool as a front-man,
-            # distinguishing it from the rest of the tools.
-
             "function": {
+                # The description acts as an initial prompt. 
                 "description": "Assist caller with searching an url.",
                 "parameters": {
                     "type": "object",


### PR DESCRIPTION
* Vet front man to be sure it does not have a class or toolbox definition
* Clearer assert if front man cannot be found
* Modify comments in hocon files to better reflect front-man criteria
* Modify comments in hocon files that do not actually apply to the situation.