### PR TITLE
Handle None raw_manifest in restore methods

### DIFF
--- a/neuro_san/internals/graph/persistence/registry_manifest_restorer.py
+++ b/neuro_san/internals/graph/persistence/registry_manifest_restorer.py
@@ -151,6 +151,11 @@ class RegistryManifestRestorer(Restorer):
         raw_restorer = RawManifestRestorer()
         raw_manifest: Dict[str, Any] = raw_restorer.restore(file_reference=manifest_file)
 
+        if raw_manifest is None:
+            self.logger.warning("Manifest file %s is empty or could not be read. Skipping.",
+                                manifest_file)
+            return agent_networks
+
         # By the end of the filter chain, only served entries will be included.
         manifest_filter = ManifestFilterChain(manifest_file)
         one_manifest: Dict[str, Dict[str, Any]] = manifest_filter.filter_config(raw_manifest)
@@ -194,6 +199,11 @@ class RegistryManifestRestorer(Restorer):
 
         raw_restorer = RawManifestRestorer()
         raw_manifest: Dict[str, Any] = await raw_restorer.async_restore(file_reference=manifest_file)
+
+        if raw_manifest is None:
+            self.logger.warning("Manifest file %s is empty or could not be read. Skipping.",
+                                manifest_file)
+            return agent_networks
 
         # By the end of the filter chain, only served entries will be included.
         manifest_filter = ManifestFilterChain(manifest_file)


### PR DESCRIPTION
## Summary

Fixes a crash when a manifest file is empty, missing, or cannot be parsed. `RawManifestRestorer` (with `must_exist=False`) can return `None`, which was passed directly into `ManifestFilterChain.filter_config()`. This caused `ManifestKeyConfigFilter` to crash with `AttributeError: 'NoneType' object has no attribute 'items'` on line 54.

The fix adds a `None` guard in both `restore_one_manifest()` and `async_restore_one_manifest()`. When `raw_manifest` is `None`, a warning is logged and the method returns an empty `agent_networks` dict instead of crashing.

Reported when running nsflow's quick-start (`python -m nsflow.run`), which starts the neuro-san server. If the manifest file at the configured path is empty or absent, the server crashes instead of starting gracefully with no agents.

## Review & Testing Checklist for Human

- [ ] **Verify degraded behavior is acceptable**: When manifest is `None`, the server will start with zero agents loaded. Confirm this is preferable to a hard failure (note: `RawManifestRestorer` already uses `must_exist=False`, suggesting graceful handling was intended).
- [ ] **Log level**: The fix uses `warning`. Consider whether `error` would be more appropriate for a missing/empty manifest, since it likely indicates a misconfiguration.
- [ ] **Test manually**: Run `python -m neuro_san.service.main_loop.server_main_loop` with an empty manifest file and confirm the server starts with a warning instead of crashing.

### Notes
- The same guard is applied to both the sync (`restore_one_manifest`) and async (`async_restore_one_manifest`) code paths, which have parallel structure.
- The port 4173 conflict the user also saw is a separate user-side issue (a prior process still occupying the port), not a code bug.

Link to Devin session: https://app.devin.ai/sessions/408682af9b384507added8d5255322ff
Requested by: @donn-leaf
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cognizant-ai-lab/neuro-san/pull/876" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
