### PR TITLE
Comment some models that are marked for shutdown by OpenAI

### DIFF
--- a/neuro_san/internals/run_context/langchain/llms/default_llm_info.hocon
+++ b/neuro_san/internals/run_context/langchain/llms/default_llm_info.hocon
@@ -183,10 +183,12 @@
 
     "gpt-4-turbo-preview": {
         # FYI: LLMs that do not support tools cannot be used as front-men or branch nodes
+        # Per OpenAI, marked for shutdown on 03/26/2026.
         "use_model_name": "gpt-4-0125-preview",
     },
     "gpt-4-0125-preview": {
         # FYI: LLMs that do not support tools cannot be used as front-men or branch nodes
+        # Per OpenAI, marked for shutdown on 03/26/2026.
         "class": "openai",
         "model_info_url": "https://platform.openai.com/docs/models/gpt-4-turbo",
         "modalities": {
@@ -218,6 +220,7 @@
     },
     "gpt-4-0314": {
         # FYI: LLMs that do not support tools cannot be used as front-men or branch nodes
+        # Per OpenAI, marked for shutdown on 03/26/2026.
         "class": "openai",
         "model_info_url": "https://platform.openai.com/docs/models/gpt-4",
         "modalities": {
@@ -253,6 +256,7 @@
     },
     "gpt-3.5-turbo-1106": {
         # FYI: LLMs that do not support tools cannot be used as front-men or branch nodes
+        # Per OpenAI, marked for shutdown on 09/28/2026.
         "class": "openai",
         "model_info_url": "https://platform.openai.com/docs/models/gpt-3.5-turbo",
         "modalities": {
@@ -266,6 +270,7 @@
     },
     "gpt-3.5-turbo-instruct": {
         # FYI: LLMs that do not support tools cannot be used as front-men or branch nodes
+        # Per OpenAI, marked for shutdown on 09/28/2026.
         "class": "openai",
         "model_info_url": "https://platform.openai.com/docs/models/gpt-3.5-turbo",
         "modalities": {


### PR DESCRIPTION
Per recent email from OpenAI some models are scheduled for shutdown:

Shutdown on March 26, 2026
* gpt-4-0314
* gpt-4-1106-preview
* gpt-4-0125-preview (including gpt-4-turbo-preview and gpt-4-turbo-preview-completions, which point to this snapshot)

Shutdown on September 28, 2026
* gpt-3.5-turbo-instruct
* babbage-002
* davinci-002
* gpt-3.5-turbo-1106

We refer to some of these, so adding a comment in the default_llm_info.hocon file about this.