### PR TITLE
Fix MCP tool filtering

### DIFF
--- a/neuro_san/internals/run_context/langchain/mcp/langchain_mcp_adapter.py
+++ b/neuro_san/internals/run_context/langchain/mcp/langchain_mcp_adapter.py
@@ -90,7 +90,7 @@ class LangChainMcpAdapter:
         client_allowed_tools: List[str] = allowed_tools
         if client_allowed_tools is None:
             # Check if MCP client info has a "tools" field to use as allowed tools.
-            client_allowed_tools = LangChainMcpAdapter._mcp_clients_info.get("tools")
+            client_allowed_tools = LangChainMcpAdapter._mcp_clients_info.get(server_url, {}).get("tools")
         if client_allowed_tools:
             mcp_tools = [tool for tool in mcp_tools if tool.name in client_allowed_tools]
 


### PR DESCRIPTION
### Issue
- `LangChainMcpAdapter.get_mcp_tools` fails to filter the tools.
- This is because we are looking for field "tools" before the URL. 

### Solution
- Look for "tools" after the URL.