### PR TITLE
Add description validation to KeywordNetworkValidator

### DIFF
--- a/neuro_san/internals/validation/network/keyword_network_validator.py
+++ b/neuro_san/internals/validation/network/keyword_network_validator.py
@@ -89,13 +89,14 @@ class KeywordNetworkValidator(AbstractNetworkValidator):
             )
             return errors
         description: Any = function.get("description")
-        if description is not None and not isinstance(description, str):
-            errors.append(
-                f"{agent_name} 'function.description' must be a str,"
-                f" got {type(description).__name__}."
-            )
-        elif description == "":
-            errors.append(f"{agent_name} 'function.description' cannot be empty.")
+        if description is not None:
+            if not isinstance(description, str):
+                errors.append(
+                    f"{agent_name} 'function.description' must be a str,"
+                    f" got {type(description).__name__}."
+                )
+            elif description.strip() == "":
+                errors.append(f"{agent_name} 'function.description' cannot be empty.")
         return errors
 
     @staticmethod
@@ -109,13 +110,14 @@ class KeywordNetworkValidator(AbstractNetworkValidator):
         """
         errors: List[str] = []
         instructions: Any = agent.get("instructions")
-        if instructions is not None and not isinstance(instructions, str):
-            errors.append(
-                f"{agent_name} 'instructions' must be a str,"
-                f" got {type(instructions).__name__}."
-            )
-        elif instructions == "":
-            errors.append(f"{agent_name} 'instructions' cannot be empty.")
+        if instructions is not None:
+            if not isinstance(instructions, str):
+                errors.append(
+                    f"{agent_name} 'instructions' must be a str,"
+                    f" got {type(instructions).__name__}."
+                )
+            elif instructions.strip() == "":
+                errors.append(f"{agent_name} 'instructions' cannot be empty.")
         return errors
 
     @staticmethod

--- a/neuro_san/internals/validation/network/keyword_network_validator.py
+++ b/neuro_san/internals/validation/network/keyword_network_validator.py
@@ -32,7 +32,7 @@ class KeywordNetworkValidator(AbstractNetworkValidator):
     AgentNetworkValidator that looks for correct keywords in an agent network
     """
 
-    ALL_KEYWORDS: Set[str] = {"instructions", "tools"}
+    ALL_KEYWORDS: Set[str] = {"description", "instructions", "tools"}
 
     def __init__(self, keywords: Iterable[str] = None):
         """
@@ -56,6 +56,8 @@ class KeywordNetworkValidator(AbstractNetworkValidator):
         self.logger.info("Validating agent network keywords...")
 
         for agent_name, agent in name_to_spec.items():
+            if "description" in self.keywords:
+                errors.extend(self.validate_description(agent_name, agent))
             if "instructions" in self.keywords:
                 errors.extend(self.validate_instructions(agent_name, agent))
             if "tools" in self.keywords:
@@ -65,6 +67,35 @@ class KeywordNetworkValidator(AbstractNetworkValidator):
         if len(errors) > 0:
             self.logger.warning(str(errors))
 
+        return errors
+
+    @staticmethod
+    def validate_description(agent_name: str, agent: Dict[str, Any]) -> List[str]:
+        """
+        Validate that 'function.description' is a non-empty string when present.
+
+        :param agent_name: The name of the agent being validated
+        :param agent: The agent spec dictionary
+        :return: A list of error messages
+        """
+        errors: List[str] = []
+        function: Any = agent.get("function")
+        if function is None:
+            return errors
+        if not isinstance(function, dict):
+            errors.append(
+                f"{agent_name} 'function' must be a dict,"
+                f" got {type(function).__name__}."
+            )
+            return errors
+        description: Any = function.get("description")
+        if description is not None and not isinstance(description, str):
+            errors.append(
+                f"{agent_name} 'function.description' must be a str,"
+                f" got {type(description).__name__}."
+            )
+        elif description == "":
+            errors.append(f"{agent_name} 'function.description' cannot be empty.")
         return errors
 
     @staticmethod

--- a/tests/neuro_san/internals/validation/network/test_keyword_network_validator.py
+++ b/tests/neuro_san/internals/validation/network/test_keyword_network_validator.py
@@ -100,6 +100,45 @@ class TestKeywordNetworkValidator(TestCase, AbstractNetworkValidatorTest):
         errors: List[str] = validator.validate(config)
         self.assertEqual(0, len(errors))
 
+    def test_description_empty(self):
+        """
+        Tests a network where function.description is empty
+        """
+        validator: DictionaryValidator = self.create_validator()
+
+        config: Dict[str, Any] = self.restore("hello_world.hocon")
+        config["tools"][0]["function"]["description"] = ""
+
+        errors: List[str] = validator.validate(config)
+        self.assertEqual(1, len(errors))
+        self.assertIn("function.description", errors[0])
+
+    def test_description_wrong_type(self):
+        """
+        Tests a network where function.description is not a string
+        """
+        validator: DictionaryValidator = self.create_validator()
+
+        config: Dict[str, Any] = self.restore("hello_world.hocon")
+        config["tools"][0]["function"]["description"] = 123
+
+        errors: List[str] = validator.validate(config)
+        self.assertEqual(1, len(errors))
+        self.assertIn("must be a str", errors[0])
+
+    def test_function_wrong_type(self):
+        """
+        Tests a network where function is not a dict
+        """
+        validator: DictionaryValidator = self.create_validator()
+
+        config: Dict[str, Any] = self.restore("hello_world.hocon")
+        config["tools"][0]["function"] = "not a dict"
+
+        errors: List[str] = validator.validate(config)
+        self.assertEqual(1, len(errors))
+        self.assertIn("'function' must be a dict", errors[0])
+
     def test_keywords_filter(self):
         """
         Tests that the keywords parameter controls which validations run


### PR DESCRIPTION
Fix #861

## Summary
- Add validation that function is a dict and function.description is a non-empty string when present
- Add description to the set of default validated keywords
- Add tests for this in the unit test