### PR TITLE
close() objects on sly_data that can be closed at the end of a session

### DIFF
--- a/neuro_san/coded_tools/math_guy/async_closeable.py
+++ b/neuro_san/coded_tools/math_guy/async_closeable.py
@@ -1,0 +1,27 @@
+
+# Copyright (C) 2023-2025 Cognizant Digital Business, Evolutionary AI.
+# All Rights Reserved.
+# Issued under the Academic Public License.
+#
+# You can be released from the terms, and requirements of the Academic Public
+# License by purchasing a commercial license.
+# Purchase of a commercial license is mandatory for any use of the
+# neuro-san SDK Software in commercial settings.
+#
+# END COPYRIGHT
+
+from logging import getLogger
+from logging import Logger
+
+
+class AsyncCloseable:
+    """
+    A simple object used to test the asynchronous close()-ing of objects on sly_data.
+    """
+
+    async def close(self):
+        """
+        Close the object
+        """
+        logger: Logger = getLogger(self.__class__.__name__)
+        logger.info("async close() called")

--- a/neuro_san/coded_tools/math_guy/calculator.py
+++ b/neuro_san/coded_tools/math_guy/calculator.py
@@ -14,6 +14,8 @@ from typing import Any
 from typing import Dict
 
 from neuro_san.interfaces.coded_tool import CodedTool
+from neuro_san.coded_tools.math_guy.async_closeable import AsyncCloseable
+from neuro_san.coded_tools.math_guy.sync_closeable import SyncCloseable
 
 
 class Calculator(CodedTool):
@@ -77,5 +79,11 @@ class Calculator(CodedTool):
                 return "Can't divide by 0"
 
         sly_data["equals"] = retval
+
+        # Add close()-able objects to test closing of sly_data
+        # These are only to enhance testing coverage and are non-essential
+        # to the function of this coded tool.
+        sly_data["sync_closeable"] = SyncCloseable()
+        sly_data["async_closeable"] = AsyncCloseable()
 
         return "Check sly_data['equals'] for the result"

--- a/neuro_san/coded_tools/math_guy/sync_closeable.py
+++ b/neuro_san/coded_tools/math_guy/sync_closeable.py
@@ -1,0 +1,27 @@
+
+# Copyright (C) 2023-2025 Cognizant Digital Business, Evolutionary AI.
+# All Rights Reserved.
+# Issued under the Academic Public License.
+#
+# You can be released from the terms, and requirements of the Academic Public
+# License by purchasing a commercial license.
+# Purchase of a commercial license is mandatory for any use of the
+# neuro-san SDK Software in commercial settings.
+#
+# END COPYRIGHT
+
+from logging import getLogger
+from logging import Logger
+
+
+class SyncCloseable:
+    """
+    A simple object used to test the synchronous close()-ing of objects on sly_data.
+    """
+
+    def close(self):
+        """
+        Close the object
+        """
+        logger: Logger = getLogger(self.__class__.__name__)
+        logger.info("sync close() called")

--- a/neuro_san/internals/chat/data_driven_chat_session.py
+++ b/neuro_san/internals/chat/data_driven_chat_session.py
@@ -315,5 +315,5 @@ class DataDrivenChatSession:
         except TypeError:
             # Not enough arguments to call close().
             logger: Logger = getLogger(self.__class__.__name__)
-            logger.error(f"Unable to close() {description}")
+            logger.error("Unable to close() %s", description)
             logger.error(traceback.format_exc())


### PR DESCRIPTION
This will allow folks to share longer-lived objects amongst coded tools more properly.
Sharing could be amongst different coded tools, or different invocations of the same coded tool within the same agent network invocation.  This should also contribute to the resistance of anyone needing to use a global variable.