### PR TITLE
Fix possible bug leading to wrong error message when instantiating LLM

### DIFF
--- a/neuro_san/internals/run_context/langchain/llms/default_llm_factory.py
+++ b/neuro_san/internals/run_context/langchain/llms/default_llm_factory.py
@@ -36,7 +36,6 @@ from neuro_san.internals.run_context.langchain.util.api_key_error_check import A
 from neuro_san.internals.run_context.langchain.util.argument_validator import ArgumentValidator
 from neuro_san.internals.utils.resolver_util import ResolverUtil
 
-DEFAULT_LLM_CLASSES: Set[str] = {"anthropic", "azure-openai", "bedrock", "gemini", "ollama", "openai", "nvidia"}
 KEYS_TO_REMOVE_FOR_USER_CLASS: Set[str] = {"class", "verbose"}
 
 
@@ -315,10 +314,11 @@ class DefaultLlmFactory(ContextTypeLlmFactory, LangChainLlmFactory):
         # This fallback only applies when the user provides a non-default class path
         # and factory resolution failed.
         class_path: str = config.get("class")
+        default_llm_classes: Set[str] = set(self.llm_infos.get("classes"))
         if (
             llm is None
             and found_exception is not None
-            and class_path not in DEFAULT_LLM_CLASSES
+            and class_path not in default_llm_classes
         ):
             llm = self.create_base_chat_model_from_user_class(class_path, config)
             found_exception = None

--- a/neuro_san/internals/run_context/langchain/llms/default_llm_factory.py
+++ b/neuro_san/internals/run_context/langchain/llms/default_llm_factory.py
@@ -36,7 +36,7 @@ from neuro_san.internals.run_context.langchain.util.api_key_error_check import A
 from neuro_san.internals.run_context.langchain.util.argument_validator import ArgumentValidator
 from neuro_san.internals.utils.resolver_util import ResolverUtil
 
-DEFAULT_LLM_CLASS: Set[str] = {"anthropic", "azure-openai", "bedrock", "gemini", "ollama", "openai", "nvidia"}
+DEFAULT_LLM_CLASSES: Set[str] = {"anthropic", "azure-openai", "bedrock", "gemini", "ollama", "openai", "nvidia"}
 KEYS_TO_REMOVE_FOR_USER_CLASS: Set[str] = {"class", "verbose"}
 
 
@@ -318,7 +318,7 @@ class DefaultLlmFactory(ContextTypeLlmFactory, LangChainLlmFactory):
         if (
             llm is None
             and found_exception is not None
-            and class_path not in DEFAULT_LLM_CLASS
+            and class_path not in DEFAULT_LLM_CLASSES
         ):
             llm = self.create_base_chat_model_from_user_class(class_path, config)
             found_exception = None

--- a/neuro_san/internals/run_context/langchain/llms/default_llm_factory.py
+++ b/neuro_san/internals/run_context/langchain/llms/default_llm_factory.py
@@ -36,6 +36,7 @@ from neuro_san.internals.run_context.langchain.util.api_key_error_check import A
 from neuro_san.internals.run_context.langchain.util.argument_validator import ArgumentValidator
 from neuro_san.internals.utils.resolver_util import ResolverUtil
 
+DEFAULT_LLM_CLASS: Set[str] = {"anthropic", "azure-openai", "bedrock", "gemini", "ollama", "openai", "nvidia"}
 KEYS_TO_REMOVE_FOR_USER_CLASS: Set[str] = {"class", "verbose"}
 
 
@@ -304,9 +305,21 @@ class DefaultLlmFactory(ContextTypeLlmFactory, LangChainLlmFactory):
                 # Let the next model have a crack
                 found_exception = exception
 
-        # Try resolving via 'class' in config if factories failed
+        # Try resolving via "class" in config if llm factories failed
+        #
+        # Note: config["class"] is always set — if the user intended to use a default LLMs,
+        # it will point to a known default like "openai" or "bedrock". In those cases,
+        # we avoid re-resolving it here to prevent masking the original error with
+        # a new one from create_base_chat_model_from_user_class.
+        #
+        # This fallback only applies when the user provides a non-default class path
+        # and factory resolution failed.
         class_path: str = config.get("class")
-        if llm is None and found_exception is not None and class_path:
+        if (
+            llm is None
+            and found_exception is not None
+            and class_path not in DEFAULT_LLM_CLASS
+        ):
             llm = self.create_base_chat_model_from_user_class(class_path, config)
             found_exception = None
 


### PR DESCRIPTION
This PR improves error handling during LLM instantiation when factory-based resolution fails.

### Problem:

When all `llm_factories` fail to create an LLM, we fallback to using the `"class"` value in the config to attempt instantiation via a user-defined class. However, `"class"` is always set — even for factory-backed models like `"openai"` or `"bedrock"`.

If we blindly attempt to resolve these default classes again via `create_base_chat_model_from_user_class`, it can raise a secondary error that masks the original factory error, making debugging much harder.

### Fix:

Add a check to skip fallback resolution if `config["class"]` is one of the default classes.

This ensures we preserve and raise the original, meaningful exception instead of a misleading one from reprocessing default class paths.