### PR TITLE
Add data-driven test case guide to docs

### DIFF
--- a/docs/test_case_hocon_reference.md
+++ b/docs/test_case_hocon_reference.md
@@ -3,6 +3,9 @@
 This document describes the neuro-san specifications for the test case .hocon files
 found within this repo under the [tests/fixtures](../tests/fixtures) section of this repo.
 
+For instructions on how to run tests and register new test cases with pytest,
+see [tests.md](tests.md).
+
 The neuro-san system uses the HOCON (Human-Optimized Config Object Notation) file format
 for its data-driven configuration elements.  Very simply put, you can think of
 .hocon files as JSON files that allow comments, but there is more to the hocon

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -78,6 +78,38 @@ Required environment variables:
     export AGENT_TOOL_PATH="./neuro_san/coded_tools"
     export AGENT_MANIFEST_FILE="./neuro_san/registries/manifest.hocon"
 
+### Adding a new data-driven test case
+
+Data-driven tests use HOCON fixture files to define test cases declaratively.
+See [test_case_hocon_reference.md](test_case_hocon_reference.md) for the full HOCON schema.
+
+To add a new test case:
+
+1. Create a fixture HOCON file under `tests/fixtures/<agent_name>/your_test.hocon`
+
+2. Register the HOCON file in the appropriate test class under
+   `tests/neuro_san/zzz_hocons/` by adding it to the list inside
+   `@parameterized.expand()`:
+
+   - For integration tests: `test_integration_test_hocons.py`
+   - For smoke tests: `test_smoke_test_hocons.py`
+
+   Example:
+
+        @parameterized.expand(DynamicHoconUnitTests.from_hocon_list([
+            "my_agent/my_new_test.hocon",
+        ]), skip_on_empty=True)
+
+3. Run the test (integration example):
+
+        export PYTHONPATH=$(pwd)
+        export AGENT_TOOL_PATH="./neuro_san/coded_tools"
+        export AGENT_MANIFEST_FILE="./neuro_san/registries/manifest.hocon"
+        pytest -s --verbose -m "integration" -k "my_agent_my_new_test" --timer-top-n 100
+
+   The `-k` filter name is derived from the HOCON path: slashes become `_`
+   and `.hocon` is stripped.
+
 ### Debugging
 
 To debug a specific unit test, import pytest in the test source file


### PR DESCRIPTION
This PR adds documentation on how to create and register new data-driven fixture test cases.

I will add this as a link reference to ANTeGen MD studio [#846] afterward. How to help some upcoming users.


Changes:

1. docs/tests.md — Add a new "Adding a new data-driven test case" section (after smoke tests, before Debugging) that covers:

- Creating a fixture HOCON file under tests/fixtures/
- Registering it in the appropriate test_*_hocons.py file via @parameterized.expand()
- Running the test with required environment variables

2. docs/test_case_hocon_reference.md — Add a cross-reference to tests.md in the introduction for instructions on running tests and registering new test cases with pytest.