### PR TITLE
NS-688 pass request header metadata to sly_data

### DIFF
--- a/neuro_san/internals/chat/data_driven_chat_session.py
+++ b/neuro_san/internals/chat/data_driven_chat_session.py
@@ -118,8 +118,11 @@ class DataDrivenChatSession(RunTarget):
 
         # Update sly data with metadata from the request headers so this information
         # can be made available in CodedTools, privately, without any leakage to LLMs.
+        # Only add this if it doesn't already exist w/rt what the user gave us.
         if self.sly_data.get("request_metadata") is None:
-            self.sly_data["request_metadata"] = invocation_context.get_metadata()
+            # Make a deep copy so the server's idea of the original metadata doesn't get modified
+            # should any CodedTool somehow get the idea to modify it.
+            self.sly_data["request_metadata"] = copy.deepcopy(invocation_context.get_metadata())
 
         run_context: RunContext = RunContextFactory.create_run_context(None, None,
                                                                        invocation_context=invocation_context,


### PR DESCRIPTION
Pass the dictionary of metadata that is in the HTTP request as its own field called "request_metadata" in sly_data.

Was able to verify manually using a modified math_guy calculator that:
* "request_metadata" does indeed show up as expected
* request_metadata does not go back to client by default as expected.

Addresses #688 