### PR TITLE
NS-855 First version of neuro-san run-time profiler.

### DIFF
--- a/neuro_san/service/http/handlers/base_request_handler.py
+++ b/neuro_san/service/http/handlers/base_request_handler.py
@@ -39,6 +39,7 @@ from neuro_san.internals.network_providers.expiring_agent_network_storage import
 from neuro_san.service.generic.async_agent_service import AsyncAgentService
 from neuro_san.service.generic.async_agent_service_provider import AsyncAgentServiceProvider
 from neuro_san.service.interfaces.agent_authorizer import AgentAuthorizer
+from neuro_san.service.utils.request_util import RequestUtil
 from neuro_san.service.utils.server_context import ServerContext
 from neuro_san.service.http.logging.http_logger import HttpLogger
 
@@ -238,7 +239,9 @@ class BaseRequestHandler(RequestHandler):
         if status_code != HTTPStatus.OK:
             self.set_status(status_code)
             if err_message:
-                self.write({"error": err_message})
+                # HTML-escape the error message defensively, since some err_message
+                # values may originate from user-controlled input.
+                self.write({"error": RequestUtil.safe_message(err_message)})
         try:
             self.finish()
         except tornado.iostream.StreamClosedError:

--- a/neuro_san/service/http/handlers/profiler_control_handler.py
+++ b/neuro_san/service/http/handlers/profiler_control_handler.py
@@ -87,4 +87,4 @@ class ProfilerControlHandler(RequestHandler):
         This method is required to be implemented as part of RequestHandler subclass,
         but is not used in our case as we do not expect any data in the request body.
         """
-
+    

--- a/neuro_san/service/http/handlers/profiler_control_handler.py
+++ b/neuro_san/service/http/handlers/profiler_control_handler.py
@@ -87,4 +87,3 @@ class ProfilerControlHandler(RequestHandler):
         This method is required to be implemented as part of RequestHandler subclass,
         but is not used in our case as we do not expect any data in the request body.
         """
-

--- a/neuro_san/service/http/handlers/profiler_control_handler.py
+++ b/neuro_san/service/http/handlers/profiler_control_handler.py
@@ -27,7 +27,6 @@ try:
     HAS_PROFILER = True
 except ImportError:
     HAS_PROFILER = False
-    print("yappi library is required for profiling. Please install it with 'pip install yappi'")
 
 from http import HTTPStatus
 from tornado.web import RequestHandler
@@ -56,27 +55,6 @@ class ProfilerControlHandler(RequestHandler):
             self.prof_data_path = "profile.prof"
         self.logger = logging.getLogger(self.__class__.__name__)
 
-    @staticmethod
-    def get_profiler_context_id() -> int:
-        """
-        Get the context ID for the current execution context, which is used by yappi to differentiate
-        between different threads or async tasks. In this case, we use the ID of the current asyncio task.
-        If there is no current task (e.g., if we're not in an async context), we return 0.
-        """
-        try:
-            print("Getting profiler context ID for current asyncio task...")
-            task_id = id(asyncio.current_task())
-            if task_id:
-                return 1   #task_id & 0x7FFFFFFF  # yappi expects a 32-bit integer context ID
-            return 0
-        except RuntimeError:
-            # This can happen if we're not in an async context, so we return 0 as the default context ID.
-            print(f"Error getting profiler context ID: RuntimeError")
-            return 0
-        except Exception as exc:  # pylint: disable=broad-exception-caught
-            print(f"Error getting profiler context ID: {str(exc)}")
-            return 0
-
     async def get(self):
         """
         Implementation of GET request handler for profiler control.
@@ -89,7 +67,7 @@ class ProfilerControlHandler(RequestHandler):
 
         try:
             if self.op == "start":
-                #yappi.set_context_id_callback(ProfilerControlHandler.get_profiler_context_id)
+                # Set clock type to "wall" time to get more accurate profiling results in async code
                 yappi.set_clock_type("wall")
                 yappi.start()
                 self.write("profiling started")
@@ -111,3 +89,4 @@ class ProfilerControlHandler(RequestHandler):
         This method is required to be implemented as part of RequestHandler subclass,
         but is not used in our case as we do not expect any data in the request body.
         """
+        pass

--- a/neuro_san/service/http/handlers/profiler_control_handler.py
+++ b/neuro_san/service/http/handlers/profiler_control_handler.py
@@ -87,4 +87,4 @@ class ProfilerControlHandler(RequestHandler):
         This method is required to be implemented as part of RequestHandler subclass,
         but is not used in our case as we do not expect any data in the request body.
         """
-        pass
+

--- a/neuro_san/service/http/handlers/profiler_control_handler.py
+++ b/neuro_san/service/http/handlers/profiler_control_handler.py
@@ -87,4 +87,4 @@ class ProfilerControlHandler(RequestHandler):
         This method is required to be implemented as part of RequestHandler subclass,
         but is not used in our case as we do not expect any data in the request body.
         """
-    
+

--- a/neuro_san/service/http/handlers/profiler_control_handler.py
+++ b/neuro_san/service/http/handlers/profiler_control_handler.py
@@ -20,6 +20,8 @@ See class comment for details
 from typing import Optional
 import logging
 
+import asyncio
+
 try:
     import yappi
     HAS_PROFILER = True
@@ -54,6 +56,27 @@ class ProfilerControlHandler(RequestHandler):
             self.prof_data_path = "profile.prof"
         self.logger = logging.getLogger(self.__class__.__name__)
 
+    @staticmethod
+    def get_profiler_context_id() -> int:
+        """
+        Get the context ID for the current execution context, which is used by yappi to differentiate
+        between different threads or async tasks. In this case, we use the ID of the current asyncio task.
+        If there is no current task (e.g., if we're not in an async context), we return 0.
+        """
+        try:
+            print("Getting profiler context ID for current asyncio task...")
+            task_id = id(asyncio.current_task())
+            if task_id:
+                return 1   #task_id & 0x7FFFFFFF  # yappi expects a 32-bit integer context ID
+            return 0
+        except RuntimeError:
+            # This can happen if we're not in an async context, so we return 0 as the default context ID.
+            print(f"Error getting profiler context ID: RuntimeError")
+            return 0
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            print(f"Error getting profiler context ID: {str(exc)}")
+            return 0
+
     async def get(self):
         """
         Implementation of GET request handler for profiler control.
@@ -66,6 +89,7 @@ class ProfilerControlHandler(RequestHandler):
 
         try:
             if self.op == "start":
+                #yappi.set_context_id_callback(ProfilerControlHandler.get_profiler_context_id)
                 yappi.set_clock_type("wall")
                 yappi.start()
                 self.write("profiling started")

--- a/neuro_san/service/http/handlers/profiler_control_handler.py
+++ b/neuro_san/service/http/handlers/profiler_control_handler.py
@@ -87,4 +87,3 @@ class ProfilerControlHandler(RequestHandler):
         This method is required to be implemented as part of RequestHandler subclass,
         but is not used in our case as we do not expect any data in the request body.
         """
-        pass

--- a/neuro_san/service/http/handlers/profiler_control_handler.py
+++ b/neuro_san/service/http/handlers/profiler_control_handler.py
@@ -29,57 +29,64 @@ except ImportError:
 from http import HTTPStatus
 from tornado.web import RequestHandler
 
+import json
+from json.decoder import JSONDecodeError
+
 
 class ProfilerControlHandler(RequestHandler):
     """
     Handler class for controlling run-time profiler (yappi) via HTTP API calls.
     """
-    # pylint: disable=attribute-defined-outside-init
-    def initialize(self,
-                   op: str,
-                   prof_data_path: Optional[str]):
-        """
-        This method is called by Tornado framework to allow
-        injecting service-specific data into local handler context.
-        :param op: requested profiler operation:
-                   "start" for starting run-time profiler
-                   "stop" for stopping profiler
-        :param prof_data_path: optional path to save profiler data when stopping profiler;
-            if not provided, data will be saved in current working directory with default name "profile.prof"
-        """
-        self.op: str = op
-        self.prof_data_path: Optional[str] = prof_data_path
-        if self.prof_data_path is None:
-            self.prof_data_path = "profile.prof"
-        self.logger = logging.getLogger(self.__class__.__name__)
 
-    async def get(self):
+    async def post(self):
         """
-        Implementation of GET request handler for profiler control.
+        Implementation of POST request handler for profiler control.
         """
+        logger = logging.getLogger(self.__class__.__name__)
+
         if not HAS_PROFILER:
             self.set_status(HTTPStatus.SERVICE_UNAVAILABLE)
             self.write("Profiler library yappi is not available. Please install it with 'pip install yappi'")
             self.logger.info("Profiler library yappi is not available. Please install it with 'pip install yappi'")
             return
 
+        action: Optional[str] = None
+        profiler_data_path: Optional[str] = None
+
+        # Parse the JSON request body:
+        request_dict: Dict[str, Any] = None
         try:
-            if self.op == "start":
+            # Parse JSON body
+            request_dict = json.loads(self.request.body)
+            action = request_dict.get("action", "none").lower()
+            profiler_data_path = request_dict.get("profiler_data_path")
+        except JSONDecodeError as exc:
+            self.set_status(HTTPStatus.BAD_REQUEST)
+            self.write("Invalid JSON in request body")
+            logger.info("Invalid JSON in request body: %s", str(exc))
+            return
+
+        try:
+            if action == "start":
                 # Set clock type to "wall" time to get more accurate profiling results in async code
                 yappi.set_clock_type("wall")
                 yappi.start()
                 self.write("profiling started")
-                self.logger.info("PROFILER STARTED")
-            else:
+                logger.info("PROFILER STARTED")
+            elif action == "stop":
                 yappi.stop()
                 stats = yappi.get_func_stats()
-                stats.save(self.prof_data_path, type="pstat")
-                self.write(f"profiling stopped and saved to {self.prof_data_path}")
-                self.logger.info("PROFILER STOPPED AND SAVED TO %s", self.prof_data_path)
+                stats.save(profiler_data_path, type="pstat")
+                self.write(f"profiling stopped and saved to {profiler_data_path}")
+                logger.info("PROFILER STOPPED AND SAVED TO %s", profiler_data_path)
+            else:
+                self.write("Invalid profiler control action. Expected 'start' or 'stop'.")
+                logger.info("Invalid profiler control action received: %s", action)
+                self.set_status(HTTPStatus.BAD_REQUEST)
         except Exception as exception:  # pylint: disable=broad-exception-caught
-            self.logger.error("Error during profiler control operation '%s': %s",
-                              self.op, str(exception), exc_info=True)
-            self.write(f"FAILED to {self.op} profiler")
+            logger.error("Error during profiler control operation '%s': %s",
+                              action, str(exception), exc_info=True)
+            self.write(f"FAILED to {action} profiler")
             self.set_status(HTTPStatus.INTERNAL_SERVER_ERROR)
 
     def data_received(self, chunk):

--- a/neuro_san/service/http/handlers/profiler_control_handler.py
+++ b/neuro_san/service/http/handlers/profiler_control_handler.py
@@ -20,8 +20,6 @@ See class comment for details
 from typing import Optional
 import logging
 
-import asyncio
-
 try:
     import yappi
     HAS_PROFILER = True

--- a/neuro_san/service/http/handlers/profiler_control_handler.py
+++ b/neuro_san/service/http/handlers/profiler_control_handler.py
@@ -69,13 +69,13 @@ class ProfilerControlHandler(RequestHandler):
                 yappi.set_clock_type("wall")
                 yappi.start()
                 self.write("profiling started")
-                self.logger.info(">>>>>PROFILER STARTED")
+                self.logger.info("PROFILER STARTED")
             else:
                 yappi.stop()
                 stats = yappi.get_func_stats()
                 stats.save(self.prof_data_path, type="pstat")
                 self.write(f"profiling stopped and saved to {self.prof_data_path}")
-                self.logger.info(">>>>>PROFILER STOPPED AND SAVED TO %s", self.prof_data_path)
+                self.logger.info("PROFILER STOPPED AND SAVED TO %s", self.prof_data_path)
         except Exception as exception:  # pylint: disable=broad-exception-caught
             self.logger.error("Error during profiler control operation '%s': %s",
                               self.op, str(exception), exc_info=True)

--- a/neuro_san/service/http/handlers/profiler_control_handler.py
+++ b/neuro_san/service/http/handlers/profiler_control_handler.py
@@ -25,6 +25,8 @@ import logging
 from http import HTTPStatus
 from tornado.web import RequestHandler
 
+from neuro_san.service.utils.request_util import RequestUtil
+
 try:
     import yappi
     HAS_PROFILER = True
@@ -77,7 +79,7 @@ class ProfilerControlHandler(RequestHandler):
                 stats = yappi.get_func_stats()
                 # pylint: disable=no-member
                 stats.save(profiler_data_path, type="pstat")
-                self.write(f"profiling stopped and saved to {profiler_data_path}")
+                self.write(f"profiling stopped and saved to {RequestUtil.safe_message(str(profiler_data_path))}")
                 logger.info("PROFILER STOPPED AND SAVED TO %s", profiler_data_path)
             else:
                 self.write("Invalid profiler control action. Expected 'start' or 'stop'.")
@@ -86,7 +88,7 @@ class ProfilerControlHandler(RequestHandler):
         except Exception as exception:  # pylint: disable=broad-exception-caught
             logger.error("Error during profiler control operation '%s': %s",
                          action, str(exception), exc_info=True)
-            self.write(f"FAILED to {action} profiler")
+            self.write(f"FAILED to {RequestUtil.safe_message(str(action))} profiler")
             self.set_status(HTTPStatus.INTERNAL_SERVER_ERROR)
 
     def data_received(self, chunk):

--- a/neuro_san/service/http/handlers/profiler_control_handler.py
+++ b/neuro_san/service/http/handlers/profiler_control_handler.py
@@ -17,20 +17,19 @@
 """
 See class comment for details
 """
-from typing import Optional
+from typing import Any, Dict, Optional
+import json
+from json.decoder import JSONDecodeError
 import logging
+
+from http import HTTPStatus
+from tornado.web import RequestHandler
 
 try:
     import yappi
     HAS_PROFILER = True
 except ImportError:
     HAS_PROFILER = False
-
-from http import HTTPStatus
-from tornado.web import RequestHandler
-
-import json
-from json.decoder import JSONDecodeError
 
 
 class ProfilerControlHandler(RequestHandler):
@@ -76,6 +75,7 @@ class ProfilerControlHandler(RequestHandler):
             elif action == "stop":
                 yappi.stop()
                 stats = yappi.get_func_stats()
+                # pylint: disable=no-member
                 stats.save(profiler_data_path, type="pstat")
                 self.write(f"profiling stopped and saved to {profiler_data_path}")
                 logger.info("PROFILER STOPPED AND SAVED TO %s", profiler_data_path)
@@ -85,7 +85,7 @@ class ProfilerControlHandler(RequestHandler):
                 self.set_status(HTTPStatus.BAD_REQUEST)
         except Exception as exception:  # pylint: disable=broad-exception-caught
             logger.error("Error during profiler control operation '%s': %s",
-                              action, str(exception), exc_info=True)
+                         action, str(exception), exc_info=True)
             self.write(f"FAILED to {action} profiler")
             self.set_status(HTTPStatus.INTERNAL_SERVER_ERROR)
 

--- a/neuro_san/service/http/handlers/profiler_control_handler.py
+++ b/neuro_san/service/http/handlers/profiler_control_handler.py
@@ -22,9 +22,9 @@ import logging
 
 try:
     import yappi
-    has_profiler = True
+    HAS_PROFILER = True
 except ImportError:
-    has_profiler = False
+    HAS_PROFILER = False
     print("yappi library is required for profiling. Please install it with 'pip install yappi'")
 
 from http import HTTPStatus
@@ -58,7 +58,7 @@ class ProfilerControlHandler(RequestHandler):
         """
         Implementation of GET request handler for profiler control.
         """
-        if not has_profiler:
+        if not HAS_PROFILER:
             self.set_status(HTTPStatus.SERVICE_UNAVAILABLE)
             self.write("Profiler library yappi is not available. Please install it with 'pip install yappi'")
             self.logger.info("Profiler library yappi is not available. Please install it with 'pip install yappi'")
@@ -81,3 +81,10 @@ class ProfilerControlHandler(RequestHandler):
                               self.op, str(exception), exc_info=True)
             self.write(f"FAILED to {self.op} profiler")
             self.set_status(HTTPStatus.INTERNAL_SERVER_ERROR)
+
+    def data_received(self, chunk):
+        """
+        This method is required to be implemented as part of RequestHandler subclass,
+        but is not used in our case as we do not expect any data in the request body.
+        """
+        pass

--- a/neuro_san/service/http/handlers/profiler_control_handler.py
+++ b/neuro_san/service/http/handlers/profiler_control_handler.py
@@ -13,8 +13,6 @@ except ImportError:
 from http import HTTPStatus
 from tornado.web import RequestHandler
 
-from neuro_san.service.http.logging.http_logger import HttpLogger
-
 
 class ProfilerControlHandler(RequestHandler):
 

--- a/neuro_san/service/http/handlers/profiler_control_handler.py
+++ b/neuro_san/service/http/handlers/profiler_control_handler.py
@@ -17,8 +17,6 @@
 """
 See class comment for details
 """
-from typing import Any
-from typing import Dict
 from typing import Optional
 import logging
 
@@ -56,7 +54,7 @@ class ProfilerControlHandler(RequestHandler):
             self.prof_data_path = "profile.prof"
         self.logger = logging.getLogger(self.__class__.__name__)
 
-    def get(self):
+    async def get(self):
         """
         Implementation of GET request handler for profiler control.
         """
@@ -66,14 +64,20 @@ class ProfilerControlHandler(RequestHandler):
             self.logger.info("Profiler library yappi is not available. Please install it with 'pip install yappi'")
             return
 
-        if self.op == "start":
-            yappi.set_clock_type("wall")
-            yappi.start()
-            self.write("profiling started")
-            self.logger.info(">>>>>PROFILER STARTED")
-        else:
-            yappi.stop()
-            stats = yappi.get_func_stats()
-            stats.save(self.prof_data_path, type="pstat")
-            self.write(f"profiling stopped and saved to {self.prof_data_path}")
-            self.logger.info(">>>>>PROFILER STOPPED AND SAVED TO %s", self.prof_data_path)
+        try:
+            if self.op == "start":
+                yappi.set_clock_type("wall")
+                yappi.start()
+                self.write("profiling started")
+                self.logger.info(">>>>>PROFILER STARTED")
+            else:
+                yappi.stop()
+                stats = yappi.get_func_stats()
+                stats.save(self.prof_data_path, type="pstat")
+                self.write(f"profiling stopped and saved to {self.prof_data_path}")
+                self.logger.info(">>>>>PROFILER STOPPED AND SAVED TO %s", self.prof_data_path)
+        except Exception as exception:  # pylint: disable=broad-exception-caught
+            self.logger.error("Error during profiler control operation '%s': %s",
+                              self.op, str(exception), exc_info=True)
+            self.write(f"FAILED to {self.op} profiler")
+            self.set_status(HTTPStatus.INTERNAL_SERVER_ERROR)

--- a/neuro_san/service/http/handlers/profiler_control_handler.py
+++ b/neuro_san/service/http/handlers/profiler_control_handler.py
@@ -40,7 +40,6 @@ class ProfilerControlHandler(RequestHandler):
     # pylint: disable=attribute-defined-outside-init
     def initialize(self,
                    op: str,
-                   logging_config: Dict[str, Any],
                    prof_data_path: Optional[str]):
         """
         This method is called by Tornado framework to allow
@@ -52,8 +51,7 @@ class ProfilerControlHandler(RequestHandler):
             if not provided, data will be saved in current working directory with default name "profile.prof"
         """
         self.op: str = op
-        self.logging_config: Dict[str, Any] = logging_config
-        self.prof_data_path: str = prof_data_path
+        self.prof_data_path: Optional[str] = prof_data_path
         if self.prof_data_path is None:
             self.prof_data_path = "profile.prof"
         self.logger = logging.getLogger(self.__class__.__name__)

--- a/neuro_san/service/http/handlers/profiler_control_handler.py
+++ b/neuro_san/service/http/handlers/profiler_control_handler.py
@@ -1,3 +1,22 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+"""
+See class comment for details
+"""
 from typing import Any
 from typing import Dict
 from typing import Optional
@@ -15,7 +34,9 @@ from tornado.web import RequestHandler
 
 
 class ProfilerControlHandler(RequestHandler):
-
+    """
+    Handler class for controlling run-time profiler (yappi) via HTTP API calls.
+    """
     # pylint: disable=attribute-defined-outside-init
     def initialize(self,
                    op: str,

--- a/neuro_san/service/http/handlers/profiler_control_handler.py
+++ b/neuro_san/service/http/handlers/profiler_control_handler.py
@@ -1,0 +1,62 @@
+from typing import Any
+from typing import Dict
+from typing import Optional
+import logging
+
+try:
+    import yappi
+    has_profiler = True
+except ImportError:
+    has_profiler = False
+    print("yappi library is required for profiling. Please install it with 'pip install yappi'")
+
+from http import HTTPStatus
+from tornado.web import RequestHandler
+
+from neuro_san.service.http.logging.http_logger import HttpLogger
+
+
+class ProfilerControlHandler(RequestHandler):
+
+    # pylint: disable=attribute-defined-outside-init
+    def initialize(self,
+                   op: str,
+                   logging_config: Dict[str, Any],
+                   prof_data_path: Optional[str]):
+        """
+        This method is called by Tornado framework to allow
+        injecting service-specific data into local handler context.
+        :param op: requested profiler operation:
+                   "start" for starting run-time profiler
+                   "stop" for stopping profiler
+        :param prof_data_path: optional path to save profiler data when stopping profiler;
+            if not provided, data will be saved in current working directory with default name "profile.prof"
+        """
+        self.op: str = op
+        self.logging_config: Dict[str, Any] = logging_config
+        self.prof_data_path: str = prof_data_path
+        if self.prof_data_path is None:
+            self.prof_data_path = "profile.prof"
+        self.logger = logging.getLogger(self.__class__.__name__)
+
+    def get(self):
+        """
+        Implementation of GET request handler for profiler control.
+        """
+        if not has_profiler:
+            self.set_status(HTTPStatus.SERVICE_UNAVAILABLE)
+            self.write("Profiler library yappi is not available. Please install it with 'pip install yappi'")
+            self.logger.info("Profiler library yappi is not available. Please install it with 'pip install yappi'")
+            return
+
+        if self.op == "start":
+            yappi.set_clock_type("wall")
+            yappi.start()
+            self.write("profiling started")
+            self.logger.info(">>>>>PROFILER STARTED")
+        else:
+            yappi.stop()
+            stats = yappi.get_func_stats()
+            stats.save(self.prof_data_path, type="pstat")
+            self.write(f"profiling stopped and saved to {self.prof_data_path}")
+            self.logger.info(">>>>>PROFILER STOPPED AND SAVED TO %s", self.prof_data_path)

--- a/neuro_san/service/http/server/http_server.py
+++ b/neuro_san/service/http/server/http_server.py
@@ -218,18 +218,8 @@ class HttpServer(AgentStateListener):
         handlers.append(("/readyz", HealthCheckHandler, ready_request_initialize_data))
         handlers.append(("/livez", HealthCheckHandler, live_request_initialize_data))
 
-        # Setup handlers for profiler control (start/stop)
-        profiler_start_initialize_data: Dict[str, Any] = {
-            "op": "start",
-            "prof_data_path": None
-        }
-        handlers.append(("/prof/start", ProfilerControlHandler, profiler_start_initialize_data))
-
-        profiler_stop_initialize_data: Dict[str, Any] = {
-            "op": "stop",
-            "prof_data_path": None
-        }
-        handlers.append(("/prof/stop", ProfilerControlHandler, profiler_stop_initialize_data))
+        # Setup handler for profiler control
+        handlers.append(("/profiler", ProfilerControlHandler))
 
         if enable_http_handlers:
             handlers.append(("/api/v1/list", ConciergeHandler, request_initialize_data))

--- a/neuro_san/service/http/server/http_server.py
+++ b/neuro_san/service/http/server/http_server.py
@@ -43,6 +43,7 @@ from neuro_san.service.http.handlers.function_handler import FunctionHandler
 from neuro_san.service.http.handlers.health_check_handler import HealthCheckHandler
 from neuro_san.service.http.handlers.openapi_publish_handler import OpenApiPublishHandler
 from neuro_san.service.http.handlers.streaming_chat_handler import StreamingChatHandler
+from neuro_san.service.http.handlers.profiler_control_handler import ProfilerControlHandler
 from neuro_san.service.http.logging.http_logger import HttpLogger
 from neuro_san.service.http.server.agent_authorization_policy import AgentAuthorizationPolicy
 from neuro_san.service.http.server.http_server_app import HttpServerApp
@@ -216,6 +217,21 @@ class HttpServer(AgentStateListener):
         handlers.append(("/healthz", HealthCheckHandler, ready_request_initialize_data))
         handlers.append(("/readyz", HealthCheckHandler, ready_request_initialize_data))
         handlers.append(("/livez", HealthCheckHandler, live_request_initialize_data))
+
+        # Setup handlers for profiler control (start/stop)
+        profiler_start_initialize_data: Dict[str, Any] = {
+            "op": "start",
+            "logging_config": self.logging_config,
+            "prof_data_path": None
+        }
+        handlers.append(("/prof/start", ProfilerControlHandler, profiler_start_initialize_data))
+
+        profiler_stop_initialize_data: Dict[str, Any] = {
+            "op": "stop",
+            "logging_config": self.logging_config,
+            "prof_data_path": None
+        }
+        handlers.append(("/prof/stop", ProfilerControlHandler, profiler_stop_initialize_data))
 
         if enable_http_handlers:
             handlers.append(("/api/v1/list", ConciergeHandler, request_initialize_data))

--- a/neuro_san/service/http/server/http_server.py
+++ b/neuro_san/service/http/server/http_server.py
@@ -221,14 +221,12 @@ class HttpServer(AgentStateListener):
         # Setup handlers for profiler control (start/stop)
         profiler_start_initialize_data: Dict[str, Any] = {
             "op": "start",
-            "logging_config": self.logging_config,
             "prof_data_path": None
         }
         handlers.append(("/prof/start", ProfilerControlHandler, profiler_start_initialize_data))
 
         profiler_stop_initialize_data: Dict[str, Any] = {
             "op": "stop",
-            "logging_config": self.logging_config,
             "prof_data_path": None
         }
         handlers.append(("/prof/stop", ProfilerControlHandler, profiler_stop_initialize_data))

--- a/neuro_san/service/mcp/processors/mcp_ping_processor.py
+++ b/neuro_san/service/mcp/processors/mcp_ping_processor.py
@@ -21,7 +21,7 @@ from typing import Any
 from typing import Dict
 
 from neuro_san.service.http.logging.http_logger import HttpLogger
-from neuro_san.service.mcp.util.mcp_request_util import McpRequestUtil
+from neuro_san.service.utils.request_util import RequestUtil
 
 
 class McpPingProcessor:
@@ -44,6 +44,6 @@ class McpPingProcessor:
         _ = metadata
         return {
             "jsonrpc": "2.0",
-            "id": McpRequestUtil.safe_request_id(request_id),
+            "id": RequestUtil.safe_request_id(request_id),
             "result": {}
         }

--- a/neuro_san/service/mcp/processors/mcp_prompts_processor.py
+++ b/neuro_san/service/mcp/processors/mcp_prompts_processor.py
@@ -21,7 +21,7 @@ from typing import Any
 from typing import Dict
 
 from neuro_san.service.http.logging.http_logger import HttpLogger
-from neuro_san.service.mcp.util.mcp_request_util import McpRequestUtil
+from neuro_san.service.utils.request_util import RequestUtil
 
 
 class McpPromptsProcessor:
@@ -43,7 +43,7 @@ class McpPromptsProcessor:
         _ = metadata
         return {
             "jsonrpc": "2.0",
-            "id": McpRequestUtil.safe_request_id(request_id),
+            "id": RequestUtil.safe_request_id(request_id),
             "result": {
                 "prompts": []
             }

--- a/neuro_san/service/mcp/processors/mcp_resources_processor.py
+++ b/neuro_san/service/mcp/processors/mcp_resources_processor.py
@@ -21,7 +21,7 @@ from typing import Any
 from typing import Dict
 
 from neuro_san.service.http.logging.http_logger import HttpLogger
-from neuro_san.service.mcp.util.mcp_request_util import McpRequestUtil
+from neuro_san.service.utils.request_util import RequestUtil
 
 
 class McpResourcesProcessor:
@@ -44,7 +44,7 @@ class McpResourcesProcessor:
         _ = metadata
         return {
             "jsonrpc": "2.0",
-            "id": McpRequestUtil.safe_request_id(request_id),
+            "id": RequestUtil.safe_request_id(request_id),
             "result": {
                 "resources": []
             }

--- a/neuro_san/service/mcp/processors/mcp_tools_processor.py
+++ b/neuro_san/service/mcp/processors/mcp_tools_processor.py
@@ -35,8 +35,8 @@ from neuro_san.service.generic.async_agent_service import AsyncAgentService
 from neuro_san.service.generic.async_agent_service_provider import AsyncAgentServiceProvider
 from neuro_san.service.interfaces.agent_authorizer import AgentAuthorizer
 from neuro_san.service.mcp.util.mcp_errors_util import McpErrorsUtil
-from neuro_san.service.mcp.util.mcp_request_util import McpRequestUtil
 from neuro_san.service.mcp.validation.tool_request_validator import ToolRequestValidator
+from neuro_san.service.utils.request_util import RequestUtil
 from neuro_san.service.http.logging.http_logger import HttpLogger
 
 
@@ -83,7 +83,7 @@ class McpToolsProcessor:
                     tools_description.append(tool_dict)
         return {
             "jsonrpc": "2.0",
-            "id": McpRequestUtil.safe_request_id(request_id),
+            "id": RequestUtil.safe_request_id(request_id),
             "result": {
                 "tools": tools_description
             }
@@ -189,7 +189,7 @@ class McpToolsProcessor:
 
         call_result: Dict[str, Any] = {
             "jsonrpc": "2.0",
-            "id": McpRequestUtil.safe_request_id(request_id),
+            "id": RequestUtil.safe_request_id(request_id),
             "result": {
                 "content": [
                     {
@@ -209,7 +209,7 @@ class McpToolsProcessor:
             if structure_data is not None:
                 structure_str: str = f"```json\n{json.dumps(structure_data, indent=2)}\n```"
                 result_text = result_text + structure_str
-        call_result["result"]["content"][0]["text"] = McpRequestUtil.safe_message(result_text)
+        call_result["result"]["content"][0]["text"] = RequestUtil.safe_message(result_text)
         return call_result
 
     async def _get_tool_description(self, agent_name: str, metadata: Dict[str, Any]) -> Dict[str, Any]:

--- a/neuro_san/service/mcp/util/mcp_errors_util.py
+++ b/neuro_san/service/mcp/util/mcp_errors_util.py
@@ -21,7 +21,7 @@ from typing import Any
 from typing import Dict
 
 from neuro_san.service.mcp.mcp_errors import McpError
-from neuro_san.service.mcp.util.mcp_request_util import McpRequestUtil
+from neuro_san.service.utils.request_util import RequestUtil
 
 
 class McpErrorsUtil:
@@ -44,10 +44,10 @@ class McpErrorsUtil:
         return {
             "jsonrpc": "2.0",
             # Appease code scanning tools by escaping the id field:
-            "id": McpRequestUtil.safe_request_id(request_id),
+            "id": RequestUtil.safe_request_id(request_id),
             "error": {
                 "code": error.num_value,
-                "message": McpRequestUtil.safe_message(msg)
+                "message": RequestUtil.safe_message(msg)
             }
         }
 
@@ -62,12 +62,12 @@ class McpErrorsUtil:
         return {
             "jsonrpc": "2.0",
             # Appease code scanning tools by escaping the id field:
-            "id": McpRequestUtil.safe_request_id(request_id),
+            "id": RequestUtil.safe_request_id(request_id),
             "result": {
                 "content": [
                     {
                         "type": "text",
-                        "text": McpRequestUtil.safe_message(error_msg)
+                        "text": RequestUtil.safe_message(error_msg)
                     }
                 ],
                 "isError": True

--- a/neuro_san/service/mcp/util/mcp_request_util.py
+++ b/neuro_san/service/mcp/util/mcp_request_util.py
@@ -19,10 +19,8 @@ See class comment for details
 """
 from typing import Any
 from typing import Dict
-from typing import Union
 
-import html
-
+from neuro_san.service.utils.request_util import RequestUtil
 from neuro_san.session.mcp_service_agent_session import MCP_VERSION
 
 
@@ -48,7 +46,7 @@ class McpRequestUtil:
         """
         return {
             "jsonrpc": "2.0",
-            "id": McpRequestUtil.safe_request_id(request_id),
+            "id": RequestUtil.safe_request_id(request_id),
             "result": {
                 "protocolVersion": MCP_VERSION,
                 "capabilities": {
@@ -67,27 +65,3 @@ class McpRequestUtil:
                 "instructions": ""
             }
         }
-
-    @staticmethod
-    def safe_request_id(request_id: Union[int, str]) -> str:
-        """
-        Return HTML-safe representation of user request id to be sent back in MCP response.
-        :param request_id: MCP request id (as received from user);
-        :return: HTML-escaped request id string
-        """
-        # Always return a string and always HTML-escape it to avoid XSS
-        # vulnerabilities in any HTML-based consumers of the MCP response.
-        if isinstance(request_id, str):
-            return html.escape(request_id)
-        # For non-string IDs (including integers), convert to string first,
-        # then escape to ensure the returned value is HTML-safe.
-        return html.escape(str(request_id))
-
-    @staticmethod
-    def safe_message(msg: str) -> str:
-        """
-        Return HTML-safe representation of string message to be sent back in MCP response.
-        :param msg: message string;
-        :return: HTML-escaped message string
-        """
-        return html.escape(msg)

--- a/neuro_san/service/utils/request_util.py
+++ b/neuro_san/service/utils/request_util.py
@@ -1,0 +1,56 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+"""
+See class comment for details
+"""
+from typing import Union
+
+import html
+
+
+class RequestUtil:
+    """
+    Utility class for sanitizing user-controlled values that flow back into
+    HTTP / MCP responses, so HTML-based consumers cannot be tricked into
+    rendering unescaped client input.
+    """
+
+    @staticmethod
+    def safe_request_id(request_id: Union[int, str]) -> str:
+        """
+        Return HTML-safe representation of a user-supplied request id to be
+        echoed back in a response.
+        :param request_id: request id (as received from the user);
+        :return: HTML-escaped request id string.
+        """
+        # Always return a string and always HTML-escape it to avoid XSS
+        # vulnerabilities in any HTML-based consumers of the response.
+        if isinstance(request_id, str):
+            return html.escape(request_id)
+        # For non-string IDs (including integers), convert to string first,
+        # then escape to ensure the returned value is HTML-safe.
+        return html.escape(str(request_id))
+
+    @staticmethod
+    def safe_message(msg: str) -> str:
+        """
+        Return HTML-safe representation of a string message to be echoed back
+        in a response.
+        :param msg: message string;
+        :return: HTML-escaped message string.
+        """
+        return html.escape(msg)


### PR DESCRIPTION
This PR adds run-time profiler capabilities to neuro-san service.
Profiler chosen is "yappi" library - said to be good for analyzing async services/event loops and such.
Profiler operations are controlled through http endpoints - start/stop+local profile data file creation.
Note that "yappi" is not added to strictly required neuro-san dependencies - if this package is not installed,
neuro-san will gracefully fall back to not using this profiler at run time.
If run-time profiler is desired, a developer should "pip install yappi" separately in neuro-san environment.

 