### PR TITLE
UN-3428 Change temperature of openai class in llm hocon to null to match the default value of ChatOpenAI

### DIFF
--- a/neuro_san/internals/run_context/langchain/llms/default_llm_info.hocon
+++ b/neuro_san/internals/run_context/langchain/llms/default_llm_info.hocon
@@ -810,7 +810,7 @@
             "args": {
                 # Note that we can only supply arguments that are "Just Data" in nature.
                 # See https://python.langchain.com/api_reference/openai/chat_models/langchain_openai.chat_models.base.ChatOpenAI.html
-                "temperature": 0.7,
+                "temperature": null,
                 "openai_api_key": null,
                 "openai_api_base": null,
                 "openai_organization": null,


### PR DESCRIPTION
Reference:
https://python.langchain.com/api_reference/openai/chat_models/langchain_openai.chat_models.base.ChatOpenAI.html#langchain_openai.chat_models.base.ChatOpenAI.temperature