### PR TITLE
UN-3377 Initialize logging setup for AsyncioExecutor.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 # requirements-build.txt
 
 # In-house dependencies
-leaf-common>=1.2.26
+leaf-common>=1.2.27
 leaf-server-common>=0.1.21
 
 # These are needed for generating code from .proto files


### PR DESCRIPTION
This PR attempts to address missing logging metadata issue by running logging setup
for each AsyncioExecutor instance as blocking call - making sure it is done
before we hand over this AsyncioExecutor for request processing.
