### PR TITLE
Remove agent_scratchpad

### DIFF
--- a/neuro_san/internals/run_context/langchain/core/langchain_run_context.py
+++ b/neuro_san/internals/run_context/langchain/core/langchain_run_context.py
@@ -285,7 +285,6 @@ class LangChainRunContext(RunContext):
         message_list.extend([
             ("placeholder", "{chat_history}"),
             ("human", "{input}"),
-            ("placeholder", "{agent_scratchpad}"),
         ])
 
         prompt: ChatPromptTemplate = ChatPromptTemplate.from_messages(message_list)


### PR DESCRIPTION
### Issue
#525 

### Description
`agent_scratchpad` is only used for `AgentExecutor` of `langchain < 1.0` not `create_agent` of `langchain >= 1.0`.

### Test
The following agent networks have been tested via the CLI, and both the responses and thinking files have been verified as valid.
- `music_nerd_pro`
- `music_nerd_pro_llm_anthropic`
- `music_nerd_pro_llm_ollama`
- `music_nerd_pro_multi_agents`
- `esp_decision_assistant`
- `intranet_agents`