### PR TITLE
Un-3330 Set metadata keys from env variables.

### DIFF
--- a/neuro_san/service/http/handlers/base_request_handler.py
+++ b/neuro_san/service/http/handlers/base_request_handler.py
@@ -38,17 +38,6 @@ class BaseRequestHandler(RequestHandler):
     Provides logic to inject neuro-san service specific data
     into local handler context.
     """
-    grpc_to_http = {
-        grpc.StatusCode.INVALID_ARGUMENT: 400,
-        grpc.StatusCode.UNAUTHENTICATED: 401,
-        grpc.StatusCode.PERMISSION_DENIED: 403,
-        grpc.StatusCode.NOT_FOUND: 404,
-        grpc.StatusCode.ALREADY_EXISTS: 409,
-        grpc.StatusCode.INTERNAL: 500,
-        grpc.StatusCode.UNAVAILABLE: 503,
-        grpc.StatusCode.DEADLINE_EXCEEDED: 504
-    }
-
     request_id: int = 0
 
     # pylint: disable=attribute-defined-outside-init
@@ -83,7 +72,12 @@ class BaseRequestHandler(RequestHandler):
         if os.environ.get("AGENT_ALLOW_CORS_HEADERS") is not None:
             self.set_header("Access-Control-Allow-Origin", "*")
             self.set_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
-            self.set_header("Access-Control-Allow-Headers", "Content-Type, Transfer-Encoding, User_id")
+            headers: str = "Content-Type, Transfer-Encoding"
+            metadata_headers: str = ", ".join(forwarded_request_metadata)
+            if len(metadata_headers) > 0:
+                headers += f", {metadata_headers}"
+            # Set all allowed headers:
+            self.set_header("Access-Control-Allow-Headers", headers)
 
     def get_metadata(self) -> Dict[str, Any]:
         """
@@ -118,19 +112,6 @@ class BaseRequestHandler(RequestHandler):
             self.process_exception(exc)
             return False
 
-    def extract_grpc_error_info(self, exc: grpc.aio.AioRpcError) -> Tuple[int, str, str]:
-        """
-        Extract user-friendly information from gRPC exception
-        :param exc: gRPC service exception
-        :return: tuple of 3 values:
-            corresponding HTTP error code;
-            name of gRPC code;
-            string with additional error details.
-        """
-        code = exc.code()
-        http_code = BaseRequestHandler.grpc_to_http.get(code, 500)
-        return http_code, code.name, exc.details()
-
     def process_exception(self, exc: Exception):
         """
         Process exception raised during request handling
@@ -142,15 +123,6 @@ class BaseRequestHandler(RequestHandler):
             self.set_status(400)
             self.write({"error": "Invalid JSON format"})
             self.logger.error(self.get_metadata(), "error: Invalid JSON format")
-            return
-
-        if isinstance(exc, grpc.aio.AioRpcError):
-            http_status, err_name, err_details =\
-                self.extract_grpc_error_info(exc)
-            self.set_status(http_status)
-            err_msg: str = f"status: {http_status} grpc: {err_name} details: {err_details}"
-            self.write({"error": err_msg})
-            self.logger.error(self.get_metadata(), "Http server error: %s", err_msg)
             return
 
         # General exception case:

--- a/neuro_san/service/main_loop/server_main_loop.py
+++ b/neuro_san/service/main_loop/server_main_loop.py
@@ -118,8 +118,10 @@ class ServerMainLoop(ServerLoopCallbacks):
         self.max_concurrent_requests = args.max_concurrent_requests
         self.request_limit = args.request_limit
         self.forwarded_request_metadata = args.forwarded_request_metadata
+        if not self.forwarded_request_metadata:
+            self.forwarded_request_metadata = ""
         self.usage_logger_metadata = args.usage_logger_metadata
-        if len(self.usage_logger_metadata) == 0:
+        if not self.usage_logger_metadata:
             self.usage_logger_metadata = self.forwarded_request_metadata
         self.service_openapi_spec_file = args.openapi_service_spec_path
         self.manifest_update_period_seconds = args.manifest_update_period_seconds


### PR DESCRIPTION
This PR extends setup for server requests metadata keys by using both:
--forwarded_request_metadata CLI parameter (env var AGENT_FORWARDED_REQUEST_METADATA) and
--usage_logger_metadata CLI parameter (env var AGENT_USAGE_LOGGER_METADATA).
Final metadata keys set is a union of both collections.
If CORS headers are enabled for http server,
they are specified also as those combined metadata keys.

Tested by manual debug output of final metadata keys for various combinations of env variables.
