### PR TITLE
UN-3425 Duplicate outputs in thinking file for Anthropic models

### DIFF
--- a/neuro_san/internals/run_context/langchain/core/langchain_run_context.py
+++ b/neuro_san/internals/run_context/langchain/core/langchain_run_context.py
@@ -523,7 +523,7 @@ class LangChainRunContext(RunContext):
                     exception = value_error
                     backtrace = traceback.format_exc()
 
-        output: Union[str, List[str]] = None
+        output: Union[str, List[Dict[str, Any]]] = None
         if return_dict is None and exception is not None:
             output = f"Agent stopped due to exception {exception}"
         else:


### PR DESCRIPTION
### Problem

When using Anthropic models, the thinking file shows duplicate outputs. For example:

```markdown
[AI]:
{'running_cost': 3.0}

[AGENT]:
{
    "answer": "The Beatles wrote and recorded 'Yellow Submarine' for their 1966 album 'Revolver'. The song was primarily written by Paul McCartney (though credited to Lennon-McCartney, as was their standard practice), and it was sung by Ringo Starr. It's a playful, childlike tune that became a beloved track, particularly popular with younger listeners. The song was also featured in the animated film of the same name in 1968, which further cemented its place in pop culture history. 

Interesting trivia: While the song sounds whimsical, it was actually recorded with multiple additional musicians and sound effects, including a group of friends and Beatles staff members who were invited to the studio to create the singalong chorus, giving it that communal, jovial feel.",
    "running_cost": 3.00
}

[AI]:
{
    "answer": "The Beatles wrote and recorded 'Yellow Submarine' for their 1966 album 'Revolver'. The song was primarily written by Paul McCartney (though credited to Lennon-McCartney, as was their standard practice), and it was sung by Ringo Starr. It's a playful, childlike tune that became a beloved track, particularly popular with younger listeners. The song was also featured in the animated film of the same name in 1968, which further cemented its place in pop culture history. 

Interesting trivia: While the song sounds whimsical, it was actually recorded with multiple additional musicians and sound effects, including a group of friends and Beatles staff members who were invited to the studio to create the singalong chorus, giving it that communal, jovial feel.",
    "running_cost": 3.00
}
```

This creates confusion and bloats the journal.

### Root Cause

In the logic below:

```python
# Avoid cases where two different kinds of message hold the same content.
if self.pending.content != message.content:
    await self.wrapped_journal.write_message(self.pending, use_origin)
```

- `self.pending.content` (set by JournalingCallbackHandler.on_llm_end) is a string from `ChatGeneration.text`.

- `message.content` (from `LangchainRunContext.ainvoke()`) is a list of dicts for Anthropic models.

Because the types differ, they are never equal, triggering the journal to redundantly write the agent message, even though its content duplicates the AI message.

### Fix

In `LangchainRunContext.ainvoke()`:

- If the output is a list, extract the string portion before creating the `AIMessage`.

This ensures content comparisons are accurate and prevents duplicated messages.

### Tests

Ran the following flows and verified thinking file contents

- `music_nerd_pro`

- `music_nerd_pro_llm_anthropic`

- `music_nerd_pro_llm_gemini`

- `music_nerd_pro_llm_ollama`

Confirmed that duplicate entries no longer appear when using Anthropic models.