### PR TITLE
Fixed DeepWiki broken test case

### DIFF
--- a/neuro_san/registries/mcp_deepwiki_dict.hocon
+++ b/neuro_san/registries/mcp_deepwiki_dict.hocon
@@ -49,7 +49,8 @@
 
                     # Optional: restricts which tools are available.
                     # If omitted, all tools are enabled.
-                    "tools": ["read_wiki_structure", "ask_question"]
+                    # note that tools [read_wiki_content & ask_question] not work on www.wikipedia.org/cognizant-ai-lab/neuro-san
+                    "tools": ["read_wiki_structure"]
 
                     # For authentication, see https://github.com/cognizant-ai-lab/neuro-san/blob/main/docs/agent_hocon_reference.md#authentication
                 }


### PR DESCRIPTION
This PR is to get this integration test running again. It has been requested that the tool "ask_question" be removed from the test checklist. We don't know the root cause of why it is no longer working.
The purpose of this test on DeepWiki was to verify the connection to DeepWiki, so the tool's "read_wiki_structure" check is sufficient.