### PR TITLE
UN-3389 Agent Network metadata tags for grouping

### DIFF
--- a/docs/agent_hocon_reference.md
+++ b/docs/agent_hocon_reference.md
@@ -353,6 +353,8 @@ A string description of the agent network.
 #### tags
 
 A list of strings that describe grouping attributes of the agent network.
+The idea here is that any given server can describe groupings of agent networks
+however it wants to.
 
 ## Single Agent Specification
 

--- a/docs/agent_hocon_reference.md
+++ b/docs/agent_hocon_reference.md
@@ -40,7 +40,7 @@ Sub-keys to those dictionaries will be described in the next-level down heading 
 - [Single Agent Specification](#single-agent-specification)
     - [name](#name)
     - [function](#function)
-        - [description](#description)
+        - [description](#description-1)
         - [parameters](#parameters)
             - [type](#type)
             - [properties](#properties)
@@ -384,6 +384,7 @@ and we also do not require redefining the `type` as this is always the same for 
 
 What is defined in this dictionary is what is returned for the agent's Function() neuro-san web API call.
 
+<!--- pyml disable-next-line no-duplicate-heading -->
 #### description
 
 Every agent _must_ have its function description filled out.

--- a/docs/agent_hocon_reference.md
+++ b/docs/agent_hocon_reference.md
@@ -34,6 +34,9 @@ Sub-keys to those dictionaries will be described in the next-level down heading 
     - [error_formatter](#error_formatter)
     - [error_fragments](#error_fragments)
     - [tools](#tools)
+    - [metadata](#metadata)
+        - [decription](#decription)
+        - [tags](#tags)
 - [Single Agent Specification](#single-agent-specification)
     - [name](#name)
     - [function](#function)
@@ -337,6 +340,19 @@ Typically any agent that is not the front-man is considered an implementation de
 to the agent network definition. It is not possible to call these internal agents except from within
 the agent network that defines them.  If you find your agent networks have some shared functionality
 between them, consider elevating sub-networks to [external agent](#external-agents) status.
+
+### metadata
+
+An optional dictionary containing metadata about the agent network.
+Any metadata is by definition merely informational and non-functional.
+
+#### description
+
+A string description of the agent network.
+
+#### tags
+
+A list of strings that describe grouping attributes of the agent network.
 
 ## Single Agent Specification
 

--- a/docs/agent_hocon_reference.md
+++ b/docs/agent_hocon_reference.md
@@ -345,6 +345,7 @@ between them, consider elevating sub-networks to [external agent](#external-agen
 
 An optional dictionary containing metadata about the agent network.
 Any metadata is by definition merely informational and non-functional.
+At least some of the keys mentioned below can be transmitted back to a Concierge service client
 
 #### description
 

--- a/neuro_san/api/grpc/agent_service.json
+++ b/neuro_san/api/grpc/agent_service.json
@@ -186,6 +186,13 @@
           "description": {
             "type": "string",
             "description": "Outward-facing description of what the agent does."
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Optional metadata describing where this agent falls into larger agent grouping(s)."
           }
         },
         "description": "Description of an agent's function"

--- a/neuro_san/api/grpc/concierge.proto
+++ b/neuro_san/api/grpc/concierge.proto
@@ -47,6 +47,9 @@ message AgentInfo {
 
     // Outward-facing description of what the agent does.
     string description = 2 [json_name="description"];
+
+    // Optional metadata describing where this agent falls into larger agent grouping(s).
+    repeated string tags = 3 [json_name="tags"];
 }
 
 // Response structure for List gRPC method

--- a/neuro_san/api/grpc/concierge_pb2.py
+++ b/neuro_san/api/grpc/concierge_pb2.py
@@ -26,7 +26,7 @@ _sym_db = _symbol_database.Default()
 from google.api import annotations_pb2 as google_dot_api_dot_annotations__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\"neuro_san/api/grpc/concierge.proto\x12-dev.cognizant_ai.neuro_san.api.grpc.concierge\x1a\x1cgoogle/api/annotations.proto\"\x12\n\x10\x43onciergeRequest\"M\n\tAgentInfo\x12\x1e\n\nagent_name\x18\x01 \x01(\tR\nagent_name\x12 \n\x0b\x64\x65scription\x18\x02 \x01(\tR\x0b\x64\x65scription\"e\n\x11\x43onciergeResponse\x12P\n\x06\x61gents\x18\x01 \x03(\x0b\x32\x38.dev.cognizant_ai.neuro_san.api.grpc.concierge.AgentInfoR\x06\x61gents2\xb4\x01\n\x10\x43onciergeService\x12\x9f\x01\n\x04List\x12?.dev.cognizant_ai.neuro_san.api.grpc.concierge.ConciergeRequest\x1a@.dev.cognizant_ai.neuro_san.api.grpc.concierge.ConciergeResponse\"\x14\x82\xd3\xe4\x93\x02\x0e\x12\x0c/api/v1/listBoZmgithub.com/cognizant-ai-lab/neuro_san/internal/gen/dev.cognizant_ai/neuro_san/api/grpc/concierge/v1;conciergeb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\"neuro_san/api/grpc/concierge.proto\x12-dev.cognizant_ai.neuro_san.api.grpc.concierge\x1a\x1cgoogle/api/annotations.proto\"\x12\n\x10\x43onciergeRequest\"a\n\tAgentInfo\x12\x1e\n\nagent_name\x18\x01 \x01(\tR\nagent_name\x12 \n\x0b\x64\x65scription\x18\x02 \x01(\tR\x0b\x64\x65scription\x12\x12\n\x04tags\x18\x03 \x03(\tR\x04tags\"e\n\x11\x43onciergeResponse\x12P\n\x06\x61gents\x18\x01 \x03(\x0b\x32\x38.dev.cognizant_ai.neuro_san.api.grpc.concierge.AgentInfoR\x06\x61gents2\xb4\x01\n\x10\x43onciergeService\x12\x9f\x01\n\x04List\x12?.dev.cognizant_ai.neuro_san.api.grpc.concierge.ConciergeRequest\x1a@.dev.cognizant_ai.neuro_san.api.grpc.concierge.ConciergeResponse\"\x14\x82\xd3\xe4\x93\x02\x0e\x12\x0c/api/v1/listBoZmgithub.com/cognizant-ai-lab/neuro_san/internal/gen/dev.cognizant_ai/neuro_san/api/grpc/concierge/v1;conciergeb\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -39,9 +39,9 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   _globals['_CONCIERGEREQUEST']._serialized_start=115
   _globals['_CONCIERGEREQUEST']._serialized_end=133
   _globals['_AGENTINFO']._serialized_start=135
-  _globals['_AGENTINFO']._serialized_end=212
-  _globals['_CONCIERGERESPONSE']._serialized_start=214
-  _globals['_CONCIERGERESPONSE']._serialized_end=315
-  _globals['_CONCIERGESERVICE']._serialized_start=318
-  _globals['_CONCIERGESERVICE']._serialized_end=498
+  _globals['_AGENTINFO']._serialized_end=232
+  _globals['_CONCIERGERESPONSE']._serialized_start=234
+  _globals['_CONCIERGERESPONSE']._serialized_end=335
+  _globals['_CONCIERGESERVICE']._serialized_start=338
+  _globals['_CONCIERGESERVICE']._serialized_end=518
 # @@protoc_insertion_point(module_scope)

--- a/neuro_san/client/agent_cli.py
+++ b/neuro_san/client/agent_cli.py
@@ -433,7 +433,7 @@ Have external tools that can be found in the local agent manifest use a service 
             hostname=hostname,
             port=self.args.port,
             metadata=metadata,
-            connection_timeout_in_seconds=self.args.timeout)
+            connect_timeout_in_seconds=self.args.timeout)
 
         request_dict: Dict[str, Any] = {}
         response_dict: Dict[str, Any] = concierge_session.list(request_dict)

--- a/neuro_san/client/agent_cli.py
+++ b/neuro_san/client/agent_cli.py
@@ -242,7 +242,7 @@ Some suggestions:
         Adds arguments.  Allows subclasses a chance to add their own.
         :param arg_parser: The argparse.ArgumentParser to add.
         """
-        # What agent/service are we talking to?
+        # What agent are we talking to?
         arg_parser.add_argument("--agent", type=str, default="esp_decision_assistant",
                                 help="Name of the agent to talk to")
 

--- a/neuro_san/client/concierge_session_factory.py
+++ b/neuro_san/client/concierge_session_factory.py
@@ -1,0 +1,83 @@
+
+# Copyright (C) 2023-2025 Cognizant Digital Business, Evolutionary AI.
+# All Rights Reserved.
+# Issued under the Academic Public License.
+#
+# You can be released from the terms, and requirements of the Academic Public
+# License by purchasing a commercial license.
+# Purchase of a commercial license is mandatory for any use of the
+# neuro-san SDK Software in commercial settings.
+#
+# END COPYRIGHT
+from typing import Any
+from typing import Dict
+
+from leaf_common.time.timeout import Timeout
+
+from neuro_san.client.direct_agent_storage_util import DirectAgentStorageUtil
+from neuro_san.interfaces.concierge_session import ConciergeSession
+from neuro_san.internal.interfaces.agent_network_storage import AgentNetworkStorage
+from neuro_san.session.direct_concierge_session import DirectConciergeSession
+from neuro_san.session.grpc_concierge_session import GrpcConciergeSession
+from neuro_san.session.http_concierge_session import HttpConciergeSession
+
+
+# pylint: disable=too-many-arguments,too-many-positional-arguments
+class ConciergeSessionFactory:
+    """
+    Factory class for ConciregeSessions.
+    """
+
+    def create_session(self, session_type: str,
+                       hostname: str = None,
+                       port: int = None,
+                       metadata: Dict[str, str] = None,
+                       connect_timeout_in_seconds: float = None) -> ConciergeSession:
+        """
+        :param session_type: The type of session to create
+        :param hostname: The name of the host to connect to (if applicable)
+        :param port: The port on the host to connect to (if applicable)
+        :param metadata: A grpc metadata of key/value pairs to be inserted into
+                         the header. Default is None. Preferred format is a
+                         dictionary of string keys to string values.
+        :param connect_timeout_in_seconds: A timeout in seconds after which attempts
+                        to reach a server will stop. By default this is None,
+                        meaning sessions will try forever.
+        """
+        session: ConciergeSession = None
+
+        umbrella_timeout: Timeout = None
+        if connect_timeout_in_seconds is not None:
+            umbrella_timeout = Timeout()
+            umbrella_timeout.set_limit_in_seconds(connect_timeout_in_seconds)
+
+        # Incorrectly flagged as destination of Trust Boundary Violation 1
+        #   Reason: This is the place where the session_type enforced-string argument is
+        #           actually checked for positive use.
+        if session_type == "direct":
+            network_storage: AgentNetworkStorage = DirectAgentStorageUtil.create_network_storage()
+            session = DirectConciergeSession(network_storage, metadata=metadata)
+        elif session_type in ("service", "grpc"):
+            session = GrpcConciergeSession(host=hostname, port=port,
+                                           metadata=metadata, umbrella_timeout=umbrella_timeout)
+        elif session_type in ("http", "https"):
+
+            # If there is no port really specified, use the other default port
+            use_port = port
+            if port is None or port == ConciergeSession.DEFAULT_PORT:
+                use_port = ConciergeSession.DEFAULT_HTTP_PORT
+
+            security_cfg: Dict[str, Any] = None
+            if session_type == "https":
+                # For now, to get the https scheme
+                security_cfg = {}
+            session = HttpConciergeSession(host=hostname, port=use_port,
+                                           security_cfg=security_cfg, metadata=metadata,
+                                           timeout_in_seconds=connect_timeout_in_seconds)
+        else:
+            # Incorrectly flagged as destination of Trust Boundary Violation 2
+            #   Reason: This is the place where the session_type enforced-string argument is
+            #           actually checked for negative use.
+            raise ValueError(f"session_type {session_type} is not understood")
+
+        return session

--- a/neuro_san/client/concierge_session_factory.py
+++ b/neuro_san/client/concierge_session_factory.py
@@ -16,7 +16,7 @@ from leaf_common.time.timeout import Timeout
 
 from neuro_san.client.direct_agent_storage_util import DirectAgentStorageUtil
 from neuro_san.interfaces.concierge_session import ConciergeSession
-from neuro_san.internal.interfaces.agent_network_storage import AgentNetworkStorage
+from neuro_san.internals.network_providers.agent_network_storage import AgentNetworkStorage
 from neuro_san.session.direct_concierge_session import DirectConciergeSession
 from neuro_san.session.grpc_concierge_session import GrpcConciergeSession
 from neuro_san.session.http_concierge_session import HttpConciergeSession

--- a/neuro_san/client/direct_agent_session_factory.py
+++ b/neuro_san/client/direct_agent_session_factory.py
@@ -15,6 +15,7 @@ from typing import Dict
 from leaf_common.time.timeout import Timeout
 from leaf_common.asyncio.asyncio_executor_pool import AsyncioExecutorPool
 
+from neuro_san.client.direct_agent_storage_util import DirectAgentStorageUtil
 from neuro_san.interfaces.agent_session import AgentSession
 from neuro_san.internals.interfaces.context_type_toolbox_factory import ContextTypeToolboxFactory
 from neuro_san.internals.graph.registry.agent_network import AgentNetwork
@@ -22,7 +23,6 @@ from neuro_san.internals.interfaces.context_type_llm_factory import ContextTypeL
 from neuro_san.internals.run_context.factory.master_toolbox_factory import MasterToolboxFactory
 from neuro_san.internals.run_context.factory.master_llm_factory import MasterLlmFactory
 from neuro_san.internals.graph.persistence.agent_network_restorer import AgentNetworkRestorer
-from neuro_san.internals.graph.persistence.registry_manifest_restorer import RegistryManifestRestorer
 from neuro_san.internals.interfaces.agent_network_provider import AgentNetworkProvider
 from neuro_san.internals.network_providers.agent_network_storage import AgentNetworkStorage
 from neuro_san.session.direct_agent_session import DirectAgentSession
@@ -45,11 +45,7 @@ class DirectAgentSessionFactory:
         """
         Constructor
         """
-        manifest_restorer = RegistryManifestRestorer()
-        self.manifest_networks: Dict[str, AgentNetwork] = manifest_restorer.restore()
-        self.network_storage = AgentNetworkStorage()
-        for agent_name, agent_network in self.manifest_networks.items():
-            self.network_storage.add_agent_network(agent_name, agent_network)
+        self.network_storage: AgentNetworkStorage = DirectAgentStorageUtil.create_network_storage()
 
     def create_session(self, agent_name: str, use_direct: bool = False,
                        metadata: Dict[str, str] = None, umbrella_timeout: Timeout = None) -> AgentSession:

--- a/neuro_san/client/direct_agent_storage_util.py
+++ b/neuro_san/client/direct_agent_storage_util.py
@@ -1,0 +1,36 @@
+
+# Copyright (C) 2023-2025 Cognizant Digital Business, Evolutionary AI.
+# All Rights Reserved.
+# Issued under the Academic Public License.
+#
+# You can be released from the terms, and requirements of the Academic Public
+# License by purchasing a commercial license.
+# Purchase of a commercial license is mandatory for any use of the
+# neuro-san SDK Software in commercial settings.
+#
+# END COPYRIGHT
+from typing import Dict
+
+from neuro_san.internals.graph.registry.agent_network import AgentNetwork
+from neuro_san.internals.graph.persistence.registry_manifest_restorer import RegistryManifestRestorer
+from neuro_san.internals.network_providers.agent_network_storage import AgentNetworkStorage
+
+
+class DirectAgentStorageUtil:
+    """
+    Sets up AgentNetworkStorage for direct usage.
+    """
+
+    @staticmethod
+    def create_network_storage() -> AgentNetworkStorage:
+        """
+        :return: An AgentNetworkStorage populated from the Registry Manifest
+        """
+        network_storage = AgentNetworkStorage()
+        manifest_restorer = RegistryManifestRestorer()
+        manifest_networks: Dict[str, AgentNetwork] = manifest_restorer.restore()
+
+        for agent_name, agent_network in manifest_networks.items():
+            network_storage.add_agent_network(agent_name, agent_network)
+
+        return network_storage

--- a/neuro_san/registries/assess_failure.hocon
+++ b/neuro_san/registries/assess_failure.hocon
@@ -14,6 +14,12 @@
 # https://github.com/cognizant-ai-lab/neuro-san/blob/main/docs/agent_hocon_reference.md
 
 {
+    # Optional metadata describing this agent network
+    "metadata": {
+        "description": "Used by Neuro-SAN Assessor in its test infrastruture to classify agent network failures",
+        "tags": ["test_infrastructure"]
+    },
+
     "llm_config": {
         "model_name": "gpt-4o",
     },

--- a/neuro_san/registries/bing_search.hocon
+++ b/neuro_san/registries/bing_search.hocon
@@ -14,6 +14,11 @@
 # https://github.com/cognizant-ai-lab/neuro-san/blob/main/docs/agent_hocon_reference.md
 
 {
+    # Optional metadata describing this agent network
+    "metadata": {
+        "description": "Example of web search using Bing Search.",
+        "tags": ["example", "web_search"],
+    },
     "llm_config": {
         "model_name": "gpt-4o",
     },

--- a/neuro_san/registries/date_time.hocon
+++ b/neuro_san/registries/date_time.hocon
@@ -14,6 +14,11 @@
 # https://github.com/cognizant-ai-lab/neuro-san/blob/main/docs/agent_hocon_reference.md
 
 {
+    # Optional metadata describing this agent network
+    "metadata": {
+        "description": "Gets date and time",
+        "tags": ["example", "utility"],
+    },
     "llm_config": {
         "model_name": "gpt-4o",
     },

--- a/neuro_san/registries/esp_decision_assistant.hocon
+++ b/neuro_san/registries/esp_decision_assistant.hocon
@@ -14,6 +14,11 @@
 # https://github.com/cognizant-ai-lab/neuro-san/blob/main/docs/agent_hocon_reference.md
 
 {
+    # Optional metadata describing this agent network
+    "metadata": {
+        "description": "Example of generic decision-making broken down into Context, Actions and Outcomes attributes.",
+        "tags": ["example"],
+    },
     "llm_config": {
         # Demonstration of the config for llm fallbacks.
         # This is a list of llm configs where the order describes which LLM

--- a/neuro_san/registries/gist.hocon
+++ b/neuro_san/registries/gist.hocon
@@ -14,6 +14,12 @@
 # https://github.com/cognizant-ai-lab/neuro-san/blob/main/docs/agent_hocon_reference.md
 
 {
+    # Optional metadata describing this agent network
+    "metadata": {
+        "description": "Used by Neuro-SAN test infrastruture to determine agent network response failures",
+        "tags": ["test_infrastructure"]
+    },
+
     "llm_config": {
         "model_name": "gpt-4o",
     },

--- a/neuro_san/registries/google_serper.hocon
+++ b/neuro_san/registries/google_serper.hocon
@@ -14,6 +14,11 @@
 # https://github.com/cognizant-ai-lab/neuro-san/blob/main/docs/agent_hocon_reference.md
 
 {
+    # Optional metadata describing this agent network
+    "metadata": {
+        "description": "Example of web search using Google Serper",
+        "tags": ["example", "web_search"],
+    },
     "llm_config": {
         "model_name": "gpt-4o",
     },

--- a/neuro_san/registries/hello_world.hocon
+++ b/neuro_san/registries/hello_world.hocon
@@ -14,6 +14,11 @@
 # https://github.com/cognizant-ai-lab/neuro-san/blob/main/docs/agent_hocon_reference.md
 
 {
+    # Optional metadata describing this agent network
+    "metadata": {
+        "description": "Simple agent network consisting of two LLM-based agents."
+        "tags": ["example"],
+    },
     "llm_config": {
         "model_name": "gpt-4o",
     },

--- a/neuro_san/registries/intranet_agents.hocon
+++ b/neuro_san/registries/intranet_agents.hocon
@@ -14,6 +14,11 @@
 # https://github.com/cognizant-ai-lab/neuro-san/blob/main/docs/agent_hocon_reference.md
 
 {
+    # Optional metadata describing this agent network
+    "metadata": {
+        "description": "Complex agent network consisting of several LLM-based agents using AAOSA prompting federation."
+        "tags": ["example", "aaosa"],
+    },
     "llm_config": {
         "model_name": "gpt-4o",
     },

--- a/neuro_san/registries/math_guy.hocon
+++ b/neuro_san/registries/math_guy.hocon
@@ -14,6 +14,11 @@
 # https://github.com/cognizant-ai-lab/neuro-san/blob/main/docs/agent_hocon_reference.md
 
 {
+    # Optional metadata describing this agent network
+    "metadata": {
+        "description": "Simple agent network using a CodedTool and sly_data"
+        "tags": ["example"],
+    },
     "llm_config": {
         "model_name": "gpt-4o",
     },

--- a/neuro_san/registries/math_guy_passthrough.hocon
+++ b/neuro_san/registries/math_guy_passthrough.hocon
@@ -14,6 +14,11 @@
 # https://github.com/cognizant-ai-lab/neuro-san/blob/main/docs/agent_hocon_reference.md
 
 {
+    # Optional metadata describing this agent network
+    "metadata": {
+        "description": "Simple agent network using external agent calls with sly_data"
+        "tags": ["example"],
+    },
     "llm_config": {
         "model_name": "gpt-4o",
     },

--- a/neuro_san/registries/music_nerd.hocon
+++ b/neuro_san/registries/music_nerd.hocon
@@ -14,6 +14,11 @@
 # https://github.com/cognizant-ai-lab/neuro-san/blob/main/docs/agent_hocon_reference.md
 
 {
+    # Optional metadata describing this agent network
+    "metadata": {
+        "description": "Simple agent network using a single LLM-based agent",
+        "tags": ["example"],
+    },
     "llm_config": {
         "model_name": "gpt-4o",
     },

--- a/neuro_san/registries/music_nerd_pro.hocon
+++ b/neuro_san/registries/music_nerd_pro.hocon
@@ -14,6 +14,11 @@
 # https://github.com/cognizant-ai-lab/neuro-san/blob/main/docs/agent_hocon_reference.md
 
 {
+    # Optional metadata describing this agent network
+    "metadata": {
+        "description": "Simple agent network using a single OpenAI-based agent and a single CodedTool",
+        "tags": ["example"],
+    },
     "llm_config": {
         "model_name": "gpt-4o",
     },

--- a/neuro_san/registries/music_nerd_pro_llm_anthropic.hocon
+++ b/neuro_san/registries/music_nerd_pro_llm_anthropic.hocon
@@ -14,6 +14,11 @@
 # https://github.com/cognizant-ai-lab/neuro-san/blob/main/docs/agent_hocon_reference.md
 
 {
+    # Optional metadata describing this agent network
+    "metadata": {
+        "description": "Simple agent network using a single Anthropic-based agent and a single CodedTool",
+        "tags": ["example", "llm_tests"],
+    },
     "llm_config": {
         "model_name": "claude-3-7-sonnet",
     },

--- a/neuro_san/registries/music_nerd_pro_llm_azure.hocon
+++ b/neuro_san/registries/music_nerd_pro_llm_azure.hocon
@@ -14,6 +14,11 @@
 # https://github.com/cognizant-ai-lab/neuro-san/blob/main/docs/agent_hocon_reference.md
 
 {
+    # Optional metadata describing this agent network
+    "metadata": {
+        "description": "Simple agent network using a single Azure-based agent and a single CodedTool",
+        "tags": ["example", "llm_tests"],
+    },
     "llm_config": {
         "model_name": "azure-gpt-4o",
         "deployment_name": "gpt-4o",

--- a/neuro_san/registries/music_nerd_pro_llm_bedrock_claude.hocon
+++ b/neuro_san/registries/music_nerd_pro_llm_bedrock_claude.hocon
@@ -14,6 +14,11 @@
 # https://github.com/cognizant-ai-lab/neuro-san/blob/main/docs/agent_hocon_reference.md
 
 {
+    # Optional metadata describing this agent network
+    "metadata": {
+        "description": "Simple agent network using a single Bedrock-based agent and a single CodedTool",
+        "tags": ["example", "llm_tests"],
+    },
     "llm_config": {
         "model_name": "bedrock-us-claude-3-7-sonnet",
     },

--- a/neuro_san/registries/music_nerd_pro_llm_gemini.hocon
+++ b/neuro_san/registries/music_nerd_pro_llm_gemini.hocon
@@ -14,6 +14,11 @@
 # https://github.com/cognizant-ai-lab/neuro-san/blob/main/docs/agent_hocon_reference.md
 
 {
+    # Optional metadata describing this agent network
+    "metadata": {
+        "description": "Simple agent network using a single Gemini-based agent and a single CodedTool",
+        "tags": ["example", "llm_tests"],
+    },
     "llm_config": {
         "model_name": "gemini-2.5-flash",
     },

--- a/neuro_san/registries/music_nerd_pro_llm_ollama.hocon
+++ b/neuro_san/registries/music_nerd_pro_llm_ollama.hocon
@@ -14,6 +14,11 @@
 # https://github.com/cognizant-ai-lab/neuro-san/blob/main/docs/agent_hocon_reference.md
 
 {
+    # Optional metadata describing this agent network
+    "metadata": {
+        "description": "Simple agent network using a single Ollama-based agent and a single CodedTool",
+        "tags": ["example", "llm_tests"],
+    },
     "llm_config": {
         "model_name": "qwen3:8b",
         "reasoning": false,

--- a/neuro_san/registries/music_nerd_pro_multi_agents.hocon
+++ b/neuro_san/registries/music_nerd_pro_multi_agents.hocon
@@ -14,6 +14,11 @@
 # https://github.com/cognizant-ai-lab/neuro-san/blob/main/docs/agent_hocon_reference.md
 
 {
+    # Optional metadata describing this agent network
+    "metadata": {
+        "description": "Slightly more complex agent network breaking down tasks",
+        "tags": ["example"],
+    },
     "llm_config": {
         "model_name": "gpt-4o",
     },

--- a/neuro_san/registries/website_rag.hocon
+++ b/neuro_san/registries/website_rag.hocon
@@ -14,6 +14,11 @@
 # https://github.com/cognizant-ai-lab/neuro-san/blob/main/docs/agent_hocon_reference.md
 
 {
+    # Optional metadata describing this agent network
+    "metadata": {
+        "description": "Example of web search using RAG.",
+        "tags": ["example", "web_search", "rag"],
+    },
     "llm_config": {
         "model_name": "gpt-4o",
     },

--- a/neuro_san/registries/website_search.hocon
+++ b/neuro_san/registries/website_search.hocon
@@ -14,6 +14,11 @@
 # https://github.com/cognizant-ai-lab/neuro-san/blob/main/docs/agent_hocon_reference.md
 
 {
+    # Optional metadata describing this agent network
+    "metadata": {
+        "description": "Example of web search",
+        "tags": ["example", "web_search"],
+    },
     "llm_config": {
         "model_name": "gpt-4o",
     },

--- a/neuro_san/registries/website_search_usage_example.hocon
+++ b/neuro_san/registries/website_search_usage_example.hocon
@@ -14,6 +14,11 @@
 # https://github.com/cognizant-ai-lab/neuro-san/blob/main/docs/agent_hocon_reference.md
 
 {
+    # Optional metadata describing this agent network
+    "metadata": {
+        "description": "Example of web search",
+        "tags": ["example", "web_search"],
+    },
     "llm_config": {
         "model_name": "gpt-4o",
     },

--- a/neuro_san/session/abstract_http_service_agent_session.py
+++ b/neuro_san/session/abstract_http_service_agent_session.py
@@ -84,6 +84,8 @@ class AbstractHttpServiceAgentSession(AgentSessionConstants):
         if self.security_cfg is not None:
             scheme = "https"
 
+        if self.agent_name is None:
+            return f"{scheme}://{self.use_host}:{self.use_port}/api/v1/{method}"
         return f"{scheme}://{self.use_host}:{self.use_port}/api/v1/{self.agent_name}/{method}"
 
     def get_headers(self) -> Dict[str, Any]:

--- a/neuro_san/session/abstract_http_service_agent_session.py
+++ b/neuro_san/session/abstract_http_service_agent_session.py
@@ -67,8 +67,6 @@ class AbstractHttpServiceAgentSession(AgentSessionConstants):
         if port is not None:
             self.use_port = port
 
-        if agent_name is None:
-            raise ValueError("agent_name is None")
         self.agent_name: str = agent_name
 
         self.timeout_in_seconds: int = timeout_in_seconds

--- a/neuro_san/session/direct_concierge_session.py
+++ b/neuro_san/session/direct_concierge_session.py
@@ -56,7 +56,17 @@ class DirectConciergeSession(ConciergeSession):
                 "agents" - the sequence of dictionaries describing available agents
         """
         agents_names: List[str] = self.network_storage.get_agent_names()
+
         agents_list: List[Dict[str, Any]] = []
         for agent_name in agents_names:
-            agents_list.append({"agent_name": agent_name, "description": ""})
-        return {"agents": agents_list}
+            agent_info: Dict[str, Any] = {
+                "agent_name": agent_name,
+                "description": "",
+                "tags": []
+            }
+            agents_list.append(agent_info)
+
+        response: Dict[str, Any] = {
+            "agents": agents_list
+        }
+        return response

--- a/neuro_san/session/direct_concierge_session.py
+++ b/neuro_san/session/direct_concierge_session.py
@@ -66,7 +66,7 @@ class DirectConciergeSession(ConciergeSession):
         for agent_name in agents_names:
 
             # Get the spec for the agent network
-            provider: AgentNetworkProvider = self.network_storage.get_agent_network(agent_name)
+            provider: AgentNetworkProvider = self.network_storage.get_agent_network_provider(agent_name)
             agent_network: AgentNetwork = provider.get_agent_network()
             agent_spec: Dict[str, Any] = agent_network.get_config()
             extractor = DictionaryExtractor(agent_spec)

--- a/neuro_san/session/direct_concierge_session.py
+++ b/neuro_san/session/direct_concierge_session.py
@@ -71,8 +71,8 @@ class DirectConciergeSession(ConciergeSession):
             agent_spec: Dict[str, Any] = agent_network.get_config()
             extractor = DictionaryExtractor(agent_spec)
 
-            # It's concievable we could get the description from the front man's function
-            # We haven't done that yet, though, so deferring until a hew a cry emerges.
+            # It's concievable we could get the description from the front man's function.
+            # We haven't done that yet, though, so deferring until a hew and cry emerges.
             description: str = extractor.get("metadata.description", "")
             tags: List[str] = extractor.get("metadata.tags", empty_list)
 

--- a/neuro_san/session/direct_concierge_session.py
+++ b/neuro_san/session/direct_concierge_session.py
@@ -14,7 +14,11 @@ from typing import Any
 from typing import Dict
 from typing import List
 
+from leaf_common.parsers.dictionary_extractor import DictionaryExtractor
+
 from neuro_san.interfaces.concierge_session import ConciergeSession
+from neuro_san.internals.graph.registry.agent_network import AgentNetwork
+from neuro_san.internals.interfaces.agent_network_provider import AgentNetworkProvider
 from neuro_san.internals.network_providers.agent_network_storage import AgentNetworkStorage
 
 
@@ -56,13 +60,27 @@ class DirectConciergeSession(ConciergeSession):
                 "agents" - the sequence of dictionaries describing available agents
         """
         agents_names: List[str] = self.network_storage.get_agent_names()
+        empty_list: List[str] = []
 
         agents_list: List[Dict[str, Any]] = []
         for agent_name in agents_names:
+
+            # Get the spec for the agent network
+            provider: AgentNetworkProvider = self.network_storage.get_agent_network(agent_name)
+            agent_network: AgentNetwork = provider.get_agent_network()
+            agent_spec: Dict[str, Any] = agent_network.get_config()
+            extractor = DictionaryExtractor(agent_spec)
+
+            # It's concievable we could get the description from the front man's function
+            # We haven't done that yet, though, so deferring until a hew a cry emerges.
+            description: str = extractor.get("metadata.description", "")
+            tags: List[str] = extractor.get("metadata.tags", empty_list)
+
+            # Construct an AgentInfo entry
             agent_info: Dict[str, Any] = {
                 "agent_name": agent_name,
-                "description": "",
-                "tags": []
+                "description": description,
+                "tags": tags,
             }
             agents_list.append(agent_info)
 

--- a/neuro_san/session/http_concierge_session.py
+++ b/neuro_san/session/http_concierge_session.py
@@ -1,0 +1,45 @@
+
+# Copyright (C) 2023-2025 Cognizant Digital Business, Evolutionary AI.
+# All Rights Reserved.
+# Issued under the Academic Public License.
+#
+# You can be released from the terms, and requirements of the Academic Public
+# License by purchasing a commercial license.
+# Purchase of a commercial license is mandatory for any use of the
+# neuro-san SDK Software in commercial settings.
+#
+# END COPYRIGHT
+
+from typing import Any
+from typing import Dict
+
+import json
+import requests
+
+from neuro_san.interfaces.concierge_session import ConciergeSession
+from neuro_san.session.abstract_http_service_agent_session import AbstractHttpServiceAgentSession
+
+
+class HttpConciergeSession(AbstractHttpServiceAgentSession, ConciergeSession):
+    """
+    Implementation of ConciergeSession that talks to an HTTP service.
+    This is largely only used by command-line tests.
+    """
+
+    def list(self, request_dict: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        :param request_dict: A dictionary version of the ConciergeRequest
+                    protobuf structure. Has the following keys:
+                        <None>
+        :return: A dictionary version of the ConciergeResponse
+                    protobuf structure. Has the following keys:
+                "agents" - the sequence of dictionaries describing available agents
+        """
+        path: str = self.get_request_path("list")
+        try:
+            response = requests.get(path, json=request_dict, headers=self.get_headers(),
+                                    timeout=self.timeout_in_seconds)
+            result_dict = json.loads(response.text)
+            return result_dict
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            raise ValueError(self.help_message(path)) from exc


### PR DESCRIPTION
This feature was requested by Rimna's team as a UI-enabler.
Looks like a lot, but more than half of these files are small mods to existing hocon files.

New Data:
* Allow an optional "metadata" dictionary to be specified at the top-level of any hocon file. This can have two keys:
    * "description":  brief description of what the network is about
    * "tags": a list of string descriptions that apply for to the agent network for grouping
* Add docs in agent_hocon_reference.md for these too
* Add above metadata for all agent networks in neuro-san/registries

Sessions:
* Modify the Concierge response protobuf to return a list of string tags
* Modify the DirectConciergeSession to return descriptions and tags
* Add an HttpConciergeSession to round out the concierge offerings

Client:
* Add a ConciergeSessionFactory to allow for different ways of connecting to concierge service
* Factor out a DirectAgentStorageUtil which sets up an AgentNetworkStorage from the manifest for common --direct usage from agent_cli
* Add a few new agent_cli args:
    * --list: lists all agent networks
    * --tags: list all agent network tags
    * --tag <str>: list all agent networks grouped into the given tag

---
@dsargent and @deepsaia : Take a look over the new additions to the protocol/sessions for Concierge service and see if they are what you'd expect
@Noravee and @vince-leaf : Take a look over the new metadata added to each agent network hocon file
@andreidenissov-cog : Take a look at general implementation.

Worth noting that when this gets taken up by neuro-san-studio, it will be a worthwhile effort to similarly add metadata to all the agents there.