### PR TITLE
Add langfuse trace attributes to metadata

### DIFF
--- a/neuro_san/internals/run_context/langchain/tracing/neuro_san_runnable.py
+++ b/neuro_san/internals/run_context/langchain/tracing/neuro_san_runnable.py
@@ -195,6 +195,15 @@ class NeuroSanRunnable(RunnablePassthrough, RunTarget):
         to_add: Dict[str, Any] = MetadataUtil.minimize_metadata(request_metadata, request_keys)
         runnable_metadata.update(to_add)
 
+        # Add langfuse-prefixed keys so the Langfuse LangChain
+        # CallbackHandler maps them to first-class trace attributes.
+        user_id: str = runnable_metadata.get("user_id")
+        if user_id:
+            runnable_metadata["langfuse_user_id"] = user_id
+        session_id: str = runnable_metadata.get("request_id")
+        if session_id:
+            runnable_metadata["langfuse_session_id"] = session_id
+
         return runnable_metadata
 
     def get_intercepted_outputs(self) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary

Maps `user_id` and `request_id` from the existing LangChain tracing metadata to `langfuse_user_id` and `langfuse_session_id` respectively in `prepare_tracing_metadata()`.

The Langfuse LangChain `CallbackHandler` (v3.14.2+) automatically parses these prefixed keys from LangChain metadata and sets them as **first-class Langfuse trace attributes**, enabling:
- The **Users view** in the Langfuse dashboard (per-user cost, trace count, etc.)
- **Session grouping** of traces by request_id

Without this change, `user_id` only appears in generic LangChain metadata — it does not populate Langfuse's dedicated user tracking features.

No new dependencies. The `langfuse_` keys are ignored by other tracing backends (e.g. LangSmith).

## Review & Testing Checklist for Human
- [ ] Deploy to dev with Langfuse enabled, make a request with a known `user_id` header, and verify the user appears in the Langfuse Users view
- [ ] Confirm that `request_id` shows up as a Langfuse session_id, grouping related traces together

### Notes
The Langfuse CallbackHandler's support for `langfuse_user_id` / `langfuse_session_id` in LangChain metadata was added in [langfuse-python#1284](https://github.com/langfuse/langfuse-python/pull/1284). The neuro-san-studio langfuse plugin already pins `langfuse==3.14.2` which includes this feature.

Link to Devin session: https://app.devin.ai/sessions/124e572311934330846adbfcab3793ed
Requested by: @donn-leaf