### PR TITLE
Fix setting up agent client timeout.

### DIFF
--- a/neuro_san/session/async_http_service_agent_session.py
+++ b/neuro_san/session/async_http_service_agent_session.py
@@ -108,6 +108,9 @@ class AsyncHttpServiceAgentSession(AbstractHttpServiceAgentSession, AsyncAgentSe
             # To specify complete timeout value, we must use "total" parameter of ClientTimeout.
             # See https://docs.aiohttp.org/en/stable/client_reference.html#aiohttp.ClientTimeout for details.
             timeout: ClientTimeout = ClientTimeout(total=None)
+            # That will make sure that the connection will stay open until the (last) result is yielded,
+            # which is what we want here.
+            # Not specifying "total" parameter will invoke lower-level aiohttp timeout, which is 300 seconds by default
             if self.streaming_timeout_in_seconds is not None:
                 timeout = ClientTimeout(total=self.streaming_timeout_in_seconds)
             async with ClientSession(headers=self.get_headers(),


### PR DESCRIPTION
This PR fixes timeout setting for our async client streaming http connection.
Previously, lower-level default timeout has been silently used,
so instead of "timeout never" we had "aiohttp connection will timeout after 300 seconds".
Found and fix is tested with Agent Network Designer stress-test.
