### PR TITLE
Demote temp storage update log to debug level

### DIFF
--- a/neuro_san/service/watcher/temp_networks/temp_network_storage_updater.py
+++ b/neuro_san/service/watcher/temp_networks/temp_network_storage_updater.py
@@ -115,7 +115,6 @@ class TempNetworkStorageUpdater(AbstractStorageUpdater):
 
         # Process all our queues.
         # We take a copy because during processing we might remove a queue from the pool.
-        self.logger.debug("Updating temp storage from %d queues", before)
         for queue in self.queue_pool.copy():
             self.process_one_queue(queue)
 

--- a/neuro_san/service/watcher/temp_networks/temp_network_storage_updater.py
+++ b/neuro_san/service/watcher/temp_networks/temp_network_storage_updater.py
@@ -115,6 +115,7 @@ class TempNetworkStorageUpdater(AbstractStorageUpdater):
 
         # Process all our queues.
         # We take a copy because during processing we might remove a queue from the pool.
+        self.logger.debug("Updating temp storage from %d queues", before)
         for queue in self.queue_pool.copy():
             self.process_one_queue(queue)
 

--- a/neuro_san/service/watcher/temp_networks/temp_network_storage_updater.py
+++ b/neuro_san/service/watcher/temp_networks/temp_network_storage_updater.py
@@ -115,7 +115,7 @@ class TempNetworkStorageUpdater(AbstractStorageUpdater):
 
         # Process all our queues.
         # We take a copy because during processing we might remove a queue from the pool.
-        self.logger.info("Updating temp storage from %d queues", before)
+        self.logger.debug("Updating temp storage from %d queues", before)
         for queue in self.queue_pool.copy():
             self.process_one_queue(queue)
 


### PR DESCRIPTION
# Demote temp storage update log to debug level

## Summary

Demotes the `"Updating temp storage from N queues"` log message in `TempNetworkStorageUpdater.update_storage()` from `info` to `debug` level. This message fires every update cycle (~10 seconds) as long as there are queues in the pool, even when no actual work is processed, creating significant log spam in production.

The `"Temp storage from N queues finished"` message remains at `info` level since it only fires when queues actually complete — a meaningful state change worth logging.

## Updates since last revision

- Per reviewer feedback, restored the log line at `debug` level instead of removing it entirely.

## Review & Testing Checklist for Human

- [ ] **Important caveat**: The deployment (`neuro-san-deploy`) currently configures `AGENT_SERVICE_LOG_LEVEL="DEBUG"`, which means this change alone will **not** suppress the spam in production. You may need to raise the deployment log level (e.g. to `INFO`) or adjust `logging.json` filtering to see the benefit of this change.
- [ ] Verify no other high-frequency log messages in the temp networks feature need similar treatment.

### Notes

- Requested by: @donn-leaf
- [Link to Devin run](https://app.devin.ai/sessions/c45642535ff34434aa6870406d949105)