### PR TITLE
UN-3360 Fix the HttpServer logger crash.

### DIFF
--- a/neuro_san/service/http/handlers/base_request_handler.py
+++ b/neuro_san/service/http/handlers/base_request_handler.py
@@ -83,9 +83,20 @@ class BaseRequestHandler(RequestHandler):
         from incoming request.
         :return: dictionary of user request metadata; possibly empty
         """
-        headers: Dict[str, Any] = self.request.headers
+        return BaseRequestHandler.get_request_metadata(self.request, self.forwarded_request_metadata)
+
+    @classmethod
+    def get_request_metadata(cls, request, forwarded_request_metadata: List[str]) -> Dict[str, Any]:
+        """
+        Extract user metadata defined by forwarded_request_metadata list
+        from incoming request.
+        :param request: incoming http request
+        :param forwarded_request_metadata: list of metadata keys
+        :return: dictionary of user request metadata; possibly empty
+        """
+        headers: Dict[str, Any] = request.headers
         result: Dict[str, Any] = {}
-        for item_name in self.forwarded_request_metadata:
+        for item_name in forwarded_request_metadata:
             if item_name in headers.keys():
                 result[item_name] = headers[item_name]
             elif item_name == "request_id":

--- a/neuro_san/service/http/server/http_server.py
+++ b/neuro_san/service/http/server/http_server.py
@@ -144,7 +144,7 @@ class HttpServer(AgentAuthorizer, AgentStateListener):
         handlers.append((r"/api/v1/([^/]+)/connectivity", ConnectivityHandler, request_initialize_data))
         handlers.append((r"/api/v1/([^/]+)/streaming_chat", StreamingChatHandler, request_initialize_data))
 
-        return HttpServerApp(handlers, requests_limit, logger)
+        return HttpServerApp(handlers, requests_limit, logger, self.forwarded_request_metadata)
 
     def allow(self, agent_name) -> AsyncAgentServiceProvider:
         return self.allowed_agents.get(agent_name, None)


### PR DESCRIPTION
This PR fixes a crash in neuro-san http server when we try to log an error in incoming request.
(Error code 404 for example).
Along the way, I added some extra logging logic for "standard" Tornado ErrorHandler to display client metadata together with other request parameters. Helpful for debugging the source of a problem.
