### PR TITLE
1C: Fix handling of reloaded AgentNetwork definition.

### DIFF
--- a/neuro_san/internals/network_providers/agent_network_storage.py
+++ b/neuro_san/internals/network_providers/agent_network_storage.py
@@ -71,10 +71,10 @@ class AgentNetworkStorage(AgentStorageSource):
         for listener in self.listeners:
             if is_new:
                 listener.agent_added(agent_name, self)
-                self.logger.info("ADDED network for agent %s", agent_name)
+                self.logger.info("ADDED network for agent %s : %d", agent_name, id(agent_network))
             else:
                 listener.agent_modified(agent_name, self)
-                self.logger.info("REPLACED network for agent %s", agent_name)
+                self.logger.info("REPLACED network for agent %s : %d", agent_name, id(agent_network))
 
     def setup_agent_networks(self, agent_networks: Dict[str, AgentNetwork]):
         """
@@ -97,13 +97,15 @@ class AgentNetworkStorage(AgentStorageSource):
         so that agent becomes unavailable on our server.
         """
         with self.lock:
+            agent_network: AgentNetwork = self.agents_table.get(agent_name, None)
             self.agents_table.pop(agent_name, None)
 
         # Notify listeners about this state change:
         # do it outside of internal lock
         for listener in self.listeners:
             listener.agent_removed(agent_name, self)
-        self.logger.info("REMOVED network for agent %s", agent_name)
+        # We can log id(None) if necessary - that's a legal value
+        self.logger.info("REMOVED network for agent %s : %d", agent_name, id(agent_network))
 
     def get_agent_network_provider(self, agent_name: str) -> AgentNetworkProvider:
         """

--- a/neuro_san/service/generic/async_agent_service_provider.py
+++ b/neuro_san/service/generic/async_agent_service_provider.py
@@ -84,6 +84,14 @@ class AsyncAgentServiceProvider:
                         self.server_context)
         return self.service_instance
 
+    def reset_service(self):
+        """
+        Reset service instance to None to allow re-creation on next get_service() call
+        in case underlying AgentNetwork has changed.
+        """
+        with self.lock:
+            self.service_instance = None
+
     def service_created(self) -> bool:
         """
         Return True if service instance has already been instantiated;

--- a/neuro_san/service/http/server/http_server.py
+++ b/neuro_san/service/http/server/http_server.py
@@ -264,9 +264,10 @@ class HttpServer(AgentAuthorizer, AgentStateListener):
         :param agent_name: name of an agent
         :param source: The AgentStorageSource source of the message
         """
-        # Endpoints configuration has not changed,
-        # so nothing to do here, actually.
-        _ = agent_name
+        agent_service_provider: AsyncAgentServiceProvider = self.allowed_agents.get(agent_name, None)
+        if agent_service_provider is not None:
+            agent_service_provider.reset_service()
+            self.logger.info({}, "Reset service for modified agent %s", agent_name)
 
     def build_request_data(self) -> Dict[str, Any]:
         """


### PR DESCRIPTION
This PR does 2 things in an attempt to address 1C team reported problem with dynamic update of agent .hocon definitions:
1. Adds logic to force reloading of AsyncAgentService instance when agent definition is being replaced with modified one.   Previously, we did use some stale cached values from previous AgentNetwork configuration;
2. Adds more debug logging to check which AgentService instances are used for API calls.
    Tested by manually updating manifest file of running neuro-san server, and also by running short mini-stress test.
