### PR TITLE
Add "runtime" to the policy object keys to remove from messages

### DIFF
--- a/neuro_san/internals/journals/tool_argument_reporting.py
+++ b/neuro_san/internals/journals/tool_argument_reporting.py
@@ -27,8 +27,9 @@ class ToolArgumentReporting:
     """
 
     # List of keys for policy objects that cannot be serialized in a message.
-    # These are set in AbstractClassActivation.
-    POLICY_OBJECT_KEYS: List[str] = ["reservationist", "progress_reporter"]
+    # The first two are set in AbstractClassActivation.
+    # The last one is injected by Langgraph when using MCP tools with langchain-mcp-adapters>=0.1.14.
+    POLICY_OBJECT_KEYS: List[str] = ["reservationist", "progress_reporter", "runtime"]
 
     @staticmethod
     def prepare_tool_start_dict(tool_args: Dict[str, Any],


### PR DESCRIPTION
#658 

Thinking file JSON parsing error when using MCP tools

```
TypeError: Object of type ToolRuntime is not JSON serializable
when serializing dict item 'runtime'
when serializing dict item 'params'
```

This is because since version 0.1.14, `langchain-mcp-adapters` automatically injects the full `ToolRuntime` object as a parameter to all tool invocations.

https://github.com/langchain-ai/langchain-mcp-adapters/releases/tag/langchain-mcp-adapters%3D%3D0.1.14
https://github.com/langchain-ai/langchain-mcp-adapters/issues/376