### PR TITLE
Bump smoke test to use v1.0.4 build-common

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Setup Python environment
         # 1.0.4
-        uses: cognizant-ai-lab/build-common/actions/slack-notify@f5836555ee8e04413a8f9b313a431ab36337045b
+        uses: cognizant-ai-lab/build-common/actions/python-setup-env@f5836555ee8e04413a8f9b313a431ab36337045b
         with:
           python-version: '3.10'
           requirements-file: ''

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,9 +22,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
-      # 1.0.0
       - name: Setup Python environment
-        uses: cognizant-ai-lab/build-common/actions/setup-python-env@455db3cc40e9ed6a0fb9bbaf8188888c1ae315c2
+        # 1.0.4
+        uses: cognizant-ai-lab/build-common/actions/slack-notify@f5836555ee8e04413a8f9b313a431ab36337045b
         with:
           python-version: '3.10'
           requirements-file: ''
@@ -38,10 +38,10 @@ jobs:
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
 
-      # 1.0.0
       - name: Notify Slack
         if: ${{ !cancelled() }}
-        uses: cognizant-ai-lab/build-common/actions/slack-notify@455db3cc40e9ed6a0fb9bbaf8188888c1ae315c2
+        # 1.0.4
+        uses: cognizant-ai-lab/build-common/actions/slack-notify@f5836555ee8e04413a8f9b313a431ab36337045b
         with:
           status: ${{ job.status }}
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -63,6 +63,7 @@ jobs:
         run: pip freeze
 
       - name: Start server and run smoke tests
+        id: smoke
         shell: bash
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
@@ -75,8 +76,16 @@ jobs:
           PYTHONPATH: ${{ env.PYTHONPATH }}:.
         run: |
           build_scripts/server_start.sh
-
-          if ! pytest --capture=no --verbose -m "smoke" --timer-top-n 100 -n auto; then
+ 
+          set +e
+          pytest --capture=no --verbose -m "smoke" --timer-top-n 100 -n auto 2>&1 | tee pytest_output.txt
+          exit_code=${PIPESTATUS[0]}
+          set -e
+ 
+          summary=$(tail --lines=20 pytest_output.txt | grep -E '(passed|failed|error)' | tail --lines=1)
+          echo "summary=${summary}" >> "$GITHUB_OUTPUT"
+ 
+          if [ "$exit_code" -ne 0 ]; then
             echo "===================================================="
             echo "===================================================="
             echo "=== Server_Sevice_Agent.LOG ==="
@@ -84,6 +93,7 @@ jobs:
             echo "===================================================="
             exit 1
           fi
+
 
       - name: Notify Slack
         if: ${{ !cancelled() }}

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -76,7 +76,7 @@ jobs:
           PYTHONPATH: ${{ env.PYTHONPATH }}:.
         run: |
           build_scripts/server_start.sh
-
+ 
           set +e
           pytest --capture=no --verbose -m "smoke" --timer-top-n 100 -n auto 2>&1 | tee pytest_output.txt
           exit_code=${PIPESTATUS[0]}
@@ -97,7 +97,7 @@ jobs:
       - name: Notify Slack
         if: ${{ !cancelled() }}
         # 1.0.4
-        uses: cognizant-ai-lab/build-common@a5d9045
+        uses: cognizant-ai-lab/build-common/actions/slack-notify@f5836555ee8e04413a8f9b313a431ab36337045b
         with:
           status: ${{ job.status }}
           details: ${{ steps.smoke.outputs.summary }}

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -76,7 +76,7 @@ jobs:
           PYTHONPATH: ${{ env.PYTHONPATH }}:.
         run: |
           build_scripts/server_start.sh
- 
+
           set +e
           pytest --capture=no --verbose -m "smoke" --timer-top-n 100 -n auto 2>&1 | tee pytest_output.txt
           exit_code=${PIPESTATUS[0]}
@@ -93,7 +93,6 @@ jobs:
             echo "===================================================="
             exit 1
           fi
-
 
       - name: Notify Slack
         if: ${{ !cancelled() }}

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -87,8 +87,8 @@ jobs:
 
       - name: Notify Slack
         if: ${{ !cancelled() }}
-        # 1.0.3
-        uses: cognizant-ai-lab/build-common/actions/slack-notify@a5d90457ea6e44b8f24f878755f77c00216e2947
+        # 1.0.4
+        uses: cognizant-ai-lab/build-common/actions/slack-notify@f5836555ee8e04413a8f9b313a431ab36337045b
         with:
           status: ${{ job.status }}
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Notify Slack
         if: ${{ !cancelled() }}
         # 1.0.4
-        uses: cognizant-ai-lab/build-common/actions/slack-notify@f5836555ee8e04413a8f9b313a431ab36337045b
+        uses: cognizant-ai-lab/build-common@a5d9045
         with:
           status: ${{ job.status }}
           details: ${{ steps.smoke.outputs.summary }}

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -91,4 +91,5 @@ jobs:
         uses: cognizant-ai-lab/build-common/actions/slack-notify@f5836555ee8e04413a8f9b313a431ab36337045b
         with:
           status: ${{ job.status }}
+          details: ${{ steps.smoke.outputs.summary }}
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
## Summary
Bumps the slack-notify action in smoke.yml from build-common 1.0.3 to 1.0.4.

## Changes
- Updated slack-notify SHA from 1.0.3 (a5d90457) to 1.0.4 (f5836555)
- Added pytest summary capture to pass as \`details\` to the new slack-notify \`details\` input
- Smoke test: Slack notifications now include the pytest result summary line


### Before:
:white_check_mark: Passed for cognizant-ai-lab/neuro-san on 924-bump-smoke-test-to-use-v104-build-common
[View build run](https://github.com/cognizant-ai-lab/neuro-san/actions/runs/25690504170)Workflow: Smoke Tests | Triggered by: vince-leafAdded by [Github CI Notifier](https://cognizant.enterprise.slack.com/services/B08NT3ZL1M1)

### After:
:white_check_mark: Passed for cognizant-ai-lab/neuro-san on 924-bump-smoke-test-to-use-v104-build-common
[View build run](https://github.com/cognizant-ai-lab/neuro-san/actions/runs/25694846012)
============= 7 passed, 2 skipped, 6 warnings in 190.62s (0:03:10) =============
Workflow: Smoke Tests | Triggered by: vince-leafAdded by [Github CI Notifier](https://cognizant.enterprise.slack.com/services/B08NT3ZL1M1)