### PR TITLE
Add network metadata to MCP tool _meta field

### DIFF
--- a/neuro_san/client/agent_cli.py
+++ b/neuro_san/client/agent_cli.py
@@ -509,7 +509,7 @@ Have external tools that can be found in the local agent manifest use a service 
         tools_list: List[Dict[str, Any]] = response_dict.get("result", {}).get("tools", [])
         tools_description: List[Dict[str, Any]] = []
         for tool in tools_list:
-            metadata: Dict[str, str] = tool.get("_meta", {})
+            metadata: Dict[str, Any] = tool.get("_meta", {})
             tool_description: Dict[str, Any] = {
                 "agent_name": tool.get("name", "<Unnamed Tool>"),
                 "description": metadata.get("description", ""),
@@ -517,7 +517,7 @@ Have external tools that can be found in the local agent manifest use a service 
             }
             tools_description.append(tool_description)
 
-        empty_list: List[Dict[str, Any]] = []
+        empty_list: List[str] = []
         if self.args.tags:
             tags = set()
             for tool_info in tools_description:

--- a/neuro_san/client/agent_cli.py
+++ b/neuro_san/client/agent_cli.py
@@ -528,5 +528,6 @@ Have external tools that can be found in the local agent manifest use a service 
         else:
             print(f"Available tools:\n{json.dumps(response_dict, indent=4, sort_keys=True)}")
 
+
 if __name__ == '__main__':
     AgentCli().main()

--- a/neuro_san/client/agent_cli.py
+++ b/neuro_san/client/agent_cli.py
@@ -513,7 +513,7 @@ Have external tools that can be found in the local agent manifest use a service 
         tools_list: List[Dict[str, Any]] = response_dict.get("result", {}).get("tools", [])
         tools_description: List[Dict[str, Any]] = []
         for tool in tools_list:
-            metadata: Dict[str, str] = tool.get("_meta", {})
+            metadata: Dict[str, Any] = tool.get("_meta", {})
             tool_description: Dict[str, Any] = {
                 "agent_name": tool.get("name", "<Unnamed Tool>"),
                 "description": metadata.get("description", ""),
@@ -521,7 +521,7 @@ Have external tools that can be found in the local agent manifest use a service 
             }
             tools_description.append(tool_description)
 
-        empty_list: List[Dict[str, Any]] = []
+        empty_list: List[str] = []
         if self.args.tags:
             tags = set()
             for tool_info in tools_description:

--- a/neuro_san/client/agent_cli.py
+++ b/neuro_san/client/agent_cli.py
@@ -510,23 +510,35 @@ Have external tools that can be found in the local agent manifest use a service 
 
         mcp_session: McpServiceAgentSession = self.session
         response_dict: Dict[str, Any] = mcp_session.list({})
+        tools_list: List[Dict[str, Any]] = response_dict.get("result", {}).get("tools", [])
+        tools_description: List[Dict[str, Any]] = []
+        for tool in tools_list:
+            metadata: Dict[str, str] = tool.get("_meta", {})
+            tool_description: Dict[str, Any] = {
+                "agent_name": tool.get("name", "<Unnamed Tool>"),
+                "description": metadata.get("description", ""),
+                "tags": metadata.get("tags", [])
+            }
+            tools_description.append(tool_description)
+
         empty_list: List[Dict[str, Any]] = []
         if self.args.tags:
             tags = set()
-            for agent_info in response_dict.get("agents", empty_list):
-                agent_tags: List[str] = agent_info.get("tags", empty_list)
-                tags.update(agent_tags)
+            for tool_info in tools_description:
+                tool_tags: List[str] = tool_info.get("tags", empty_list)
+                tags.update(tool_tags)
             print(f"Available tags:\n{json.dumps(list(tags), indent=4, sort_keys=True)}")
 
         elif self.args.tag:
-            print(f"Available agents for tag {self.args.tag}:\n")
-            for agent_info in response_dict.get("agents", empty_list):
-                agent_tags: List[str] = agent_info.get("tags", empty_list)
-                if self.args.tag in agent_tags:
-                    print(json.dumps(agent_info, indent=4, sort_keys=True))
+            print(f"Available tools for tag {self.args.tag}:\n")
+            for tool_info in tools_description:
+                tool_tags: List[str] = tool_info.get("tags", empty_list)
+                if self.args.tag in tool_tags:
+                    print(json.dumps(tool_info, indent=4, sort_keys=True))
 
         else:
-            print(f"Available tools:\n{json.dumps(response_dict, indent=4, sort_keys=True)}")
+            print(f'Available tools:\n{json.dumps({"tools": tools_description}, indent=4, sort_keys=True)}')
+
 
 if __name__ == '__main__':
     AgentCli().main()

--- a/neuro_san/client/agent_cli.py
+++ b/neuro_san/client/agent_cli.py
@@ -284,7 +284,7 @@ Some suggestions:
         group = arg_parser.add_argument_group(title="Session Type",
                                               description="How will we connect to neuro-san?")
         group.add_argument("--connection", default="direct", type=str,
-                           choices=["direct", "http", "https"],
+                           choices=["direct", "http", "https", "mcp"],
                            help="""
 The type of connection to initiate. Choices are to connect to:
     "http"      - an agent service via HTTP. Needs host and port.

--- a/neuro_san/client/agent_cli.py
+++ b/neuro_san/client/agent_cli.py
@@ -36,6 +36,7 @@ from neuro_san.client.concierge_session_factory import ConciergeSessionFactory
 from neuro_san.client.streaming_input_processor import StreamingInputProcessor
 from neuro_san.interfaces.agent_session import AgentSession
 from neuro_san.interfaces.concierge_session import ConciergeSession
+from neuro_san.session.mcp_service_agent_session import McpServiceAgentSession
 
 
 class AgentCli:
@@ -68,12 +69,22 @@ class AgentCli:
         """
         self.parse_args(args)
 
-        # See if we are doing a list operation
-        if self.args.list or self.args.tags or self.args.tag:
+        use_mcp: bool = self.args.connection == "mcp"
+        do_list: bool = self.args.list or self.args.tags or self.args.tag
+
+        # See if we are doing a list operation for non-MCP connection types:
+        if not use_mcp and do_list:
             self.list()
             return
 
         self.open_session()
+
+        # Now check if we are doing a list operation for MCP connection type,
+        # for this we need to have the session open since the MCP tools are listed via a session call:
+        if use_mcp and do_list:
+            self.mcp_list()
+            return
+
         if self.args.connectivity:
             self.connectivity()
         else:
@@ -485,6 +496,37 @@ Have external tools that can be found in the local agent manifest use a service 
         else:
             print(f"Available agents:\n{json.dumps(response_dict, indent=4, sort_keys=True)}")
 
+    def mcp_list(self):
+        """
+        List available MCP tools (agents) via a MCP tools/list request
+        """
+        # We assume MCP session is already set up thanks to "mcp" connection type,
+        # so we just need to send the list request.
+
+        if not isinstance(self.session, McpServiceAgentSession):
+            print("McpServiceAgentSession is not set up.")
+            print("Please use the --mcp connection type to connect to an MCP server.")
+            return
+
+        mcp_session: McpServiceAgentSession = self.session
+        response_dict: Dict[str, Any] = mcp_session.list({})
+        empty_list: List[Dict[str, Any]] = []
+        if self.args.tags:
+            tags = set()
+            for agent_info in response_dict.get("agents", empty_list):
+                agent_tags: List[str] = agent_info.get("tags", empty_list)
+                tags.update(agent_tags)
+            print(f"Available tags:\n{json.dumps(list(tags), indent=4, sort_keys=True)}")
+
+        elif self.args.tag:
+            print(f"Available agents for tag {self.args.tag}:\n")
+            for agent_info in response_dict.get("agents", empty_list):
+                agent_tags: List[str] = agent_info.get("tags", empty_list)
+                if self.args.tag in agent_tags:
+                    print(json.dumps(agent_info, indent=4, sort_keys=True))
+
+        else:
+            print(f"Available tools:\n{json.dumps(response_dict, indent=4, sort_keys=True)}")
 
 if __name__ == '__main__':
     AgentCli().main()

--- a/neuro_san/client/agent_cli.py
+++ b/neuro_san/client/agent_cli.py
@@ -506,23 +506,35 @@ Have external tools that can be found in the local agent manifest use a service 
 
         mcp_session: McpServiceAgentSession = self.session
         response_dict: Dict[str, Any] = mcp_session.list({})
+        tools_list: List[Dict[str, Any]] = response_dict.get("result", {}).get("tools", [])
+        tools_description: List[Dict[str, Any]] = []
+        for tool in tools_list:
+            metadata: Dict[str, str] = tool.get("_meta", {})
+            tool_description: Dict[str, Any] = {
+                "agent_name": tool.get("name", "<Unnamed Tool>"),
+                "description": metadata.get("description", ""),
+                "tags": metadata.get("tags", [])
+            }
+            tools_description.append(tool_description)
+
         empty_list: List[Dict[str, Any]] = []
         if self.args.tags:
             tags = set()
-            for agent_info in response_dict.get("agents", empty_list):
-                agent_tags: List[str] = agent_info.get("tags", empty_list)
-                tags.update(agent_tags)
+            for tool_info in tools_description:
+                tool_tags: List[str] = tool_info.get("tags", empty_list)
+                tags.update(tool_tags)
             print(f"Available tags:\n{json.dumps(list(tags), indent=4, sort_keys=True)}")
 
         elif self.args.tag:
-            print(f"Available agents for tag {self.args.tag}:\n")
-            for agent_info in response_dict.get("agents", empty_list):
-                agent_tags: List[str] = agent_info.get("tags", empty_list)
-                if self.args.tag in agent_tags:
-                    print(json.dumps(agent_info, indent=4, sort_keys=True))
+            print(f"Available tools for tag {self.args.tag}:\n")
+            for tool_info in tools_description:
+                tool_tags: List[str] = tool_info.get("tags", empty_list)
+                if self.args.tag in tool_tags:
+                    print(json.dumps(tool_info, indent=4, sort_keys=True))
 
         else:
-            print(f"Available tools:\n{json.dumps(response_dict, indent=4, sort_keys=True)}")
+            print(f'Available tools:\n{json.dumps({"tools": tools_description}, indent=4, sort_keys=True)}')
+
 
 if __name__ == '__main__':
     AgentCli().main()

--- a/neuro_san/client/agent_cli.py
+++ b/neuro_san/client/agent_cli.py
@@ -36,6 +36,7 @@ from neuro_san.client.concierge_session_factory import ConciergeSessionFactory
 from neuro_san.client.streaming_input_processor import StreamingInputProcessor
 from neuro_san.interfaces.agent_session import AgentSession
 from neuro_san.interfaces.concierge_session import ConciergeSession
+from neuro_san.session.mcp_service_agent_session import McpServiceAgentSession
 
 
 class AgentCli:
@@ -66,12 +67,22 @@ class AgentCli:
         """
         self.parse_args()
 
-        # See if we are doing a list operation
-        if self.args.list or self.args.tags or self.args.tag:
+        use_mcp: bool = self.args.connection == "mcp"
+        do_list: bool = self.args.list or self.args.tags or self.args.tag
+
+        # See if we are doing a list operation for non-MCP connection types:
+        if not use_mcp and do_list:
             self.list()
             return
 
         self.open_session()
+
+        # Now check if we are doing a list operation for MCP connection type,
+        # for this we need to have the session open since the MCP tools are listed via a session call:
+        if use_mcp and do_list:
+            self.mcp_list()
+            return
+
         if self.args.connectivity:
             self.connectivity()
         else:
@@ -481,6 +492,37 @@ Have external tools that can be found in the local agent manifest use a service 
         else:
             print(f"Available agents:\n{json.dumps(response_dict, indent=4, sort_keys=True)}")
 
+    def mcp_list(self):
+        """
+        List available MCP tools (agents) via a MCP tools/list request
+        """
+        # We assume MCP session is already set up thanks to "mcp" connection type,
+        # so we just need to send the list request.
+
+        if not isinstance(self.session, McpServiceAgentSession):
+            print("McpServiceAgentSession is not set up.")
+            print("Please use the --mcp connection type to connect to an MCP server.")
+            return
+
+        mcp_session: McpServiceAgentSession = self.session
+        response_dict: Dict[str, Any] = mcp_session.list({})
+        empty_list: List[Dict[str, Any]] = []
+        if self.args.tags:
+            tags = set()
+            for agent_info in response_dict.get("agents", empty_list):
+                agent_tags: List[str] = agent_info.get("tags", empty_list)
+                tags.update(agent_tags)
+            print(f"Available tags:\n{json.dumps(list(tags), indent=4, sort_keys=True)}")
+
+        elif self.args.tag:
+            print(f"Available agents for tag {self.args.tag}:\n")
+            for agent_info in response_dict.get("agents", empty_list):
+                agent_tags: List[str] = agent_info.get("tags", empty_list)
+                if self.args.tag in agent_tags:
+                    print(json.dumps(agent_info, indent=4, sort_keys=True))
+
+        else:
+            print(f"Available tools:\n{json.dumps(response_dict, indent=4, sort_keys=True)}")
 
 if __name__ == '__main__':
     AgentCli().main()

--- a/neuro_san/client/agent_cli.py
+++ b/neuro_san/client/agent_cli.py
@@ -510,35 +510,23 @@ Have external tools that can be found in the local agent manifest use a service 
 
         mcp_session: McpServiceAgentSession = self.session
         response_dict: Dict[str, Any] = mcp_session.list({})
-        tools_list: List[Dict[str, Any]] = response_dict.get("result", {}).get("tools", [])
-        tools_description: List[Dict[str, Any]] = []
-        for tool in tools_list:
-            metadata: Dict[str, Any] = tool.get("_meta", {})
-            tool_description: Dict[str, Any] = {
-                "agent_name": tool.get("name", "<Unnamed Tool>"),
-                "description": metadata.get("description", tool.get("description", "")),
-                "tags": metadata.get("tags", [])
-            }
-            tools_description.append(tool_description)
-
-        empty_list: List[str] = []
+        empty_list: List[Dict[str, Any]] = []
         if self.args.tags:
             tags = set()
-            for tool_info in tools_description:
-                tool_tags: List[str] = tool_info.get("tags", empty_list)
-                tags.update(tool_tags)
+            for agent_info in response_dict.get("agents", empty_list):
+                agent_tags: List[str] = agent_info.get("tags", empty_list)
+                tags.update(agent_tags)
             print(f"Available tags:\n{json.dumps(list(tags), indent=4, sort_keys=True)}")
 
         elif self.args.tag:
-            print(f"Available tools for tag {self.args.tag}:\n")
-            for tool_info in tools_description:
-                tool_tags: List[str] = tool_info.get("tags", empty_list)
-                if self.args.tag in tool_tags:
-                    print(json.dumps(tool_info, indent=4, sort_keys=True))
+            print(f"Available agents for tag {self.args.tag}:\n")
+            for agent_info in response_dict.get("agents", empty_list):
+                agent_tags: List[str] = agent_info.get("tags", empty_list)
+                if self.args.tag in agent_tags:
+                    print(json.dumps(agent_info, indent=4, sort_keys=True))
 
         else:
-            print(f'Available tools:\n{json.dumps({"tools": tools_description}, indent=4, sort_keys=True)}')
-
+            print(f"Available tools:\n{json.dumps(response_dict, indent=4, sort_keys=True)}")
 
 if __name__ == '__main__':
     AgentCli().main()

--- a/neuro_san/client/agent_cli.py
+++ b/neuro_san/client/agent_cli.py
@@ -516,7 +516,7 @@ Have external tools that can be found in the local agent manifest use a service 
             metadata: Dict[str, Any] = tool.get("_meta", {})
             tool_description: Dict[str, Any] = {
                 "agent_name": tool.get("name", "<Unnamed Tool>"),
-                "description": metadata.get("description", ""),
+                "description": metadata.get("description", tool.get("description", "")),
                 "tags": metadata.get("tags", [])
             }
             tools_description.append(tool_description)

--- a/neuro_san/internals/graph/registry/agent_network.py
+++ b/neuro_san/internals/graph/registry/agent_network.py
@@ -17,6 +17,7 @@
 from typing import Any
 from typing import Dict
 from typing import List
+from typing import Optional
 
 from objsize import get_deep_size
 
@@ -167,7 +168,7 @@ However, the front man must not be:
 
         return front_man
 
-    def get_metadata(self) -> Dict[str, Any]:
+    def get_metadata(self) -> Optional[Dict[str, Any]]:
         """
         :return: The metadata dictionary from the agent network config,
                  or None if no metadata is defined.

--- a/neuro_san/internals/graph/registry/agent_network.py
+++ b/neuro_san/internals/graph/registry/agent_network.py
@@ -163,6 +163,13 @@ However, the front man must not be:
 
         return front_man
 
+    def get_metadata(self) -> Dict[str, Any]:
+        """
+        :return: The metadata dictionary from the agent network config,
+                 or None if no metadata is defined.
+        """
+        return self.config.get("metadata", None)
+
     def get_network_name(self) -> str:
         """
         :return: The network name of this AgentNetwork

--- a/neuro_san/internals/graph/registry/agent_network.py
+++ b/neuro_san/internals/graph/registry/agent_network.py
@@ -167,6 +167,13 @@ However, the front man must not be:
 
         return front_man
 
+    def get_metadata(self) -> Dict[str, Any]:
+        """
+        :return: The metadata dictionary from the agent network config,
+                 or None if no metadata is defined.
+        """
+        return self.config.get("metadata", None)
+
     def get_network_name(self) -> str:
         """
         :return: The network name of this AgentNetwork

--- a/neuro_san/internals/graph/registry/agent_network.py
+++ b/neuro_san/internals/graph/registry/agent_network.py
@@ -17,6 +17,7 @@
 from typing import Any
 from typing import Dict
 from typing import List
+from typing import Optional
 
 from leaf_common.parsers.dictionary_extractor import DictionaryExtractor
 
@@ -163,7 +164,7 @@ However, the front man must not be:
 
         return front_man
 
-    def get_metadata(self) -> Dict[str, Any]:
+    def get_metadata(self) -> Optional[Dict[str, Any]]:
         """
         :return: The metadata dictionary from the agent network config,
                  or None if no metadata is defined.

--- a/neuro_san/service/mcp/processors/mcp_tools_processor.py
+++ b/neuro_san/service/mcp/processors/mcp_tools_processor.py
@@ -80,7 +80,7 @@ class McpToolsProcessor:
             if provider is not None:
                 agent_network: AgentNetwork = provider.get_agent_network()
                 if agent_network.is_mcp_tool():
-                    tool_dict: Dict[str, Any] = \
+                    tool_dict: Optional[Dict[str, Any]] = \
                         await self._get_tool_description(agent_name, agent_network, metadata)
                     if tool_dict is not None:
                         tools_description.append(tool_dict)

--- a/neuro_san/service/mcp/processors/mcp_tools_processor.py
+++ b/neuro_san/service/mcp/processors/mcp_tools_processor.py
@@ -235,8 +235,8 @@ class McpToolsProcessor:
             "inputSchema": self.tool_request_validator.get_request_schema()
         }
         # Include agent network metadata in MCP _meta field if available:
-        network_metadata: Dict[str, Any] = agent_network.get_metadata()
-        if network_metadata is not None:
+        network_metadata: Any = agent_network.get_metadata()
+        if isinstance(network_metadata, dict):
             tool_dict["_meta"] = network_metadata
         return tool_dict
 

--- a/neuro_san/service/mcp/processors/mcp_tools_processor.py
+++ b/neuro_san/service/mcp/processors/mcp_tools_processor.py
@@ -81,7 +81,8 @@ class McpToolsProcessor:
                 if agent_network.is_mcp_tool():
                     tool_dict: Dict[str, Any] = \
                         await self._get_tool_description(agent_name, agent_network, metadata)
-                    tools_description.append(tool_dict)
+                    if tool_dict is not None:
+                        tools_description.append(tool_dict)
         return {
             "jsonrpc": "2.0",
             "id": RequestUtil.safe_request_id(request_id),

--- a/neuro_san/service/mcp/processors/mcp_tools_processor.py
+++ b/neuro_san/service/mcp/processors/mcp_tools_processor.py
@@ -79,7 +79,8 @@ class McpToolsProcessor:
             if provider is not None:
                 agent_network: AgentNetwork = provider.get_agent_network()
                 if agent_network.is_mcp_tool():
-                    tool_dict: Dict[str, Any] = await self._get_tool_description(agent_name, metadata)
+                    tool_dict: Dict[str, Any] = \
+                        await self._get_tool_description(agent_name, agent_network, metadata)
                     tools_description.append(tool_dict)
         return {
             "jsonrpc": "2.0",
@@ -212,7 +213,11 @@ class McpToolsProcessor:
         call_result["result"]["content"][0]["text"] = RequestUtil.safe_message(result_text)
         return call_result
 
-    async def _get_tool_description(self, agent_name: str, metadata: Dict[str, Any]) -> Dict[str, Any]:
+    async def _get_tool_description(
+            self,
+            agent_name: str,
+            agent_network: AgentNetwork,
+            metadata: Dict[str, Any]) -> Dict[str, Any]:
 
         is_authorized: bool = False
         service_provider: AsyncAgentServiceProvider = None
@@ -224,11 +229,16 @@ class McpToolsProcessor:
         service: AsyncAgentService = service_provider.get_service()
         function_dict: Dict[str, Any] = await service.function({}, metadata)
         tool_description: str = function_dict.get("function", {}).get("description", "")
-        return {
+        tool_dict: Dict[str, Any] = {
             "name": agent_name,
             "description": tool_description,
             "inputSchema": self.tool_request_validator.get_request_schema()
         }
+        # Include agent network metadata in MCP _meta field if available:
+        network_metadata: Dict[str, Any] = agent_network.get_metadata()
+        if network_metadata is not None:
+            tool_dict["_meta"] = network_metadata
+        return tool_dict
 
     async def _extract_tool_response_part(
             self, response_dict: Dict[str, Any]) -> Tuple[str, Dict[str, Any]]:

--- a/neuro_san/service/mcp/processors/mcp_tools_processor.py
+++ b/neuro_san/service/mcp/processors/mcp_tools_processor.py
@@ -20,6 +20,7 @@ See class comment for details
 from typing import Any
 from typing import Dict
 from typing import List
+from typing import Optional
 from typing import Tuple
 
 import asyncio
@@ -236,12 +237,12 @@ class McpToolsProcessor:
             "inputSchema": self.tool_request_validator.get_request_schema()
         }
         # Include agent network metadata in MCP _meta field if available:
-        network_metadata: Dict[str, Any] = await self.get_agent_network_metadata(agent_network)
+        network_metadata: Dict[str, Any] = self.get_agent_network_metadata(agent_network)
         if network_metadata is not None:
             tool_dict["_meta"] = network_metadata
         return tool_dict
 
-    async def get_agent_network_metadata(self, agent_network: AgentNetwork) -> Dict[str, Any]:
+    def get_agent_network_metadata(self, agent_network: AgentNetwork) -> Optional[Dict[str, Any]]:
         """
         Get agent network metadata dictionary for MCP tool description.
         :param agent_network: agent network object;

--- a/neuro_san/service/mcp/processors/mcp_tools_processor.py
+++ b/neuro_san/service/mcp/processors/mcp_tools_processor.py
@@ -235,10 +235,29 @@ class McpToolsProcessor:
             "inputSchema": self.tool_request_validator.get_request_schema()
         }
         # Include agent network metadata in MCP _meta field if available:
-        network_metadata: Any = agent_network.get_metadata()
-        if isinstance(network_metadata, dict):
+        network_metadata: Dict[str, Any] = await self.get_agent_network_metadata(agent_network)
+        if network_metadata is not None:
             tool_dict["_meta"] = network_metadata
         return tool_dict
+
+    async def get_agent_network_metadata(self, agent_network: AgentNetwork) -> Dict[str, Any]:
+        """
+        Get agent network metadata dictionary for MCP tool description.
+        :param agent_network: agent network object;
+        :return: metadata dictionary or None
+        """
+        # List of keys we are interested in for MCP tool metadata - we can add more if necessary:
+        metadata_keys: List[str] = ["description", "sample_queries", "tags"]
+
+        network_metadata: Any = agent_network.get_metadata()
+        result_dict: Dict[str, Any] = {}
+        if isinstance(network_metadata, dict):
+            for key in metadata_keys:
+                if key in network_metadata:
+                    result_dict[key] = network_metadata[key]
+        if len(result_dict) > 0:
+            return result_dict
+        return None
 
     async def _extract_tool_response_part(
             self, response_dict: Dict[str, Any]) -> Tuple[str, Dict[str, Any]]:

--- a/neuro_san/session/mcp_service_agent_session.py
+++ b/neuro_san/session/mcp_service_agent_session.py
@@ -244,9 +244,16 @@ class McpServiceAgentSession(AbstractHttpServiceAgentSession, AgentSession, Conc
         path: str = self.get_request_path("list")
         try:
             with requests.post(path, json=mcp_payload, headers=headers,
+<<<<<<< HEAD
                                timeout=self.timeout_in_seconds) as response:
                 response.raise_for_status()
                 result_dict = response.json()
+=======
+                               timeout=self.streaming_timeout_in_seconds) as response:
+                response.raise_for_status()
+                result_dict = response.json()
+                #result_dict = McpChatResponseDictionaryConverter().to_dict(result_dict)
+>>>>>>> 7de2be21 (WIP.)
                 return result_dict
         except Exception as exc:  # pylint: disable=broad-exception-caught
             raise ValueError(self.help_message(path)) from exc

--- a/neuro_san/session/mcp_service_agent_session.py
+++ b/neuro_san/session/mcp_service_agent_session.py
@@ -244,16 +244,9 @@ class McpServiceAgentSession(AbstractHttpServiceAgentSession, AgentSession, Conc
         path: str = self.get_request_path("list")
         try:
             with requests.post(path, json=mcp_payload, headers=headers,
-<<<<<<< HEAD
                                timeout=self.timeout_in_seconds) as response:
                 response.raise_for_status()
                 result_dict = response.json()
-=======
-                               timeout=self.streaming_timeout_in_seconds) as response:
-                response.raise_for_status()
-                result_dict = response.json()
-                #result_dict = McpChatResponseDictionaryConverter().to_dict(result_dict)
->>>>>>> 7de2be21 (WIP.)
                 return result_dict
         except Exception as exc:  # pylint: disable=broad-exception-caught
             raise ValueError(self.help_message(path)) from exc

--- a/neuro_san/session/mcp_service_agent_session.py
+++ b/neuro_san/session/mcp_service_agent_session.py
@@ -244,7 +244,7 @@ class McpServiceAgentSession(AbstractHttpServiceAgentSession, AgentSession, Conc
         path: str = self.get_request_path("list")
         try:
             with requests.post(path, json=mcp_payload, headers=headers,
-                               timeout=self.streaming_timeout_in_seconds) as response:
+                               timeout=self.timeout_in_seconds) as response:
                 response.raise_for_status()
                 result_dict = response.json()
                 return result_dict

--- a/neuro_san/session/mcp_service_agent_session.py
+++ b/neuro_san/session/mcp_service_agent_session.py
@@ -247,7 +247,6 @@ class McpServiceAgentSession(AbstractHttpServiceAgentSession, AgentSession, Conc
                                timeout=self.streaming_timeout_in_seconds) as response:
                 response.raise_for_status()
                 result_dict = response.json()
-                #result_dict = McpChatResponseDictionaryConverter().to_dict(result_dict)
                 return result_dict
         except Exception as exc:  # pylint: disable=broad-exception-caught
             raise ValueError(self.help_message(path)) from exc

--- a/neuro_san/session/mcp_service_agent_session.py
+++ b/neuro_san/session/mcp_service_agent_session.py
@@ -26,6 +26,7 @@ import requests
 from leaf_common.time.timeout import Timeout
 
 from neuro_san.interfaces.agent_session import AgentSession
+from neuro_san.interfaces.concierge_session import ConciergeSession
 from neuro_san.session.abstract_http_service_agent_session import AbstractHttpServiceAgentSession
 from neuro_san.session.mcp_chat_response_dictionary_converter import McpChatResponseDictionaryConverter
 
@@ -35,7 +36,7 @@ from neuro_san.session.mcp_chat_response_dictionary_converter import McpChatResp
 MCP_VERSION: str = "2025-06-18"
 
 
-class McpServiceAgentSession(AbstractHttpServiceAgentSession, AgentSession):
+class McpServiceAgentSession(AbstractHttpServiceAgentSession, AgentSession, ConciergeSession):
     """
     Implementation of AgentSession that talks to an MCP protocol service.
     This is largely only used by command-line tests.
@@ -219,6 +220,35 @@ class McpServiceAgentSession(AbstractHttpServiceAgentSession, AgentSession):
                         result_dict = json.loads(line)
                         result_dict = McpChatResponseDictionaryConverter().to_dict(result_dict)
                         yield result_dict
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            raise ValueError(self.help_message(path)) from exc
+
+    def list(self, request_dict: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        :param request_dict: A request dictionary. Not used for this implementation.
+        :return: A dictionary version of the MCP protocol "tools/list" response.
+                "tools" - the sequence of dictionaries describing available MCP tools
+        """
+        # Get the list of tools available from the service
+        mcp_payload: Dict[str, Any] = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/list",
+            "params": {
+            }
+        }
+        headers: Dict[str, str] = self.get_headers()
+        headers["Content-Type"] = "application/json"
+        headers[self.MCP_PROTOCOL_VERSION] = self.protocol_version
+
+        path: str = self.get_request_path("list")
+        try:
+            with requests.post(path, json=mcp_payload, headers=headers,
+                               timeout=self.streaming_timeout_in_seconds) as response:
+                response.raise_for_status()
+                result_dict = response.json()
+                #result_dict = McpChatResponseDictionaryConverter().to_dict(result_dict)
+                return result_dict
         except Exception as exc:  # pylint: disable=broad-exception-caught
             raise ValueError(self.help_message(path)) from exc
 


### PR DESCRIPTION
NS-736 Allow --list option in agent_cli client for MCP connection.

## Summary

For MCP `tools/list` responses, the agent network's `metadata` section (from the HOCON definition) is now included in the `_meta` field of each tool description. Note that this metadata is currently filtered to only include keys `description`, `tags`, and `sample_queries`.

**Changes:**
- Added `get_metadata()` accessor to `AgentNetwork` to retrieve the `metadata` dict from the network config
- Modified `_get_tool_description` in `McpToolsProcessor` to accept the `AgentNetwork` and populate `_meta` with the network metadata when present
- Modified agent_cli tool to service --list request for MCP connection type
- Extended McpServiceAgentSession class with list() request for listing MCP tools using agent networks metadata.

## Review & Testing Checklist for Human

- [ ] Verify that placing `_meta` at the tool object level (alongside `name`, `description`, `inputSchema`) is correct per MCP 2025-06-18 spec for tool annotations
- [ ] Confirm that passing **all** metadata fields through to `_meta` is the desired behavior — no fields in the HOCON `metadata` section should be filtered or excluded from client visibility
- [ ] The return type of `get_metadata()` is annotated as `Dict[str, Any]` but can return `None` — consider whether it should be `Optional[Dict[str, Any]]`
- [ ] Test end-to-end with an MCP client: send a `tools/list` request against an agent network that has a `metadata` section and verify `_meta` appears correctly in the response; also test against one without `metadata` to confirm `_meta` is omitted

### Notes
- No new unit tests were added — existing tests pass but don't cover MCP tool listing
- Requested by: @andreidenissov-cog
- Link to Devin run: https://app.devin.ai/sessions/41d2f72b5b924a5d9f3568634e25c0d8
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cognizant-ai-lab/neuro-san/pull/769" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
