### PR TITLE
UN-3349 Neuro-SAN: Error raised when llm_config is omitted, despite being optional

### DIFF
--- a/neuro_san/internals/graph/activations/calling_activation.py
+++ b/neuro_san/internals/graph/activations/calling_activation.py
@@ -85,8 +85,6 @@ class CallingActivation(AbstractCallableActivation, ToolCaller):
         overlayer = DictionaryOverlay()
         llm_config = agent_network_config.get("llm_config", empty)
         llm_config = overlayer.overlay(llm_config, spec_llm_config)
-        if len(llm_config.keys()) == 0:
-            llm_config = None
 
         run_context_config: Dict[str, Any] = {
             "context_type": agent_network_config.get("context_type"),

--- a/neuro_san/internals/run_context/factory/run_context_factory.py
+++ b/neuro_san/internals/run_context/factory/run_context_factory.py
@@ -61,7 +61,7 @@ class RunContextFactory:
             "model_name": "gpt-4o",
             "verbose": False
         }
-        default_llm_config = use_config.get("llm_config", default_llm_config)
+        default_llm_config = use_config.get("llm_config") or default_llm_config
 
         # Prepare for sanity in checks below
         context_type: str = MasterLlmFactory.get_context_type(use_config)


### PR DESCRIPTION
### Cause

An `AttributeError` was raised when accessing `.get()` on `self.llm_config`, which was unexpectedly `None`. This happened because an empty `llm_config` in the HOCON config was being explicitly set to `None` in `calling_activation.py`, preventing the fallback logic in `run_context_factory.py` from applying the intended default configuration.

### Fix

- Removed the logic in `calling_activation.py` that sets `llm_config = None` when it is an empty dictionary.

- Updated `run_context_factory.py` to defensively fallback to the default config if `"llm_config"` is `None`, using:

```python
default_llm_config = use_config.get("llm_config") or default_llm_config
```

These changes ensure that the default LLM configuration is correctly applied when `llm_config` is missing or empty.

Please see https://leaf-ai.atlassian.net/jira/software/projects/UN/boards/51?jql=assignee%20%3D%20712020%3A18936e39-4dc4-4f08-9367-268d8c089417&selectedIssue=UN-3349 for more detail.