### PR TITLE
UN-3305 Fix message processing on grpc when text is None

### DIFF
--- a/neuro_san/internals/filters/answer_message_filter.py
+++ b/neuro_san/internals/filters/answer_message_filter.py
@@ -40,9 +40,10 @@ class AnswerMessageFilter(MessageFilter):
             # whose origin length is the only one of length 1.
             return False
 
-        text = chat_message_dict.get("text")
-        if text is None:
-            # Final answers need to be text (for now).
+        text: str = chat_message_dict.get("text")
+        structure: Dict[str, Any] = chat_message_dict.get("structure")
+        if text is None and structure is None:
+            # Final answers need to be text or structure.
             # There might be more options in the future.
             return False
 

--- a/neuro_san/message_processing/basic_message_processor.py
+++ b/neuro_san/message_processing/basic_message_processor.py
@@ -88,6 +88,8 @@ class BasicMessageProcessor(CompositeMessageProcessor):
         structure: Dict[str, Any] = self.get_structure()
         if structure is not None:
             string_struct: str = json.dumps(structure, indent=4, sort_keys=True)
+            if compiled is None:
+                compiled = ""
             compiled += f"\n```json\n{string_struct}\n```"
 
         return compiled


### PR DESCRIPTION
@vince-leaf found a problem with the new structure stuff checked in earlier today where the client side was returning None for an answer for grpc only.

What is happening is:
* server infrastructure populates text as non-None empty string (len==0). (This allows direct and http to be fine)
* grpc marshaling turns an empty string into a None value over the wire
* Client side couldn't deal with None text value even though there was happy stuff in structure.