### PR TITLE
NS-638: Fix conversion for ChatMessages.

### DIFF
--- a/neuro_san/service/generic/chat_message_converter.py
+++ b/neuro_san/service/generic/chat_message_converter.py
@@ -33,7 +33,11 @@ class ChatMessageConverter(DictionaryConverter):
         :param obj: The object (chat response) to be converted into a dictionary
         :return: chat response dictionary in format expected by clients
         """
+        # Do "the safe" copy, moving over only json serializable values.
+        # Note that values of ChatMessageType are passed through,
+        # because they are handled by a separate post-processing step.
         response_dict = self.to_json_safe(obj)
+        # This is where ChatMessageType enum values are converted:
         self.convert(response_dict)
         return response_dict
 


### PR DESCRIPTION
This PR fixes the crash encountered when using MCP tool from neuro-san agent.
The issue is: when doing ChatMessage conversion by means of ChatMessageConverter class,
we rely on deepcopy() method. But it turns out, some of our messages (especially coming back from Langchain MCP adaptors) could contain a lot of lower-level objects which are neither copy-able nor json serializable.
So the need to do a conversion in more careful manner, cutting out all "bad" sub-objects which will not go into final chat results sent back to a client.
