### PR TITLE
UN-3443: Add "reasoning", "reasoning_effort", and "verbosity" parameters to "openai" class in default llm info.

### DIFF
--- a/neuro_san/internals/run_context/langchain/llms/default_llm_info.hocon
+++ b/neuro_san/internals/run_context/langchain/llms/default_llm_info.hocon
@@ -830,6 +830,11 @@
                 "tiktoken_model_name": null,
                 "stop": null,
 
+                # The following parameters are for reasoning models only.
+                "reasoning": null, # Reasoning parameters for reasoning models (Dict[str, Any])
+                "reasoning_effort": null, # Constrains effort on reasoning for reasoning models (str)
+                "verbosity": null, # Controls the verbosity level of responses for reasoning models (str)
+
                 # If you really need more parameters, you will likely have to create your own LlmFactory.
             }
         },

--- a/neuro_san/internals/run_context/langchain/llms/standard_langchain_llm_factory.py
+++ b/neuro_san/internals/run_context/langchain/llms/standard_langchain_llm_factory.py
@@ -99,6 +99,11 @@ class StandardLangChainLlmFactory(LangChainLlmFactory):
                 tiktoken_model_name=config.get("tiktoken_model_name"),
                 stop=config.get("stop"),
 
+                # The following three parameters are for reasoning models only.
+                reasoning=config.get("reasoning"),
+                reasoning_effort=config.get("reasoning_effort"),
+                verbosity=config.get("verbosity"),
+
                 # If omitted, this defaults to the global verbose value,
                 # accessible via langchain_core.globals.get_verbose():
                 # https://github.com/langchain-ai/langchain/blob/master/libs/core/langchain_core/globals.py#L53


### PR DESCRIPTION
Add `reasoning`, `reasoning_effort`, and `verbosity` for class `openai`.