### PR TITLE
NS-571 Add local port setting for localhost situation

### DIFF
--- a/neuro_san/internals/interfaces/invocation_context.py
+++ b/neuro_san/internals/interfaces/invocation_context.py
@@ -111,3 +111,9 @@ class InvocationContext:
         :return: The Reservationist instance for the session
         """
         raise NotImplementedError
+
+    def get_port(self) -> int:
+        """
+        :return: The port on which the server was started
+        """
+        raise NotImplementedError

--- a/neuro_san/internals/run_context/utils/external_agent_parsing.py
+++ b/neuro_san/internals/run_context/utils/external_agent_parsing.py
@@ -19,7 +19,6 @@ from typing import Dict
 from typing import List
 from typing import Union
 
-from os import environ
 from urllib.parse import ParseResult
 from urllib.parse import urlparse
 
@@ -31,9 +30,11 @@ class ExternalAgentParsing:
     """
 
     @staticmethod
-    def parse_external_agent(agent_url: str) -> Dict[str, str]:
+    def parse_external_agent(agent_url: str, server_port: int = None) -> Dict[str, str]:
         """
         :param agent_url: The URL describing where to find the desired agent.
+        :param server_port: The port that the server is listening on
+                            Does not have to be set for all operations.
         :return: A Dictionary with the following keys:
                 "host" - the hostname where the agent lives
                 "port" - the port on the host which serves up the agent (if any)
@@ -76,7 +77,7 @@ class ExternalAgentParsing:
             # If we are localhost and no port was specified in the url,
             # use the port that was configured for the server.
             # If this is not set, it will default to None, which is fine.
-            port = environ.get("AGENT_HTTP_PORT")
+            port = server_port
 
         # Get the agent name from the URL by looking at the path
         # Remove any leading slashes from the path for the agent name.

--- a/neuro_san/service/generic/agent_service.py
+++ b/neuro_san/service/generic/agent_service.py
@@ -105,6 +105,7 @@ class AgentService:
         self.llm_factory: ContextTypeLlmFactory = MasterLlmFactory.create_llm_factory(config)
         self.toolbox_factory: ContextTypeToolboxFactory = MasterToolboxFactory.create_toolbox_factory(config)
         self.async_executor_pool: AsyncioExecutorPool = server_context.get_executor_pool()
+        self.port: int = server_context.get_server_port()
 
         self.request_timeout_seconds: float = agent_network.get_request_timeout_seconds()
 
@@ -255,7 +256,8 @@ class AgentService:
             self.llm_factory,
             self.toolbox_factory,
             metadata,
-            reservationist)
+            reservationist,
+            self.port)
         invocation_context.start()
 
         # Set up logging inside async thread

--- a/neuro_san/service/generic/async_agent_service.py
+++ b/neuro_san/service/generic/async_agent_service.py
@@ -93,6 +93,7 @@ class AsyncAgentService:
         self.agent_network_provider: AgentNetworkProvider = agent_network_provider
         self.agent_name: str = agent_name
         self.request_counter = AtomicCounter()
+        self.port: int = server_context.get_server_port()
 
         self.async_executor_pool: AsyncioExecutorPool = server_context.get_executor_pool()
         self.reload_factories()
@@ -254,7 +255,8 @@ class AsyncAgentService:
             self.llm_factory,
             self.toolbox_factory,
             metadata,
-            reservationist)
+            reservationist,
+            self.port)
         invocation_context.start()
 
         # Set up logging inside async thread

--- a/neuro_san/service/main_loop/server_main_loop.py
+++ b/neuro_san/service/main_loop/server_main_loop.py
@@ -167,6 +167,7 @@ class ServerMainLoop:
         self.http_port = args.http_port
         if self.http_port == 0:
             server_status.http_service.set_requested(False)
+        self.server_context.set_server_port(self.http_port)
 
         self.server_name_for_logs = args.server_name_for_logs
         self.max_concurrent_requests = args.max_concurrent_requests

--- a/neuro_san/service/utils/server_context.py
+++ b/neuro_san/service/utils/server_context.py
@@ -21,6 +21,7 @@ from janus import Queue
 
 from leaf_common.asyncio.asyncio_executor_pool import AsyncioExecutorPool
 
+from neuro_san.interfaces.agent_session_constants import AgentSessionConstants
 from neuro_san.internals.chat.async_collating_queue import AsyncCollatingQueue
 from neuro_san.internals.network_providers.agent_network_storage import AgentNetworkStorage
 from neuro_san.internals.network_providers.expiring_agent_network_storage import ExpiringAgentNetworkStorage
@@ -41,6 +42,7 @@ class ServerContext:
         self.executor_pool = AsyncioExecutorPool(reuse_mode=True)
         self.queues: Queue[AsyncCollatingQueue] = Queue()
         self.mcp_server_context: McpServerContext = McpServerContext()
+        self.server_port: int = AgentSessionConstants.DEFAULT_HTTP_PORT
 
         # Dictionary is string key (describing scope) to AgentNetworkStorage grouping.
         self.network_storage_dict: Dict[str, AgentNetworkStorage] = {
@@ -91,3 +93,15 @@ class ServerContext:
         :return: The MCPServerContext for MCP service operations
         """
         return self.mcp_server_context
+
+    def set_server_port(self, port: int):
+        """
+        Sets the server port
+        """
+        self.server_port = port
+
+    def get_server_port(self) -> int:
+        """
+        :return: The Server port
+        """
+        return self.server_port

--- a/neuro_san/session/external_agent_session_factory.py
+++ b/neuro_san/session/external_agent_session_factory.py
@@ -60,7 +60,8 @@ class ExternalAgentSessionFactory(AsyncAgentSessionFactory):
         :return: An AsyncAgentSession through which communications about the external agent can be made.
         """
 
-        agent_location: Dict[str, str] = ExternalAgentParsing.parse_external_agent(agent_url)
+        server_port: int = invocation_context.get_port()
+        agent_location: Dict[str, str] = ExternalAgentParsing.parse_external_agent(agent_url, server_port=server_port)
         session: AsyncAgentSession = self.create_session_from_location_dict(agent_location, invocation_context)
         return session
 

--- a/neuro_san/session/session_invocation_context.py
+++ b/neuro_san/session/session_invocation_context.py
@@ -54,7 +54,8 @@ class SessionInvocationContext(InvocationContext):
                  llm_factory: ContextTypeLlmFactory,
                  toolbox_factory: ContextTypeToolboxFactory = None,
                  metadata: Dict[str, str] = None,
-                 reservationist: Reservationist = None):
+                 reservationist: Reservationist = None,
+                 port: int = None):
         """
         Constructor
 
@@ -69,6 +70,7 @@ class SessionInvocationContext(InvocationContext):
                          the header. Default is None. Preferred format is a
                          dictionary of string keys to string values.
         :param reservationist: The Reservationist instance to use.
+        :param port: The port on which the server was started
         """
 
         # From args
@@ -79,6 +81,7 @@ class SessionInvocationContext(InvocationContext):
         self.toolbox_factory: ContextTypeToolboxFactory = toolbox_factory
         self.metadata: Dict[str, str] = metadata
         self.reservationist: Reservationist = reservationist
+        self.port: int = port
 
         # Internal
         # Get an async executor to run all tasks for this session instance:
@@ -181,6 +184,12 @@ class SessionInvocationContext(InvocationContext):
         :return: The agent name for the session
         """
         return self.agent_name
+
+    def get_port(self) -> int:
+        """
+        :return: The port on which the server was started
+        """
+        return self.port
 
     def reset(self):
         """


### PR DESCRIPTION
Fix local external agent connections when local server is running on something other than the default AGENT_HTTP_PORT.

Manually tested math_guy_passthrough and it's now happy.  Fixes #571 

@Noravee : Unclear if there is a separate mcp server component that would need to be addressed for the same situation.