### PR TITLE
NS-826 Preserve metadata in Reservations

### DIFF
--- a/neuro_san/service/watcher/temp_networks/s3_reservations_storage.py
+++ b/neuro_san/service/watcher/temp_networks/s3_reservations_storage.py
@@ -202,10 +202,13 @@ class S3ReservationsStorage(AbstractReservationsStorage):
             # Build complete data structure containing reservation metadata,
             # the associated agent_spec, source information, and storage timestamp
             current_time: float = time.time()
-            agent_spec["metadata"] = {
+            new_metadata: Dict[str, Any] = {
                 "reservation": self.converter.to_dict(reservation),  # Serialized reservation object
                 "stored_at": current_time              # When stored in S3
             }
+            if agent_spec.get("metadata") is None:
+                agent_spec["metadata"] = {}
+            agent_spec["metadata"].update(new_metadata)
 
             # Generate S3 key using prefix and reservation ID for easy lookup
             reservation_id: str = reservation.get_reservation_id()


### PR DESCRIPTION
@dsargent noticed that sample_queries were not coming back in the metadata from reservations.
Long story short: We were writing over the existing metadata when saving to S3.
Don't do that, add to it instead.