### PR TITLE
NS-935 Proper user_id and session_id in langfuse tracing

### DIFF
--- a/neuro_san/internals/run_context/langchain/tracing/langchain_tracing_context.py
+++ b/neuro_san/internals/run_context/langchain/tracing/langchain_tracing_context.py
@@ -53,6 +53,15 @@ class LangChainTracingContext(RunTarget):
 
         chain: Runnable = RunnablePassthrough() | runnable
 
-        await chain.ainvoke(input=inputs, config=runnable_config)
+        await self.ainvoke(chain, inputs, runnable_config)
 
         return inputs
+
+    async def ainvoke(self, chain: Runnable, inputs: Any, runnable_config: Dict[str, Any]):
+        """
+        Invoke the chain with the inputs and config
+        :param chain: The chain to invoke
+        :param inputs: The inputs to the chain
+        :param runnable_config: The config for the runnable
+        """
+        await chain.ainvoke(input=inputs, config=runnable_config)

--- a/neuro_san/internals/run_context/langchain/tracing/langchain_tracing_context.py
+++ b/neuro_san/internals/run_context/langchain/tracing/langchain_tracing_context.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 # END COPYRIGHT
-from __future__ import annotations
-
 from typing import Any
 from typing import Dict
 

--- a/neuro_san/internals/run_context/langchain/tracing/langchain_tracing_context_factory.py
+++ b/neuro_san/internals/run_context/langchain/tracing/langchain_tracing_context_factory.py
@@ -40,6 +40,7 @@ class LangChainTracingContextFactory(ContextTypeTracingContextFactory):
         :param run_target: The RunTarget instance to be traced
         :return: Another RunTarget which will be the tracing context
         """
+        tracing_context: RunTarget = None
 
         test_for_langfuse: bool = getenv("LANGFUSE_ENABLED", "false").lower() == "true"
 

--- a/neuro_san/internals/run_context/langchain/tracing/langchain_tracing_context_factory.py
+++ b/neuro_san/internals/run_context/langchain/tracing/langchain_tracing_context_factory.py
@@ -18,9 +18,13 @@
 from typing import Any
 from typing import Dict
 
+from os import getenv
+
 from neuro_san.internals.interfaces.context_type_tracing_context_factory import ContextTypeTracingContextFactory
 from neuro_san.internals.interfaces.run_target import RunTarget
 from neuro_san.internals.run_context.langchain.tracing.langchain_tracing_context import LangChainTracingContext
+from neuro_san.internals.run_context.langchain.tracing.langfuse_langchain_tracing_context \
+    import LangFuseLangChainTracingContext
 
 
 class LangChainTracingContextFactory(ContextTypeTracingContextFactory):
@@ -36,5 +40,12 @@ class LangChainTracingContextFactory(ContextTypeTracingContextFactory):
         :param run_target: The RunTarget instance to be traced
         :return: Another RunTarget which will be the tracing context
         """
-        tracing_context = LangChainTracingContext(run_target=run_target, config=config)
+
+        test_for_langfuse: bool = getenv("LANGFUSE_ENABLED", "false").lower() == "true"
+
+        if test_for_langfuse:
+            tracing_context = LangFuseLangChainTracingContext(run_target=run_target, config=config)
+        else:
+            tracing_context = LangChainTracingContext(run_target=run_target, config=config)
+
         return tracing_context

--- a/neuro_san/internals/run_context/langchain/tracing/langfuse_langchain_tracing_context.py
+++ b/neuro_san/internals/run_context/langchain/tracing/langfuse_langchain_tracing_context.py
@@ -53,16 +53,6 @@ If you didn't mean to use langfuse for observability, you can do this:
     export LANGFUSE_ENABLED=false
 """)
 
-        # We have a handler, therefore we have langfuse installed.
-        # No need to ResolverUtil absolutely everything, but we still need to locally import
-        # for the rest of the system to behave without langfuse installed.
-
-        # pylint: disable=import-outside-toplevel
-        from langfuse import get_client
-        from langfuse import propagate_attributes
-
-        langfuse_client: Any = get_client()
-
         callbacks: List[BaseCallbackHandler] = runnable_config.get("callbacks", [])
         callbacks.append(handler)
         runnable_config["callbacks"] = callbacks
@@ -70,14 +60,17 @@ If you didn't mean to use langfuse for observability, you can do this:
         request_metadata: Dict[str, Any] = runnable_config.get("metadata")
         user_id: str = request_metadata.get("user_id")
 
-        run_name: str = runnable_config.get("run_name")
+        # We have a handler, therefore we have langfuse installed.
+        # No need to ResolverUtil absolutely everything, but we still need to locally import
+        # for the rest of the system to behave without langfuse installed.
+
+        # pylint: disable=import-outside-toplevel
+        from langfuse import propagate_attributes
 
         # Weird: Langfuse docs here ...
         #   https://langfuse.com/docs/observability/features/users
         # ... say to use the with/ContextManager here, but pylint doesn't like it.
         # It works. :shrug:
         # pylint: disable=not-context-manager
-        with langfuse_client.start_as_current_observation(as_type="span", name=run_name):
-            # pylint: disable=not-context-manager
-            with propagate_attributes(user_id=user_id):
-                await super().ainvoke(chain, inputs, runnable_config)
+        with propagate_attributes(user_id=user_id):
+            await super().ainvoke(chain, inputs, runnable_config)

--- a/neuro_san/internals/run_context/langchain/tracing/langfuse_langchain_tracing_context.py
+++ b/neuro_san/internals/run_context/langchain/tracing/langfuse_langchain_tracing_context.py
@@ -82,6 +82,7 @@ If you didn't mean to use langfuse for observability, you can do this:
         #   https://langfuse.com/docs/observability/features/users
         # ... say to use the with/ContextManager here, but pylint doesn't like it.
         # It works. :shrug:
+        # According to langfuse docs, this should be safe for use in async code.
         # pylint: disable=not-context-manager
         with propagate_attributes(user_id=user_id, session_id=session_id):
             await super().ainvoke(chain, inputs, runnable_config)

--- a/neuro_san/internals/run_context/langchain/tracing/langfuse_langchain_tracing_context.py
+++ b/neuro_san/internals/run_context/langchain/tracing/langfuse_langchain_tracing_context.py
@@ -20,6 +20,8 @@ from typing import Any
 from typing import Dict
 from typing import List
 
+from socket import gethostname
+
 from langchain_core.callbacks.base import BaseCallbackHandler
 from langchain_core.runnables.base import Runnable
 
@@ -41,6 +43,7 @@ class LangFuseLangChainTracingContext(LangChainTracingContext):
         :param runnable_config: The config for the runnable
         """
 
+        # See if we can get a langfuse handler instance.
         handler = ResolverUtil.create_instance("langfuse.langchain.CallbackHandler", "langfuse", BaseCallbackHandler)
         if handler is None:
             raise ValueError("""
@@ -53,15 +56,20 @@ If you didn't mean to use langfuse for observability, you can do this:
     export LANGFUSE_ENABLED=false
 """)
 
+        # Set the callbacks per the langfuse docs
         callbacks: List[BaseCallbackHandler] = runnable_config.get("callbacks", [])
         callbacks.append(handler)
         runnable_config["callbacks"] = callbacks
 
+        # Get the user_id for the trace
         request_metadata: Dict[str, Any] = runnable_config.get("metadata")
         user_id: str = request_metadata.get("user_id")
+
+        # Create a session_id for the trace.
+        # It's possible we should move the addition of hostname up to the services infra.
+        hostname: str = gethostname()
         request_id: str = request_metadata.get("request_id")
-        # We might want to add IP address to the session_id.
-        session_id: str = request_id
+        session_id: str = f"{request_id}@{hostname}"
 
         # We have a handler, therefore we have langfuse installed.
         # No need to ResolverUtil absolutely everything, but we still need to locally import

--- a/neuro_san/internals/run_context/langchain/tracing/langfuse_langchain_tracing_context.py
+++ b/neuro_san/internals/run_context/langchain/tracing/langfuse_langchain_tracing_context.py
@@ -61,12 +61,13 @@ If you didn't mean to use langfuse for observability, you can do this:
         runnable_config["callbacks"] = callbacks
 
         # Get the user_id for the trace
-        request_metadata: Dict[str, Any] = runnable_config.get("metadata")
-        user_id: str = request_metadata.get("user_id")
+        empty: Dict[str, Any] = {}
+        request_metadata: Dict[str, Any] = runnable_config.get("metadata", empty)
+        user_id: str = request_metadata.get("user_id", "<Unknown>")
 
         # Create a session_id for the trace.
         # It's possible we should move the addition of hostname up to the services infra.
-        request_id: str = request_metadata.get("request_id")
+        request_id: str = request_metadata.get("request_id", "<Unknown>")
         now: datetime = datetime.now()
         session_id: str = f"{request_id}@{now.strftime('%Y-%m-%d-%H:%M:%S.%f')}"
         hostname: str = gethostname()

--- a/neuro_san/internals/run_context/langchain/tracing/langfuse_langchain_tracing_context.py
+++ b/neuro_san/internals/run_context/langchain/tracing/langfuse_langchain_tracing_context.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 # END COPYRIGHT
-from __future__ import annotations
-
 from typing import Any
 from typing import Dict
 from typing import List

--- a/neuro_san/internals/run_context/langchain/tracing/langfuse_langchain_tracing_context.py
+++ b/neuro_san/internals/run_context/langchain/tracing/langfuse_langchain_tracing_context.py
@@ -59,6 +59,9 @@ If you didn't mean to use langfuse for observability, you can do this:
 
         request_metadata: Dict[str, Any] = runnable_config.get("metadata")
         user_id: str = request_metadata.get("user_id")
+        request_id: str = request_metadata.get("request_id")
+        # We might want to add IP address to the session_id.
+        session_id: str = request_id
 
         # We have a handler, therefore we have langfuse installed.
         # No need to ResolverUtil absolutely everything, but we still need to locally import
@@ -72,5 +75,5 @@ If you didn't mean to use langfuse for observability, you can do this:
         # ... say to use the with/ContextManager here, but pylint doesn't like it.
         # It works. :shrug:
         # pylint: disable=not-context-manager
-        with propagate_attributes(user_id=user_id):
+        with propagate_attributes(user_id=user_id, session_id=session_id):
             await super().ainvoke(chain, inputs, runnable_config)

--- a/neuro_san/internals/run_context/langchain/tracing/langfuse_langchain_tracing_context.py
+++ b/neuro_san/internals/run_context/langchain/tracing/langfuse_langchain_tracing_context.py
@@ -43,7 +43,7 @@ class LangFuseLangChainTracingContext(LangChainTracingContext):
 
         handler = ResolverUtil.create_instance("langfuse.langchain.CallbackHandler", "langfuse", BaseCallbackHandler)
         if handler is None:
-            raise Exception("""
+            raise ValueError("""
 Failed to create LangFuse CallbackHandler. Try one of the following:
 
 If you really wanted to use langfuse for observability, you can install it with

--- a/neuro_san/internals/run_context/langchain/tracing/langfuse_langchain_tracing_context.py
+++ b/neuro_san/internals/run_context/langchain/tracing/langfuse_langchain_tracing_context.py
@@ -1,0 +1,83 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+from __future__ import annotations
+
+from typing import Any
+from typing import Dict
+from typing import List
+
+from langchain_core.callbacks.base import BaseCallbackHandler
+from langchain_core.runnables.base import Runnable
+
+from leaf_common.config.resolver_util import ResolverUtil
+
+from neuro_san.internals.run_context.langchain.tracing.langchain_tracing_context import LangChainTracingContext
+
+
+class LangFuseLangChainTracingContext(LangChainTracingContext):
+    """
+    RunTarget interface for a TracingContext in langchain with LangFuse tracing hooks.
+    """
+
+    async def ainvoke(self, chain: Runnable, inputs: Any, runnable_config: Dict[str, Any]):
+        """
+        Invoke the chain with the inputs and config
+        :param chain: The chain to invoke
+        :param inputs: The inputs to the chain
+        :param runnable_config: The config for the runnable
+        """
+
+        handler = ResolverUtil.create_instance("langfuse.langchain.CallbackHandler", "langfuse", BaseCallbackHandler)
+        if handler is None:
+            raise Exception("""
+Failed to create LangFuse CallbackHandler. Try one of the following:
+
+If you really wanted to use langfuse for observability, you can install it with
+    pip install langfuse
+
+If you didn't mean to use langfuse for observability, you can do this:
+    export LANGFUSE_ENABLED=false
+""")
+
+        # We have a handler, therefore we have langfuse installed.
+        # No need to ResolverUtil absolutely everything, but we still need to locally import
+        # for the rest of the system to behave without langfuse installed.
+
+        # pylint: disable=import-outside-toplevel
+        from langfuse import get_client
+        from langfuse import propagate_attributes
+
+        langfuse_client: Any = get_client()
+
+        callbacks: List[BaseCallbackHandler] = runnable_config.get("callbacks", [])
+        callbacks.append(handler)
+        runnable_config["callbacks"] = callbacks
+
+        request_metadata: Dict[str, Any] = runnable_config.get("metadata")
+        user_id: str = request_metadata.get("user_id")
+
+        run_name: str = runnable_config.get("run_name")
+
+        # Weird: Langfuse docs here ...
+        #   https://langfuse.com/docs/observability/features/users
+        # ... say to use the with/ContextManager here, but pylint doesn't like it.
+        # It works. :shrug:
+        # pylint: disable=not-context-manager
+        with langfuse_client.start_as_current_observation(as_type="span", name=run_name):
+            # pylint: disable=not-context-manager
+            with propagate_attributes(user_id=user_id):
+                await super().ainvoke(chain, inputs, runnable_config)

--- a/neuro_san/internals/run_context/langchain/tracing/langfuse_langchain_tracing_context.py
+++ b/neuro_san/internals/run_context/langchain/tracing/langfuse_langchain_tracing_context.py
@@ -20,6 +20,7 @@ from typing import Any
 from typing import Dict
 from typing import List
 
+from datetime import datetime
 from socket import gethostname
 
 from langchain_core.callbacks.base import BaseCallbackHandler
@@ -67,9 +68,11 @@ If you didn't mean to use langfuse for observability, you can do this:
 
         # Create a session_id for the trace.
         # It's possible we should move the addition of hostname up to the services infra.
-        hostname: str = gethostname()
         request_id: str = request_metadata.get("request_id")
-        session_id: str = f"{request_id}@{hostname}"
+        now: datetime = datetime.now()
+        session_id: str = f"{request_id}@{now.strftime('%Y-%m-%d-%H:%M:%S.%f')}"
+        hostname: str = gethostname()
+        session_id: str = f"{session_id}@{hostname}"
 
         # We have a handler, therefore we have langfuse installed.
         # No need to ResolverUtil absolutely everything, but we still need to locally import

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -11,6 +11,9 @@ langchain-ollama>=1.0.0,<2.0
 # Optional Authorization
 openfga-sdk
 
+# Optional Observability
+langfuse
+
 # Tests
 pytest==9.0.3
 pytest-asyncio==1.3.0


### PR DESCRIPTION
* Make it so that LangChainTracingContext can have its use of ainvoke() be overridable
* Create a new LangFuseLangChainTracingContext that overrides this with optional langfuse mojo to get user_id and session_id in the traces.
* to create reasonable session_ids that don't overlap, we use a format of `<request_id>@<timestamp>@<hostname>` so that going to a langfuse console gives you unique information on a per-request basis.
* Modify the Factory for TracingContexts to detect whether LANGFUSE_ENABLED is on and if so use the new LangFuse class.

Worth noting that:
* the only thing that is not happening here that the studio-level langfuse plugin is doing is the handling of the flush() for langfuse trace data upon shutdown.  That's probably OK for now and certainly not appropriate to continually flush() at this level. LangFuse seems to have an env var to set how often tracing information is sent out anyway.
* With this change it should be possible to eliminate the code for the studio-level langfuse plugin and just operate on env vars. That is, unless we really want to have the flushing behavior upon shutdown. I'll leave that up to @ofrancon 
* @donn-leaf : This could mean that the container you are using doesn't need to do the studio run.py stuff. It just needs to have langfuse pip installed and the LANGFUSE_* env vars set.  I'll let you duke that out with @ofrancon though.