### PR TITLE
Add empty dict validator for HOCON configs

### DIFF
--- a/neuro_san/internals/validation/network/empty_dict_network_validator.py
+++ b/neuro_san/internals/validation/network/empty_dict_network_validator.py
@@ -1,0 +1,89 @@
+
+# Copyright (C) 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+from typing import Any
+from typing import Dict
+from typing import List
+
+from logging import getLogger
+from logging import Logger
+
+from neuro_san.internals.interfaces.dictionary_validator import DictionaryValidator
+
+
+class EmptyDictNetworkValidator(DictionaryValidator):
+    """
+    DictionaryValidator that detects empty dictionaries ({}) in agent network
+    configurations. An empty dictionary typically indicates an incomplete or
+    erroneous configuration entry.
+    """
+
+    def __init__(self):
+        """
+        Constructor
+        """
+        self.logger: Logger = getLogger(self.__class__.__name__)
+
+    def validate(self, candidate: Dict[str, Any]) -> List[str]:
+        """
+        Validate the given dictionary by recursively checking for empty
+        dictionary values.
+
+        :param candidate: The dictionary to validate
+        :return: A list of error messages for each empty dictionary found
+        """
+        errors: List[str] = []
+
+        if not candidate:
+            errors.append("Agent network is empty.")
+            return errors
+
+        self._check_empty_dicts(candidate, "", errors)
+
+        if len(errors) > 0:
+            self.logger.warning(str(errors))
+
+        return errors
+
+    def _check_empty_dicts(
+        self, obj: Any, path: str, errors: List[str]
+    ) -> None:
+        """
+        Recursively walk the configuration and flag any empty dictionaries.
+
+        :param obj: The current object to inspect
+        :param path: The dot-separated path to this object in the config
+        :param errors: Accumulator for error messages (modified in place)
+        """
+        if isinstance(obj, dict):
+            for key, value in obj.items():
+                current_path: str = f"{path}.{key}" if path else str(key)
+                if isinstance(value, dict) and len(value) == 0:
+                    errors.append(
+                        f"Empty dictionary found at '{current_path}'."
+                    )
+                else:
+                    self._check_empty_dicts(value, current_path, errors)
+        elif isinstance(obj, list):
+            for i, item in enumerate(obj):
+                current_path: str = f"{path}[{i}]"
+                if isinstance(item, dict) and len(item) == 0:
+                    errors.append(
+                        f"Empty dictionary found at '{current_path}'."
+                    )
+                else:
+                    self._check_empty_dicts(item, current_path, errors)

--- a/neuro_san/internals/validation/network/manifest_network_validator.py
+++ b/neuro_san/internals/validation/network/manifest_network_validator.py
@@ -18,6 +18,7 @@ from typing import List
 
 from neuro_san.internals.interfaces.dictionary_validator import DictionaryValidator
 from neuro_san.internals.validation.common.composite_dictionary_validator import CompositeDictionaryValidator
+from neuro_san.internals.validation.network.empty_dict_network_validator import EmptyDictNetworkValidator
 from neuro_san.internals.validation.network.keyword_network_validator import KeywordNetworkValidator
 from neuro_san.internals.validation.network.missing_nodes_network_validator import MissingNodesNetworkValidator
 from neuro_san.internals.validation.network.tool_name_network_validator import ToolNameNetworkValidator
@@ -40,6 +41,7 @@ class ManifestNetworkValidator(CompositeDictionaryValidator):
         """
         validators: List[DictionaryValidator] = [
             # Note we do use the CyclesNetworkValidator here because cycles are actually OK.
+            EmptyDictNetworkValidator(),
             KeywordNetworkValidator(),
             MissingNodesNetworkValidator(),
             UnreachableNodesNetworkValidator(),

--- a/neuro_san/internals/validation/network/structure_network_validator.py
+++ b/neuro_san/internals/validation/network/structure_network_validator.py
@@ -19,6 +19,7 @@ from typing import List
 from neuro_san.internals.interfaces.dictionary_validator import DictionaryValidator
 from neuro_san.internals.validation.common.composite_dictionary_validator import CompositeDictionaryValidator
 from neuro_san.internals.validation.network.cycles_network_validator import CyclesNetworkValidator
+from neuro_san.internals.validation.network.empty_dict_network_validator import EmptyDictNetworkValidator
 from neuro_san.internals.validation.network.missing_nodes_network_validator import MissingNodesNetworkValidator
 from neuro_san.internals.validation.network.unreachable_nodes_network_validator import UnreachableNodesNetworkValidator
 
@@ -35,6 +36,7 @@ class StructureNetworkValidator(CompositeDictionaryValidator):
         Constructor
         """
         validators: List[DictionaryValidator] = [
+            EmptyDictNetworkValidator(),
             CyclesNetworkValidator(),
             MissingNodesNetworkValidator(),
             UnreachableNodesNetworkValidator(),

--- a/tests/neuro_san/internals/validation/network/test_empty_dict_network_validator.py
+++ b/tests/neuro_san/internals/validation/network/test_empty_dict_network_validator.py
@@ -1,0 +1,173 @@
+
+# Copyright (C) 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+from typing import Any
+from typing import Dict
+from typing import List
+
+from unittest import TestCase
+
+from neuro_san.internals.interfaces.dictionary_validator import DictionaryValidator
+from neuro_san.internals.validation.network.empty_dict_network_validator import EmptyDictNetworkValidator
+
+from tests.neuro_san.internals.validation.network.abstract_network_validator_test import AbstractNetworkValidatorTest
+
+
+class TestEmptyDictNetworkValidator(TestCase, AbstractNetworkValidatorTest):
+    """
+    Unit tests for EmptyDictNetworkValidator class.
+    """
+
+    def create_validator(self) -> DictionaryValidator:
+        """
+        Creates an instance of the validator
+        """
+        return EmptyDictNetworkValidator()
+
+    def test_empty_dict_in_llm_config(self):
+        """
+        Tests that an empty llm_config dictionary is detected
+        """
+        validator: DictionaryValidator = self.create_validator()
+
+        config: Dict[str, Any] = self.restore("hello_world.hocon")
+        config["llm_config"] = {}
+
+        errors: List[str] = validator.validate(config)
+        self.assertEqual(1, len(errors))
+        self.assertIn("llm_config", errors[0])
+
+    def test_empty_dict_in_function(self):
+        """
+        Tests that an empty function dictionary on an agent is detected
+        """
+        validator: DictionaryValidator = self.create_validator()
+
+        config: Dict[str, Any] = self.restore("hello_world.hocon")
+        config["tools"][0]["function"] = {}
+
+        errors: List[str] = validator.validate(config)
+        self.assertEqual(1, len(errors))
+        self.assertIn("function", errors[0])
+
+    def test_empty_dict_nested(self):
+        """
+        Tests that an empty dictionary nested deeply in the config is detected
+        """
+        validator: DictionaryValidator = self.create_validator()
+
+        config: Dict[str, Any] = {
+            "llm_config": {
+                "model_name": "gpt-4"
+            },
+            "tools": [
+                {
+                    "name": "test_agent",
+                    "function": {
+                        "description": "A test agent",
+                        "parameters": {}
+                    },
+                    "instructions": "Do stuff",
+                }
+            ]
+        }
+
+        errors: List[str] = validator.validate(config)
+        self.assertEqual(1, len(errors))
+        self.assertIn("parameters", errors[0])
+
+    def test_multiple_empty_dicts(self):
+        """
+        Tests that multiple empty dictionaries are all detected
+        """
+        validator: DictionaryValidator = self.create_validator()
+
+        config: Dict[str, Any] = {
+            "llm_config": {},
+            "tools": [
+                {
+                    "name": "test_agent",
+                    "function": {},
+                    "instructions": "Do stuff",
+                }
+            ]
+        }
+
+        errors: List[str] = validator.validate(config)
+        self.assertEqual(2, len(errors))
+
+    def test_no_empty_dicts(self):
+        """
+        Tests that a config with no empty dicts produces no errors
+        """
+        validator: DictionaryValidator = self.create_validator()
+
+        config: Dict[str, Any] = {
+            "llm_config": {
+                "model_name": "gpt-4"
+            },
+            "tools": [
+                {
+                    "name": "test_agent",
+                    "function": {
+                        "description": "A test agent"
+                    },
+                    "instructions": "Do stuff",
+                }
+            ]
+        }
+
+        errors: List[str] = validator.validate(config)
+        self.assertEqual(0, len(errors))
+
+    def test_empty_dict_in_list(self):
+        """
+        Tests that an empty dictionary inside a list is detected
+        """
+        validator: DictionaryValidator = self.create_validator()
+
+        config: Dict[str, Any] = {
+            "tools": [
+                {}
+            ]
+        }
+
+        errors: List[str] = validator.validate(config)
+        self.assertEqual(1, len(errors))
+        self.assertIn("tools[0]", errors[0])
+
+    def test_error_message_contains_path(self):
+        """
+        Tests that error messages include the path to the empty dictionary
+        """
+        validator: DictionaryValidator = self.create_validator()
+
+        config: Dict[str, Any] = {
+            "tools": [
+                {
+                    "name": "agent",
+                    "allow": {
+                        "connectivity": {}
+                    },
+                    "instructions": "Do stuff",
+                }
+            ]
+        }
+
+        errors: List[str] = validator.validate(config)
+        self.assertEqual(1, len(errors))
+        self.assertIn("tools[0].allow.connectivity", errors[0])


### PR DESCRIPTION
## Summary
Adds `EmptyDictNetworkValidator` that recursively walks agent network HOCON configurations and reports any empty dictionary values (`{}`). Empty dicts typically indicate incomplete or erroneous configuration entries.

The validator is added to both:
- `ManifestNetworkValidator` (used at runtime when reading agent networks)
- `StructureNetworkValidator` (used by the agent network designer)

Error messages include the full dotted path to the empty dict for easy debugging, e.g.:
- `Empty dictionary found at 'llm_config'.`
- `Empty dictionary found at 'tools[0].function'.`
- `Empty dictionary found at 'tools[0].allow.connectivity'.`

## Review & Testing Checklist for Human
- [ ] Verify the validator correctly flags empty dicts `{}` in your HOCON configs by running `python -m neuro_san.client.hocon_validator_cli <your_hocon_file>`
- [ ] Confirm no false positives on legitimate HOCON files (the existing `hello_world.hocon` passes clean)
- [ ] Check that the error path messages are clear enough for debugging

### Notes
- 10 new unit tests added, all passing
- All 44 existing validation tests continue to pass
- Lint (flake8 + pylint) clean at 10.00/10

Link to Devin session: https://app.devin.ai/sessions/d70059e5dc0149738db200852286a563
Requested by: @shrushtiimehta