### PR TITLE
Add sonnet 4.6 and gemini 3.1 pro

### DIFF
--- a/neuro_san/internals/run_context/langchain/llms/default_llm_info.hocon
+++ b/neuro_san/internals/run_context/langchain/llms/default_llm_info.hocon
@@ -497,6 +497,20 @@
         "knowledge_cutoff": "07/2025",
     },
 
+    "claude-sonnet-4-6": {
+        "class": "anthropic",
+        "model_info_url": "https://docs.anthropic.com/en/docs/about-claude/models/all-models#model-comparison-table",
+        "modalities": {
+            "input": [ "text", "image" ],
+            "output": [ "text" ],
+        },
+        # Tool use: https://docs.anthropic.com/en/docs/build-with-claude/tool-use/overview#pricing
+        "capabilities": [ "tools" ],
+        "context_window_size": 200000,
+        "max_output_tokens": 64000,
+        "knowledge_cutoff": "01/2026",
+    },
+
     "claude-opus-4-5": {
         "use_model_name": "claude-opus-4-5-20251101"
     },
@@ -728,6 +742,44 @@
     },
 
     # Google Gemini
+    "gemini-3.1-pro": {
+        "use_model_name": "gemini-3.1-pro-preview"
+    },
+    "gemini-3.1-pro-preview": {
+        "class": "gemini",
+        "model_info_url": "https://ai.google.dev/gemini-api/docs/models/gemini-3.1-pro-preview",
+        "modalities": {
+            "input": [ "text", "images", "video", "audio", "pdf"],
+            "output": [ "text"],
+        },
+        "capabilities": [ "tools" ],
+        "context_window_size": 1048576,
+        "max_output_tokens": 65536,
+        "knowledge_cutoff": "01/2025",
+        # https://cloud.google.com/vertex-ai/generative-ai/pricing
+        "price_per_1k_input_tokens": 0.002,
+        "price_per_1k_output_tokens": 0.012,
+    },
+    # This model is optimized for agentic workflows that use custom tools and bash
+    "gemini-3.1-pro-customtools": {
+        "use_model_name": "gemini-3.1-pro-preview-customtools"
+    },
+    "gemini-3.1-pro-preview-customtools": {
+        "class": "gemini",
+        "model_info_url": "https://ai.google.dev/gemini-api/docs/models/gemini-3.1-pro-preview",
+        "modalities": {
+            "input": [ "text", "images", "video", "audio", "pdf"],
+            "output": [ "text"],
+        },
+        "capabilities": [ "tools" ],
+        "context_window_size": 1048576,
+        "max_output_tokens": 65536,
+        "knowledge_cutoff": "01/2025",
+        # https://cloud.google.com/vertex-ai/generative-ai/pricing
+        "price_per_1k_input_tokens": 0.002,
+        "price_per_1k_output_tokens": 0.012,
+    },
+
     "gemini-3-pro": {
         "use_model_name": "gemini-3-pro-preview"
     },


### PR DESCRIPTION
Add the following models in `default_llm_info.hocon`:
- `claude-sonnet-4-6`
- `gemini-3.1-pro-preview`
- `gemini-3.1-pro-preview-customtools`