### PR TITLE
Fix returned sly_data reporting in agent_cli

### DIFF
--- a/neuro_san/client/agent_cli.py
+++ b/neuro_san/client/agent_cli.py
@@ -209,8 +209,8 @@ Some suggestions:
 
             print(f"\nResponse from {state.get('origin_str')}:")
             print(f"{state.get('last_chat_response')}")
-            if state.get("sly_data") is not None:
-                pretty_sly: str = json.dumps(state.get('sly_data'), indent=4, sort_keys=True)
+            if state.get("returned_sly_data") is not None:
+                pretty_sly: str = json.dumps(state.get('returned_sly_data'), indent=4, sort_keys=True)
                 print(f"Returned sly_data is: {pretty_sly}")
 
             if self.args.tokens:

--- a/neuro_san/client/streaming_input_processor.py
+++ b/neuro_san/client/streaming_input_processor.py
@@ -124,6 +124,7 @@ class StreamingInputProcessor:
             "last_chat_response": last_chat_response,
             "user_input": None,
             "sly_data": sly_data,
+            "returned_sly_data": returned_sly_data,
             "origin_str": origin_str,
             "token_accounting": self.processor.get_token_accounting()
         }


### PR DESCRIPTION
Was getting mixed signals from the client because it was spitting out that the returned sly_data actually had extra data in it, which it did not upon low-level inspection. What had been happening is a report of a mix of old and returned sly_data, but it was advertising the output as what was returned.

This PR allows the state to be kept to report the right thing for returned sly_data.