### PR TITLE
Add notion of timestamps to AgentNetworkStorage

### DIFF
--- a/neuro_san/internals/network_providers/agent_network_storage.py
+++ b/neuro_san/internals/network_providers/agent_network_storage.py
@@ -58,7 +58,7 @@ class AgentNetworkStorage:
         """
         is_new: bool = False
         with self.lock:
-            is_new = self.agents_table.get(agent_name, None) is None
+            is_new = self.agents_table.get(agent_name) is None
             self.agents_table[agent_name] = agent_network
             self.last_modified = time.time()
 


### PR DESCRIPTION
* Add timestamp to know when AgentNetworkStorage last changed
* Use the timestamp(s) in HttpSidecar to do less work on each request.  Grpc has different mechanism entirely (listener)

This should make each and every HTTP request faster, helping us to scale up in terms of number of agents.

@andreidenissov-cog : Please look for opportunities for race conditions.
I think I am good, but you might see something I do not.

Tested math_guy_passthrough over http with mods with AGENT_MANIFEST_UPDATE_PERIOD_SECONDS=5