### PR TITLE
Add thinking fields for anthropic and bedrock models

### DIFF
--- a/neuro_san/internals/run_context/langchain/llms/default_llm_info.hocon
+++ b/neuro_san/internals/run_context/langchain/llms/default_llm_info.hocon
@@ -901,6 +901,14 @@
                 # stream_usage is always set to True so that token counting can work correctly
 
                 # The following parameters are for reasoning models only.
+                # Supported models
+                # Extended thinking is supported in the following models:
+                # Claude Sonnet 4.5 (claude-sonnet-4-5-20250929)
+                # Claude Sonnet 4 (claude-sonnet-4-20250514)
+                # Claude Sonnet 3.7 (claude-3-7-sonnet-20250219)
+                # Claude Haiku 4.5 (claude-haiku-4-5-20251001)
+                # Claude Opus 4.1 (claude-opus-4-1-20250805)
+                # Claude Opus 4 (claude-opus-4-20250514)
                 "thinking": null, # Parameters for Claude reasoning, e.g., {"type": "enabled", "budget_tokens": 10_000}
             }
         },
@@ -983,7 +991,7 @@
                 "temperature": null,
 
                 # Keyword arguments to pass to the model.
-                # Can be used to pass reasoning parameters for reasoning models.
+                # Can be used to pass reasoning parameters for Anthropic reasoning models.
                 # For example: {"thinking": {"type": "enabled", "budget_tokens": 10000}}
                 "model_kwargs": null,
             }


### PR DESCRIPTION
### Summary

Currently, only OpenAI and Ollama models support fields for adjusting thinking or reasoning effort.
This PR extends that functionality to include **Anthropic** and **Bedrock** models.

### Changes

Added `thinking` field for **Anthropic** models.

Added `model_kwargs` field for **Bedrock** models.

### Notes

**Gemini** models previously supported a `thinking_budget` field in `langchain < 1.0`, but it has been removed in newer versions.

Additional documentation on how to toggle reasoning for each provider will be included in a future PR.