### PR TITLE
Tweak agent hocon reference docs to emphasize essentials for beginners

### DIFF
--- a/docs/agent_hocon_reference.md
+++ b/docs/agent_hocon_reference.md
@@ -43,7 +43,7 @@ Items in ***bold*** are essentials. Try to understand these first.
 - [Single Agent Specification](#single-agent-specification)
     - [***name*** - the name of the agent so that other agents can reference it](#name)
     - [***function*** - specifies what the agent can do/needs as input to clients or other agents](#function)
-        - [***description*** - description of what the agent can do](#description-1)
+        - [***description*** - description of what the agent can do for both agents and clients](#description-1)
         - [***parameters*** - schema for agent input](#parameters)
             - [type](#type)
             - [properties](#properties)


### PR DESCRIPTION
Recalling some feedback from a user that though neuro-san was its own language (it isn't),
I took a fresh look at the agent hocon spec and made an effort to try to emphasize the essentials in the table of contents.
I think these little changes could go a long way towards greater understanding for noobs.

Basically:
* Move essentials to the top of the major TOC listings.
* Make the HOCON key be in a bold typeface.
* Add a short description to the TOC entry for orientation.

Tested how it looks with grip.