### PR TITLE
Fix syntax error in UsageLogger metadata parsing

### DIFF
--- a/neuro_san/service/usage/wrapped_usage_logger.py
+++ b/neuro_san/service/usage/wrapped_usage_logger.py
@@ -118,7 +118,7 @@ class WrappedUsageLogger(UsageLogger):
         if keys_string is None or len(keys_string) == 0:
             return minimized
 
-        keys: List[str] = keys_string.split[" "]
+        keys: List[str] = keys_string.split(" ")
         for key in keys:
             if key is None or len(key) == 0:
                 # Skip any empty key split from the list. Allows for multi-spaces.


### PR DESCRIPTION
## Bug Fix

Fixes a critical syntax error in `WrappedUsageLogger.minimize_metadata()` that was introduced in PR #285.

### Problem
- Line 108 had incorrect syntax: `keys_string.split[" "]` 
- Should be: `keys_string.split(" ")`
- This caused request metadata filtering to fail silently
- When `AGENT_USAGE_LOGGER_METADATA` was set, it caused internal server errors
- Request metadata was always empty `{}` instead of containing `user_id`, `request_id`, etc.

### Solution
- Fixed the syntax error from `split[" "]` to `split(" ")`
- Now properly parses the environment variable and filters metadata
- UsageLogger now receives correct request metadata as intended

### Testing
- Verified with HTTP requests containing `user_id` and `request_id` headers
- Confirmed metadata now appears correctly in UsageLogger
- No more internal server errors

### Files Changed
- `neuro_san/service/usage/wrapped_usage_logger.py` - Fixed split syntax

Closes: Issue caused by PR #285