### PR TITLE
UN-3441 UserWarning: Importing verbose from langchain root module is no longer supported langchain.globals.set_verbose()

### DIFF
--- a/neuro_san/internals/run_context/langchain/llms/default_llm_info.hocon
+++ b/neuro_san/internals/run_context/langchain/llms/default_llm_info.hocon
@@ -829,7 +829,6 @@
                 "max_tokens": null,         # This is always for output
                 "tiktoken_model_name": null,
                 "stop": null,
-                "verbose": false,
 
                 # If you really need more parameters, you will likely have to create your own LlmFactory.
             }
@@ -866,7 +865,6 @@
                 "stop_sequences": null,
                 "anthropic_api_url": "https://api.anthropic.com",
                 "anthropic_api_key": null,
-                "verbose": false,
                 # streaming is always set to True so that ...
                 # stream_usage is always set to True so that token counting can work correctly
             }
@@ -893,7 +891,6 @@
                 "top_p": null,
                 "keep_alive": null,
                 "base_url": null,
-                "verbose": false,
             }
         },
         "nvidia": {
@@ -908,7 +905,6 @@
                 "stop": null,
                 "nvidia_api_key": null,
                 "nvidia_base_url": null,
-                "verbose": false,
             }
         },
         "gemini": {
@@ -923,7 +919,6 @@
                 "timeout": null,
                 "top_k": null, 
                 "top_p": null,
-                "verbose": false,
             }
         },
         "bedrock": {
@@ -951,7 +946,6 @@
                 "system_prompt_with_tools": "",
                 "tags": null,
                 "temperature": null
-                "verbose": false,
             }
         }
     }

--- a/neuro_san/internals/run_context/langchain/llms/default_llm_info.hocon
+++ b/neuro_san/internals/run_context/langchain/llms/default_llm_info.hocon
@@ -829,6 +829,7 @@
                 "max_tokens": null,         # This is always for output
                 "tiktoken_model_name": null,
                 "stop": null,
+                "verbose": false,
 
                 # If you really need more parameters, you will likely have to create your own LlmFactory.
             }
@@ -865,6 +866,7 @@
                 "stop_sequences": null,
                 "anthropic_api_url": "https://api.anthropic.com",
                 "anthropic_api_key": null,
+                "verbose": false,
                 # streaming is always set to True so that ...
                 # stream_usage is always set to True so that token counting can work correctly
             }
@@ -891,6 +893,7 @@
                 "top_p": null,
                 "keep_alive": null,
                 "base_url": null,
+                "verbose": false,
             }
         },
         "nvidia": {
@@ -905,6 +908,7 @@
                 "stop": null,
                 "nvidia_api_key": null,
                 "nvidia_base_url": null,
+                "verbose": false,
             }
         },
         "gemini": {
@@ -919,6 +923,7 @@
                 "timeout": null,
                 "top_k": null, 
                 "top_p": null,
+                "verbose": false,
             }
         },
         "bedrock": {
@@ -946,6 +951,7 @@
                 "system_prompt_with_tools": "",
                 "tags": null,
                 "temperature": null
+                "verbose": false,
             }
         }
     }

--- a/neuro_san/internals/run_context/langchain/llms/standard_langchain_llm_factory.py
+++ b/neuro_san/internals/run_context/langchain/llms/standard_langchain_llm_factory.py
@@ -98,7 +98,21 @@ class StandardLangChainLlmFactory(LangChainLlmFactory):
                 max_tokens=config.get("max_tokens"),    # This is always for output
                 tiktoken_model_name=config.get("tiktoken_model_name"),
                 stop=config.get("stop"),
-                verbose=config.get("verbose"),
+
+                # If omitted, this defaults to the global verbose value,
+                # accessible via langchain_core.globals.get_verbose():
+                # https://github.com/langchain-ai/langchain/blob/master/libs/core/langchain_core/globals.py#L53
+                #
+                # However, accessing the global verbose value during concurrent initialization
+                # can trigger the following warning:
+                #
+                # UserWarning: Importing verbose from langchain root module is no longer supported.
+                # Please use langchain.globals.set_verbose() / langchain.globals.get_verbose() instead.
+                # old_verbose = langchain.verbose
+                #
+                # To prevent this, we explicitly set verbose=False here (which matches the default
+                # global verbose value) so that the warning is never triggered.
+                verbose=False,
 
                 # Set stream_usage to True in order to get token counting chunks.
                 stream_usage=True
@@ -136,7 +150,21 @@ class StandardLangChainLlmFactory(LangChainLlmFactory):
                 max_tokens=config.get("max_tokens"),    # This is always for output
                 tiktoken_model_name=config.get("tiktoken_model_name"),
                 stop=config.get("stop"),
-                verbose=config.get("verbose"),
+
+                # If omitted, this defaults to the global verbose value,
+                # accessible via langchain_core.globals.get_verbose():
+                # https://github.com/langchain-ai/langchain/blob/master/libs/core/langchain_core/globals.py#L53
+                #
+                # However, accessing the global verbose value during concurrent initialization
+                # can trigger the following warning:
+                #
+                # UserWarning: Importing verbose from langchain root module is no longer supported.
+                # Please use langchain.globals.set_verbose() / langchain.globals.get_verbose() instead.
+                # old_verbose = langchain.verbose
+                #
+                # To prevent this, we explicitly set verbose=False here (which matches the default
+                # global verbose value) so that the warning is never triggered.
+                verbose=False,
 
                 # Azure-specific
                 azure_endpoint=self.get_value_or_env(config, "azure_endpoint",
@@ -172,7 +200,21 @@ class StandardLangChainLlmFactory(LangChainLlmFactory):
                 streaming=True,     # streaming is always on. Without it token counting will not work.
                 # Set stream_usage to True in order to get token counting chunks.
                 stream_usage=True,
-                verbose=config.get("verbose"),
+
+                # If omitted, this defaults to the global verbose value,
+                # accessible via langchain_core.globals.get_verbose():
+                # https://github.com/langchain-ai/langchain/blob/master/libs/core/langchain_core/globals.py#L53
+                #
+                # However, accessing the global verbose value during concurrent initialization
+                # can trigger the following warning:
+                #
+                # UserWarning: Importing verbose from langchain root module is no longer supported.
+                # Please use langchain.globals.set_verbose() / langchain.globals.get_verbose() instead.
+                # old_verbose = langchain.verbose
+                #
+                # To prevent this, we explicitly set verbose=False here (which matches the default
+                # global verbose value) so that the warning is never triggered.
+                verbose=False,
             )
         elif chat_class == "ollama":
             # Higher temperature is more random
@@ -196,7 +238,21 @@ class StandardLangChainLlmFactory(LangChainLlmFactory):
                 top_p=config.get("top_p"),
                 keep_alive=config.get("keep_alive"),
                 base_url=config.get("base_url"),
-                verbose=config.get("verbose"),
+
+                # If omitted, this defaults to the global verbose value,
+                # accessible via langchain_core.globals.get_verbose():
+                # https://github.com/langchain-ai/langchain/blob/master/libs/core/langchain_core/globals.py#L53
+                #
+                # However, accessing the global verbose value during concurrent initialization
+                # can trigger the following warning:
+                #
+                # UserWarning: Importing verbose from langchain root module is no longer supported.
+                # Please use langchain.globals.set_verbose() / langchain.globals.get_verbose() instead.
+                # old_verbose = langchain.verbose
+                #
+                # To prevent this, we explicitly set verbose=False here (which matches the default
+                # global verbose value) so that the warning is never triggered.
+                verbose=False,
             )
         elif chat_class == "nvidia":
             # Higher temperature is more random
@@ -208,7 +264,21 @@ class StandardLangChainLlmFactory(LangChainLlmFactory):
                 top_p=config.get("top_p"),
                 seed=config.get("seed"),
                 stop=config.get("stop"),
-                verbose=config.get("verbose"),
+
+                # If omitted, this defaults to the global verbose value,
+                # accessible via langchain_core.globals.get_verbose():
+                # https://github.com/langchain-ai/langchain/blob/master/libs/core/langchain_core/globals.py#L53
+                #
+                # However, accessing the global verbose value during concurrent initialization
+                # can trigger the following warning:
+                #
+                # UserWarning: Importing verbose from langchain root module is no longer supported.
+                # Please use langchain.globals.set_verbose() / langchain.globals.get_verbose() instead.
+                # old_verbose = langchain.verbose
+                #
+                # To prevent this, we explicitly set verbose=False here (which matches the default
+                # global verbose value) so that the warning is never triggered.
+                verbose=False,
                 nvidia_api_key=self.get_value_or_env(config, "nvidia_api_key",
                                                      "NVIDIA_API_KEY"),
                 nvidia_base_url=self.get_value_or_env(config, "nvidia_base_url",
@@ -226,7 +296,21 @@ class StandardLangChainLlmFactory(LangChainLlmFactory):
                 timeout=config.get("timeout"),
                 top_k=config.get("top_k"),
                 top_p=config.get("top_p"),
-                verbose=config.get("verbose"),
+
+                # If omitted, this defaults to the global verbose value,
+                # accessible via langchain_core.globals.get_verbose():
+                # https://github.com/langchain-ai/langchain/blob/master/libs/core/langchain_core/globals.py#L53
+                #
+                # However, accessing the global verbose value during concurrent initialization
+                # can trigger the following warning:
+                #
+                # UserWarning: Importing verbose from langchain root module is no longer supported.
+                # Please use langchain.globals.set_verbose() / langchain.globals.get_verbose() instead.
+                # old_verbose = langchain.verbose
+                #
+                # To prevent this, we explicitly set verbose=False here (which matches the default
+                # global verbose value) so that the warning is never triggered.
+                verbose=False,
             )
         elif chat_class == "bedrock":
             llm = ChatBedrock(
@@ -252,7 +336,21 @@ class StandardLangChainLlmFactory(LangChainLlmFactory):
                 system_prompt_with_tools=config.get("system_prompt_with_tools"),
                 tags=config.get("tags"),
                 temperature=config.get("temperature"),
-                verbose=config.get("verbose"),
+
+                # If omitted, this defaults to the global verbose value,
+                # accessible via langchain_core.globals.get_verbose():
+                # https://github.com/langchain-ai/langchain/blob/master/libs/core/langchain_core/globals.py#L53
+                #
+                # However, accessing the global verbose value during concurrent initialization
+                # can trigger the following warning:
+                #
+                # UserWarning: Importing verbose from langchain root module is no longer supported.
+                # Please use langchain.globals.set_verbose() / langchain.globals.get_verbose() instead.
+                # old_verbose = langchain.verbose
+                #
+                # To prevent this, we explicitly set verbose=False here (which matches the default
+                # global verbose value) so that the warning is never triggered.
+                verbose=False,
             )
         elif chat_class is None:
             raise ValueError(f"Class name {chat_class} for model_name {model_name} is unspecified.")

--- a/neuro_san/internals/run_context/langchain/llms/standard_langchain_llm_factory.py
+++ b/neuro_san/internals/run_context/langchain/llms/standard_langchain_llm_factory.py
@@ -98,6 +98,7 @@ class StandardLangChainLlmFactory(LangChainLlmFactory):
                 max_tokens=config.get("max_tokens"),    # This is always for output
                 tiktoken_model_name=config.get("tiktoken_model_name"),
                 stop=config.get("stop"),
+                verbose=config.get("verbose"),
 
                 # Set stream_usage to True in order to get token counting chunks.
                 stream_usage=True
@@ -135,6 +136,7 @@ class StandardLangChainLlmFactory(LangChainLlmFactory):
                 max_tokens=config.get("max_tokens"),    # This is always for output
                 tiktoken_model_name=config.get("tiktoken_model_name"),
                 stop=config.get("stop"),
+                verbose=config.get("verbose"),
 
                 # Azure-specific
                 azure_endpoint=self.get_value_or_env(config, "azure_endpoint",
@@ -170,6 +172,7 @@ class StandardLangChainLlmFactory(LangChainLlmFactory):
                 streaming=True,     # streaming is always on. Without it token counting will not work.
                 # Set stream_usage to True in order to get token counting chunks.
                 stream_usage=True,
+                verbose=config.get("verbose"),
             )
         elif chat_class == "ollama":
             # Higher temperature is more random
@@ -192,7 +195,8 @@ class StandardLangChainLlmFactory(LangChainLlmFactory):
                 top_k=config.get("top_k"),
                 top_p=config.get("top_p"),
                 keep_alive=config.get("keep_alive"),
-                base_url=config.get("base_url")
+                base_url=config.get("base_url"),
+                verbose=config.get("verbose"),
             )
         elif chat_class == "nvidia":
             # Higher temperature is more random
@@ -204,6 +208,7 @@ class StandardLangChainLlmFactory(LangChainLlmFactory):
                 top_p=config.get("top_p"),
                 seed=config.get("seed"),
                 stop=config.get("stop"),
+                verbose=config.get("verbose"),
                 nvidia_api_key=self.get_value_or_env(config, "nvidia_api_key",
                                                      "NVIDIA_API_KEY"),
                 nvidia_base_url=self.get_value_or_env(config, "nvidia_base_url",
@@ -221,6 +226,7 @@ class StandardLangChainLlmFactory(LangChainLlmFactory):
                 timeout=config.get("timeout"),
                 top_k=config.get("top_k"),
                 top_p=config.get("top_p"),
+                verbose=config.get("verbose"),
             )
         elif chat_class == "bedrock":
             llm = ChatBedrock(
@@ -246,6 +252,7 @@ class StandardLangChainLlmFactory(LangChainLlmFactory):
                 system_prompt_with_tools=config.get("system_prompt_with_tools"),
                 tags=config.get("tags"),
                 temperature=config.get("temperature"),
+                verbose=config.get("verbose"),
             )
         elif chat_class is None:
             raise ValueError(f"Class name {chat_class} for model_name {model_name} is unspecified.")


### PR DESCRIPTION
The warning is from
https://github.com/langchain-ai/langchain/blob/master/libs/core/langchain_core/globals.py 
and can be trace back to https://github.com/langchain-ai/langchain/blob/master/libs/core/langchain_core/language_models/base.py#L92.

The fix is to set the value of `verbose` for chat models so it does not have to call the method to figure out the global default value.

Note that this warning only display for concurrent runs and is likely due to concurrent import of `langchain`.