### PR TITLE
Make math_guy unit test more reliable

### DIFF
--- a/neuro_san/registries/math_guy.hocon
+++ b/neuro_san/registries/math_guy.hocon
@@ -84,15 +84,19 @@ on the secret numbers.
             },
 
             "instructions": """
-Always call the calculator tool to populate the return sly_data correctly.
-Return verbatim whatever it returns.
+You are an interface for a calculator tool.
+Always call the real_calculator tool to perform the arithmetic calculation,
+but know that the operand values will always be hidden from you. Do not ask
+for them. Instead trust that the real_calculator tool will get the operands
+by some other means, and just pass the name of the operator to the real_calculator tool.
+Return verbatim whatever real_calculator returns.
 """,
             "allow": {
                 "to_upstream": {
                     "sly_data": ["equals"]
                 }
             },
-            "tools": ["calculator"],
+            "tools": ["real_calculator"],
 
             "metadata": {
                 "rai_scores": {
@@ -106,7 +110,7 @@ Return verbatim whatever it returns.
         # The calculator is a low-level CodedTool and does not call anyone else.
         # He is called by the front-man.
         {
-            "name": "calculator",
+            "name": "real_calculator",
             "function": {
                 "description": "Performs arithmetic on sly-data values x and y given the operator",
                 "parameters": {

--- a/tests/fixtures/math_guy/basic_sly_data.hocon
+++ b/tests/fixtures/math_guy/basic_sly_data.hocon
@@ -22,7 +22,7 @@
     "interactions": [
         {
             # This is what we send as input to streaming_chat()
-            "text": "times",
+            "text": "multiply",
 
             "sly_data": {
                 "x": 847,

--- a/tests/fixtures/math_guy/forwarded_sly_data.hocon
+++ b/tests/fixtures/math_guy/forwarded_sly_data.hocon
@@ -25,7 +25,7 @@
     "interactions": [
         {
             # This is what we send as input to streaming_chat()
-            "text": "times",
+            "text": "multiply",
 
             "sly_data": {
                 "x": 847,


### PR DESCRIPTION
Existing prompting on math_guy has started to fail intermittently in unit tests.
Most of the time the LLM was worried that it wasn't receiving any input and asking for it, when the input was actually coming from the sly_data.  This expectation of further input is what was making the unit tests fail because they only expected a single interaction.

This change makes the prompting less vague and asks the LLM to trust that the calculator tool will get its inputs by other means.  It's less anxious now and so far I haven't seen a failure.