### PR TITLE
NS-472 Use latest langchain-nvidia-ai-endpoints which is compatible with langchain v1

### DIFF
--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -5,8 +5,7 @@
 langchain-anthropic>=1.0.0,<1.1
 langchain-aws>=1.0.0,<1.1
 langchain-google-genai>=3.0.0,<3.1
-# Note: As of 10/20/2025 langchain-nvidia is not ready for langchain==1.0.x
-#langchain-nvidia-ai-endpoints>=0.3.8,<1.1
+langchain-nvidia-ai-endpoints>=1.0.0,<1.1
 langchain-ollama>=1.0.0,<1.1
 
 # Tests


### PR DESCRIPTION
Title sez it all

Worth noting that this dependency is only in requirements-build.txt, but it's significant that it's back online for neuro-san usage again.