### PR TITLE
UN-3352 Add synchronous flag to AsyncCollatingQueue.put() to be very clear as to what's going on

### DIFF
--- a/neuro_san/deploy/Dockerfile
+++ b/neuro_san/deploy/Dockerfile
@@ -191,7 +191,7 @@ ENV AGENT_REQUEST_LIMIT=-1
 # agent registry files could be added or deleted from registry directory
 # with corresponding changes in manifest file.
 # Update will be done every AGENT_MANIFEST_UPDATE_PERIOD_SECONDS seconds;
-# if value is not specified or <= 0, no dynamic updates will be executed.
+# if value is not specified or <= 0, no such dynamic updates will be executed.
 ENV AGENT_MANIFEST_UPDATE_PERIOD_SECONDS=0
 
 # By default, the HTTP service reports the neuro-san library pip version in its health-check response.

--- a/neuro_san/internals/journals/message_journal.py
+++ b/neuro_san/internals/journals/message_journal.py
@@ -51,4 +51,8 @@ class MessageJournal(Journal):
 
         # Queue Producer from this:
         #   https://stackoverflow.com/questions/74130544/asyncio-yielding-results-from-multiple-futures-as-they-arrive
-        await self.hopper.put(message_dict)
+        # The synchronous=True is necessary when an async HTTP request is at the get()-ing end of the queue,
+        # as the journal messages come from inside a separate event loop from that request. The lock
+        # taken here ends up being harmless in the synchronous request case (like for gRPC) because
+        # we would only be blocking our own event loop.
+        await self.hopper.put(message_dict, synchronous=True)

--- a/neuro_san/internals/network_providers/agent_network_storage.py
+++ b/neuro_san/internals/network_providers/agent_network_storage.py
@@ -9,10 +9,11 @@
 #
 # END COPYRIGHT
 
-import logging
-import threading
 from typing import Dict
 from typing import List
+
+import logging
+import threading
 
 from neuro_san.internals.graph.registry.agent_network import AgentNetwork
 from neuro_san.internals.interfaces.agent_network_provider import AgentNetworkProvider
@@ -56,8 +57,9 @@ class AgentNetworkStorage(AgentStorageSource):
         """
         is_new: bool = False
         with self.lock:
-            is_new = self.agents_table.get(agent_name, None) is None
+            is_new = self.agents_table.get(agent_name) is None
             self.agents_table[agent_name] = agent_network
+
         # Notify listeners about this state change:
         # do it outside of internal lock
         for listener in self.listeners:
@@ -90,6 +92,7 @@ class AgentNetworkStorage(AgentStorageSource):
         """
         with self.lock:
             self.agents_table.pop(agent_name, None)
+
         # Notify listeners about this state change:
         # do it outside of internal lock
         for listener in self.listeners:


### PR DESCRIPTION
I was looking to re-use AsyncCollatingQueue and I found something I thought to be suspicious:
an asynchronous call put() was putting something in the queue synchronously.
After some digging, I found this to be OK, but its usage needed to be made much more up-front than was currently done.

A couple other minor tweaks.

Tested: http chicken scenario. All agent_thinking comes over as expected.