### PR TITLE
NS-863 Fix AgentFrameworkMessage chat_context default

### DIFF
--- a/neuro_san/internals/chat/data_driven_chat_session.py
+++ b/neuro_san/internals/chat/data_driven_chat_session.py
@@ -168,9 +168,8 @@ class DataDrivenChatSession(RunTarget, LingeringResource):
             # This can happen if the user is trying to send a new message
             # while it is still working on a previous message that has not
             # yet returned.
-            empty: Dict[str, Any] = {}
             raw_messages: List[BaseMessage] = [
-                AgentFrameworkMessage(content="Patience, please. I'm working on it.", chat_context=empty)
+                AgentFrameworkMessage(content="Patience, please. I'm working on it.")
             ]
 
             logger: Logger = getLogger(self.__class__.__name__)
@@ -257,9 +256,8 @@ class DataDrivenChatSession(RunTarget, LingeringResource):
 
         # If we are invoked as an event, tell the caller that it's OK to disconnect early.
         # By definition, they are not expecting a custom response.
-        empty: Dict[str, Any] = {}
         if self.invocation_context.get_effective_invocation() == "event":
-            event_acknowledge = AgentFrameworkMessage(content="Event acknowledged", chat_context=empty)
+            event_acknowledge = AgentFrameworkMessage(content="Event acknowledged")
             await self.finalize_request(event_acknowledge)
 
         # Get all our real input values from the original_input_message.
@@ -275,7 +273,7 @@ class DataDrivenChatSession(RunTarget, LingeringResource):
             except ValueError as exc:
                 # This can happen if we have problems with LLM clients API keys:
                 # Construct a message to send back to the client with the error information.
-                message = AgentFrameworkMessage(content=str(exc), chat_context=empty)
+                message = AgentFrameworkMessage(content=str(exc))
                 await self.finalize_request(message)
                 return message
 

--- a/neuro_san/internals/chat/data_driven_chat_session.py
+++ b/neuro_san/internals/chat/data_driven_chat_session.py
@@ -168,8 +168,9 @@ class DataDrivenChatSession(RunTarget, LingeringResource):
             # This can happen if the user is trying to send a new message
             # while it is still working on a previous message that has not
             # yet returned.
+            empty: Dict[str, Any] = {}
             raw_messages: List[BaseMessage] = [
-                AgentFrameworkMessage(content="Patience, please. I'm working on it.")
+                AgentFrameworkMessage(content="Patience, please. I'm working on it.", chat_context=empty)
             ]
 
             logger: Logger = getLogger(self.__class__.__name__)
@@ -256,8 +257,8 @@ class DataDrivenChatSession(RunTarget, LingeringResource):
 
         # If we are invoked as an event, tell the caller that it's OK to disconnect early.
         # By definition, they are not expecting a custom response.
+        empty: Dict[str, Any] = {}
         if self.invocation_context.get_effective_invocation() == "event":
-            empty: Dict[str, Any] = {}
             event_acknowledge = AgentFrameworkMessage(content="Event acknowledged", chat_context=empty)
             await self.finalize_request(event_acknowledge)
 
@@ -274,7 +275,7 @@ class DataDrivenChatSession(RunTarget, LingeringResource):
             except ValueError as exc:
                 # This can happen if we have problems with LLM clients API keys:
                 # Construct a message to send back to the client with the error information.
-                message = AgentFrameworkMessage(content=str(exc))
+                message = AgentFrameworkMessage(content=str(exc), chat_context=empty)
                 await self.finalize_request(message)
                 return message
 

--- a/neuro_san/internals/messages/agent_framework_message.py
+++ b/neuro_san/internals/messages/agent_framework_message.py
@@ -63,7 +63,13 @@ class AgentFrameworkMessage(TracedMessage):
         :param kwargs: Additional fields to pass to the superclass
         """
         super().__init__(content=content, trace_source=trace_source, **kwargs)
+
         self.chat_context: Dict[str, Any] = chat_context
+        if chat_context is None:
+            # Special case default so that the MinimalMessageFilter, which only
+            # looks for chat_context, does not fail to send the final AgentFrameworkMessage.
+            self.chat_context = {}
+
         self.sly_data: Dict[str, Any] = sly_data
         self.structure: Dict[str, Any] = structure
 


### PR DESCRIPTION
The MinimalMessageFilter had kinda required us to send an empty dictionary for the chat_context argument of the AgentFrameworkMessage.  There were 2 places in the code where we were not sending this and at least one of them was causing some problems in the tests.

The main situation here that was fixed was in the case where the network execution returned an exception of some kind.

This does _not_ solve the problem of final AgentFramework messages not showing up in thinking files.
That will be a separate investigation.