### PR TITLE
Add unit test coverage stats when running regular unit tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,7 @@ jobs:
         shell: bash
         run: |
           build_scripts/server_start.sh
-          pytest --verbose -m "not integration and not smoke" --timer-top-n 10 -n auto
+          pytest --verbose -m "not integration and not smoke" --timer-top-n 10 -n auto --cov=neuro_san
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           AGENT_TOOL_PATH: "./neuro_san/coded_tools"


### PR DESCRIPTION
It's possible we can add this to other kinds of tests too (integration, smoke), but first things first.

We are at 50% overall coverage. Not bad given that there's a bunch of stuff that is very difficult to unit test.
Some specific areas have 100%, others have 0%.  The stuff that is 0% tends to be about server, interfaces, or CodedTool code that are not exercised during regular unit tests, but do have coverage in other ways, so 50% is actually a very low estimate.