### PR TITLE
Update default LLM info file

### DIFF
--- a/neuro_san/internals/run_context/langchain/llms/default_llm_info.hocon
+++ b/neuro_san/internals/run_context/langchain/llms/default_llm_info.hocon
@@ -841,7 +841,6 @@
         "price_per_1k_input_tokens": 0.002,
         "price_per_1k_output_tokens": 0.012,
     },
-
     "gemini-3-flash": {
         "use_model_name": "gemini-3-flash-preview"
     },

--- a/neuro_san/internals/run_context/langchain/llms/default_llm_info.hocon
+++ b/neuro_san/internals/run_context/langchain/llms/default_llm_info.hocon
@@ -800,9 +800,27 @@
         "context_window_size": 1048576,
         "max_output_tokens": 65536,
         "knowledge_cutoff": "01/2025",
-        # https://cloud.google.com/vertex-ai/generative-ai/pricing
+        # https://cloud.google.com/gemini-enterprise-agent-platform/generative-ai/pricing
         "price_per_1k_input_tokens": 0.002,
         "price_per_1k_output_tokens": 0.012,
+    },
+    "gemini-3.1-flash-lite": {
+        "use_model_name": "gemini-3.1-flash-lite-preview"
+    },
+    "gemini-3.1-flash-lite-preview": {
+        "class": "gemini",
+        "model_info_url": "https://ai.google.dev/gemini-api/docs/models/gemini-3.1-flash-lite-preview",
+        "modalities": {
+            "input": [ "text", "images", "video", "audio", "pdf"],
+            "output": [ "text"],
+        },
+        "capabilities": [ "tools" ],
+        "context_window_size": 1048576,
+        "max_output_tokens": 65536,
+        "knowledge_cutoff": "01/2025",
+        # https://cloud.google.com/gemini-enterprise-agent-platform/generative-ai/pricing
+        "price_per_1k_input_tokens": 0.00025,
+        "price_per_1k_output_tokens": 0.0015,
     },
     # This model is optimized for agentic workflows that use custom tools and bash
     "gemini-3.1-pro-customtools": {
@@ -819,35 +837,17 @@
         "context_window_size": 1048576,
         "max_output_tokens": 65536,
         "knowledge_cutoff": "01/2025",
-        # https://cloud.google.com/vertex-ai/generative-ai/pricing
+        # https://cloud.google.com/gemini-enterprise-agent-platform/generative-ai/pricing
         "price_per_1k_input_tokens": 0.002,
         "price_per_1k_output_tokens": 0.012,
     },
 
-    "gemini-3-pro": {
-        "use_model_name": "gemini-3-pro-preview"
-    },
-    "gemini-3-pro-preview": {
-        "class": "gemini",
-        "model_info_url": "https://ai.google.dev/gemini-api/docs/models#gemini-3-pro",
-        "modalities": {
-            "input": [ "text", "images", "video", "audio", "pdf"],
-            "output": [ "text"],
-        },
-        "capabilities": [ "tools" ],
-        "context_window_size": 1048576,
-        "max_output_tokens": 65536,
-        "knowledge_cutoff": "01/2025",
-        # https://cloud.google.com/vertex-ai/generative-ai/pricing
-        "price_per_1k_input_tokens": 0.002,
-        "price_per_1k_output_tokens": 0.012,
-    },
     "gemini-3-flash": {
         "use_model_name": "gemini-3-flash-preview"
     },
     "gemini-3-flash-preview": {
         "class": "gemini",
-        "model_info_url": "https://ai.google.dev/gemini-api/docs/models#gemini-3-flash",
+        "model_info_url": "https://ai.google.dev/gemini-api/docs/models/gemini-3-flash-preview",
         "modalities": {
             "input": [ "text", "images", "video", "audio", "pdf"],
             "output": [ "text"],
@@ -856,13 +856,13 @@
         "context_window_size": 1048576,
         "max_output_tokens": 65536,
         "knowledge_cutoff": "01/2025",
-        # https://cloud.google.com/vertex-ai/generative-ai/pricing
+        # https://cloud.google.com/gemini-enterprise-agent-platform/generative-ai/pricing
         "price_per_1k_input_tokens": 0.0005,
         "price_per_1k_output_tokens": 0.003,
     },
     "gemini-2.5-pro": {
         "class": "gemini",
-        "model_info_url": "https://ai.google.dev/gemini-api/docs/models#gemini-2.5-pro",
+        "model_info_url": "https://ai.google.dev/gemini-api/docs/models/gemini-2.5-pro",
         "modalities": {
             "input": [ "text", "images", "video", "audio", "pdf"],
             "output": [ "text"],
@@ -871,13 +871,13 @@
         "context_window_size": 1048576,
         "max_output_tokens": 65536,
         "knowledge_cutoff": "01/2025",
-        # https://cloud.google.com/vertex-ai/generative-ai/pricing
+        # https://cloud.google.com/gemini-enterprise-agent-platform/generative-ai/pricing
         "price_per_1k_input_tokens": 0.00125,
         "price_per_1k_output_tokens": 0.01,
     },
     "gemini-2.5-flash": {
         "class": "gemini",
-        "model_info_url": "https://ai.google.dev/gemini-api/docs/models#gemini-2.5-flash",
+        "model_info_url": "https://ai.google.dev/gemini-api/docs/models/gemini-2.5-flash",
         "modalities": {
             "input": [ "text", "images", "video", "audio" ],
             "output": [ "text"],
@@ -886,13 +886,28 @@
         "context_window_size": 1048576,
         "max_output_tokens": 65536,
         "knowledge_cutoff": "01/2025",
-        # https://cloud.google.com/vertex-ai/generative-ai/pricing
+        # https://cloud.google.com/gemini-enterprise-agent-platform/generative-ai/pricing
         "price_per_1k_input_tokens": 0.0003,
         "price_per_1k_output_tokens": 0.0025,
     },
+    "gemini-2.5-flash-lite": {
+        "class": "gemini",
+        "model_info_url": "https://ai.google.dev/gemini-api/docs/models/gemini-2.5-flash-lite",
+        "modalities": {
+            "input": [ "text", "images", "video", "audio" ],
+            "output": [ "text"],
+        },
+        "capabilities": [ "tools" ],
+        "context_window_size": 1048576,
+        "max_output_tokens": 65536,
+        "knowledge_cutoff": "01/2025",
+        # https://cloud.google.com/gemini-enterprise-agent-platform/generative-ai/pricing
+        "price_per_1k_input_tokens": 0.0001,
+        "price_per_1k_output_tokens": 0.0004,
+    },
     "gemini-2.0-flash": {
         "class": "gemini",
-        "model_info_url": "https://ai.google.dev/gemini-api/docs/models#gemini-2.0-flash",
+        "model_info_url": "https://ai.google.dev/gemini-api/docs/models/gemini-2.0-flash",
         "modalities": {
             "input": [ "text", "images", "video", "audio" ],
             "output": [ "text", "images" ],
@@ -901,13 +916,13 @@
         "context_window_size": 1048576,
         "max_output_tokens": 8192,
         "knowledge_cutoff": "08/2024",
-        # https://cloud.google.com/vertex-ai/generative-ai/pricing
+        # https://cloud.google.com/gemini-enterprise-agent-platform/generative-ai/pricing
         "price_per_1k_input_tokens": 0.00015,
         "price_per_1k_output_tokens": 0.0006,
     },
     "gemini-2.0-flash-lite": {
         "class": "gemini",
-        "model_info_url": "https://ai.google.dev/gemini-api/docs/models#gemini-2.0-flash-lite",
+        "model_info_url": "https://ai.google.dev/gemini-api/docs/models/gemini-2.0-flash-lite",
         "modalities": {
             "input": [ "text", "images", "video", "audio" ],
             "output": [ "text" ],
@@ -916,7 +931,7 @@
         "context_window_size": 1048576,
         "max_output_tokens": 8192,
         "knowledge_cutoff": "08/2024",
-        # https://cloud.google.com/vertex-ai/generative-ai/pricing
+        # https://cloud.google.com/gemini-enterprise-agent-platform/generative-ai/pricing
         "price_per_1k_input_tokens": 0.000075,
         "price_per_1k_output_tokens": 0.0003,
     },
@@ -961,22 +976,6 @@
         "max_output_tokens": 64000,
         "knowledge_cutoff": "03/2025",
     },
-    "bedrock-us-claude-3-7-sonnet": {
-        "use_model_name": "us.anthropic.claude-3-7-sonnet-20250219-v1:0"
-    },
-    "us.anthropic.claude-3-7-sonnet-20250219-v1:0": {
-        "class": "bedrock",
-        "model_info_url": "https://docs.anthropic.com/en/docs/about-claude/models/all-models#model-comparison-table",
-        "modalities": {
-            "input": [ "text", "image" ],
-            "output": [ "text" ],
-        },
-        # Tool use: https://docs.anthropic.com/en/docs/build-with-claude/tool-use/overview#pricing
-        "capabilities": [ "tools" ],
-        "context_window_size": 200000,
-        "max_output_tokens": 64000,
-        "knowledge_cutoff": "11/2024",
-    }
 
     # These are data for each LLM class, so they don't have to be repeated for each
     # LLM info entry above.

--- a/neuro_san/registries/music_nerd_pro_llm_bedrock_claude.hocon
+++ b/neuro_san/registries/music_nerd_pro_llm_bedrock_claude.hocon
@@ -29,7 +29,7 @@
         ]
     },
     "llm_config": {
-        "model_name": "bedrock-us-claude-3-7-sonnet",
+        "model_name": "bedrock-us-claude-sonnet-4",
     },
     "tools": [
         # This first agent definition is regarded as the "Front Man", which


### PR DESCRIPTION
- Add gemini 2.5 flash lite and 3.1 flash lite and remove 3.0 pro preview. See https://ai.google.dev/gemini-api/docs/models and https://ai.google.dev/gemini-api/docs/deprecations
- Remove bedrock sonnet 3.7. See https://docs.aws.amazon.com/bedrock/latest/userguide/model-lifecycle.html
- Modify `music_nerd_pro_llm_bedrock_claude` to use sonnet 4 instead since it used sonnet 3.7 from bedrock