### PR TITLE
NS-906 Read text files in several possible encodings

### DIFF
--- a/neuro_san/client/agent_cli.py
+++ b/neuro_san/client/agent_cli.py
@@ -29,6 +29,7 @@ from pathlib import Path
 from timedinput import timedinput
 
 from leaf_common.config.file_of_class import FileOfClass
+from leaf_common.serialization.util.bytes_decoder import BytesDecoder
 
 from neuro_san.client.agent_session_factory import AgentSessionFactory
 from neuro_san.client.concierge_session_factory import ConciergeSessionFactory
@@ -108,9 +109,10 @@ class AgentCli:
             #           recognize pathlib as a valid library with which to resolve these kinds
             #           of issues.  Furthermore, this is a client command line tool that is never
             #           used inside servers which just happens to be part of a library offering.
-            prompt: Path = Path(self.args.first_prompt_file)
-            with prompt.open('r', encoding="utf-8") as prompt_file:
-                user_input = prompt_file.read()
+            prompt_path: str = self.args.first_prompt_file
+            with open(prompt_path, "rb") as binary_file:
+                contents: bytes = binary_file.read()
+                user_input, _ = BytesDecoder.decode_bytes(contents, source_name=prompt_path)
 
         sly_data: Dict[str, Any] = None
         if self.args.sly_data is not None:

--- a/neuro_san/internals/authorization/openfga/open_fga_init.py
+++ b/neuro_san/internals/authorization/openfga/open_fga_init.py
@@ -37,6 +37,8 @@ from openfga_sdk.models.write_authorization_model_request import WriteAuthorizat
 from openfga_sdk.models.write_authorization_model_response import WriteAuthorizationModelResponse
 from openfga_sdk.client.client import OpenFgaClient
 
+from neuro_san.internals.utils.text_file_reader import TextFileReader
+
 
 class OpenFgaInit:
     """
@@ -180,9 +182,8 @@ class OpenFgaInit:
 
         # Read the OpenFGA policy from configuration
         policy: Dict[str, Any] = {}
-        async with aiofiles.open(open_fga_policy_file, "r", encoding="utf-8") as policy_file:
-            content: str = await policy_file.read()
-            policy = json.loads(content)
+        content: str = await TextFileReader.async_read_text_file(open_fga_policy_file)
+        policy = json.loads(content)
 
         found_auth_model: str = await self.find_auth_model(open_fga_client, policy)
 

--- a/neuro_san/internals/authorization/openfga/open_fga_init.py
+++ b/neuro_san/internals/authorization/openfga/open_fga_init.py
@@ -23,7 +23,6 @@ from logging import Logger
 
 import json
 import os
-import aiofiles
 
 from openfga_sdk import ClientConfiguration
 from openfga_sdk.credentials import CredentialConfiguration

--- a/neuro_san/internals/persistence/abstract_async_config_restorer.py
+++ b/neuro_san/internals/persistence/abstract_async_config_restorer.py
@@ -100,10 +100,10 @@ class AbstractAsyncConfigRestorer(Restorer, ConfigFilter):
             return config
 
         # Do a synchronous read of the file contents
-        file_contents: str = None
+        file_contents: bytes = None
 
         try:
-            with open(file_path, "r", encoding="utf-8") as file_obj:
+            with open(file_path, "rb") as file_obj:
                 file_contents = file_obj.read()
         except FileNotFoundError:
             # Swallow this in favor of common exception verbiage in filter_config()
@@ -130,9 +130,9 @@ class AbstractAsyncConfigRestorer(Restorer, ConfigFilter):
             return config
 
         # Do an asynchronous read of the file contents
-        file_contents: str = None
+        file_contents: bytes = None
         try:
-            async with async_open(file_path, "r", encoding="utf-8") as file_obj:
+            async with async_open(file_path, "rb") as file_obj:
                 file_contents = await file_obj.read()
         except FileNotFoundError:
             # Swallow this in favor of common exception verbiage in filter_config()
@@ -143,14 +143,15 @@ class AbstractAsyncConfigRestorer(Restorer, ConfigFilter):
 
         return self.filter_config(config, file_path)
 
-    def deserialize_file_contents(self, file_path: str, file_contents: str) -> Dict[str, Any]:
+    def deserialize_file_contents(self, file_path: str, file_contents: bytes) -> Dict[str, Any]:
         """
         :param file_path: The path to the file being restored
-        :param file_contents: The contents of the file
+        :param file_contents: The contents of the file as bytes
         :return: a dictionary
         """
-        # Create a file-like object from the string
-        string_file = BytesIO(file_contents.encode("utf-8"))
+        # Create a file-like object from the input bytes.
+        # This allows us to use the same deserialization code for both sync and async reads.
+        bytes_file = BytesIO(file_contents)
 
         # Determine the serialization format
         serialization: SerializationFormat = None
@@ -165,7 +166,7 @@ class AbstractAsyncConfigRestorer(Restorer, ConfigFilter):
 
         # Read the contents
         try:
-            config = serialization.to_object(string_file)
+            config = serialization.to_object(bytes_file)
         except (ParseException, ParseSyntaxException, JSONDecodeError, ConfigException) as exception:
             message: str = f"""
 There was an error parsing {self.file_purpose} file "{file_path}".

--- a/neuro_san/internals/utils/text_file_reader.py
+++ b/neuro_san/internals/utils/text_file_reader.py
@@ -39,7 +39,7 @@ class TextFileReader:
             return text
 
     @staticmethod
-    async def async_read_text_file(self, filepath: str) -> str:
+    async def async_read_text_file(filepath: str) -> str:
         """
         Asynchronously read the content of a text file in some encoding and return it as a string.
         :param filepath: The path to the text file to read

--- a/neuro_san/internals/utils/text_file_reader.py
+++ b/neuro_san/internals/utils/text_file_reader.py
@@ -1,0 +1,51 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+"""
+See class comment for details
+"""
+import aiofiles
+from leaf_common.serialization.util.bytes_decoder import BytesDecoder
+
+
+class TextFileReader:
+    """
+    Class providing utility methods for reading text files in several possible encodings.
+    """
+
+    @staticmethod
+    def read_text_file(filepath: str) -> str:
+        """
+        Read the content of a text file in some encoding and return it as a string.
+        :param filepath: The path to the text file to read
+        :return: The content of the text file as a string
+        """
+        with open(filepath, "rb") as binary_file:
+            contents: bytes = binary_file.read()
+            text, _ = BytesDecoder.decode_bytes(contents, source_name=filepath)
+            return text
+
+    @staticmethod
+    async def async_read_text_file(self, filepath: str) -> str:
+        """
+        Asynchronously read the content of a text file in some encoding and return it as a string.
+        :param filepath: The path to the text file to read
+        :return: The content of the text file as a string
+        """
+        async with aiofiles.open(filepath, "rb") as binary_file:
+            contents: bytes = await binary_file.read()
+            text, _ = BytesDecoder.decode_bytes(contents, source_name=filepath)
+            return text

--- a/neuro_san/service/http/server/http_server.py
+++ b/neuro_san/service/http/server/http_server.py
@@ -52,6 +52,7 @@ from neuro_san.internals.interfaces.startable import Startable
 from neuro_san.service.mcp.handlers.mcp_root_handler import McpRootHandler
 from neuro_san.service.utils.server_context import ServerContext
 from neuro_san.service.utils.server_status import ServerStatus
+from neuro_san.internals.utils.text_file_reader import TextFileReader
 
 
 DEFAULT_SERVER_NAME: str = 'neuro-san.Agent'
@@ -295,8 +296,8 @@ class HttpServer(AgentStateListener):
         """
         open_api_dict: Dict[str, Any] = None
         try:
-            with open(self.openapi_service_spec_path, "r", encoding='utf-8') as f_out:
-                open_api_dict = json.load(f_out)
+            f_str: str = TextFileReader.read_text_file(self.openapi_service_spec_path)
+            open_api_dict = json.loads(f_str)
         except Exception as exc:  # pylint: disable=broad-exception-caught
             raise ValueError(f"Failed to load '{self.openapi_service_spec_path}'") from exc
 

--- a/neuro_san/service/utils/mcp_server_context.py
+++ b/neuro_san/service/utils/mcp_server_context.py
@@ -25,6 +25,7 @@ from neuro_san.service.mcp.validation.mcp_request_validator import McpRequestVal
 from neuro_san.service.mcp.interfaces.client_session_policy import ClientSessionPolicy
 from neuro_san.service.mcp.session.mcp_no_sessions_policy import McpNoSessionsPolicy
 from neuro_san.service.mcp.util.mcp_request_util import McpRequestUtil
+from neuro_san.internals.utils.text_file_reader import TextFileReader
 
 
 class McpServerContext:
@@ -51,9 +52,9 @@ class McpServerContext:
             schema_name: str = f"service/mcp/validation/mcp-schema-{McpRequestUtil.get_mcp_version()}.json"
             self.protocol_schema_filepath = TOP_LEVEL_DIR.get_file_in_basis(schema_name)
             try:
-                with open(self.protocol_schema_filepath, "r", encoding="utf-8") as schema_file:
-                    self.protocol_schema = json.load(schema_file)
-                    self.request_validator = McpRequestValidator(self.protocol_schema)
+                schema_str: str = TextFileReader.read_text_file(self.protocol_schema_filepath)
+                self.protocol_schema = json.loads(schema_str)
+                self.request_validator = McpRequestValidator(self.protocol_schema)
             except Exception as exc:  # pylint: disable=broad-exception-caught
                 raise RuntimeError(f"Cannot load MCP protocol schema from "
                                    f"'{self.protocol_schema_filepath}': {str(exc)}") from exc

--- a/tests/neuro_san/internals/persistence/test_abstract_async_config_restorer.py
+++ b/tests/neuro_san/internals/persistence/test_abstract_async_config_restorer.py
@@ -203,7 +203,7 @@ class TestAbstractAsyncConfigRestorer:
         r: ConcreteRestorer = self.make_restorer()
         result: Dict[str, Any] = r.deserialize_file_contents(
             str(FIXTURES_DIR / "valid.json"),
-            (FIXTURES_DIR / "valid.json").read_text(encoding="utf-8"),
+            (FIXTURES_DIR / "valid.json").read_bytes(),
         )
         assert result == VALID_DICT
 
@@ -212,7 +212,7 @@ class TestAbstractAsyncConfigRestorer:
         r: ConcreteRestorer = self.make_restorer()
         result: Dict[str, Any] = r.deserialize_file_contents(
             str(FIXTURES_DIR / "valid.hocon"),
-            (FIXTURES_DIR / "valid.hocon").read_text(encoding="utf-8"),
+            (FIXTURES_DIR / "valid.hocon").read_bytes(),
         )
         assert result == VALID_DICT
 
@@ -228,7 +228,7 @@ class TestAbstractAsyncConfigRestorer:
         with pytest.raises(ParseException):
             r.deserialize_file_contents(
                 str(FIXTURES_DIR / "invalid.json"),
-                (FIXTURES_DIR / "invalid.json").read_text(encoding="utf-8"),
+                (FIXTURES_DIR / "invalid.json").read_bytes(),
             )
 
     def test_deserialize_raises_parse_exception_on_invalid_hocon(self) -> None:
@@ -237,7 +237,7 @@ class TestAbstractAsyncConfigRestorer:
         with pytest.raises(ParseException):
             r.deserialize_file_contents(
                 str(FIXTURES_DIR / "invalid.hocon"),
-                (FIXTURES_DIR / "invalid.hocon").read_text(encoding="utf-8"),
+                (FIXTURES_DIR / "invalid.hocon").read_bytes(),
             )
 
     def test_deserialize_parse_exception_wraps_original(self) -> None:
@@ -246,7 +246,7 @@ class TestAbstractAsyncConfigRestorer:
         with pytest.raises(ParseException) as exc_info:
             r.deserialize_file_contents(
                 str(FIXTURES_DIR / "invalid.json"),
-                (FIXTURES_DIR / "invalid.json").read_text(encoding="utf-8"),
+                (FIXTURES_DIR / "invalid.json").read_bytes(),
             )
         assert exc_info.value.__cause__ is not None
 

--- a/tests/neuro_san/internals/persistence/test_abstract_async_config_restorer.py
+++ b/tests/neuro_san/internals/persistence/test_abstract_async_config_restorer.py
@@ -220,7 +220,7 @@ class TestAbstractAsyncConfigRestorer:
         """A ValueError is raised for file extensions other than .json and .hocon."""
         r: ConcreteRestorer = self.make_restorer()
         with pytest.raises(ValueError, match="must be a .json or .hocon file"):
-            r.deserialize_file_contents("config.yaml", "{}")
+            r.deserialize_file_contents("config.yaml", b'{}')
 
     def test_deserialize_raises_parse_exception_on_invalid_json(self) -> None:
         """A ParseException is raised when JSON content is syntactically invalid."""

--- a/tests/neuro_san/internals/utils/test_text_file_reader.py
+++ b/tests/neuro_san/internals/utils/test_text_file_reader.py
@@ -1,0 +1,127 @@
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+import asyncio
+from pathlib import Path
+from typing import Awaitable, TypeVar
+
+import pytest
+
+from neuro_san.internals.utils.text_file_reader import TextFileReader
+
+T = TypeVar("T")
+
+# ---------------------------------------------------------------------------
+# Encoding fixtures
+#
+# BytesDecoder tries the encodings utf-8, cp1252, latin-1 in that order and
+# returns as soon as one succeeds. The byte sequences below are chosen so
+# that each encoding's branch is exercised exactly once:
+#
+#   * utf-8     : valid UTF-8 multibyte sequence (E2 80 99 -> U+2019)
+#   * cp1252    : 0x92 -- invalid as standalone UTF-8, valid in cp1252 (U+2019)
+#   * latin-1   : 0x81 -- invalid in UTF-8 *and* in strict cp1252, valid in latin-1 (U+0081)
+# ---------------------------------------------------------------------------
+
+UTF8_BYTES: bytes = "hello ’world’".encode("utf-8")
+UTF8_EXPECTED: str = "hello ’world’"
+
+CP1252_BYTES: bytes = b"hello \x92world\x92"
+CP1252_EXPECTED: str = "hello ’world’"
+
+LATIN1_BYTES: bytes = b"hello \x81world\x81"
+LATIN1_EXPECTED: str = "hello world"
+
+
+class TestTextFileReader:
+    """
+    Tests for TextFileReader.read_text_file and TextFileReader.async_read_text_file
+    covering all three encodings tried by BytesDecoder (utf-8, cp1252, latin-1).
+    """
+
+    # -----------------------------------------------------------------------
+    # Class-level helpers
+    # -----------------------------------------------------------------------
+
+    @staticmethod
+    def run(coro: Awaitable[T]) -> T:
+        """Run an awaitable to completion using asyncio.run."""
+        return asyncio.run(coro)
+
+    @staticmethod
+    def write_bytes(tmp_path: Path, content: bytes, filename: str = "sample.txt") -> str:
+        """Write raw bytes to a temporary file and return its path."""
+        path: Path = tmp_path / filename
+        path.write_bytes(content)
+        return str(path)
+
+    # -----------------------------------------------------------------------
+    # read_text_file (synchronous)
+    # -----------------------------------------------------------------------
+
+    def test_read_text_file_decodes_utf8(self, tmp_path: Path) -> None:
+        """A UTF-8 encoded file is decoded via the utf-8 branch."""
+        path: str = self.write_bytes(tmp_path, UTF8_BYTES)
+        assert TextFileReader.read_text_file(path) == UTF8_EXPECTED
+
+    def test_read_text_file_decodes_cp1252(self, tmp_path: Path) -> None:
+        """A cp1252-only byte sequence falls through utf-8 and is decoded as cp1252."""
+        path: str = self.write_bytes(tmp_path, CP1252_BYTES)
+        assert TextFileReader.read_text_file(path) == CP1252_EXPECTED
+
+    def test_read_text_file_decodes_latin1(self, tmp_path: Path) -> None:
+        """A latin-1-only byte sequence falls through utf-8 and cp1252, decoded as latin-1."""
+        path: str = self.write_bytes(tmp_path, LATIN1_BYTES)
+        assert TextFileReader.read_text_file(path) == LATIN1_EXPECTED
+
+    def test_read_text_file_empty_file_returns_empty_string(self, tmp_path: Path) -> None:
+        """An empty file decodes to an empty string."""
+        path: str = self.write_bytes(tmp_path, b"")
+        assert TextFileReader.read_text_file(path) == ""
+
+    def test_read_text_file_raises_file_not_found(self, tmp_path: Path) -> None:
+        """A missing file raises FileNotFoundError."""
+        with pytest.raises(FileNotFoundError):
+            TextFileReader.read_text_file(str(tmp_path / "does_not_exist.txt"))
+
+    # -----------------------------------------------------------------------
+    # async_read_text_file
+    # -----------------------------------------------------------------------
+
+    def test_async_read_text_file_decodes_utf8(self, tmp_path: Path) -> None:
+        """A UTF-8 encoded file is decoded via the utf-8 branch (async)."""
+        path: str = self.write_bytes(tmp_path, UTF8_BYTES)
+        assert self.run(TextFileReader.async_read_text_file(path)) == UTF8_EXPECTED
+
+    def test_async_read_text_file_decodes_cp1252(self, tmp_path: Path) -> None:
+        """A cp1252-only byte sequence falls through utf-8 and is decoded as cp1252 (async)."""
+        path: str = self.write_bytes(tmp_path, CP1252_BYTES)
+        assert self.run(TextFileReader.async_read_text_file(path)) == CP1252_EXPECTED
+
+    def test_async_read_text_file_decodes_latin1(self, tmp_path: Path) -> None:
+        """A latin-1-only byte sequence falls through utf-8 and cp1252, decoded as latin-1 (async)."""
+        path: str = self.write_bytes(tmp_path, LATIN1_BYTES)
+        assert self.run(TextFileReader.async_read_text_file(path)) == LATIN1_EXPECTED
+
+    def test_async_read_text_file_empty_file_returns_empty_string(self, tmp_path: Path) -> None:
+        """An empty file decodes to an empty string (async)."""
+        path: str = self.write_bytes(tmp_path, b"")
+        assert self.run(TextFileReader.async_read_text_file(path)) == ""
+
+    def test_async_read_text_file_raises_file_not_found(self, tmp_path: Path) -> None:
+        """A missing file raises FileNotFoundError (async)."""
+        with pytest.raises(FileNotFoundError):
+            self.run(TextFileReader.async_read_text_file(str(tmp_path / "does_not_exist.txt")))

--- a/tests/neuro_san/internals/utils/test_text_file_reader.py
+++ b/tests/neuro_san/internals/utils/test_text_file_reader.py
@@ -43,7 +43,7 @@ CP1252_BYTES: bytes = b"hello \x92world\x92"
 CP1252_EXPECTED: str = "hello ’world’"
 
 LATIN1_BYTES: bytes = b"hello \x81world\x81"
-LATIN1_EXPECTED: str = "hello world"
+LATIN1_EXPECTED: str = "hello \u0081world\u0081"
 
 
 class TestTextFileReader:


### PR DESCRIPTION
This PR replaces text files input throughout neuro-san code with functions supporting several possible encodings.
The core logic is BytesDecoder class from leaf-common, handling utf-8, cp1252 (Windows) and ASCII latin-1 encodings.

