### PR TITLE
NS-917 Remove unnecessary sleep() in HTTP request handler.

### DIFF
--- a/neuro_san/service/http/handlers/base_request_handler.py
+++ b/neuro_san/service/http/handlers/base_request_handler.py
@@ -251,19 +251,6 @@ class BaseRequestHandler(RequestHandler):
         """
         try:
             await self.flush()
-            # What happens here: we have finished writing out one data item in our output stream,
-            # and we have flushed Tornado output.
-            # BUT: this does not guarantee in general that underlying TCP/IP transport
-            # will flush its own buffers, so low-level buffering is still possible.
-            # Result would be that several chat responses will be bunched together
-            # and received by a client as one data piece.
-            # If client is not ready for this, there will be problems.
-            # SO: this real wall clock delay here helps to encourage underlying transport
-            # to flush its own buffers - and we are good.
-            # Duration of delay is speculative and maybe could be adjusted.
-            # But best solution and reliable one: make client accept multiple data items
-            # in one "get" request - as it should when dealing with streaming service.
-            await asyncio.sleep(0.3)
             return True
         except tornado.iostream.StreamClosedError:
             self.logger.warning(self.get_metadata(), "Flush: client closed connection unexpectedly.")

--- a/neuro_san/service/http/handlers/openapi_publish_handler.py
+++ b/neuro_san/service/http/handlers/openapi_publish_handler.py
@@ -30,7 +30,7 @@ class OpenApiPublishHandler(BaseRequestHandler):
     Handler class for neuro-san OpenAPI service spec publishing"concierge" API call.
     """
 
-    def get(self):
+    async def get(self):
         """
         Implementation of GET request handler
         for "publish my OpenAPI specification document" call.

--- a/neuro_san/session/async_http_service_agent_session.py
+++ b/neuro_san/session/async_http_service_agent_session.py
@@ -126,19 +126,18 @@ class AsyncHttpServiceAgentSession(AbstractHttpServiceAgentSession, AsyncAgentSe
                     #               ... blah blah ...
                     #       but that could fail with ValueError("Chunk too big")
                     #       if a single line was too long.
-                    accumulator: bytes = b""
+                    accumulator: bytearray = bytearray(b"")
                     async for data in response.content.iter_chunked(max_chunk_size):
 
                         # Concatenate data as it comes in
-                        accumulator += data
+                        accumulator.extend(data)
 
                         # Try to find our line separator
                         index: int = accumulator.find(separator)
                         while index >= 0:
 
                             # Grab a single line
-                            line: bytes = accumulator[:index]
-                            unicode_line = line.decode("utf-8")
+                            unicode_line: str = accumulator[:index].decode("utf-8")
                             if unicode_line.strip():    # Skip empty lines
 
                                 # We have a line with something in it.
@@ -147,7 +146,7 @@ class AsyncHttpServiceAgentSession(AbstractHttpServiceAgentSession, AsyncAgentSe
                                 yield result_dict
 
                             # Remove the previous line from the accumulator
-                            accumulator = accumulator[index + len(separator):]
+                            del accumulator[:index + len(separator)]
 
                             # Allow for case of multiple lines in one chunk
                             index = accumulator.find(separator)

--- a/neuro_san/session/async_http_service_agent_session.py
+++ b/neuro_san/session/async_http_service_agent_session.py
@@ -137,9 +137,8 @@ class AsyncHttpServiceAgentSession(AbstractHttpServiceAgentSession, AsyncAgentSe
                         while index >= 0:
 
                             # Grab a single line
-                            unicode_line: str = accumulator[:index].decode("utf-8")
-                            if unicode_line.strip():    # Skip empty lines
-
+                            unicode_line: str = accumulator[:index].decode("utf-8").strip()
+                            if unicode_line:    # Skip empty lines
                                 # We have a line with something in it.
                                 # Decode and yield as a dictionary
                                 result_dict = json.loads(unicode_line)
@@ -153,8 +152,10 @@ class AsyncHttpServiceAgentSession(AbstractHttpServiceAgentSession, AsyncAgentSe
 
                     # If there is anything left in the accumulator, yield it
                     if len(accumulator) > 0:
-                        result_dict = json.loads(accumulator.decode("utf-8"))
-                        yield result_dict
+                        unicode_line: str = accumulator.decode("utf-8").strip()
+                        if unicode_line:
+                            result_dict = json.loads(unicode_line)
+                            yield result_dict
 
         except (asyncio.TimeoutError, ClientOSError, ClientPayloadError) as exc:
             # Pass on a couple of asserts that are known to represent

--- a/neuro_san/session/http_service_agent_session.py
+++ b/neuro_san/session/http_service_agent_session.py
@@ -84,6 +84,8 @@ class HttpServiceAgentSession(AbstractHttpServiceAgentSession, AgentSession):
             Note that responses to the chat input might be numerous and will come as they
             are produced until the system decides there are no more messages to be sent.
         """
+        separator: bytes = b"\n"
+        max_chunk_size: int = 64 * 1024
         path: str = self.get_request_path("streaming_chat")
         try:
             with requests.post(path, json=request_dict, headers=self.get_headers(),
@@ -91,9 +93,42 @@ class HttpServiceAgentSession(AbstractHttpServiceAgentSession, AgentSession):
                                timeout=self.streaming_timeout_in_seconds) as response:
                 response.raise_for_status()
 
-                for line in response.iter_lines(decode_unicode=True):
-                    if line.strip():  # Skip empty lines
-                        result_dict = json.loads(line)
-                        yield result_dict
+                # Iterate over the content stream as it comes in.
+                # Note: We used to iterate over lines with the simpler:
+                #           for line in response.iter_lines(decode_unicode=True):
+                #               ...
+                #       but that delegated UTF-8 handling to the response's
+                #       Content-Type charset (which the server may not set),
+                #       and split on universal newlines instead of strict "\n".
+                #       We now buffer raw bytes, split strictly on "\n",
+                #       and decode UTF-8 explicitly -- mirroring the async client.
+                accumulator: bytes = b""
+                for data in response.iter_content(chunk_size=max_chunk_size):
+
+                    # Concatenate data as it comes in
+                    accumulator += data
+
+                    # Try to find our line separator
+                    index: int = accumulator.find(separator)
+                    while index >= 0:
+                        # Grab a single line
+                        line: bytes = accumulator[:index]
+                        unicode_line = line.decode("utf-8")
+                        if unicode_line.strip():    # Skip empty lines
+                            # We have a line with something in it.
+                            # Decode and yield as a dictionary
+                            result_dict = json.loads(unicode_line)
+                            yield result_dict
+
+                        # Remove the previous line from the accumulator
+                        accumulator = accumulator[index + len(separator):]
+                        # Allow for case of multiple lines in one chunk
+                        index = accumulator.find(separator)
+
+                # If there is anything left in the accumulator, yield it
+                if len(accumulator) > 0:
+                    result_dict = json.loads(accumulator.decode("utf-8"))
+                    yield result_dict
+
         except Exception as exc:  # pylint: disable=broad-exception-caught
             raise ValueError(self.help_message(path)) from exc

--- a/neuro_san/session/http_service_agent_session.py
+++ b/neuro_san/session/http_service_agent_session.py
@@ -129,8 +129,10 @@ class HttpServiceAgentSession(AbstractHttpServiceAgentSession, AgentSession):
 
                 # If there is anything left in the accumulator, yield it
                 if len(accumulator) > 0:
-                    result_dict = json.loads(accumulator.decode("utf-8"))
-                    yield result_dict
+                    unicode_line: str = accumulator.decode("utf-8").strip()
+                    if unicode_line:
+                        result_dict = json.loads(unicode_line)
+                        yield result_dict
 
         except Exception as exc:  # pylint: disable=broad-exception-caught
             raise ValueError(self.help_message(path)) from exc

--- a/neuro_san/session/http_service_agent_session.py
+++ b/neuro_san/session/http_service_agent_session.py
@@ -102,26 +102,28 @@ class HttpServiceAgentSession(AbstractHttpServiceAgentSession, AgentSession):
                 #       and split on universal newlines instead of strict "\n".
                 #       We now buffer raw bytes, split strictly on "\n",
                 #       and decode UTF-8 explicitly -- mirroring the async client.
-                accumulator: bytes = b""
+                accumulator: bytearray = bytearray(b"")
                 for data in response.iter_content(chunk_size=max_chunk_size):
 
                     # Concatenate data as it comes in
-                    accumulator += data
+                    accumulator.extend(data)
 
                     # Try to find our line separator
                     index: int = accumulator.find(separator)
                     while index >= 0:
+
                         # Grab a single line
-                        line: bytes = accumulator[:index]
-                        unicode_line = line.decode("utf-8")
-                        if unicode_line.strip():    # Skip empty lines
+                        unicode_line: str = accumulator[:index].decode("utf-8")
+                        if unicode_line.strip():  # Skip empty lines
+
                             # We have a line with something in it.
                             # Decode and yield as a dictionary
                             result_dict = json.loads(unicode_line)
                             yield result_dict
 
                         # Remove the previous line from the accumulator
-                        accumulator = accumulator[index + len(separator):]
+                        del accumulator[:index + len(separator)]
+
                         # Allow for case of multiple lines in one chunk
                         index = accumulator.find(separator)
 

--- a/neuro_san/session/http_service_agent_session.py
+++ b/neuro_san/session/http_service_agent_session.py
@@ -113,9 +113,8 @@ class HttpServiceAgentSession(AbstractHttpServiceAgentSession, AgentSession):
                     while index >= 0:
 
                         # Grab a single line
-                        unicode_line: str = accumulator[:index].decode("utf-8")
-                        if unicode_line.strip():  # Skip empty lines
-
+                        unicode_line: str = accumulator[:index].decode("utf-8").strip()
+                        if unicode_line:  # Skip empty lines
                             # We have a line with something in it.
                             # Decode and yield as a dictionary
                             result_dict = json.loads(unicode_line)


### PR DESCRIPTION
This PR:
1.  removes unconditional sleep() we have put in HTTP request handler to work around UX client problems in incoming messages decoding. These problems has now been fixed, so we were just wasting 0.3 seconds on each outgoing message;
2. modifies logic for incoming messages decoding in neuro-san http clients (both sync and async) to be more efficient and uniform for both modes.
 