### PR TITLE
Use minimal permissions in github action workflows

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,5 +1,8 @@
 name: Integration
 
+permissions:
+    contents: read
+
 on:
   schedule:
     - cron: '0 12 * * *'  # 12:00 PM UTC = 4:00 AM PT (standard)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,8 @@
 name: Publish to PyPI
 
+permissions:
+    contents: read
+
 on:
   release:
     types: [published]  # Trigger only when a GitHub Release is published.

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,5 +1,8 @@
 name: Smoke Tests
 
+permissions:
+    contents: read
+
 on:
   schedule:
     - cron: '0 12 * * *'  # 12:00 PM UTC = 4:00 AM PT (standard)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,8 @@
 name: Test
 
+permissions:
+    contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
As per best practices, this PR explicitly sets github permissions in our action workflows. The workflows modified in this PR need only read access to the repo, so this is now spelled out explicitly.