### PR TITLE
UN-3355 Let through some specific asserts for AsyncHttpServiceAgentSession.streaming_chat()

### DIFF
--- a/neuro_san/session/async_http_service_agent_session.py
+++ b/neuro_san/session/async_http_service_agent_session.py
@@ -115,7 +115,7 @@ class AsyncHttpServiceAgentSession(AbstractHttpServiceAgentSession, AsyncAgentSe
                             yield result_dict
 
         except (asyncio.TimeoutError, ClientOSError) as exc:
-            # Pass on a couple of asserts that are known to represent 
+            # Pass on a couple of asserts that are known to represent
             # real problems that a client has to deal with.
             # We figure this is OK for streaming_chat() because normally
             # in order to get to using streaming_chat() clients will most


### PR DESCRIPTION
Let some specific asyncio-oriented asserts through so well-constructed clients can retry on them.
These cases were found by 1C stress tests.