### PR TITLE
NS-641 Remove colons from filename to fix hocon test cases on Windows

### DIFF
--- a/neuro_san/test/driver/data_driven_agent_test_driver.py
+++ b/neuro_san/test/driver/data_driven_agent_test_driver.py
@@ -232,7 +232,7 @@ Need at least {num_need_success} to consider {hocon_file} test to be successful.
 
         # Prepare the processor
         now = datetime.now()
-        datestr: str = now.strftime("%Y-%m-%d-%H:%M:%S")
+        datestr: str = now.strftime("%Y-%m-%d-%H_%M_%S")
         thinking_file: str = f"/tmp/agent_test/{datestr}_agent.txt"
         # Added fixture_hocon_name to thinking_dir
         # for better uniqueness and traceability across different test fixtures.


### PR DESCRIPTION
Fixes worst part of #641 which had windows machines failing on the directory created because of colons in the file path