### PR TITLE
Fix readiness check 503 by removing unused temporary_network_update_period_seconds

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -75,7 +75,6 @@ jobs:
           AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
           AZURE_OPENAI_ENDPOINT: ${{ vars.AZURE_OPENAI_ENDPOINT }}
           OPENAI_API_VERSION: ${{ vars.OPENAI_API_VERSION }}
-          AGENT_TEMPORARY_NETWORK_UPDATE_PERIOD_SECONDS: 5
           AGENT_TOOL_PATH: "./neuro_san/coded_tools"
           PYTHONPATH: ${{ env.PYTHONPATH }}:.
         run: |

--- a/neuro_san/deploy/Dockerfile
+++ b/neuro_san/deploy/Dockerfile
@@ -289,14 +289,6 @@ ENV AGENT_HTTP_SERVER_INSTANCES=1
 # Logging period is specified in seconds.
 ENV AGENT_HTTP_RESOURCES_MONITOR_INTERVAL=0
 
-# If this value is specified and >0,
-# it will enable dynamic temporary network updates of the server agents
-# allowing CodedTools to reserve temporary networks via the Reservationist
-# interface, if the agent network hocon file specifically allows it for the tool.
-# Update will be done every AGENT_TEMPORARY_NETWORK_UPDATE_PERIOD_SECONDS seconds;
-# if value is not specified or <= 0, no such dynamic updates will be executed.
-ENV AGENT_TEMPORARY_NETWORK_UPDATE_PERIOD_SECONDS=0
-
 # Optional URL describing how the server is to be referenced by the outside world.
 # This is useful when a server is behind a load-balancer as part of a larger cluster.
 ENV AGENT_EXTERNAL_SERVER_URL=""

--- a/neuro_san/service/main_loop/server_main_loop.py
+++ b/neuro_san/service/main_loop/server_main_loop.py
@@ -118,10 +118,6 @@ class ServerMainLoop:
                                 default=int(os.environ.get("AGENT_MANIFEST_UPDATE_PERIOD_SECONDS", "0")),
                                 help="Periodic run-time update period for manifest in seconds."
                                      " Value <= 0 disables updates.")
-        arg_parser.add_argument("--temporary_network_update_period_seconds", type=int,
-                                default=int(os.environ.get("AGENT_TEMPORARY_NETWORK_UPDATE_PERIOD_SECONDS", "0")),
-                                help="Periodic run-time update period for temporary networks in seconds."
-                                     " Value <= 0 disables updates.")
         arg_parser.add_argument("--http_connections_backlog", type=int,
                                 default=int(os.environ.get("AGENT_HTTP_CONNECTIONS_BACKLOG",
                                                            DEFAULT_HTTP_CONNECTIONS_BACKLOG)),
@@ -181,14 +177,9 @@ class ServerMainLoop:
             self.usage_logger_metadata = self.forwarded_request_metadata
         self.service_openapi_spec_file = args.openapi_service_spec_path
 
-        if args.manifest_update_period_seconds <= 0 and \
-                args.temporary_network_update_period_seconds <= 0:
+        if args.manifest_update_period_seconds <= 0:
             # StorageWatcher is disabled:
             server_status.updater.set_requested(False)
-        if args.temporary_network_update_period_seconds <= 0:
-            # We don't need the queues in this situation either.
-            # This is a signal to other code to not even bother with Reservationists
-            self.server_context.no_queues()
         # Do we to enable MCP service?
         if args.mcp_enable.lower() != "true":
             server_status.mcp_service.set_requested(False)
@@ -210,7 +201,6 @@ class ServerMainLoop:
         self.watcher_config = {
             "manifest_path": manifest_files,
             "manifest_update_period_seconds": args.manifest_update_period_seconds,
-            "temporary_network_update_period_seconds": args.temporary_network_update_period_seconds
         }
 
         self.agent_networks = manifest_agent_networks

--- a/neuro_san/service/watcher/main_loop/storage_watcher.py
+++ b/neuro_san/service/watcher/main_loop/storage_watcher.py
@@ -97,9 +97,6 @@ class StorageWatcher(Startable):
         """
         Function runs manifest file update cycle.
         """
-        server_status: ServerStatus = self.server_context.get_server_status()
-        server_status.updater.set_status(True)
-
         if self.update_period_in_seconds <= 0:
             # We should not run at all.
             return
@@ -107,6 +104,9 @@ class StorageWatcher(Startable):
         # Initial value entering the loop
         sleep_for_seconds: float = self.update_period_in_seconds
         while self.keep_running:
+
+            server_status: ServerStatus = self.server_context.get_server_status()
+            server_status.updater.set_status(True)
 
             sleep(sleep_for_seconds)
 


### PR DESCRIPTION
## Summary

Fixes a permanent 503 on `/`, `/healthz`, and `/readyz` endpoints in deployments where `AGENT_MANIFEST_UPDATE_PERIOD_SECONDS=0` but `AGENT_TEMPORARY_NETWORK_UPDATE_PERIOD_SECONDS > 0` (e.g. the dev environment).

**Root cause:** `server_main_loop.py` marks the updater as "requested" when `temporary_network_update_period_seconds > 0`, but `StorageWatcher._run()` exits immediately when its computed update period is 0 — without ever calling `server_status.updater.set_status(True)`. Since `is_server_ready()` requires all requested services to be ready, the health check permanently returns 503.

This became a problem after `TempNetworkStorageUpdater` was removed from the `StorageWatcher` (commit `7497606`), leaving only `RegistryStorageUpdater` (period=0). `TempNetworkStorageUpdater` now runs independently via queues, making `temporary_network_update_period_seconds` a dead runtime property.

**Fix (per reviewer feedback):** Remove `temporary_network_update_period_seconds` from the codebase entirely rather than patching `StorageWatcher`:
- Remove `--temporary_network_update_period_seconds` CLI argument from `server_main_loop.py`
- Simplify updater-requested logic to only gate on `manifest_update_period_seconds`
- Remove the `no_queues()` call (queues are always needed since `TempNetworkStorageUpdater` runs independently)
- Remove `AGENT_TEMPORARY_NETWORK_UPDATE_PERIOD_SECONDS` from `Dockerfile` and `smoke.yml`

### Notes
- `/livez` currently returns 200 — the server is running and serving agent requests fine. Only the readiness check is broken.
- `reservation_util.py` still references `AGENT_TEMPORARY_NETWORK_UPDATE_PERIOD_SECONDS` in a user-facing error message string — this is documentation/guidance only, not runtime logic.
- Deployments (e.g. `neuro-san-deploy`) that still set `AGENT_TEMPORARY_NETWORK_UPDATE_PERIOD_SECONDS` in their configMaps will be unaffected — the env var is simply ignored.
- The `no_queues()` removal means `server_context.queues` is never set to `None` anymore. `agent_service.py` and `async_agent_service.py` both consume `get_queues()` — verify they handle an active (but unused) queue correctly.

## Review & Testing Checklist for Human
- [ ] Verify that removing the `no_queues()` call doesn't break `agent_service.py` / `async_agent_service.py` when no temp networks are actually deployed — queues will now always be non-None
- [ ] Confirm smoke tests still pass without `AGENT_TEMPORARY_NETWORK_UPDATE_PERIOD_SECONDS=5` in the workflow env
- [ ] Confirm on the dev cluster: after deploying a new build, `curl https://neuro-san-dev.decisionai.ml/` returns a version report instead of 503
- [ ] Consider cleaning up `AGENT_TEMPORARY_NETWORK_UPDATE_PERIOD_SECONDS` from `neuro-san-deploy` configMaps (not blocking, but avoids confusion)

Link to Devin session: https://app.devin.ai/sessions/7d67b7392de14367b09f3a9b85ca2f7d
Requested by: @donn-leaf
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cognizant-ai-lab/neuro-san/pull/825" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
