### PR TITLE
UN-3310 Faster server startup.

### DIFF
--- a/neuro_san/service/generic/agent_service_provider.py
+++ b/neuro_san/service/generic/agent_service_provider.py
@@ -1,0 +1,81 @@
+
+# Copyright (C) 2023-2025 Cognizant Digital Business, Evolutionary AI.
+# All Rights Reserved.
+# Issued under the Academic Public License.
+#
+# You can be released from the terms, and requirements of the Academic Public
+# License by purchasing a commercial license.
+# Purchase of a commercial license is mandatory for any use of the
+# neuro-san SDK Software in commercial settings.
+#
+# END COPYRIGHT
+
+from typing import Any
+from typing import Dict
+from threading import Lock
+import copy
+
+from leaf_server_common.server.request_logger import RequestLogger
+
+from neuro_san.service.generic.agent_service import AgentService
+from neuro_san.internals.interfaces.agent_network_provider import AgentNetworkProvider
+from neuro_san.service.generic.agent_server_logging import AgentServerLogging
+
+
+class AgentServiceProvider:
+    """
+    Class providing lazy construction of AgentService instance
+    with given constructor parameters.
+    """
+
+    # pylint: disable=too-many-arguments,too-many-positional-arguments
+    def __init__(self,
+                 request_logger: RequestLogger,
+                 security_cfg: Dict[str, Any],
+                 agent_name: str,
+                 agent_network_provider: AgentNetworkProvider,
+                 server_logging: AgentServerLogging):
+        """
+        Constructor.
+        :param request_logger: The instance of the RequestLogger that helps
+                    keep track of stats
+        :param security_cfg: A dictionary of parameters used to
+                        secure the TLS and the authentication of the gRPC
+                        connection.  Supplying this implies use of a secure
+                        GRPC Channel.  If None, uses insecure channel.
+        :param agent_name: The agent name for the service
+        :param agent_network_provider: The AgentNetworkProvider to use for the session.
+        :param server_logging: An AgentServerLogging instance initialized so that
+                        spawned asynchronous threads can also properly initialize
+                        their logging.
+        """
+        self.request_logger = request_logger
+        self.security_cfg = copy.deepcopy(security_cfg)
+        self.server_logging: AgentServerLogging = server_logging
+        self.agent_network_provider: AgentNetworkProvider = agent_network_provider
+        self.agent_name: str = agent_name
+        self.lock: Lock = Lock()
+        self.service_instance: AgentService = None
+
+    def get_service(self) -> AgentService:
+        """
+        Get service instance.
+        Create it if it is not instantiated yet.
+        """
+        if self.service_instance is None:
+            with self.lock:
+                if self.service_instance is None:
+                    self.service_instance = AgentService(
+                        self.request_logger,
+                        self.security_cfg,
+                        self.agent_name,
+                        self.agent_network_provider,
+                        self.server_logging)
+        return self.service_instance
+
+    def service_created(self) -> bool:
+        """
+        Return True if service instance has already been instantiated;
+               False otherwise
+        """
+        return self.service_instance is not None

--- a/neuro_san/service/generic/async_agent_service_provider.py
+++ b/neuro_san/service/generic/async_agent_service_provider.py
@@ -1,0 +1,80 @@
+
+# Copyright (C) 2023-2025 Cognizant Digital Business, Evolutionary AI.
+# All Rights Reserved.
+# Issued under the Academic Public License.
+#
+# You can be released from the terms, and requirements of the Academic Public
+# License by purchasing a commercial license.
+# Purchase of a commercial license is mandatory for any use of the
+# neuro-san SDK Software in commercial settings.
+#
+# END COPYRIGHT
+
+from typing import Any
+from typing import Dict
+from threading import Lock
+import copy
+
+from neuro_san.service.generic.async_agent_service import AsyncAgentService
+from neuro_san.internals.interfaces.agent_network_provider import AgentNetworkProvider
+from neuro_san.service.interfaces.event_loop_logger import EventLoopLogger
+from neuro_san.service.generic.agent_server_logging import AgentServerLogging
+
+
+class AsyncAgentServiceProvider:
+    """
+    Class providing lazy construction of AsyncAgentService instance
+    with given constructor parameters.
+    """
+
+    # pylint: disable=too-many-arguments,too-many-positional-arguments
+    def __init__(self,
+                 request_logger: EventLoopLogger,
+                 security_cfg: Dict[str, Any],
+                 agent_name: str,
+                 agent_network_provider: AgentNetworkProvider,
+                 server_logging: AgentServerLogging):
+        """
+        Constructor.
+        :param request_logger: The instance of the EventLoopLogger that helps
+                        log information from running event loop
+        :param security_cfg: A dictionary of parameters used to
+                        secure the TLS and the authentication of the gRPC
+                        connection.  Supplying this implies use of a secure
+                        GRPC Channel.  If None, uses insecure channel.
+        :param agent_name: The agent name for the service
+        :param agent_network_provider: The AgentNetworkProvider to use for the session.
+        :param server_logging: An AgentServerLogging instance initialized so that
+                        spawned asynchronous threads can also properly initialize
+                        their logging.
+        """
+        self.request_logger = request_logger
+        self.security_cfg = copy.deepcopy(security_cfg)
+        self.server_logging: AgentServerLogging = server_logging
+        self.agent_network_provider: AgentNetworkProvider = agent_network_provider
+        self.agent_name: str = agent_name
+        self.lock: Lock = Lock()
+        self.service_instance: AsyncAgentService = None
+
+    def get_service(self) -> AsyncAgentService:
+        """
+        Get service instance.
+        Create it if it is not instantiated yet.
+        """
+        if self.service_instance is None:
+            with self.lock:
+                if self.service_instance is None:
+                    self.service_instance = AsyncAgentService(
+                        self.request_logger,
+                        self.security_cfg,
+                        self.agent_name,
+                        self.agent_network_provider,
+                        self.server_logging)
+        return self.service_instance
+
+    def service_created(self) -> bool:
+        """
+        Return True if service instance has already been instantiated;
+               False otherwise
+        """
+        return self.service_instance is not None

--- a/neuro_san/service/http/handlers/connectivity_handler.py
+++ b/neuro_san/service/http/handlers/connectivity_handler.py
@@ -29,15 +29,8 @@ class ConnectivityHandler(BaseRequestHandler):
         Implementation of GET request handler for "connectivity" API call.
         """
         metadata: Dict[str, Any] = self.get_metadata()
-        update_done: bool = await self.update_agents(metadata=metadata)
-        if not update_done:
-            return
-
-        service: AsyncAgentService = self.agent_policy.allow(agent_name)
+        service: AsyncAgentService = await self.get_service(agent_name, metadata)
         if service is None:
-            self.set_status(404)
-            self.logger.error({}, "error: Invalid request path %s", self.request.path)
-            self.do_finish()
             return
 
         self.application.start_client_request(metadata, f"{agent_name}/connectivity")

--- a/neuro_san/service/http/handlers/function_handler.py
+++ b/neuro_san/service/http/handlers/function_handler.py
@@ -29,15 +29,8 @@ class FunctionHandler(BaseRequestHandler):
         Implementation of GET request handler for "function" API call.
         """
         metadata: Dict[str, Any] = self.get_metadata()
-        update_done: bool = await self.update_agents(metadata=metadata)
-        if not update_done:
-            return
-
-        service: AsyncAgentService = self.agent_policy.allow(agent_name)
+        service: AsyncAgentService = await self.get_service(agent_name, metadata)
         if service is None:
-            self.set_status(404)
-            self.logger.error({}, "error: Invalid request path %s", self.request.path)
-            self.do_finish()
             return
 
         self.application.start_client_request(metadata, f"{agent_name}/function")

--- a/neuro_san/service/http/handlers/streaming_chat_handler.py
+++ b/neuro_san/service/http/handlers/streaming_chat_handler.py
@@ -58,15 +58,8 @@ class StreamingChatHandler(BaseRequestHandler):
         """
 
         metadata: Dict[str, Any] = self.get_metadata()
-        update_done: bool = await self.update_agents(metadata=metadata)
-        if not update_done:
-            return
-
-        service: AsyncAgentService = self.agent_policy.allow(agent_name)
+        service: AsyncAgentService = await self.get_service(agent_name, metadata)
         if service is None:
-            self.set_status(404)
-            self.logger.error({}, "error: Invalid request path %s", self.request.path)
-            self.do_finish()
             return
 
         self.application.start_client_request(metadata, f"{agent_name}/streaming_chat")

--- a/neuro_san/service/http/server/http_sidecar.py
+++ b/neuro_san/service/http/server/http_sidecar.py
@@ -104,12 +104,12 @@ class HttpSidecar(AgentAuthorizer, AgentsUpdater):
                               self.TIMEOUT_TO_START_SECONDS)
 
         app.listen(self.http_port)
-        self.logger.info({}, "HTTP server is running on port %d", self.http_port)
-        self.logger.info({}, "HTTP server is shutting down after %d requests", self.requests_limit)
         # Construct initial "allowed" list of agents:
         # no metadata to use here yet.
         self.update_agents(metadata={})
         self.logger.debug({}, "Serving agents: %s", repr(self.allowed_agents.keys()))
+        self.logger.info({}, "HTTP server is running on port %d", self.http_port)
+        self.logger.info({}, "HTTP server is shutting down after %d requests", self.requests_limit)
 
         IOLoop.current().start()
         self.logger.info({}, "Http server stopped.")

--- a/neuro_san/service/http/server/http_sidecar.py
+++ b/neuro_san/service/http/server/http_sidecar.py
@@ -26,7 +26,7 @@ from neuro_san.interfaces.concierge_session import ConciergeSession
 from neuro_san.internals.network_providers.service_agent_network_storage import ServiceAgentNetworkStorage
 from neuro_san.internals.network_providers.single_agent_network_provider import SingleAgentNetworkProvider
 from neuro_san.service.generic.agent_server_logging import AgentServerLogging
-from neuro_san.service.generic.async_agent_service import AsyncAgentService
+from neuro_san.service.generic.async_agent_service_provider import AsyncAgentServiceProvider
 from neuro_san.service.http.handlers.health_check_handler import HealthCheckHandler
 from neuro_san.service.http.handlers.connectivity_handler import ConnectivityHandler
 from neuro_san.service.http.handlers.function_handler import FunctionHandler
@@ -84,7 +84,7 @@ class HttpSidecar(AgentAuthorizer, AgentsUpdater):
         self.logger = None
         self.openapi_service_spec_path: str = openapi_service_spec_path
         self.forwarded_request_metadata: List[str] = forwarded_request_metadata.split(" ")
-        self.allowed_agents: Dict[str, AsyncAgentService] = {}
+        self.allowed_agents: Dict[str, AsyncAgentServiceProvider] = {}
         self.lock = None
 
     def __call__(self, other_server: AgentServer):
@@ -138,7 +138,7 @@ class HttpSidecar(AgentAuthorizer, AgentsUpdater):
 
         return HttpServerApp(handlers, requests_limit, logger)
 
-    def allow(self, agent_name) -> AsyncAgentService:
+    def allow(self, agent_name) -> AsyncAgentServiceProvider:
         return self.allowed_agents.get(agent_name, None)
 
     def update_agents(self, metadata: Dict[str, Any]):
@@ -176,9 +176,14 @@ class HttpSidecar(AgentAuthorizer, AgentsUpdater):
         request_metadata_str: str = " ".join(self.forwarded_request_metadata)
         agent_server_logging: AgentServerLogging = \
             AgentServerLogging(self.server_name_for_logs, request_metadata_str)
-        agent_service: AsyncAgentService = \
-            AsyncAgentService(self.logger, None, agent_name, agent_network_provider, agent_server_logging)
-        self.allowed_agents[agent_name] = agent_service
+        agent_service_provider: AsyncAgentServiceProvider = \
+            AsyncAgentServiceProvider(
+                self.logger,
+                None,
+                agent_name,
+                agent_network_provider,
+                agent_server_logging)
+        self.allowed_agents[agent_name] = agent_service_provider
 
     def remove_agent(self, agent_name: str):
         """

--- a/neuro_san/service/http/server/http_sidecar.py
+++ b/neuro_san/service/http/server/http_sidecar.py
@@ -107,11 +107,11 @@ class HttpSidecar(AgentAuthorizer, AgentsUpdater):
                               "Timeout (%d sec) waiting for signal to HTTP server to start",
                               self.TIMEOUT_TO_START_SECONDS)
 
-        app.listen(self.http_port)
         # Construct initial "allowed" list of agents:
         # no metadata to use here yet.
         self.update_agents(metadata={})
         self.logger.debug({}, "Serving agents: %s", repr(self.allowed_agents.keys()))
+        app.listen(self.http_port)
         self.logger.info({}, "HTTP server is running on port %d", self.http_port)
         self.logger.info({}, "HTTP server is shutting down after %d requests", self.requests_limit)
 


### PR DESCRIPTION
Main idea of this PR is switch to "lazy" service instances instantiation.
Right now, we always create service instances - 2 of them in fact for each agent defined in server manifest;
one for gRPC, one for http, even if say we don't use gRPC for this particular server invocation,
and only use a single agent for chat.
Each service creation involves reading at least 2 files, which adds up.
Changing to service instantiation on demand makes server start up much faster.
There is an initial lag of course for loading all Python classes, but nothing to be done for that I guess.
