### PR TITLE
Remove retired LLM models

### DIFF
--- a/neuro_san/internals/run_context/langchain/llms/default_llm_info.hocon
+++ b/neuro_san/internals/run_context/langchain/llms/default_llm_info.hocon
@@ -54,21 +54,6 @@
         "max_output_tokens": 100000,
         "knowledge_cutoff": "09/30/2023",
     },
-    "o1-preview": {
-        "use_model_name": "o1-preview-2024-09-12",
-    },
-    "o1-preview-2024-09-12": {
-        "class": "openai",
-        "model_info_url": "https://platform.openai.com/docs/models/o1",
-        "modalities": {
-            "input": [ "text" ],
-            "output": [ "text" ],
-        },
-        "capabilities": [ "tools" ],
-        "context_window_size": 128000,
-        "max_output_tokens": 32768,
-        "knowledge_cutoff": "09/30/2023",
-    },
     "gpt-5": {
         "use_model_name": "gpt-5-2025-08-07",
     },
@@ -378,23 +363,6 @@
         "context_window_size": 200000,
         "max_output_tokens": 8192,
         "knowledge_cutoff": "07/2024",
-    },
-
-    "claude-3-5-sonnet": {
-        "use_model_name": "claude-3-5-sonnet-20241022",
-    },
-    "claude-3-5-sonnet-20241022": {
-        "class": "anthropic",
-        "model_info_url": "https://docs.anthropic.com/en/docs/about-claude/models/all-models#model-comparison-table",
-        "modalities": {
-            "input": [ "text", "image" ],
-            "output": [ "text" ],
-        },
-        # Tool use: https://docs.anthropic.com/en/docs/build-with-claude/tool-use/overview#pricing
-        "capabilities": [ "tools" ],
-        "context_window_size": 200000,
-        "max_output_tokens": 8192,
-        "knowledge_cutoff": "04/2024",
     },
 
     "claude-3-7-sonnet": {
@@ -760,44 +728,6 @@
         # https://cloud.google.com/vertex-ai/generative-ai/pricing
         "price_per_1k_input_tokens": 0.000075,
         "price_per_1k_output_tokens": 0.0003,
-    },
-    # According to https://cloud.google.com/vertex-ai/generative-ai/pricing
-    # gemini models older than 2.0 are priced based on number of characters not tokens.
-    "gemini-1.5-flash": {
-        "class": "gemini",
-        "model_info_url": "https://ai.google.dev/gemini-api/docs/models#gemini-1.5-flash",
-        "modalities": {
-            "input": [ "text", "images", "video", "audio" ],
-            "output": [ "text" ],
-        },
-        "capabilities": [ "tools" ],
-        "context_window_size": 1048576,
-        "max_output_tokens": 8192,
-        "knowledge_cutoff": "09/2024",
-    },
-    "gemini-1.5-flash-8b": {
-        "class": "gemini",
-        "model_info_url": "https://ai.google.dev/gemini-api/docs/models#gemini-1.5-flash-8b",
-        "modalities": {
-            "input": [ "text", "images", "video", "audio" ],
-            "output": [ "text" ],
-        },
-        "capabilities": [ "tools" ],
-        "context_window_size": 1048576,
-        "max_output_tokens": 8192,
-        "knowledge_cutoff": "10/2024",
-    },
-    "gemini-1.5-pro": {
-        "class": "gemini",
-        "model_info_url": "https://ai.google.dev/gemini-api/docs/models#gemini-1.5-pro",
-        "modalities": {
-            "input": [ "text", "images", "video", "audio" ],
-            "output": [ "text" ],
-        },
-        "capabilities": [ "tools" ],
-        "context_window_size": 2097152,
-        "max_output_tokens": 8192,
-        "knowledge_cutoff": "09/2024",
     },
 
     # Bedrock


### PR DESCRIPTION
The following models have been removed:
- `o1-preview-2024-09-12`
- `claude-3-5-sonnet-20241022`
- `gemini-1.5-flash-8b`
- `gemini-1.5-flash`
- `gemini-1.5-pro`

### Tests
All the above models have been tested to make sure that they are no longer available.

### References
- https://platform.openai.com/docs/deprecations
- https://docs.claude.com/en/docs/about-claude/model-deprecations
- https://ai.google.dev/gemini-api/docs/deprecations