### PR TITLE
UN-3432 Fix duplicate request ids.

### DIFF
--- a/neuro_san/service/http/handlers/base_request_handler.py
+++ b/neuro_san/service/http/handlers/base_request_handler.py
@@ -164,6 +164,8 @@ class BaseRequestHandler(RequestHandler):
         """
         return
 
+    # Tornado can handle both syns and async versions of "prepare" method
+    # pylint: disable=invalid-overridden-method
     async def prepare(self):
         if not self.application.is_serving():
             self.set_status(503)

--- a/neuro_san/service/http/handlers/base_request_handler.py
+++ b/neuro_san/service/http/handlers/base_request_handler.py
@@ -90,8 +90,10 @@ class BaseRequestHandler(RequestHandler):
                 self.show_absent,
                 self.logger)
         # Put in our own unique id so we have some way to track this request:
-        if "request_id" not in metadata_dict:
-            metadata_dict["request_id"] = self.request_id
+        user_request_id: str = metadata_dict.get("request_id", "None")
+        if user_request_id == "None":
+            metadata_dict["request_id"] = f"request-{self.request_id}"
+        return metadata_dict
 
     @classmethod
     def get_request_metadata(cls, request,

--- a/neuro_san/service/http/handlers/base_request_handler.py
+++ b/neuro_san/service/http/handlers/base_request_handler.py
@@ -24,6 +24,7 @@ import asyncio
 import tornado
 from tornado.web import RequestHandler
 
+from neuro_san.service.utils.async_atomic_counter import AsyncAtomicCounter
 from neuro_san.service.generic.async_agent_service import AsyncAgentService
 from neuro_san.service.generic.async_agent_service_provider import AsyncAgentServiceProvider
 from neuro_san.internals.network_providers.agent_network_storage import AgentNetworkStorage
@@ -37,7 +38,7 @@ class BaseRequestHandler(RequestHandler):
     Provides logic to inject neuro-san service specific data
     into local handler context.
     """
-    request_id: int = 0
+    request_id_counter: AsyncAtomicCounter = AsyncAtomicCounter()
 
     # pylint: disable=attribute-defined-outside-init
     # pylint: disable=too-many-arguments
@@ -64,9 +65,7 @@ class BaseRequestHandler(RequestHandler):
         self.logger = HttpLogger(forwarded_request_metadata)
         self.network_storage_dict: Dict[str, AgentNetworkStorage] = network_storage_dict
         self.show_absent: bool = os.environ.get("SHOW_ABSENT_METADATA") is not None
-
-        # Set default request_id for this request handler in case we will need it:
-        BaseRequestHandler.request_id += 1
+        self.request_id: int = 0
 
         if os.environ.get("AGENT_ALLOW_CORS_HEADERS") is not None:
             self.set_header("Access-Control-Allow-Origin", "*")
@@ -84,11 +83,15 @@ class BaseRequestHandler(RequestHandler):
         from incoming request.
         :return: dictionary of user request metadata; possibly empty
         """
-        return BaseRequestHandler.get_request_metadata(
-            self.request,
-            self.forwarded_request_metadata,
-            self.show_absent,
-            self.logger)
+        metadata_dict: Dict[str, Any] =\
+            BaseRequestHandler.get_request_metadata(
+                self.request,
+                self.forwarded_request_metadata,
+                self.show_absent,
+                self.logger)
+        # Put in our own unique id so we have some way to track this request:
+        if "request_id" not in metadata_dict:
+            metadata_dict["request_id"] = self.request_id
 
     @classmethod
     def get_request_metadata(cls, request,
@@ -112,9 +115,6 @@ class BaseRequestHandler(RequestHandler):
         for item_name in forwarded_request_metadata:
             if item_name in headers.keys():
                 result[item_name] = headers[item_name]
-            elif item_name == "request_id":
-                # Generate unique id so we have some way to track this request:
-                result[item_name] = f"request-{BaseRequestHandler.request_id}"
             else:
                 if show_absent and logger:
                     logger.warning({}, "MISSING METADATA VALUE: %s request %s", item_name, request.uri)
@@ -162,13 +162,16 @@ class BaseRequestHandler(RequestHandler):
         """
         return
 
-    def prepare(self):
+    async def prepare(self):
         if not self.application.is_serving():
             self.set_status(503)
             self.write({"error": "Server is shutting down"})
             self.logger.error(self.get_metadata(), "Server is shutting down")
             self.do_finish()
             return
+
+        # Get unique request id in case we will need it:
+        self.request_id = await self.request_id_counter.next()
 
         self.logger.debug(self.get_metadata(), f"[REQUEST RECEIVED] {self.request.method} {self.request.uri}")
 

--- a/neuro_san/service/utils/async_atomic_counter.py
+++ b/neuro_san/service/utils/async_atomic_counter.py
@@ -1,11 +1,18 @@
 import asyncio
 
+
 class AsyncAtomicCounter:
-    def __init__(self, start=1):
+    """
+    Class implements atomic incrementing counter for async execution environment.
+    """
+    def __init__(self, start: int = 1):
         self._value = start
         self._lock = asyncio.Lock()
 
     async def next(self):
+        """
+        Get next counter value
+        """
         async with self._lock:
             v = self._value
             self._value += 1

--- a/neuro_san/service/utils/async_atomic_counter.py
+++ b/neuro_san/service/utils/async_atomic_counter.py
@@ -1,0 +1,12 @@
+import asyncio
+
+class AsyncAtomicCounter:
+    def __init__(self, start=1):
+        self._value = start
+        self._lock = asyncio.Lock()
+
+    async def next(self):
+        async with self._lock:
+            v = self._value
+            self._value += 1
+            return v

--- a/neuro_san/service/utils/service_resources.py
+++ b/neuro_san/service/utils/service_resources.py
@@ -12,8 +12,15 @@
 """
 See class definition for comments.
 """
+from typing import Any
+from typing import Dict
+from typing import Set
 from typing import Tuple
+import os
 import resource
+import socket
+import stat
+import sys
 import psutil
 
 
@@ -24,17 +31,71 @@ class ServiceResources:
     """
 
     @classmethod
-    def get_fd_usage(cls) -> Tuple[int, int, int]:
+    def iter_fds(cls):
         """
-        :return: tuple of 3 integer values:
-            number of file descriptors in use;
+        Iterator for all open file descriptors in current process:
+        """
+        fd_dir = "/proc/self/fd" if sys.platform.startswith("linux") else "/dev/fd"
+        for name in os.listdir(fd_dir):
+            try:
+                fd = int(name)
+            except Exception:  # pylint: disable=broad-exception-caught
+                continue
+            yield fd
+
+    @classmethod
+    def classify_fds(cls) -> Dict[str, int]:
+        """
+        Returns dictionary with counts for different kinds of file descriptors
+        currently open for our process
+        """
+        p = psutil.Process()
+
+        # Build maps of socket FDs for finer classification
+        inet_fds = {c.fd for c in p.connections(kind="inet")}  # tcp/udp
+        unix_fds = {c.fd for c in p.connections(kind="unix")}  # unix sockets
+
+        fd_dict: Dict[str, int] = {}
+        total_fds: int = 0
+        for fd in cls.iter_fds():
+            try:
+                st = os.fstat(fd)
+            except OSError:
+                continue  # fd may be closed already
+            mode = st.st_mode
+
+            if stat.S_ISREG(mode):
+                kind = "regular_file"
+            elif stat.S_ISSOCK(mode):
+                if fd in inet_fds:
+                    kind = "socket_inet"
+                elif fd in unix_fds:
+                    kind = "socket_unix"
+                else:
+                    kind = "other"
+            elif stat.S_ISFIFO(mode):
+                kind = "fifo_pipe"
+            else:
+                kind = "other"
+
+            total_fds = total_fds+1
+            count = fd_dict.get(kind, 0)
+            fd_dict[kind] = count+1
+        fd_dict["total"] = total_fds
+        return fd_dict
+
+    @classmethod
+    def get_fd_usage(cls) -> Tuple[Dict[str, int], int, int]:
+        """
+        :return: tuple of 3 values:
+            dictionary for kinds of file descriptors in use;
             soft limit for file descriptors for current process;
             hard limit for file descriptors for current process;
         """
         p = psutil.Process()
-        open_fds = p.num_fds()  # includes sockets, pipes, files
+        fd_dict: Dict[str, int] = cls.classify_fds()
         soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
-        return open_fds, soft, hard
+        return fd_dict, soft, hard
 
     @classmethod
     def active_tcp_on_port(cls, port: int) -> int:
@@ -47,3 +108,126 @@ class ServiceResources:
             if c.laddr and c.laddr.port == port and c.status != psutil.CONN_CLOSE:
                 cnt += 1
         return cnt
+
+    @classmethod
+    def classify_outbound_sockets(cls, outbound_tcp) -> Dict[str, Any]:
+        result: Dict[str, Any] = {}
+        for conn in outbound_tcp:
+            sock_addr: str = f"{conn.raddr}"
+            if sock_addr not in result:
+                result[sock_addr] = {}
+            sock_status: str = f"{conn.status}"
+            status_count: int = result[sock_addr].get(sock_status, 0)
+            result[sock_addr][sock_status] = status_count+1
+        return result
+
+    @classmethod
+    def classify_sockets(cls, server_port: int):
+        p = psutil.Process()
+        tcp = p.connections(kind="tcp")
+
+        inbound_listen = []
+        inbound_accepted = []
+        outbound_tcp = []
+
+        for c in tcp:
+            lport = c.laddr.port if c.laddr else None
+            # LISTEN sockets on the server port(s)
+            if c.status == psutil.CONN_LISTEN and lport==server_port:
+                inbound_listen.append(c)
+                continue
+            # Accepted inbound sockets on the server port(s)
+            if lport==server_port and c.status != psutil.CONN_LISTEN:
+                inbound_accepted.append(c)
+                continue
+            # Everything else TCP is outbound (client) from this process
+            outbound_tcp.append(c)
+
+        return {
+            "inbound_listen": len(inbound_listen),
+            "inbound_accepted": len(inbound_accepted),
+            "outbound_tcp": cls.classify_outbound_sockets(outbound_tcp)
+        }
+
+    @classmethod
+    def _fd_target(cls, fd: int) -> str | None:
+        """Best-effort: show what the fd points to via /proc or /dev/fd."""
+        try:
+            path = f"/proc/self/fd/{fd}" if sys.platform.startswith("linux") else f"/dev/fd/{fd}"
+            return os.readlink(path)
+        except Exception:
+            return None
+
+    @classmethod
+    def classify_unix_sockets(cls):
+        """
+        Classify Unix sockets open for current process
+        """
+        p = psutil.Process()
+        # psutil: kind="unix" returns only AF_UNIX sockets
+        conns = p.connections(kind="unix")
+
+        items = []  # list of dicts with details per socket
+
+        for c in conns:
+            fd = getattr(c, "fd", None)
+            addr = c.laddr  # For AF_UNIX: this is typically a string path or ''/None
+            s_type = {
+                socket.SOCK_STREAM: "STREAM",
+                socket.SOCK_DGRAM: "DGRAM",
+                socket.SOCK_SEQPACKET: "SEQPACKET",
+            }.get(getattr(c, "type", None), str(getattr(c, "type", None)))
+
+            # Determine category
+            if isinstance(addr, str) and addr:
+                if sys.platform.startswith("linux") and addr.startswith("\x00"):
+                    kind = "abstract"  # Linux abstract namespace
+                    disp = f"@{addr[1:]}"  # pretty form (tools often show '@name')
+                else:
+                    kind = "named"  # has filesystem pathname
+                    disp = addr
+            else:
+                # No address/path; typical for socketpair()/unnamed sockets
+                kind = "unnamed"
+                disp = ""
+
+            fd_link = cls._fd_target(fd) if fd is not None else None
+
+            items.append({
+                "fd": fd,
+                "kind": kind,
+                "type": s_type,
+                "address": disp,
+                "fd_target": fd_link,  # e.g., "socket:[12345]" (Linux) or "-> socket" (macOS)
+            })
+
+        return items
+
+    # if __name__ == "__main__":
+    #     items, counts = classify_unix_sockets()
+    #
+    #     total = sum(counts.values())
+    #     print(f"Unix domain sockets in this process: {total}")
+    #     for k in ("named", "abstract", "unnamed"):
+    #         if counts[k]:
+    #             print(f"  {k:8s}: {counts[k]}")
+    #
+    #     # Show a few examples for each category
+    #     print("\nExamples:")
+    #     by_kind = {"named": [], "abstract": [], "unnamed": []}
+    #     for it in items:
+    #         if len(by_kind[it["kind"]]) < 5:
+    #             by_kind[it["kind"]].append(it)
+    #
+    #     for k in ("named", "abstract", "unnamed"):
+    #         if not by_kind[k]:
+    #             continue
+    #         print(f"\n{k.upper()}:")
+    #         for it in by_kind[k]:
+    #             fd = it["fd"]
+    #             t = it["type"]
+    #             addr = it["address"] or "(no path)"
+    #             tgt = it["fd_target"] or "(n/a)"
+    #             print(f"  fd={fd} type={t:<9} addr={addr}  target={tgt}")
+
+


### PR DESCRIPTION
This PR does 2 things:
1. Fixes the logic for generating server-supplied request ids in case a client doesn't provide this information in request metadata;
2. Extends information for periodic logging of server run-time resources used, now it shows what kinds of file descriptors
    are currently opened by the server and describes inbound/outbound socket connections.
    This extra information helps with identifying potential points of resources leakage.
  