### PR TITLE
Some build tweaks

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,23 @@
+[run]
+# Include specific source so we can tell when entire directories are not measured
+# XXX It'd sure be nice to have a way to make this repo-agnostic.
+source = 
+    neuro_san
+
+# Omit specific files or directories from the coverage measurement
+omit =
+    # Exclude the entire 'tests' directory
+    tests/*
+    # Exclude everything in /usr which usually also means Python standard library
+    /usr/*
+
+# Do not measure coverage for the Python standard library
+cover_pylib = false
+
+[report]
+# Omit specific files or directories from the coverage measurement
+omit =
+    # Exclude the entire 'tests' directory
+    tests/*
+    # Exclude everything in /usr which usually also means Python standard library
+    /usr/*

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,7 @@ on:
     branches:
       - "**"
   pull_request:
+    types: [opened, reopened]
     branches:
       - main
 jobs:
@@ -47,7 +48,7 @@ jobs:
         shell: bash
         run: |
           build_scripts/server_start.sh
-          pytest --verbose -m "not integration and not smoke" --timer-top-n 10 -n auto --cov=neuro_san
+          pytest --verbose -m "not integration and not smoke" --timer-top-n 10 -n auto --cov-config=.coveragerc --cov
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           AGENT_TOOL_PATH: "./neuro_san/coded_tools"

--- a/.gitignore
+++ b/.gitignore
@@ -36,10 +36,9 @@ site/
 # macOS folder metadata
 .DS_Store
 
-# Temporary integrtion test files
+# Temporary integration test files
 tmp_*
 .coverage
-.coverage*
 
 # Transient openapi file
 neuro_san/api/grpc/openapi.yaml


### PR DESCRIPTION
* Use a .coveragerc instead of piling the coverage needs on the pytest command line
* This makes test.yml more repo-agnostic
* Add config to not have tests.yml run more than once per PR checkin after a PR is opened.