### PR TITLE
UN-3406 Multiple frontman error when branch also has no parameters

### DIFF
--- a/neuro_san/internals/graph/registry/agent_network.py
+++ b/neuro_san/internals/graph/registry/agent_network.py
@@ -128,10 +128,8 @@ No front man found for the {self.name} agent network.
 
 The front man is the first agent listed under the "tools" section of your agent HOCON file.
 However, the front man must not be:
-
-- A CodedTool (i.e., an agent defined with a "class" field)
-
-- A toolbox agent (i.e., defined with a "toolbox" field)
+* A CodedTool (i.e., an agent defined with a "class" field)
+* A toolbox agent (i.e., defined with a "toolbox" field)
 """)
 
         # The front-man is the first agent that is not coded tool ("class")

--- a/neuro_san/internals/graph/registry/agent_network.py
+++ b/neuro_san/internals/graph/registry/agent_network.py
@@ -101,26 +101,26 @@ Some things to try:
     def find_front_man(self) -> str:
         """
         :return: A single tool name to use as the root of the chat agent.
-                 This guy will be user facing.  If there are none or > 1,
+                 This guy will be user facing. If there are none,
                  an exception will be raised.
         """
 
-        # Initially all agents are front-man candidates.
-        front_men: List[str] = list(self.agent_spec_map.keys())
+        # List all agents in the same order as agent network HOCON.
+        agent_list: List[str] = list(self.agent_spec_map.keys())
 
         # Check for validity of our front-man candidates.
-        valid_front_men: List[str] = copy(front_men)
-        for front_man in front_men:
+        valid_front_men: List[str] = copy(agent_list)
+        for agent in agent_list:
 
             # Check the agent spec of the front man for validity
-            agent_spec: Dict[str, Any] = self.get_agent_tool_spec(front_man)
+            agent_spec: Dict[str, Any] = self.get_agent_tool_spec(agent)
 
             if agent_spec.get("class") is not None:
                 # Currently, front man cannot be a coded tool
-                valid_front_men.remove(front_man)
+                valid_front_men.remove(agent)
             elif agent_spec.get("toolbox") is not None:
                 # Currently, front man cannot from a toolbox
-                valid_front_men.remove(front_man)
+                valid_front_men.remove(agent)
 
         if len(valid_front_men) == 0:
             raise ValueError(f"""

--- a/neuro_san/internals/graph/registry/agent_network.py
+++ b/neuro_san/internals/graph/registry/agent_network.py
@@ -126,11 +126,12 @@ Some things to try:
             raise ValueError(f"""
 No front man found for the {self.name} agent network.
 
-The agent is the first listed among the "tools" of your agent hocon file
+The front man is the first agent listed under the "tools" section of your agent HOCON file.
+However, the front man must not be:
 
-Disqualifiers. A front man cannot:
-* be a CodedTool with a "class" definition
-* be a tool with a "toolbox" definition
+- A CodedTool (i.e., an agent defined with a "class" field)
+
+- A toolbox agent (i.e., defined with a "toolbox" field)
 """)
 
         # The front-man is the first agent that is not coded tool ("class")


### PR DESCRIPTION
### Change

- Change logic of `AgentNetwork.find_front_man()` so that the first agent that is not coded tool or toolbox is the front man.

### Test

- Ran `music_nerd_pro_multi_agents` and confirmed correct front man selection.