### PR TITLE
NS-661 Optimize ServiceAgentReservationist queue creation for each instance.

### DIFF
--- a/neuro_san/service/generic/agent_service.py
+++ b/neuro_san/service/generic/agent_service.py
@@ -251,8 +251,7 @@ class AgentService:
         # Create a reservationist
         reservationist: Reservationist = None
         if self.queues is not None:
-            reservationist = ServiceAgentReservationist()
-            self.queues.sync_q.put(reservationist.get_queue())
+            reservationist = ServiceAgentReservationist(self.queues)
 
         # Prepare
         factory = ExternalAgentSessionFactory(use_direct=False)

--- a/neuro_san/service/generic/async_agent_service.py
+++ b/neuro_san/service/generic/async_agent_service.py
@@ -249,8 +249,7 @@ class AsyncAgentService:
         # Create a reservationist for the occasion
         reservationist: Reservationist = None
         if self.queues is not None:
-            reservationist = ServiceAgentReservationist()
-            self.queues.sync_q.put(reservationist.get_queue())
+            reservationist = ServiceAgentReservationist(self.queues)
 
         # Prepare
         factory = ExternalAgentSessionFactory(use_direct=False)

--- a/neuro_san/service/generic/service_agent_reservationist.py
+++ b/neuro_san/service/generic/service_agent_reservationist.py
@@ -21,6 +21,8 @@ from typing import Union
 from asyncio import Event
 from asyncio import get_running_loop
 
+from janus import Queue
+
 from neuro_san.interfaces.reservation import Reservation
 from neuro_san.interfaces.reservationist import Reservationist
 from neuro_san.internals.chat.async_collating_queue import AsyncCollatingQueue
@@ -33,20 +35,18 @@ class ServiceAgentReservationist(Reservationist):
     for a specific amount of time.
     """
 
-    def __init__(self, max_lifetime_in_seconds: float = Reservationist.DEFAULT_LIFETIME):
+    def __init__(self, main_queue: Queue[AsyncCollatingQueue],
+                 max_lifetime_in_seconds: float = Reservationist.DEFAULT_LIFETIME):
         """
         Constructor
 
+        :param main_queue: The main Queue of AsyncCollatingQueues to which this instance
+                   will add its own AsyncCollatingQueue for deployment when it will be created.
         :param max_lifetime_in_seconds: The maximum lifetime allowed for any Reservation.
         """
         self.max_lifetime_in_seconds: float = max_lifetime_in_seconds
-        self.queue: AsyncCollatingQueue = AsyncCollatingQueue()
-
-    def get_queue(self) -> AsyncCollatingQueue:
-        """
-        :return: The AsyncCollatingQueue belonging to this Reservationist
-        """
-        return self.queue
+        self.main_queue: Queue[AsyncCollatingQueue] = main_queue
+        self.queue: AsyncCollatingQueue = None
 
     async def reserve(self, lifetime_in_seconds: float = Reservationist.DEFAULT_LIFETIME,
                       prefix: str = "") -> Reservation:
@@ -109,6 +109,11 @@ class ServiceAgentReservationist(Reservationist):
                 if isinstance(key, Event):
                     queued_item["event"] = key
                     queued_item["event_loop"] = get_running_loop()
+
+                if self.queue is None:
+                    # We haven't created our queue yet, so we need to do that and put it on the main queue.
+                    self.queue = AsyncCollatingQueue()
+                    self.main_queue.sync_q.put(self.queue)
 
                 await self.queue.put(queued_item, synchronous=False)
 

--- a/neuro_san/service/generic/service_agent_reservationist.py
+++ b/neuro_san/service/generic/service_agent_reservationist.py
@@ -113,7 +113,7 @@ class ServiceAgentReservationist(Reservationist):
                 if self.queue is None:
                     # We haven't created our queue yet, so we need to do that and put it on the main queue.
                     self.queue = AsyncCollatingQueue()
-                    self.main_queue.sync_q.put(self.queue)
+                    self.main_queue.sync_q.put_nowait(self.queue)
 
                 await self.queue.put(queued_item, synchronous=False)
 
@@ -125,4 +125,5 @@ class ServiceAgentReservationist(Reservationist):
         """
         # Use synchronous side of the queue because this will not
         # be part of the same event loop the put() in deploy() above is done.
-        await self.queue.put_final_item(synchronous=True)
+        if self.queue is not None:
+            await self.queue.put_final_item(synchronous=True)


### PR DESCRIPTION
Simple optimization for ServiceAgentReservationist own processing queues.
Right now we create an empty queue in ServiceAgentReservationist constructor and immediately submit it to "main" queue of queues. This will result in some processing thread to latch on this empty queue and start blocking until something appears in it.
Instead, we now create the queue only when we have at least the first generated reservation item, so we'll not use up a thread from our pool for nothing.

Tested: running limited stress-test.

