### PR TITLE
Upgrade langchain-openai to a minimum of 1.0.0 to match langchain and langchain-core

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -48,7 +48,8 @@ pydantic>=2.9.2,<3.0
 # those guys work, but we do not want to make everyone install everything
 # and all the ensuing transient dependencies for the world.
 # For a list of other LLMs we support out of the box, see requirements-build.txt
-langchain-openai>=0.3.29,<1.1
+# NOTE: This version should be aligned with the langchain and langchain-core versions above.
+langchain-openai>=1.0.0,<1.1
 
 httpx>=0.28.1
 


### PR DESCRIPTION
Upgraded `langchain-openai` minimum version to `1.0.0`
It now matches the version requirements of `langchain` and `langchain-core` and should probably be kept in synch with them.

For reference, the image generation API has changed and versions prior to `langchain-openai` `1.0.0` won't work for  the image generation tool in Neuro SAN Studio (added in https://github.com/cognizant-ai-lab/neuro-san-studio/pull/492)

