### PR TITLE
UN-3542 disable noisy ollama smoketest failure test case

### DIFF
--- a/tests/neuro_san/zzz_hocons/test_smoke_test_hocons.py
+++ b/tests/neuro_san/zzz_hocons/test_smoke_test_hocons.py
@@ -121,21 +121,21 @@ class TestSmokeTestHocons(TestCase):
 
         # List more hocon files as they become available here.
     ]))
-    @pytest.mark.timeout(12 * 60)  # in mins for this test
-    @pytest.mark.smoke
-    @pytest.mark.needs_server
-    @pytest.mark.non_default_llm_provider
-    @pytest.mark.ollama
-    def test_hocon_with_server_non_default_llm(self, test_name: str, test_hocon: str):
-        """
-        Test method for a single parameterized test case specified by a hocon file.
-        Arguments to this method are given by the iteration that happens as a result
-        of the magic of the @parameterized.expand annotation above.
+    # @pytest.mark.timeout(12 * 60)  # in mins for this test
+    # @pytest.mark.smoke
+    # @pytest.mark.needs_server
+    # @pytest.mark.non_default_llm_provider
+    # @pytest.mark.ollama
+    # def test_hocon_with_server_non_default_llm(self, test_name: str, test_hocon: str):
+    #     """
+    #     Test method for a single parameterized test case specified by a hocon file.
+    #     Arguments to this method are given by the iteration that happens as a result
+    #     of the magic of the @parameterized.expand annotation above.
 
-        :param test_name: The name of a single test.
-        :param test_hocon: The hocon file of a single data-driven test case.
-        """
-        # Call the guts of the dynamic test driver.
-        # This will expand the test_hocon file name from the expanded list to
-        # include the file basis implied by the __file__ and path_to_basis above.
-        self.DYNAMIC.one_test_hocon(self, test_name, test_hocon)
+    #     :param test_name: The name of a single test.
+    #     :param test_hocon: The hocon file of a single data-driven test case.
+    #     """
+    #     # Call the guts of the dynamic test driver.
+    #     # This will expand the test_hocon file name from the expanded list to
+    #     # include the file basis implied by the __file__ and path_to_basis above.
+    #     self.DYNAMIC.one_test_hocon(self, test_name, test_hocon)

--- a/tests/neuro_san/zzz_hocons/test_smoke_test_hocons.py
+++ b/tests/neuro_san/zzz_hocons/test_smoke_test_hocons.py
@@ -113,14 +113,14 @@ class TestSmokeTestHocons(TestCase):
         # include the file basis implied by the __file__ and path_to_basis above.
         self.DYNAMIC.one_test_hocon(self, test_name, test_hocon)
 
-    @parameterized.expand(DynamicHoconUnitTests.from_hocon_list([
-        # These can be in any order.
-        # Ideally more basic functionality will come first.
-        # Barring that, try to stick to alphabetical order.
-        "music_nerd_pro_llm_ollama/combination_responses_with_history_http.hocon",
+    # @parameterized.expand(DynamicHoconUnitTests.from_hocon_list([
+    #     # These can be in any order.
+    #     # Ideally more basic functionality will come first.
+    #     # Barring that, try to stick to alphabetical order.
+    #     "music_nerd_pro_llm_ollama/combination_responses_with_history_http.hocon",
 
-        # List more hocon files as they become available here.
-    ]))
+    #     # List more hocon files as they become available here.
+    # ]))
     # @pytest.mark.timeout(12 * 60)  # in mins for this test
     # @pytest.mark.smoke
     # @pytest.mark.needs_server


### PR DESCRIPTION
This PR is set to bypass the smoke test Ollama test case as it is becoming noisy for now [UN-3519]. We will reenable it after the issue has been addressed. I have added the comment to that ticket.