### PR TITLE
Factor out arg prep in ServerMainLoop

### DIFF
--- a/neuro_san/service/main_loop/server_main_loop.py
+++ b/neuro_san/service/main_loop/server_main_loop.py
@@ -71,9 +71,9 @@ class ServerMainLoop(ServerLoopCallbacks):
         self.http_server_config = HttpServerConfig()
         self.watcher_config: Dict[str, Any] = {}
 
-    def parse_args(self):
+    def prepare_args(self) -> ArgumentParser:
         """
-        Parse command-line arguments into member variables
+        :return: An ArgumentParser set up to parse command-line arguments
         """
         # Set up the CLI parser
         arg_parser = ArgumentParser()
@@ -133,6 +133,13 @@ class ServerMainLoop(ServerLoopCallbacks):
                                                            DEFAULT_HTTP_SERVER_MONITOR_INTERVAL_SECONDS)),
                                 help="Http server resources monitoring/logging interval in seconds "
                                      "0 means no logging")
+        return arg_parser
+
+    def parse_args(self):
+        """
+        Parse command-line arguments into member variables
+        """
+        arg_parser: ArgumentParser = self.prepare_args()
 
         # Actually parse the args into class variables
 


### PR DESCRIPTION
In another branch when adding new args, pylint started complaining about parse_args() being to big. 
So this breaks it up.