### PR TITLE
UN-3427 Updated model name on Anthropic test case

### DIFF
--- a/neuro_san/registries/music_nerd_pro_llm_anthropic.hocon
+++ b/neuro_san/registries/music_nerd_pro_llm_anthropic.hocon
@@ -15,7 +15,7 @@
 
 {
     "llm_config": {
-        "model_name": "claude-3-5-haiku",
+        "model_name": "claude-3-7-sonnet",
     },
     "tools": [
         # These tool definitions do not have to be in any particular order

--- a/neuro_san/registries/music_nerd_pro_llm_ollama.hocon
+++ b/neuro_san/registries/music_nerd_pro_llm_ollama.hocon
@@ -83,7 +83,7 @@ Once you receive the updated running cost, respond with a JSON object that has e
             "name": "Accountant",
             "function": {
                 "description": """
-You are an API that keeps track of the running cost of the MusicNerdPro service. Pass the current running cost
+You are an API that keeps track of the ruhttps://leaf-ai.atlassian.net/browse/UN-2785ning cost of the MusicNerdPro service. Pass the current running cost
 to the API to get the updated running cost. If no running cost it known, pass 0.00.
                 """,
                 "parameters": {


### PR DESCRIPTION
The new neuro-san-studio user's guide has been updated with a new model on the Anthropic model name example. Since Bedrock is using this newer model, we want this test case to use the same model to be consistent.
