### PR TITLE
436 - fix generation of safe MCP server response.

### DIFF
--- a/neuro_san/service/mcp/util/requests_util.py
+++ b/neuro_san/service/mcp/util/requests_util.py
@@ -29,6 +29,8 @@ class RequestsUtil:
         """
         if isinstance(request_id, str):
             return html.escape(request_id)
+        # Do not escape integers, just return as-is
+        # otherwise, MCP client gets confused and could reject this response
         if isinstance(request_id, int):
             return request_id
         return "invalid"


### PR DESCRIPTION
Turns out it matters:
when generating an "HTTP safe" service response,
do not convert request id from int to a string - MCP client get confused and freezes.
