### PR TITLE
Send the source of the message to the AgentStateListener

### DIFF
--- a/neuro_san/internals/interfaces/agent_state_listener.py
+++ b/neuro_san/internals/interfaces/agent_state_listener.py
@@ -9,6 +9,8 @@
 # neuro-san SDK Software in commercial settings.
 #
 # END COPYRIGHT
+from typing import Any
+
 
 class AgentStateListener:
     """
@@ -16,23 +18,26 @@ class AgentStateListener:
     when an agent is being added or removed from the service.
     """
 
-    def agent_added(self, agent_name: str):
+    def agent_added(self, agent_name: str, source: Any):
         """
         Agent is being added to the service.
         :param agent_name: name of an agent
+        :param source: The AgentNetworkStorage source of the message
         """
         raise NotImplementedError
 
-    def agent_modified(self, agent_name: str):
+    def agent_modified(self, agent_name: str, source: Any):
         """
         Existing agent has been modified in service scope.
         :param agent_name: name of an agent
+        :param source: The AgentNetworkStorage source of the message
         """
         raise NotImplementedError
 
-    def agent_removed(self, agent_name: str):
+    def agent_removed(self, agent_name: str, source: Any):
         """
         Agent is being removed from the service.
         :param agent_name: name of an agent
+        :param source: The AgentNetworkStorage source of the message
         """
         raise NotImplementedError

--- a/neuro_san/internals/interfaces/agent_state_listener.py
+++ b/neuro_san/internals/interfaces/agent_state_listener.py
@@ -9,7 +9,8 @@
 # neuro-san SDK Software in commercial settings.
 #
 # END COPYRIGHT
-from typing import Any
+
+from neuro_san.internals.interfaces.agent_storage_source import AgentStorageSource
 
 
 class AgentStateListener:
@@ -18,26 +19,26 @@ class AgentStateListener:
     when an agent is being added or removed from the service.
     """
 
-    def agent_added(self, agent_name: str, source: Any):
+    def agent_added(self, agent_name: str, source: AgentStorageSource):
         """
         Agent is being added to the service.
         :param agent_name: name of an agent
-        :param source: The AgentNetworkStorage source of the message
+        :param source: The AgentStorageSource source of the message
         """
         raise NotImplementedError
 
-    def agent_modified(self, agent_name: str, source: Any):
+    def agent_modified(self, agent_name: str, source: AgentStorageSource):
         """
         Existing agent has been modified in service scope.
         :param agent_name: name of an agent
-        :param source: The AgentNetworkStorage source of the message
+        :param source: The AgentStorageSource source of the message
         """
         raise NotImplementedError
 
-    def agent_removed(self, agent_name: str, source: Any):
+    def agent_removed(self, agent_name: str, source: AgentStorageSource):
         """
         Agent is being removed from the service.
         :param agent_name: name of an agent
-        :param source: The AgentNetworkStorage source of the message
+        :param source: The AgentStorageSource source of the message
         """
         raise NotImplementedError

--- a/neuro_san/internals/interfaces/agent_storage_source.py
+++ b/neuro_san/internals/interfaces/agent_storage_source.py
@@ -1,0 +1,25 @@
+# Copyright (C) 2023-2025 Cognizant Digital Business, Evolutionary AI.
+# All Rights Reserved.
+# Issued under the Academic Public License.
+#
+# You can be released from the terms, and requirements of the Academic Public
+# License by purchasing a commercial license.
+# Purchase of a commercial license is mandatory for any use of the
+# neuro-san SDK Software in commercial settings.
+#
+# END COPYRIGHT
+
+from neuro_san.internals.interfaces.agent_network_provider import AgentNetworkProvider
+
+
+class AgentStorageSource:
+    """
+    Interface onto AgentNetworkStorage so that there is not a tangle with the service side.
+    """
+
+    def get_agent_network_provider(self, agent_name: str) -> AgentNetworkProvider:
+        """
+        Get AgentNetworkProvider for a specific agent
+        :param agent_name: name of an agent
+        """
+        raise NotImplementedError

--- a/neuro_san/internals/network_providers/agent_network_storage.py
+++ b/neuro_san/internals/network_providers/agent_network_storage.py
@@ -17,10 +17,11 @@ from typing import List
 from neuro_san.internals.graph.registry.agent_network import AgentNetwork
 from neuro_san.internals.interfaces.agent_network_provider import AgentNetworkProvider
 from neuro_san.internals.interfaces.agent_state_listener import AgentStateListener
+from neuro_san.internals.interfaces.agent_storage_source import AgentStorageSource
 from neuro_san.internals.network_providers.single_agent_network_provider import SingleAgentNetworkProvider
 
 
-class AgentNetworkStorage:
+class AgentNetworkStorage(AgentStorageSource):
     """
     Service-wide storage for AgentNetworkProviders containing
     a table of currently active AgentNetworks for each agent registered to the service.

--- a/neuro_san/internals/network_providers/agent_network_storage.py
+++ b/neuro_san/internals/network_providers/agent_network_storage.py
@@ -61,10 +61,10 @@ class AgentNetworkStorage:
         # do it outside of internal lock
         for listener in self.listeners:
             if is_new:
-                listener.agent_added(agent_name)
+                listener.agent_added(agent_name, self)
                 self.logger.info("ADDED network for agent %s", agent_name)
             else:
-                listener.agent_modified(agent_name)
+                listener.agent_modified(agent_name, self)
                 self.logger.info("REPLACED network for agent %s", agent_name)
 
     def setup_agent_networks(self, agent_networks: Dict[str, AgentNetwork]):
@@ -92,7 +92,7 @@ class AgentNetworkStorage:
         # Notify listeners about this state change:
         # do it outside of internal lock
         for listener in self.listeners:
-            listener.agent_removed(agent_name)
+            listener.agent_removed(agent_name, self)
         self.logger.info("REMOVED network for agent %s", agent_name)
 
     def get_agent_network_provider(self, agent_name: str) -> AgentNetworkProvider:


### PR DESCRIPTION
This is in preparation for > 1 source of AgentStateListener messages.  For now there is only the one public source.

Tested: math_guy_passthrough with switching agent hocon definitions.