### PR TITLE
Updated to use langchain 0.3.15 as a minimum release.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ hvac>=1.1.0
 # For LLM access
 # Keep all these guys pinned for now, as it is the wild wild west out there
 # and we don't want to be on a dependencies treadmill with timing not of our choosing.
-langchain>=0.3.7,<0.4
+langchain>=0.3.15,<0.4
 langchain-anthropic>=0.3.11,<0.4
 langchain-community>=0.3.19,<0.4
 langchain-google-genai>=2.0.11,<3.0


### PR DESCRIPTION
Blackduck is flagging langchain 0.3.10 as an issue. It advises 0.3.15 as the minimum fix. I updated the requirements.txt to specify 0.3.15 as the minimum for langchain. 