### PR TITLE
Use combined manifest networks for overlay validation

### DIFF
--- a/neuro_san/internals/graph/persistence/registry_manifest_restorer.py
+++ b/neuro_san/internals/graph/persistence/registry_manifest_restorer.py
@@ -94,9 +94,15 @@ class RegistryManifestRestorer(Restorer):
         all_agent_networks: Dict[str, Dict[str, AgentNetwork]] = {}
         overlayer = DictionaryOverlay()
 
+        # Pre-collect external network names from all manifest files so that
+        # overlays can validate references to networks defined in other files.
+        all_external_network_names: List[str] = \
+            self._collect_all_external_network_names(file_references)
+
         # Loop through all the manifest files in the list to make a composite
         for manifest_file in file_references:
-            agents_from_one_manifest: Dict[str, Dict[str, AgentNetwork]] = self.restore_one_manifest(manifest_file)
+            agents_from_one_manifest: Dict[str, Dict[str, AgentNetwork]] = \
+                self.restore_one_manifest(manifest_file, all_external_network_names)
             # Do a deep update() with the overlayer.
             all_agent_networks = overlayer.overlay(all_agent_networks, agents_from_one_manifest)
 
@@ -119,10 +125,15 @@ class RegistryManifestRestorer(Restorer):
         all_agent_networks: Dict[str, Dict[str, AgentNetwork]] = {}
         overlayer = DictionaryOverlay()
 
+        # Pre-collect external network names from all manifest files so that
+        # overlays can validate references to networks defined in other files.
+        all_external_network_names: List[str] = \
+            await self._async_collect_all_external_network_names(file_references)
+
         # Loop through all the manifest files in the list to make a composite
         for manifest_file in file_references:
             agents_from_one_manifest: Dict[str, Dict[str, AgentNetwork]] = \
-                await self.async_restore_one_manifest(manifest_file)
+                await self.async_restore_one_manifest(manifest_file, all_external_network_names)
             # Do a deep update() with the overlayer.
             all_agent_networks = overlayer.overlay(all_agent_networks, agents_from_one_manifest)
 
@@ -137,9 +148,15 @@ class RegistryManifestRestorer(Restorer):
         return all_agent_networks
 
     # pylint: disable=too-many-locals
-    def restore_one_manifest(self, manifest_file: str) -> Dict[str, Dict[str, AgentNetwork]]:
+    def restore_one_manifest(self, manifest_file: str,
+                             all_external_network_names: List[str] = None) \
+            -> Dict[str, Dict[str, AgentNetwork]]:
         """
         :param manifest_file: The file reference to use when restoring.
+        :param all_external_network_names: Optional pre-collected external
+            network names from all manifest files. When provided, these are
+            merged with the current file's names so that overlays can
+            validate references to networks defined in other manifest files.
         :return: a nested map of storage type -> (mapping of name -> agent networks)
         """
 
@@ -159,6 +176,11 @@ class RegistryManifestRestorer(Restorer):
         manifest_dir: str = file_of_class.get_basis()
 
         external_network_names: List[str] = self.find_external_network_names(one_manifest)
+        if all_external_network_names is not None:
+            # Use a set to merge and deduplicate names from all manifests
+            merged: set = set(external_network_names)
+            merged.update(all_external_network_names)
+            external_network_names = sorted(merged)
 
         # DEF - need mcp servers as well at some point
         validator = ManifestNetworkValidator(external_network_names)
@@ -181,9 +203,15 @@ class RegistryManifestRestorer(Restorer):
         return agent_networks
 
     # pylint: disable=too-many-locals
-    async def async_restore_one_manifest(self, manifest_file: str) -> Dict[str, Dict[str, AgentNetwork]]:
+    async def async_restore_one_manifest(self, manifest_file: str,
+                                         all_external_network_names: List[str] = None) \
+            -> Dict[str, Dict[str, AgentNetwork]]:
         """
         :param manifest_file: The file reference to use when restoring.
+        :param all_external_network_names: Optional pre-collected external
+            network names from all manifest files. When provided, these are
+            merged with the current file's names so that overlays can
+            validate references to networks defined in other manifest files.
         :return: a nested map of storage type -> (mapping of name -> agent networks)
         """
 
@@ -203,6 +231,11 @@ class RegistryManifestRestorer(Restorer):
         manifest_dir: str = file_of_class.get_basis()
 
         external_network_names: List[str] = self.find_external_network_names(one_manifest)
+        if all_external_network_names is not None:
+            # Use a set to merge and deduplicate names from all manifests
+            merged: set = set(external_network_names)
+            merged.update(all_external_network_names)
+            external_network_names = sorted(merged)
 
         # DEF - need mcp servers as well at some point
         validator = ManifestNetworkValidator(external_network_names)
@@ -378,3 +411,41 @@ class RegistryManifestRestorer(Restorer):
             external_network_names.append(f"/{network_name}")
 
         return external_network_names
+
+    def _collect_all_external_network_names(self, file_references: Sequence[str]) -> List[str]:
+        """
+        Pre-scan all manifest files to collect the union of external network
+        names.  This allows overlays to validate tool references that point
+        to networks defined in a different manifest file.
+
+        :param file_references: The sequence of manifest file references.
+        :return: A deduplicated list of external network name strings.
+        """
+        all_names: set = set()
+        raw_restorer = RawManifestRestorer()
+        for manifest_file in file_references:
+            raw_manifest: Dict[str, Any] = raw_restorer.restore(file_reference=manifest_file)
+            manifest_filter = ManifestFilterChain(manifest_file)
+            filtered: Dict[str, Dict[str, Any]] = manifest_filter.filter_config(raw_manifest)
+            names: List[str] = self.find_external_network_names(filtered)
+            all_names.update(names)
+        return sorted(all_names)
+
+    async def _async_collect_all_external_network_names(
+            self, file_references: Sequence[str]) -> List[str]:
+        """
+        Async version of _collect_all_external_network_names.
+
+        :param file_references: The sequence of manifest file references.
+        :return: A deduplicated list of external network name strings.
+        """
+        all_names: set = set()
+        raw_restorer = RawManifestRestorer()
+        for manifest_file in file_references:
+            raw_manifest: Dict[str, Any] = await raw_restorer.async_restore(
+                file_reference=manifest_file)
+            manifest_filter = ManifestFilterChain(manifest_file)
+            filtered: Dict[str, Dict[str, Any]] = manifest_filter.filter_config(raw_manifest)
+            names: List[str] = self.find_external_network_names(filtered)
+            all_names.update(names)
+        return sorted(all_names)


### PR DESCRIPTION
# Fix cross-manifest network validation for overlays

## Summary

When multiple manifest files are used (e.g. a base `manifest.hocon` plus `manifest_multiuser_overlay.hocon`), `restore_one_manifest` previously built its valid external network name list from only the current file's entries. This caused `UrlNetworkValidator` to reject tool references pointing to networks defined in a different manifest file — for example, the overlay's `agent_network_designer` referencing `/agent_network_editor` from the base manifest — which silently skipped the entire agent network.

The fix adds a pre-scan pass in `restore_from_files` (and its async counterpart) that collects external network names from **all** manifest files before any individual manifest is processed. This combined set is passed to each `restore_one_manifest` call via a new optional `all_external_network_names` parameter, where it is merged with the per-file names for validation.

Key changes in `registry_manifest_restorer.py`:
- `restore_from_files` / `async_restore_from_files`: call new pre-collection methods before the main processing loop
- `restore_one_manifest` / `async_restore_one_manifest`: accept optional `all_external_network_names` and merge with per-file names
- New private methods `_collect_all_external_network_names` / `_async_collect_all_external_network_names` for the pre-scan

When the new parameter is not supplied (standalone callers), behavior is unchanged.

## Review & Testing Checklist for Human

- [ ] **Verify no subclasses override `restore_one_manifest` / `async_restore_one_manifest`** — the signature gained a new optional parameter; any override that doesn't accept it would break
- [ ] **Confirm `ManifestNetworkValidator` treats the network names list as a membership set** — the merged list is now sorted, so if order mattered this could change behavior
- [ ] **Confirm acceptable startup cost of double-parsing manifests** — the pre-scan reads and filters each manifest file once before the main loop reads them again. Negligible for 1–2 files but worth awareness
- [ ] **Test with a multi-manifest deployment** (e.g. `manifest.hocon` + `manifest_multiuser_overlay.hocon` on dev) and verify that `agent_network_designer` no longer logs `"has validation errors. Skipping."` for overlay tool references like `/agent_network_editor`
- [ ] **Test single-manifest deployments still work** — the pre-collection runs but should produce the same name set as before

### Notes

- This is the proper fix for the issue that [neuro-san-studio PR #715](https://github.com/cognizant-ai-lab/neuro-san-studio/pull/715) worked around by duplicating support network entries in the overlay. With this change, that workaround is no longer needed.
- No new tests are included. The overlay validation scenario would benefit from a test with two manifest files where the second references networks from the first.

Link to Devin session: https://app.devin.ai/sessions/e2259ca83d8047cbaf83d68a9f706fdb
Requested by: @donn-leaf
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cognizant-ai-lab/neuro-san/pull/803" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
