### PR TITLE
Add effort parameter for anthropic models

### DIFF
--- a/neuro_san/internals/run_context/langchain/llms/anthropic_llm_policy.py
+++ b/neuro_san/internals/run_context/langchain/llms/anthropic_llm_policy.py
@@ -69,6 +69,7 @@ class AnthropicLlmPolicy(LlmPolicy):
             # Set stream_usage to True in order to get token counting chunks.
             stream_usage=True,
             thinking=config.get("thinking"),
+            effort=config.get("effort"),
             mcp_servers=config.get("mcp_servers"),
             context_management=config.get("context_management"),
             # If omitted, this defaults to the global verbose value,

--- a/neuro_san/internals/run_context/langchain/llms/default_llm_info.hocon
+++ b/neuro_san/internals/run_context/langchain/llms/default_llm_info.hocon
@@ -1043,19 +1043,64 @@
                 # streaming is always set to True so that ...
                 # stream_usage is always set to True so that token counting can work correctly
 
-                # The following parameters are for reasoning models only.
-                # Supported models
-                # Extended thinking is supported in the following models:
-                # Claude Opus 4.6 (claude-opus-4-6)
-                # Claude Sonnet 4.6 (claude-sonnet-4-6)
-                # Claude Sonnet 4.5 (claude-sonnet-4-5-20250929)
-                # Claude Opus 4.5 (claude-opus-4-5-20251101)
-                # Claude Opus 4.1 (claude-opus-4-1-20250805)
-                # Claude Haiku 4.5 (claude-haiku-4-5-20251001)
-                # Claude Sonnet 4 (claude-sonnet-4-20250514)
-                # Claude Opus 4 (claude-opus-4-20250514)
-                # Note: Claude Opus 4.7 does NOT support extended thinking (uses adaptive thinking instead)
-                "thinking": null, # Parameters for Claude reasoning, e.g., {"type": "enabled", "budget_tokens": 10_000}
+                # Reasoning / thinking parameters
+                #
+                # "thinking" — Controls Claude's extended or adaptive reasoning mode.
+                #   Typed as: dict[str, Any] | None (default: None)
+                #   NOTE: None means the parameter is OMITTED from the API call entirely
+                #   (i.e., the model uses its default behavior). It is NOT the same as
+                #   explicitly passing {"type": "disabled"}, which actively turns off thinking.
+                #
+                #   Manual extended thinking (type: "enabled"):
+                #     Supported on Claude Opus 4.6, Sonnet 4.6, Sonnet 4.5, Opus 4.5,
+                #     Opus 4.1, Haiku 4.5, Sonnet 4, and Opus 4.
+                #     Pass a token budget: {"type": "enabled", "budget_tokens": 10_000}
+                #     Minimum budget_tokens is 1_024. This mode is DEPRECATED on Opus 4.6
+                #     and Sonnet 4.6 and will be removed in a future model release.
+                #     ⚠ Returns a 400 error on Claude Opus 4.7 and later models.
+                #     Ref: https://platform.claude.com/docs/en/build-with-claude/extended-thinking
+                #
+                #   Adaptive thinking (type: "adaptive"):
+                #     Recommended for Claude Opus 4.7, Opus 4.6, and Sonnet 4.6.
+                #     Claude dynamically decides when and how much to think based on
+                #     request complexity — no manual budget_tokens needed.
+                #     This is the ONLY supported thinking mode on Claude Opus 4.7+.
+                #     Pair with `effort` to coarsely control thinking depth.
+                #     Example: {"type": "adaptive"}
+                #     Ref: https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking
+                #
+                #   Disabling thinking (type: "disabled"):
+                #     Explicitly turns off extended thinking. This is distinct from null/None.
+                #
+                #   LangChain usage:
+                #     https://docs.langchain.com/oss/python/integrations/chat/anthropic#extended-thinking
+                #
+                "thinking": null,
+
+                # "effort" — A coarse knob to trade off token usage vs. response depth.
+                #   Typed as: Literal['max', 'high', 'medium', 'low'] | None (default: None)
+                #   Merged into the output_config parameter when making API calls.
+                #   Works in conjunction with adaptive thinking.
+                #
+                #   "low"    — Faster, cheaper; less thorough reasoning.
+                #   "medium" — Balanced.
+                #   "high"   — ⚠ Identical to omitting the parameter altogether (None).
+                #   "max"    — Maximum reasoning; only supported on Claude Opus 4.6.
+                #   "xhigh"  — Extra-high reasoning; only supported on Claude Opus 4.7.
+                #
+                #   Supported models: Claude Mythos Preview, Opus 4.7, Opus 4.6, Sonnet 4.6,
+                #   and Opus 4.5. Not supported on Haiku or Sonnet 4.5 and below.
+                #
+                #   For Opus 4.6 and Sonnet 4.6, `effort` replaces `budget_tokens` as the
+                #   recommended way to control thinking depth. `budget_tokens` is still
+                #   accepted on those models but is deprecated.
+                #   No beta header is required to use this parameter.
+                #
+                #   Ref: https://platform.claude.com/docs/en/build-with-claude/effort
+                #   LangChain usage:
+                #     https://docs.langchain.com/oss/python/integrations/chat/anthropic#effort
+                #
+                "effort": null,
             }
         },
         "ollama": {

--- a/neuro_san/internals/run_context/langchain/llms/default_llm_info.hocon
+++ b/neuro_san/internals/run_context/langchain/llms/default_llm_info.hocon
@@ -1078,7 +1078,7 @@
                 "thinking": null,
 
                 # "effort" — A coarse knob to trade off token usage vs. response depth.
-                #   Typed as: Literal['max', 'high', 'medium', 'low'] | None (default: None)
+                #   Typed as: Literal['max', 'xhigh', 'high', 'medium', 'low'] | None (default: None)
                 #   Merged into the output_config parameter when making API calls.
                 #   Works in conjunction with adaptive thinking.
                 #

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -2,7 +2,7 @@
 # necessary for operation to minimize the size of containers
 
 # Optional LLM Access
-langchain-anthropic>=1.0.0,<2.0
+langchain-anthropic>=1.3.0,<2.0
 langchain-aws>=1.0.0,<2.0
 langchain-google-genai>=4.1.2,<5.0
 langchain-nvidia-ai-endpoints>=1.0.0,<2.0


### PR DESCRIPTION
Add `effort` parameter for anthropic models and upgrade `langchain-anthropic` to `1.3.0` to be able to use `effort`.