### PR TITLE
Put in support for tests marked 'gemini'

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -29,6 +29,7 @@ jobs:
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
           AGENT_TOOL_PATH: "./neuro_san/coded_tools"
           PYTHONPATH: ${{ env.PYTHONPATH }}:.
         run: |

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ def configure_llm_provider_keys(request, monkeypatch):
 
     is_non_default = request.node.get_closest_marker("non_default_llm_provider")
     is_anthropic = request.node.get_closest_marker("anthropic")
+    is_gemini = request.node.get_closest_marker("gemini")
 
     if is_non_default:
         # For any non-default provider: clear OPENAI key to prevent accidental use
@@ -16,6 +17,11 @@ def configure_llm_provider_keys(request, monkeypatch):
         if is_anthropic:
             if not os.getenv("ANTHROPIC_API_KEY"):
                 pytest.skip("Missing ANTHROPIC_API_KEY for test marked 'anthropic'")
+        
+        if is_gemini:
+            if not os.getenv("GOOGLE_API_KEY"):
+                pytest.skip("Missing GOOGLE_API_KEY for test marked 'gemini'")
+
         else:
             pytest.skip("Unknown non-default provider; test requires explicit key handling.")
     else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,11 +17,9 @@ def configure_llm_provider_keys(request, monkeypatch):
         if is_anthropic:
             if not os.getenv("ANTHROPIC_API_KEY"):
                 pytest.skip("Missing ANTHROPIC_API_KEY for test marked 'anthropic'")
-        
         if is_gemini:
             if not os.getenv("GOOGLE_API_KEY"):
                 pytest.skip("Missing GOOGLE_API_KEY for test marked 'gemini'")
-
         else:
             pytest.skip("Unknown non-default provider; test requires explicit key handling.")
     else:


### PR DESCRIPTION
I've added the GOOGLE_API_KEY to our neuro-san repo and this PR provides the little bit of infrastructure to use that. @vince-leaf When you are ready, just add the 'gemini' mark to your new tests and it _should_ just work. 