### PR TITLE
UN-3327 - Update neuro-san http server to allow the 'user_id' param.

### DIFF
--- a/neuro_san/service/http/handlers/base_request_handler.py
+++ b/neuro_san/service/http/handlers/base_request_handler.py
@@ -83,7 +83,7 @@ class BaseRequestHandler(RequestHandler):
         if os.environ.get("AGENT_ALLOW_CORS_HEADERS") is not None:
             self.set_header("Access-Control-Allow-Origin", "*")
             self.set_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
-            self.set_header("Access-Control-Allow-Headers", "Content-Type, Transfer-Encoding")
+            self.set_header("Access-Control-Allow-Headers", "Content-Type, Transfer-Encoding, User_id")
 
     def get_metadata(self) -> Dict[str, Any]:
         """


### PR DESCRIPTION
# Description

Update neuro-san http server to allow the 'user_id' param.

Tested this by pointing my local MAA UI with https://github.com/cognizant-ai-lab/neuro-ui/pull/66 to a local Neuro-San instance with this PR.