### PR TITLE
Add client-side local-time timestamps to events going into thinking files

### DIFF
--- a/neuro_san/client/thinking_file_message_processor.py
+++ b/neuro_san/client/thinking_file_message_processor.py
@@ -125,7 +125,7 @@ class ThinkingFileMessageProcessor(MessageProcessor):
                 # Retry with a uuid as file name.
                 # If this fails, there's no helping ya.
                 origin_filename = str(uuid.uuid4())
-                self._write_to_file(origin_filename, origin_str, message_type_str, use_origin, text)
+                self._write_to_file(origin_filename, origin_str, message_type_str, use_origin, text, timestamp)
 
                 # Squirell that uuid away so results continue to go to the same
                 # file over and over again.


### PR DESCRIPTION
An obviously necessary feature requested by @jcyn2004 

Output in thinking files now looks like this:

```
[SYSTEM] @ 2026-01-21 10:03:11:

You are a decision assistant.
...
```

The idea is that client-side timestamps is likely good enough for most cases.
Server-side timestamps could require a protocol change and innards manipulation.
For now this is the Easy (and still very useful) thing to do.
Sequence is at least preserved, which is really the most important aspect.

Fixes #670 