### PR TITLE
NS-901 Change error message mentioning AGENT_TEMPORARY_NETWORK_UPDATE_PERIOD_SECONDS

### DIFF
--- a/neuro_san/internals/reservations/reservation_util.py
+++ b/neuro_san/internals/reservations/reservation_util.py
@@ -56,8 +56,8 @@ class ReservationUtil:
         reservationist: Reservationist = args.get("reservationist")
         if reservationist is None:
             error = """
-Reservationist is None.  Try this for your server:
-    export AGENT_TEMPORARY_NETWORK_UPDATE_PERIOD_SECONDS=5
+Reservationist is None.  Make sure that temporary networks reservations
+    are allowed in agent network definition.
 """
             return (reservation, error)
 

--- a/neuro_san/internals/reservations/reservation_util.py
+++ b/neuro_san/internals/reservations/reservation_util.py
@@ -56,10 +56,10 @@ class ReservationUtil:
         reservationist: Reservationist = args.get("reservationist")
         if reservationist is None:
             error = """
-Reservationist is None.  Make sure that temporary networks reservations 
-are allowed in agent network definition by specifying:
-"allow": { "reservations": True } or 
-add a NetworkCopyMiddleware entry with allow.reservations = true.
+Reservationist is None.  Make sure that temporary networks reservations
+ are allowed in agent network definition by specifying:
+"allow": { "reservations": True } or
+ add a NetworkCopyMiddleware entry with allow.reservations = true.
 """
             return (reservation, error)
 

--- a/neuro_san/internals/reservations/reservation_util.py
+++ b/neuro_san/internals/reservations/reservation_util.py
@@ -56,8 +56,10 @@ class ReservationUtil:
         reservationist: Reservationist = args.get("reservationist")
         if reservationist is None:
             error = """
-Reservationist is None.  Make sure that temporary networks reservations
-    are allowed in agent network definition.
+Reservationist is None.  Make sure that temporary networks reservations 
+are allowed in agent network definition by specifying:
+"allow": { "reservations": True } or 
+add a NetworkCopyMiddleware entry with allow.reservations = true.
 """
             return (reservation, error)
 


### PR DESCRIPTION
This env variable is not used anymore in neuro-san stack.
This PR fixes an error message to remove misleading reference to it.