### PR TITLE
UN-3357 Add separate check for internal errors in langchain stack.

### DIFF
--- a/neuro_san/internals/run_context/langchain/core/langchain_run_context.py
+++ b/neuro_san/internals/run_context/langchain/core/langchain_run_context.py
@@ -495,14 +495,17 @@ class LangChainRunContext(RunContext):
             try:
                 return_dict: Dict[str, Any] = await agent_executor.ainvoke(inputs, invoke_config)
             except (OpenAI_APIError, Anthropic_APIError, ChatGoogleGenerativeAIError) as api_error:
-                message: str = ApiKeyErrorCheck.check_for_api_key_exception(api_error)
+                backtrace = traceback.format_exc()
+                message: str = None
+                if not ApiKeyErrorCheck.check_for_internal_error(backtrace):
+                    # Does not look like internal LLM stack error:
+                    message = ApiKeyErrorCheck.check_for_api_key_exception(api_error)
                 if message is not None:
                     raise ValueError(message) from api_error
-
+                # Continue with regular retry logic:
                 self.logger.warning("retrying from {api_error.__class__.__name__}")
                 retries = retries - 1
                 exception = api_error
-                backtrace = traceback.format_exc()
             except KeyError as key_error:
                 self.logger.warning("retrying from KeyError")
                 retries = retries - 1

--- a/neuro_san/internals/run_context/langchain/util/api_key_error_check.py
+++ b/neuro_san/internals/run_context/langchain/util/api_key_error_check.py
@@ -40,6 +40,8 @@ API_KEY_DOCUMENTATION: Dict[str, List] = {
     "AZURE_OPENAI_DEPLOYMENT_NAME": AZURE_DOCUMENTATION,
 }
 
+INTERNAL_ERRORS_LIST: List[str] = ["bound to a different event loop"]
+
 
 class ApiKeyErrorCheck:
     """
@@ -85,3 +87,18 @@ Some things to try:
 """
 
         return None
+
+    @staticmethod
+    def check_for_internal_error(exception_traceback: str) -> bool:
+        """
+        Check if exception traceback points to some internal LLM stack problem,
+        not necessarily related to API keys being absent or invalid.
+        This function used as an additional check while using check_for_api_key_exception()
+        :param exception_traceback: exception traceback string;
+        :return: True if exception seems to be caused by some internal problems,
+                 False otherwise
+        """
+        for err_msg in INTERNAL_ERRORS_LIST:
+            if err_msg in exception_traceback:
+                return True
+        return False


### PR DESCRIPTION
This PR is an attempt to neutralize a crash in LLM service stack I'm seeing when running my neuro-san stability tests,
which pretty repeatedly fail to finish now.
Essence of the problem:
a crash happens somewhere deep inside a stack and it is actually a RuntimeError ("bound to to different event loop" or something);
but while going up the call stack, it transforms into ConnectionError, which we treat specially:
we abort retry attempts and produce a helpful message to a client which in this case is very misleading.
So what I do: we try to examine not only the "final" exception, but the whole exception backtrace in search of keywords pointing to the real problem ("event loop" in our case). If these keywords are found, we fall back to general logic of running several retries.
Result: with this fix/hack, my stability tests run again: 5 concurrent clients x 30 x 3 requests, 3 http clients + 2 gRPC.
With wrong API key specified, we still have expected behaviour.

