### PR TITLE
NS-661 Switch to using event loop for reservations queues processing.

### DIFF
--- a/neuro_san/service/watcher/temp_networks/temp_network_storage_updater.py
+++ b/neuro_san/service/watcher/temp_networks/temp_network_storage_updater.py
@@ -26,7 +26,6 @@ from asyncio import sleep as asyncio_sleep
 from asyncio import CancelledError
 from logging import getLogger
 from logging import Logger
-import functools
 import queue as queue_mod
 
 from janus import Queue
@@ -146,8 +145,7 @@ class TempNetworkStorageUpdater(Startable):
                 return
 
             if self.reservationist is not None:
-                queue_processor = functools.partial(self.process_one_queue, async_collating_queue)
-                _ = self.executor.create_task(queue_processor(), "queue_processor")
+                _ = self.executor.create_task(self.process_one_queue(async_collating_queue), "queue_processor")
             else:
                 # We don't have a reservation functionality set up,
                 # so we can't do anything with this queue, but we should still close it to avoid leaks.


### PR DESCRIPTION
This PR switches TNW reservations processing from using fixed-size thread pool to a "regular" async event loop wrapped in our AsyncioExecutor instance. Event loop should provide better capability for scaling up.
Note that we are using no-wait polling on all queues with async sleeps in between to reduce mutual tasks blocking as much as possible.
Tested by 500x5 stress test: 500 agent_cli clients each generating 5 TNW reservations.
