### PR TITLE
NS-721 Log out errors from registry watchers.

### DIFF
--- a/neuro_san/service/http/server/http_server.py
+++ b/neuro_san/service/http/server/http_server.py
@@ -168,7 +168,7 @@ class HttpServer(AgentAuthorizer, AgentStateListener):
                 if isinstance(startable, Startable):
                     try:
                         startable.start()
-                    except Exception as exception: # pylint: disable=broad-exception-caught
+                    except Exception as exception:  # pylint: disable=broad-exception-caught
                         self.logger.error(
                             {}, "Failed to start %s: %s",
                             startable.__class__.__name__, str(exception))


### PR DESCRIPTION
This PR fixes the issue of not reporting any failures in registry watchers startup logic.
Exceptions were indeed thrown, but quietly suppressed in HTTP server code.
Now we log them out.
Tested by attempting to start temp networks watcher with invalid S3 bucket.


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cognizant-ai-lab/neuro-san/pull/724" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
