### PR TITLE
483-Removed gRPC test case from this list

### DIFF
--- a/tests/neuro_san/zzz_hocons/test_smoke_test_hocons.py
+++ b/tests/neuro_san/zzz_hocons/test_smoke_test_hocons.py
@@ -40,32 +40,6 @@ class TestSmokeTestHocons(TestCase):
     ]))
     @pytest.mark.timeout(30)  # 30 seconds for this test
     @pytest.mark.smoke
-    def test_hocon(self, test_name: str, test_hocon: str):
-        """
-        Test method for a single parameterized test case specified by a hocon file.
-        Arguments to this method are given by the iteration that happens as a result
-        of the magic of the @parameterized.expand annotation above.
-
-        :param test_name: The name of a single test.
-        :param test_hocon: The hocon file of a single data-driven test case.
-        """
-        # Call the guts of the dynamic test driver.
-        # This will expand the test_hocon file name from the expanded list to
-        # include the file basis implied by the __file__ and path_to_basis above.
-        self.DYNAMIC.one_test_hocon(self, test_name, test_hocon)
-
-    @parameterized.expand(DynamicHoconUnitTests.from_hocon_list([
-        # These can be in any order.
-        # Ideally more basic functionality will come first.
-        # Barring that, try to stick to alphabetical order.
-        # http has been covered by integration test
-        # "music_nerd_pro/combination_responses_with_history_http.hocon",
-        "music_nerd_pro/combination_responses_with_history_grpc.hocon",
-
-        # List more hocon files as they become available here.
-    ]))
-    @pytest.mark.timeout(30)  # 30 seconds for this test
-    @pytest.mark.smoke
     @pytest.mark.needs_server
     def test_hocon_with_server(self, test_name: str, test_hocon: str):
         """


### PR DESCRIPTION
This PR removed the failure test case from the nightly run smoke test.
The change below is the result of a smoke test failure currently.
Disable gRPC connectivity and gRPC service in neuro-san. https://github.com/cognizant-ai-lab/neuro-san/pull/476
