### PR TITLE
UN-3347 gRPC/http services separate enable/disable switch.

### DIFF
--- a/neuro_san/service/grpc/grpc_agent_server.py
+++ b/neuro_san/service/grpc/grpc_agent_server.py
@@ -184,7 +184,7 @@ class GrpcAgentServer(AgentServer, AgentStateListener):
         """
         Start serving gRPC requests
         """
-        self.server_status.set_grpc_status(True)
+        self.server_status.grpc_service.set_status(True)
         self.server_lifetime.run()
 
     def stop(self):

--- a/neuro_san/service/http/server/http_server.py
+++ b/neuro_san/service/http/server/http_server.py
@@ -106,7 +106,7 @@ class HttpServer(AgentAuthorizer, AgentStateListener):
 
         self.logger.debug({}, "Serving agents: %s", repr(self.allowed_agents.keys()))
         app.listen(self.http_port)
-        self.server_status.set_http_status(True)
+        self.server_status.http_service.set_status(True)
         self.logger.info({}, "HTTP server is running on port %d", self.http_port)
         self.logger.info({}, "HTTP server is shutting down after %d requests", self.requests_limit)
 

--- a/neuro_san/service/main_loop/server_main_loop.py
+++ b/neuro_san/service/main_loop/server_main_loop.py
@@ -21,6 +21,7 @@ import threading
 from argparse import ArgumentParser
 
 from leaf_server_common.server.server_loop_callbacks import ServerLoopCallbacks
+from leaf_server_common.logging.logging_setup import setup_logging
 
 from neuro_san.interfaces.agent_session import AgentSession
 from neuro_san.internals.graph.persistence.registry_manifest_restorer import RegistryManifestRestorer
@@ -190,6 +191,12 @@ class ServerMainLoop(ServerLoopCallbacks):
             self.grpc_server.prepare_for_serving()
 
         if self.server_status.updater.is_requested():
+            if not self.server_status.grpc_service.is_requested():
+                current_dir: str = os.path.dirname(os.path.abspath(__file__))
+                setup_logging(self.server_status.updater.get_service_name(),
+                              current_dir,
+                              'AGENT_SERVICE_LOG_JSON',
+                              'AGENT_SERVICE_LOG_LEVEL')
             manifest_file: str = self.manifest_files[0]
             updater: ManifestPeriodicUpdater =\
                 ManifestPeriodicUpdater(

--- a/neuro_san/service/main_loop/server_status.py
+++ b/neuro_san/service/main_loop/server_status.py
@@ -10,6 +10,9 @@
 #
 # END COPYRIGHT
 
+from neuro_san.service.main_loop.service_status import ServiceStatus
+
+
 class ServerStatus:
     """
     Class for registering and reporting overall status of the server,
@@ -21,27 +24,9 @@ class ServerStatus:
         Constructor.
         """
         self.server_name: str = server_name
-        self.grpc_service_ready: bool = False
-        self.http_service_ready: bool = False
-        self.updater_ready: bool = False
-
-    def set_grpc_status(self, status: bool):
-        """
-        Set the status of gRPC service
-        """
-        self.grpc_service_ready = status
-
-    def set_http_status(self, status: bool):
-        """
-        Set the status of http service
-        """
-        self.http_service_ready = status
-
-    def set_updater_status(self, status: bool):
-        """
-        Set the status of dynamic agents registry updater
-        """
-        self.updater_ready = status
+        self.grpc_service: ServiceStatus = ServiceStatus("gRPC")
+        self.http_service: ServiceStatus = ServiceStatus("http")
+        self.updater: ServiceStatus = ServiceStatus("updater")
 
     def is_server_live(self) -> bool:
         """
@@ -54,8 +39,10 @@ class ServerStatus:
         """
         Return "ready" status for the server
         """
-        # If somebody calls this, we are at least alive
-        return self.grpc_service_ready and self.http_service_ready and self.updater_ready
+        return \
+            (not self.grpc_service.is_requested() or self.grpc_service.is_ready()) and \
+            (not self.http_service.is_requested() or self.http_service.is_ready()) and \
+            (not self.updater.is_requested() or self.updater.is_ready())
 
     def get_server_name(self) -> str:
         """

--- a/neuro_san/service/main_loop/service_status.py
+++ b/neuro_san/service/main_loop/service_status.py
@@ -1,0 +1,55 @@
+
+# Copyright (C) 2023-2025 Cognizant Digital Business, Evolutionary AI.
+# All Rights Reserved.
+# Issued under the Academic Public License.
+#
+# You can be released from the terms, and requirements of the Academic Public
+# License by purchasing a commercial license.
+# Purchase of a commercial license is mandatory for any use of the
+# neuro-san SDK Software in commercial settings.
+#
+# END COPYRIGHT
+
+class ServiceStatus:
+    """
+    Class for registering and reporting overall status of the service,
+    primarily for interaction with external deployment environment.
+    """
+
+    def __init__(self, service_name: str):
+        """
+        Constructor.
+        """
+        self.service_name: str = service_name
+        self.service_requested: bool = True
+        self.service_ready: bool = False
+
+    def set_status(self, status: bool):
+        """
+        Set the status of a service
+        """
+        self.service_ready = status
+
+    def is_ready(self) -> bool:
+        """
+        True if service is ready
+        """
+        return self.service_ready
+
+    def set_requested(self, requested: bool):
+        """
+        Set if a service is requested by neuro-san server.
+        """
+        self.service_requested = requested
+
+    def is_requested(self) -> bool:
+        """
+        True if service is requested.
+        """
+        return self.service_requested
+
+    def get_service_name(self) -> str:
+        """
+        Return service name
+        """
+        return self.service_name

--- a/neuro_san/service/registries_watcher/periodic_updater/manifest_periodic_updater.py
+++ b/neuro_san/service/registries_watcher/periodic_updater/manifest_periodic_updater.py
@@ -66,7 +66,7 @@ class ManifestPeriodicUpdater:
             # We should not run at all.
             return
         while self.go_run:
-            self.server_status.set_updater_status(True)
+            self.server_status.updater.set_status(True)
             time.sleep(self.update_period_seconds)
             # Check events that may have been triggered in target registry:
             modified, added, deleted = self.observer.reset_event_counters()


### PR DESCRIPTION
This PR adds logic to separately enable or disable services we run in neuro-san server:
gRPC, http and manifest updater.
ServerStatus class is extended to use ServiceStatus instances for each service we run.

Tested: running neuro-san with different combinations of enabled services.
