### PR TITLE
UN-3376 For langchain tools, make sure the UI knows that the communication between those nodes has been completed

### DIFF
--- a/neuro_san/internals/run_context/langchain/core/langchain_run_context.py
+++ b/neuro_san/internals/run_context/langchain/core/langchain_run_context.py
@@ -190,12 +190,10 @@ class LangChainRunContext(RunContext):
 
         self.agent = self.create_agent_with_fallbacks(prompt_template)
 
-    def create_agent_with_fallbacks(self, prompt_template: ChatPromptTemplate,
-                                    callbacks: List[BaseCallbackHandler] = None) -> Agent:
+    def create_agent_with_fallbacks(self, prompt_template: ChatPromptTemplate) -> Agent:
         """
         Creates an agent with potential fallback llms to use.
         :param prompt_template: The ChatPromptTemplate to use for the agent
-        :param callbacks: The list of callbacks to use when creating any LLM via the factory
         :return: An Agent (Runnable)
         """
         # Initialize our return value
@@ -215,7 +213,7 @@ class LangChainRunContext(RunContext):
         for index, fallback in enumerate(fallbacks):
 
             # Create a model we might use.
-            one_llm: BaseLanguageModel = llm_factory.create_llm(fallback, callbacks=callbacks)
+            one_llm: BaseLanguageModel = llm_factory.create_llm(fallback)
             one_agent: Agent = self.create_agent(prompt_template, one_llm)
 
             if index == 0:

--- a/neuro_san/internals/run_context/langchain/core/langchain_run_context.py
+++ b/neuro_san/internals/run_context/langchain/core/langchain_run_context.py
@@ -446,7 +446,7 @@ class LangChainRunContext(RunContext):
         base_journal: Journal = self.invocation_context.get_journal()
         origination: Origination = self.invocation_context.get_origination()
         callbacks: List[BaseCallbackHandler] = [
-            JournalingCallbackHandler(base_journal, self.journal, parent_origin, origination)
+            JournalingCallbackHandler(self.journal, base_journal, parent_origin, origination)
         ]
         # Consult the agent spec for level of verbosity as it pertains to callbacks.
         agent_spec: Dict[str, Any] = self.tool_caller.get_agent_tool_spec()

--- a/neuro_san/internals/run_context/langchain/journaling/journaling_callback_handler.py
+++ b/neuro_san/internals/run_context/langchain/journaling/journaling_callback_handler.py
@@ -22,8 +22,11 @@ from langchain_core.documents import Document
 from langchain_core.outputs import LLMResult
 from langchain_core.outputs.chat_generation import ChatGeneration
 
+from neuro_san.internals.journals.journal import Journal
 from neuro_san.internals.journals.originating_journal import OriginatingJournal
+from neuro_san.internals.messages.origination import Origination
 from neuro_san.internals.messages.agent_message import AgentMessage
+from neuro_san.internals.run_context.interfaces.run_context import RunContext
 
 
 # pylint: disable=too-many-ancestors
@@ -52,12 +55,13 @@ class JournalingCallbackHandler(AsyncCallbackHandler):
     # a non-pydantic Journal as a member, we need to do this.
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
-    def __init__(self, journal: OriginatingJournal):
+    def __init__(self, run_context: RunContext, journal: OriginatingJournal):
         """
         Constructor
 
         :param journal: The journal to write messages to
         """
+        self.run_context: RunContext = run_context
         self.journal: OriginatingJournal = journal
 
     async def on_llm_end(self, response: LLMResult,
@@ -66,11 +70,13 @@ class JournalingCallbackHandler(AsyncCallbackHandler):
         # have a generations field which is a list of lists. Inside that inner list,
         # the first object is a ChatGeneration, whose text field tends to have agent
         # thinking in it.
+        print(f"\n\n{response=}\n\n")
         generations = response.generations[0]
         first_generation = generations[0]
         if isinstance(first_generation, ChatGeneration):
             content: str = first_generation.text
             if content is not None and len(content) > 0:
+                print(f"\n\n{content=}\n\n")
                 # Package up the thinking content as an AgentMessage to stream
                 message = AgentMessage(content=content.strip())
                 # Some AGENT messages that come from this source end up being dupes
@@ -83,19 +89,42 @@ class JournalingCallbackHandler(AsyncCallbackHandler):
         # print(f"In on_chain_end() with {outputs}")
         return
 
+    async def on_tool_start(self, serialized, input_str, *, run_id, parent_run_id = None, tags = None, metadata = None, inputs = None, **kwargs):
+        print(f"\n\n{serialized=}\n\n")
+        print(f"\n\n{input_str=}\n\n")
+        print(f"\n\n{inputs=}\n\n")
+        print(f"\n\n{kwargs=}\n\n")
+
     async def on_tool_end(self, output: Any,
                           **kwargs: Any) -> None:
-        # print(f"In on_tool_end() with {output}")
-        return
+        print(f"\n\nIn on_tool_end() with {output}\n\n")
+        print(f"\n\noutput_{kwargs=}\n\n")
+        print(f"\n\n{kwargs.get("name")=}\n\n")
+        if isinstance(output, str):
+            agent_name = kwargs.get("name")
+            # 1. Get the base journal from invocation context
+            base_journal: Journal = self.run_context.invocation_context.get_journal()
+
+            # 2. Build the origin path
+            parent_origin = self.run_context.get_origin()
+            print(f"\n\njournal_{parent_origin=}\n\n")
+            # agent_name: str = self.run_context.tool_caller.get_name()
+            origination: Origination = self.run_context.invocation_context.get_origination()
+            origin = origination.add_spec_name_to_origin(parent_origin, agent_name)
+            print(f"\n\njournal_{origin=}\n\n")
+
+            # # 3. Create the OriginatingJournal
+            journal = OriginatingJournal(base_journal, origin)
+            await journal.write_message(AgentMessage(output))
 
     async def on_agent_action(self, action: AgentAction,
                               **kwargs: Any) -> None:
-        # print(f"In on_agent_action() with {action}")
+        print(f"In on_agent_action() with {action}")
         return
 
     async def on_agent_finish(self, finish: AgentFinish,
                               **kwargs: Any) -> None:
-        # print(f"In on_agent_finish() with {finish}")
+        print(f"In on_agent_finish() with {finish}")
         return
 
     async def on_retriever_end(self, documents: Sequence[Document],

--- a/neuro_san/internals/run_context/langchain/journaling/journaling_callback_handler.py
+++ b/neuro_san/internals/run_context/langchain/journaling/journaling_callback_handler.py
@@ -59,24 +59,24 @@ class JournalingCallbackHandler(AsyncCallbackHandler):
 
     def __init__(
             self,
-            base_journal: Journal,
             calling_agent_journal: Journal,
+            base_journal: Journal,
             parent_origin: List[Dict[str, Any]],
             origination: Origination
     ):
         """
         Constructor
 
+        :param calling_agent_journal: The journal of the calling agent
         :param base_journal: The Journal instance that allows message reporting during the course of the AgentSession.
             This is used to construct the langchain_tool_journal.
-        :param calling_agent_journal: The journal of the calling agent
         :param parent_origin: A List of origin dictionaries indicating the origin of the run
             This is used to construct the langchain_tool_journal.
         :param origination: The Origination instance carrying state about tool instantation
             during the course of the AgentSession. This is used to construct the langchain_tool_journal.
         """
-        self.base_journal: Journal = base_journal
         self.calling_agent_journal: Journal = calling_agent_journal
+        self.base_journal: Journal = base_journal
         self.parent_origin: List[Dict[str, Any]] = parent_origin
         self.origination: Origination = origination
         self.langchain_tool_journal: Journal = None

--- a/neuro_san/internals/run_context/langchain/journaling/journaling_callback_handler.py
+++ b/neuro_san/internals/run_context/langchain/journaling/journaling_callback_handler.py
@@ -75,6 +75,16 @@ class JournalingCallbackHandler(AsyncCallbackHandler):
         :param origination: The Origination instance carrying state about tool instantation
             during the course of the AgentSession. This is used to construct the langchain_tool_journal.
         """
+
+        # The calling-agent journal logs the execution flow from the perspective of the agent invoking the tool
+        # (e.g., MusicNerdPro). In contrast, the LangChain tool journal represents the tool's own execution
+        # context—similar to how coded tools like Accountant have their own journal tied to their run context.
+
+        # LangChain tools don’t instantiate their own RunContext, so they lack a dedicated journal by default.
+        # To maintain consistency with how other tools are tracked, we explicitly create a langchain_tool_journal
+        # when the tool starts. This ensures tool-specific inputs and outputs are captured independently,
+        # while still allowing the calling agent to log its own perspective.
+
         self.calling_agent_journal: Journal = calling_agent_journal
         self.base_journal: Journal = base_journal
         self.parent_origin: List[Dict[str, Any]] = parent_origin

--- a/neuro_san/internals/run_context/langchain/journaling/journaling_callback_handler.py
+++ b/neuro_san/internals/run_context/langchain/journaling/journaling_callback_handler.py
@@ -12,6 +12,7 @@
 from collections.abc import Sequence
 from typing import Any
 from typing import Dict
+from typing import List
 
 from pydantic import ConfigDict
 
@@ -19,6 +20,8 @@ from langchain_core.agents import AgentAction
 from langchain_core.agents import AgentFinish
 from langchain_core.callbacks.base import AsyncCallbackHandler
 from langchain_core.documents import Document
+from langchain_core.messages.ai import AIMessage
+from langchain_core.messages.base import BaseMessage
 from langchain_core.outputs import LLMResult
 from langchain_core.outputs.chat_generation import ChatGeneration
 
@@ -26,7 +29,6 @@ from neuro_san.internals.journals.journal import Journal
 from neuro_san.internals.journals.originating_journal import OriginatingJournal
 from neuro_san.internals.messages.origination import Origination
 from neuro_san.internals.messages.agent_message import AgentMessage
-from neuro_san.internals.run_context.interfaces.run_context import RunContext
 
 
 # pylint: disable=too-many-ancestors
@@ -55,14 +57,29 @@ class JournalingCallbackHandler(AsyncCallbackHandler):
     # a non-pydantic Journal as a member, we need to do this.
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
-    def __init__(self, run_context: RunContext, journal: OriginatingJournal):
+    def __init__(
+            self,
+            base_journal: Journal,
+            calling_agent_journal: Journal,
+            parent_origin: List[Dict[str, Any]],
+            origination: Origination
+    ):
         """
         Constructor
 
-        :param journal: The journal to write messages to
+        :param base_journal: The Journal instance that allows message reporting during the course of the AgentSession.
+            This is used to construct the langchain_tool_journal.
+        :param calling_agent_journal: The journal of the calling agent
+        :param parent_origin: A List of origin dictionaries indicating the origin of the run
+            This is used to construct the langchain_tool_journal.
+        :param origination: The Origination instance carrying state about tool instantation
+            during the course of the AgentSession. This is used to construct the langchain_tool_journal.
         """
-        self.run_context: RunContext = run_context
-        self.journal: OriginatingJournal = journal
+        self.base_journal: Journal = base_journal
+        self.calling_agent_journal: Journal = calling_agent_journal
+        self.parent_origin: List[Dict[str, Any]] = parent_origin
+        self.origination: Origination = origination
+        self.langchain_tool_journal: Journal = None
 
     async def on_llm_end(self, response: LLMResult,
                          **kwargs: Any) -> None:
@@ -70,61 +87,92 @@ class JournalingCallbackHandler(AsyncCallbackHandler):
         # have a generations field which is a list of lists. Inside that inner list,
         # the first object is a ChatGeneration, whose text field tends to have agent
         # thinking in it.
-        print(f"\n\n{response=}\n\n")
         generations = response.generations[0]
         first_generation = generations[0]
         if isinstance(first_generation, ChatGeneration):
             content: str = first_generation.text
             if content is not None and len(content) > 0:
-                print(f"\n\n{content=}\n\n")
                 # Package up the thinking content as an AgentMessage to stream
                 message = AgentMessage(content=content.strip())
                 # Some AGENT messages that come from this source end up being dupes
                 # of AI messages that can come later.
                 # Use this method to put the message on hold for later comparison.
-                await self.journal.write_message_if_next_not_dupe(message)
+                await self.calling_agent_journal.write_message_if_next_not_dupe(message)
 
     async def on_chain_end(self, outputs: Dict[str, Any],
                            **kwargs: Any) -> None:
         # print(f"In on_chain_end() with {outputs}")
         return
 
-    async def on_tool_start(self, serialized, input_str, *, run_id, parent_run_id = None, tags = None, metadata = None, inputs = None, **kwargs):
-        print(f"\n\n{serialized=}\n\n")
-        print(f"\n\n{input_str=}\n\n")
-        print(f"\n\n{inputs=}\n\n")
-        print(f"\n\n{kwargs=}\n\n")
+    async def on_tool_start(
+        self,
+        serialized: Dict[str, Any],
+        input_str: str,
+        tags: List[str] = None,
+        inputs: Dict[str, Any] = None,
+        **kwargs: Any
+    ) -> None:
+        """
+        Callback triggered when a tool starts execution.
 
-    async def on_tool_end(self, output: Any,
-                          **kwargs: Any) -> None:
-        print(f"\n\nIn on_tool_end() with {output}\n\n")
-        print(f"\n\noutput_{kwargs=}\n\n")
-        print(f"\n\n{kwargs.get("name")=}\n\n")
-        if isinstance(output, str):
-            agent_name = kwargs.get("name")
-            # 1. Get the base journal from invocation context
-            base_journal: Journal = self.run_context.invocation_context.get_journal()
+        If the tool is identified as a LangChain tool (via the "langchain_tool" tag),
+        this method creates a journal entry containing the tool's input arguments,
+        origin metadata, and full tool name.
 
-            # 2. Build the origin path
-            parent_origin = self.run_context.get_origin()
-            print(f"\n\njournal_{parent_origin=}\n\n")
-            # agent_name: str = self.run_context.tool_caller.get_name()
-            origination: Origination = self.run_context.invocation_context.get_origination()
-            origin = origination.add_spec_name_to_origin(parent_origin, agent_name)
-            print(f"\n\njournal_{origin=}\n\n")
+        :param serialized: Serialized representation of the tool, including its name and description.
+        :param input_str: String representation of the tool's input.
+        :param tags: List of tags associated with the tool. Used to determine whether it is a LangChain tool.
+        :param inputs: Structured dictionary of input arguments
+            passed to the tool.
+        """
 
-            # # 3. Create the OriginatingJournal
-            journal = OriginatingJournal(base_journal, origin)
-            await journal.write_message(AgentMessage(output))
+        if "langchain_tool" in tags:
+
+            # Extract tool name from the serialized data
+            agent_name: str = serialized.get("name")
+
+            # Build the origin path
+            origin: List[Dict[str, Any]] = self.origination.add_spec_name_to_origin(self.parent_origin, agent_name)
+            full_name: str = self.origination.get_full_name_from_origin(origin)
+
+            # Combine the original tool inputs with origin metadata
+            combined_args: Dict[str, Any] = inputs.copy()
+            combined_args["origin"] = origin
+            combined_args["origin_str"] = full_name
+
+            # Create a journal entry for this invocation and log the combined inputs
+            self.langchain_tool_journal = OriginatingJournal(self.base_journal, origin)
+            message: BaseMessage = AgentMessage(content=f"Received arguments {combined_args}")
+            await self.langchain_tool_journal.write_message(message)
+
+    async def on_tool_end(self, output: Any, tags: List[str] = None, **kwargs: Any) -> None:
+        """
+        Callback triggered when a tool finishes execution.
+
+        If the tool is identified as a LangChain tool (via the "langchain_tool" tag),
+        this method logs the tool's output to both the calling agent's journal and the
+        LangChain tool's specific journal.
+
+        :param output: The result produced by the tool after execution.
+        :param tags: List of tags associated with the tool. Used to determine whether it is a LangChain tool.
+        """
+
+        if "langchain_tool" in tags:
+            # Log the tool output to the calling agent's journal
+            await self.calling_agent_journal.write_message(AIMessage(content=output))
+
+            # Also log the tool output to the LangChain tool-specific journal
+            message: BaseMessage = AgentMessage(content=f"Got result: {output}")
+            await self.langchain_tool_journal.write_message(message)
 
     async def on_agent_action(self, action: AgentAction,
                               **kwargs: Any) -> None:
-        print(f"In on_agent_action() with {action}")
+        # print(f"In on_agent_action() with {action}")
         return
 
     async def on_agent_finish(self, finish: AgentFinish,
                               **kwargs: Any) -> None:
-        print(f"In on_agent_finish() with {finish}")
+        # print(f"In on_agent_finish() with {finish}")
         return
 
     async def on_retriever_end(self, documents: Sequence[Document],

--- a/neuro_san/internals/run_context/langchain/toolbox/toolbox_factory.py
+++ b/neuro_san/internals/run_context/langchain/toolbox/toolbox_factory.py
@@ -130,6 +130,11 @@ class ToolboxFactory(ContextTypeToolboxFactory):
                  - A list of tools if "class of "tool_name points to a BaseToolkit class.
                  - A dict of tool's "description" and "parameters" if tool_name points to a CodedTool
         """
+
+        # agent_name is required when the tool is used as an internal agent.
+        # However, tools from the toolbox could potentially be used as external tools,
+        # in which case agent_name may not be needed.
+
         empty: Dict[str, Any] = {}
 
         tool_info: Dict[str, Any] = self.toolbox_infos.get(tool_name)

--- a/neuro_san/internals/run_context/langchain/toolbox/toolbox_factory.py
+++ b/neuro_san/internals/run_context/langchain/toolbox/toolbox_factory.py
@@ -116,13 +116,16 @@ class ToolboxFactory(ContextTypeToolboxFactory):
     def create_tool_from_toolbox(
             self,
             tool_name: str,
-            user_args: Dict[str, Any] = None
+            user_args: Dict[str, Any] = None,
+            agent_name: str = None
     ) -> Union[BaseTool, Dict[str, Any], List[BaseTool]]:
         """
         Resolves dependencies and instantiates the requested tool.
 
         :param tool_name: The name of the tool to instantiate.
         :param user_args: Arguments provided by the user, which override the config file.
+        :param agent_name: The name of the agent to prefix each BaseTool's name in BaseToolkit with,
+            ensuring tool names are unique and traceable to their agent.
         :return: - Instantiated tool if "class" of tool_name points to a BaseTool class
                  - A list of tools if "class of "tool_name points to a BaseToolkit class.
                  - A dict of tool's "description" and "parameters" if tool_name points to a CodedTool
@@ -168,8 +171,18 @@ class ToolboxFactory(ContextTypeToolboxFactory):
 
         # If the instantiated class has "get_tools()", assume it's a toolkit and return a list of tools
         if hasattr(instance, "get_tools") and callable(instance.get_tools):
-            return instance.get_tools()
+            toolkit: List[BaseTool] = instance.get_tools()
+            for tool in toolkit:
+                # Prefix the name of the agent to each tool
+                tool.name = f"{agent_name}_{tool.name}"
+                # Add "langchain_tool" tags so journal callback can idenitify it
+                tool.tags = ["langchain_tool"]
+            return toolkit
 
+        # Replace langchain tool's name with agent name
+        instance.name = agent_name
+        # Add "langchain_tool" tags so journal callback can idenitify it
+        instance.tags = ["langchain_tool"]
         return instance
 
     def _resolve_args(self, args: Dict[str, Any]) -> Dict[str, Any]:

--- a/neuro_san/internals/run_context/langchain/toolbox/toolbox_factory.py
+++ b/neuro_san/internals/run_context/langchain/toolbox/toolbox_factory.py
@@ -173,14 +173,16 @@ class ToolboxFactory(ContextTypeToolboxFactory):
         if hasattr(instance, "get_tools") and callable(instance.get_tools):
             toolkit: List[BaseTool] = instance.get_tools()
             for tool in toolkit:
-                # Prefix the name of the agent to each tool
-                tool.name = f"{agent_name}_{tool.name}"
+                if agent_name:
+                    # Prefix the name of the agent to each tool
+                    tool.name = f"{agent_name}_{tool.name}"
                 # Add "langchain_tool" tags so journal callback can idenitify it
                 tool.tags = ["langchain_tool"]
             return toolkit
 
-        # Replace langchain tool's name with agent name
-        instance.name = agent_name
+        if agent_name:
+            # Replace langchain tool's name with agent name
+            instance.name = agent_name
         # Add "langchain_tool" tags so journal callback can idenitify it
         instance.tags = ["langchain_tool"]
         return instance

--- a/tests/neuro_san/internals/run_context/langchain/toolbox/test_toolbox_factory.py
+++ b/tests/neuro_san/internals/run_context/langchain/toolbox/test_toolbox_factory.py
@@ -54,6 +54,8 @@ class TestBaseToolFactory:
             mock_resolver.return_value = mock_tool_class
 
             mock_instance = MagicMock(spec=BaseTool)
+            mock_instance.name = MagicMock(spec=str)
+            mock_instance.tags = MagicMock(spec=list)
             mock_tool_class.return_value = mock_instance
 
             tool = factory.create_tool_from_toolbox("test_tool", user_args)
@@ -90,7 +92,13 @@ class TestBaseToolFactory:
             mock_resolver.return_value = mock_toolkit_class
 
             mock_instance = MagicMock()
-            mock_tools = [MagicMock(spec=BaseTool), MagicMock(spec=BaseTool)]
+            mock_tool_1 = MagicMock(spec=BaseTool)
+            mock_tool_1.name = MagicMock(spec=str)
+            mock_tool_1.tags = MagicMock(spec=list)
+            mock_tool_2 = MagicMock(spec=BaseTool)
+            mock_tool_2.name = MagicMock(spec=str)
+            mock_tool_2.tags = MagicMock(spec=list)
+            mock_tools = [mock_tool_1, mock_tool_2]
             mock_instance.get_tools.return_value = mock_tools
             mock_toolkit_class.return_value = mock_instance
 
@@ -134,7 +142,11 @@ class TestBaseToolFactory:
 
             # Mock get_tools() returning a list of tools
             mock_tool_1 = MagicMock(spec=BaseTool)
+            mock_tool_1.name = MagicMock(spec=str)
+            mock_tool_1.tags = MagicMock(spec=list)
             mock_tool_2 = MagicMock(spec=BaseTool)
+            mock_tool_2.name = MagicMock(spec=str)
+            mock_tool_2.tags = MagicMock(spec=list)
             mock_toolkit_instance.get_tools.return_value = [mock_tool_1, mock_tool_2]
 
             # Call the factory method

--- a/tests/neuro_san/internals/run_context/langchain/toolbox/test_toolbox_factory.py
+++ b/tests/neuro_san/internals/run_context/langchain/toolbox/test_toolbox_factory.py
@@ -25,7 +25,7 @@ VALIDATIOR_PATH = (
 )
 
 
-class TestBaseToolFactory:
+class TestToolboxFactory:
     """Simplified test suite for ToolboxFactory."""
 
     @pytest.fixture


### PR DESCRIPTION
### Summary

This PR introduces a proof of concept for logging (journaling) output from a LangChain tool using a callback-based approach.

### Problem

For coded tools, journaling is handled within the activation class. However, LangChain tools are subclasses of LangChain’s `BaseTool`, and do not invoke our custom implementation (`LangchainOpenaiFunctionTool`) that creates an activation class and handles logging. As a result:

- No journal is created for LangChain tools.

- There is no clear indication when such a tool finishes execution.

### Solution

Leverage `JournalingCallbackHandler`, which defines `on_tool_start()` and `on_tool_end()`—methods that are triggered at the start and end of tool execution.

Previously, callbacks were passed as arguments when instantiating the LLM, which limited their use to LLM-related events (e.g., `on_llm_end()`). By instead using the **invoke config**, callbacks can now respond to a broader set of events, including tool-level events like `on_tool_start()` and `on_tool_end()`.

### Changes

- `ToolboxFactory.create_tool_from_toolbox()`
    
    - Added `agent_name` argument to override or prefix the LangChain tool name. This supports naming for single-tool agents and for agents with toolkits.

    - Added `"langchain_tool"` tag to identify tools that should trigger journaling.

- `JournalingCallbackHandler`
    
    - `__init__`:

        - Renamed `journal` to `calling_agent_journal`.

        - Added new parameters: `base_journal`, `parent_origin`, and `origination`.

    - `on_tool_start`:

        - Checks for the `"langchain_tool"` tag.

        - Creates a `langchain_tool_journal` and logs the tool’s input.

        - Prevents double journaling for coded or branch tools.

    - `on_tool_end`:

        - Logs the tool's output to both the `calling_agent_journal` and the `langchain_tool_journal`.

- `LangChainRunContext`
    - Moved callback assignment from `create_resources()` to `wait_from_run()` to ensure proper callback usage for tools as well as LLMs.

- 'TestToolboxFactory`: Added attribute `name` and `tags` to mock tools.

### Tests

Tested by running the following agents and inspecting their corresponding thinking files to verify tool-level logging:

- `bing_search`

- `music_nerd_pro`

- `music_nerd_pro_multi_agent`

Confirmed that:

- Tool input is logged at the start (`on_tool_start`)

- Tool output is logged at the end (`on_tool_end`)

- Journals are correctly scoped and do not duplicate entries for coded or branch tools

### Future Development

This callback-based approach could be extended to handle journaling for coded tools, branch tools, and other tool types—providing a unified and consistent logging mechanism across tool types.

