### PR TITLE
Migrate tests.yml to build-common quality gate

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
     uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@455db3cc40e9ed6a0fb9bbaf8188888c1ae315c2
     with:
       python-version: '3.12'
-      lint-toolchain: 'legacy'
+      lint-toolchain: 'legacy'  # flake8 only (black/isort are opt-in)
       pylint-command: 'build_scripts/run_pylint.sh'
       shellcheck-command: 'build_scripts/run_shellcheck.sh'
       run-markdownlint: true


### PR DESCRIPTION
## Summary

Replaces the inline test workflow with a `workflow_call` to the shared `_python-quality-gate.yml` reusable workflow from `build-common` (pinned to SHA `455db3c`, tag 1.0.0). All existing checks — pylint, flake8, shellcheck, markdownlint, pytest with `server_start.sh`, README PyPI rendering, and Slack notifications — are preserved through the quality gate's input parameters.

## Review & Testing Checklist for Human

- [ ] **Container → ubuntu-latest change**: The old workflow ran inside `python:3.12-slim` container; the quality gate runs on `ubuntu-latest` with `actions/setup-python`. Verify that no tests depend on Debian-slim-specific behavior or paths that differ on the full Ubuntu runner.
- [ ] **test-command-override correctness**: The server startup, env var exports (`AGENT_TOOL_PATH`, `PYTHONPATH`), and pytest invocation are collapsed into a single `bash -c` string. Confirm the `&&` chain propagates failures correctly and that `server_start.sh` works outside the container context.
- [ ] **Slack notification format**: The old workflow sent custom emoji-prefixed messages; the new `slack-notify` composite action formats messages differently. Confirm the team is okay with the new Slack message format.
- [ ] **Trigger a CI run** on this branch to verify the full quality gate passes end-to-end before merging.

### Notes
- The `pip freeze` debug step from the old workflow is not replicated (the quality gate does not include it).
- The `if:` condition gating the job (skip main-branch pushes, only run on PRs to main) is preserved on the caller job.
- `lint-toolchain: 'legacy'` runs **flake8 only** by default. `black --check` and `isort --check-only` are available but require explicit opt-in via `run-black-check` / `run-isort-check` inputs (both default to `false`).

### Updates since last revision
- Added inline comment on `lint-toolchain` line clarifying it means flake8-only, per reviewer request from Dan Fink.

Link to Devin session: https://app.devin.ai/sessions/a03b8916aaca4b139fbf4303d72f0caa
Requested by: @donn-leaf
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cognizant-ai-lab/neuro-san/pull/833" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
