### PR TITLE
Update dependencies cap to langchain-core -> 2.0 for dependabot fix

### DIFF
--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -2,11 +2,11 @@
 # necessary for operation to minimize the size of containers
 
 # For LLM Access
-langchain-anthropic>=1.0.0,<1.1
-langchain-aws>=1.0.0,<1.1
+langchain-anthropic>=1.0.0,<2.0
+langchain-aws>=1.0.0,<2.0
 langchain-google-genai>=3.0.0,<3.1
-langchain-nvidia-ai-endpoints>=1.0.0,<1.1
-langchain-ollama>=1.0.0,<1.1
+langchain-nvidia-ai-endpoints>=1.0.0,<2.0
+langchain-ollama>=1.0.0,<2.0
 
 # Tests
 pytest==8.3.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,7 +49,7 @@ pydantic>=2.9.2,<3.0
 # and all the ensuing transient dependencies for the world.
 # For a list of other LLMs we support out of the box, see requirements-build.txt
 # NOTE: This version should be aligned with the langchain and langchain-core versions above.
-langchain-openai>=1.0.0,<1.1
+langchain-openai>=1.0.0,<2.0
 
 httpx>=0.28.1
 


### PR DESCRIPTION
Fix dependabot issue by raising cap on langchain versions to 2.0 instead of 1.1
Latest security fixes are going into langchain==1.2.x these days