### PR TITLE
#523 Add kube env vars to tracing metadata by default

### DIFF
--- a/neuro_san/deploy/Dockerfile
+++ b/neuro_san/deploy/Dockerfile
@@ -200,11 +200,10 @@ ENV AGENT_USAGE_LOGGER=""
 # AGENT_FORWARDED_REQUEST_METADATA
 ENV AGENT_USAGE_LOGGER_METADATA=""
 
-# A space-delimited list of environment variables to be forwarded to observability tracing metadata
-# The defaults given here are the ones used by the default tracing implementation
-# and are standard Kubernetes environment variables for any given pod of a deployment.
+# A space-delimited list of environment variables to be forwarded to observability tracing metadata.
+# The defaults given here are standard Kubernetes environment variables for any given deployment pod.
 # Only environment variables that are set to something other than the empty string will be forwarded.
-ENV AGENT_TRACING_ENV_VARS="POD_NAME POD_NAMESPACE POD_IP NODE_NAME"
+ENV AGENT_TRACING_METADATA_ENV_VARS="POD_NAME POD_NAMESPACE POD_IP NODE_NAME"
 
 # Size of backlog for TCP connections to http server.
 # Sets the maximum number of pending TCP connections waiting to be accepted by the server.

--- a/neuro_san/internals/run_context/langchain/core/neuro_san_runnable.py
+++ b/neuro_san/internals/run_context/langchain/core/neuro_san_runnable.py
@@ -243,7 +243,7 @@ class NeuroSanRunnable(RunnablePassthrough):
 
         # Add values for listed env vars if they have values.
         # Defaults are standard env vars for kubernetes deployments
-        env_vars_str: str = os.getenv("AGENT_TRACING_ENV_VARS", "POD_NAME POD_NAMESPACE POD_IP NODE_NAME")
+        env_vars_str: str = os.getenv("AGENT_TRACING_METADATA_ENV_VARS", "POD_NAME POD_NAMESPACE POD_IP NODE_NAME")
         if env_vars_str:
             env_vars: List[str] = env_vars_str.split(" ")
             for env_var in env_vars:


### PR DESCRIPTION
* Add the ability to log env vars as tracing metadata so observability apps can pick it up
* By default we look for 4 standard Kube env vars so cluster integration is effortless.
* Add docs to example Dockerfile that tell about the new AGENT_TRACING_METADATA_ENV_VARS env var which controls this.

Addresses #523 