### PR TITLE
Add run-time snapshot query to neuro-san service.

### DIFF
--- a/neuro_san/deploy/Dockerfile
+++ b/neuro_san/deploy/Dockerfile
@@ -369,6 +369,11 @@ ENV AGENT_AUTHORIZER_RESOURCE_KEY=AgentNetwork
 # Typically "read" from CRUD-based permissions.
 ENV AGENT_AUTHORIZER_ALLOW_RELATION=read
 
+# Whether to enable run-time statistics endpoints for neuro-san server as a whole.
+# These endpoints can be used to get information about the server's current resource usage
+# and also to control run-time service profiler.
+ENV ENABLE_RUN_TIME_STATISTICS="false"
+
 # Below: Env vars specific to OpenFgaAuthorizer
 
 # Where the OpenFGA HTTP server is running for the OpenFgaAuthorizer

--- a/neuro_san/service/http/handlers/profiler_control_handler.py
+++ b/neuro_san/service/http/handlers/profiler_control_handler.py
@@ -18,6 +18,7 @@
 See class comment for details
 """
 from typing import Any, Dict, Optional
+import os
 import json
 from json.decoder import JSONDecodeError
 import logging
@@ -43,7 +44,15 @@ class ProfilerControlHandler(RequestHandler):
         """
         Implementation of POST request handler for profiler control.
         """
+        is_enabled: bool = os.getenv("ENABLE_RUN_TIME_STATISTICS", "false").lower() == "true"
         logger = logging.getLogger(self.__class__.__name__)
+
+        if not is_enabled:
+            self.set_status(HTTPStatus.SERVICE_UNAVAILABLE)
+            self.write("Run-time profiler is disabled. "
+                       "To enable it, set environment variable ENABLE_RUN_TIME_STATISTICS to 'true'.")
+            logger.info("Run-time profiler is disabled.")
+            return
 
         if not HAS_PROFILER:
             self.set_status(HTTPStatus.SERVICE_UNAVAILABLE)

--- a/neuro_san/service/http/handlers/snapshot_handler.py
+++ b/neuro_san/service/http/handlers/snapshot_handler.py
@@ -1,0 +1,59 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+"""
+See class comment for details
+"""
+from typing import Any, Dict, Optional
+import json
+import logging
+
+from http import HTTPStatus
+from tornado.web import RequestHandler
+
+from neuro_san.service.utils.service_resources import ServiceResources
+
+
+class SnapshotHandler(RequestHandler):
+    """
+    Handler class for executing system run-time snapshot query via HTTP API calls.
+    """
+
+    # pylint: disable=attribute-defined-outside-init
+    def initialize(self, **kwargs):
+        """
+        This method is called by Tornado framework to allow
+        injecting service-specific data into local handler context.
+        :param kwargs: dictionary of named parameters, including:
+            "http_port" - HTTP server port;
+        """
+        # Set up local members from kwargs dictionary passed in:
+        self.http_port: int = int(kwargs.pop("http_port"))
+        self.logger = logging.getLogger(self.__class__.__name__)
+
+    async def get(self):
+        """
+        Implementation of GET request handler for system snapshot query.
+        """
+        snapshot_dict: Dict[str, Any] = ServiceResources.get_snapshot_dict(self.http_port)
+        self.write(json.dumps(snapshot_dict, indent=4))
+        self.logger.info("Returned system snapshot: %s", json.dumps(snapshot_dict, indent=4))
+
+    def data_received(self, chunk):
+        """
+        This method is required to be implemented as part of RequestHandler subclass,
+        but is not used in our case as we do not expect any data in the request body.
+        """

--- a/neuro_san/service/http/handlers/snapshot_handler.py
+++ b/neuro_san/service/http/handlers/snapshot_handler.py
@@ -18,8 +18,10 @@
 See class comment for details
 """
 from typing import Any, Dict
+import os
 import json
 import logging
+from http import HTTPStatus
 
 from tornado.web import RequestHandler
 
@@ -42,14 +44,21 @@ class SnapshotHandler(RequestHandler):
         # Set up local members from kwargs dictionary passed in:
         self.http_port: int = int(kwargs.pop("http_port"))
         self.logger = logging.getLogger(self.__class__.__name__)
+        self.is_enabled: bool = os.getenv("ENABLE_RUN_TIME_STATISTICS", "false").lower() == "true"
 
     async def get(self):
         """
         Implementation of GET request handler for system snapshot query.
         """
-        snapshot_dict: Dict[str, Any] = ServiceResources.get_snapshot_dict(self.http_port)
-        self.write(json.dumps(snapshot_dict, indent=4))
-        self.logger.info("Returned system snapshot: %s", json.dumps(snapshot_dict, indent=4))
+        if self.is_enabled:
+            snapshot_dict: Dict[str, Any] = ServiceResources.get_snapshot_dict(self.http_port)
+            self.write(json.dumps(snapshot_dict, indent=4))
+            self.logger.info("Returned system snapshot: %s", json.dumps(snapshot_dict, indent=4))
+        else:
+            self.set_status(HTTPStatus.SERVICE_UNAVAILABLE)
+            self.write("Run-time statistics collection is disabled. "
+                       "To enable it, set environment variable ENABLE_RUN_TIME_STATISTICS to 'true'.")
+            self.logger.info("Run-time statistics collection is disabled.")
 
     def data_received(self, chunk):
         """

--- a/neuro_san/service/http/handlers/snapshot_handler.py
+++ b/neuro_san/service/http/handlers/snapshot_handler.py
@@ -17,11 +17,10 @@
 """
 See class comment for details
 """
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 import json
 import logging
 
-from http import HTTPStatus
 from tornado.web import RequestHandler
 
 from neuro_san.service.utils.service_resources import ServiceResources

--- a/neuro_san/service/http/server/http_server.py
+++ b/neuro_san/service/http/server/http_server.py
@@ -225,7 +225,7 @@ class HttpServer(AgentStateListener):
         handlers.append(("/profiler", ProfilerControlHandler))
 
         # Setup handler for system snapshot query:
-        handlers.append(("/snapshot", SnapshotHandler, {"http_port": self.http_port}))
+        handlers.append(("/resources_utilization", SnapshotHandler, {"http_port": self.http_port}))
 
         if enable_http_handlers:
             handlers.append(("/api/v1/list", ConciergeHandler, request_initialize_data))

--- a/neuro_san/service/http/server/http_server.py
+++ b/neuro_san/service/http/server/http_server.py
@@ -44,6 +44,7 @@ from neuro_san.service.http.handlers.health_check_handler import HealthCheckHand
 from neuro_san.service.http.handlers.openapi_publish_handler import OpenApiPublishHandler
 from neuro_san.service.http.handlers.streaming_chat_handler import StreamingChatHandler
 from neuro_san.service.http.handlers.profiler_control_handler import ProfilerControlHandler
+from neuro_san.service.http.handlers.snapshot_handler import SnapshotHandler
 from neuro_san.service.http.logging.http_logger import HttpLogger
 from neuro_san.service.http.server.agent_authorization_policy import AgentAuthorizationPolicy
 from neuro_san.service.http.server.http_server_app import HttpServerApp
@@ -222,6 +223,9 @@ class HttpServer(AgentStateListener):
 
         # Setup handler for profiler control
         handlers.append(("/profiler", ProfilerControlHandler))
+
+        # Setup handler for system snapshot query:
+        handlers.append(("/snapshot", SnapshotHandler, {"http_port": self.http_port}))
 
         if enable_http_handlers:
             handlers.append(("/api/v1/list", ConciergeHandler, request_initialize_data))

--- a/neuro_san/service/http/server/resources_usage_logger.py
+++ b/neuro_san/service/http/server/resources_usage_logger.py
@@ -54,7 +54,7 @@ class ResourcesUsageLogger(Startable):
         Log current usage of server run-time resources:
         file descriptors and open inet connections on server port.
         """
-        snapshot_dict: Dict[str, Any] = ServiceResources.get_resources_snapshot(self.http_port)
+        snapshot_dict: Dict[str, Any] = ServiceResources.get_snapshot_dict(self.http_port)
         self.logger.info({}, "Used: %s", json.dumps(snapshot_dict, indent=4))
 
     async def run_resources_usage(self):

--- a/neuro_san/service/http/server/resources_usage_logger.py
+++ b/neuro_san/service/http/server/resources_usage_logger.py
@@ -54,16 +54,8 @@ class ResourcesUsageLogger(Startable):
         Log current usage of server run-time resources:
         file descriptors and open inet connections on server port.
         """
-        # Get used file descriptors:
-        fd_dict, soft_limit, hard_limit = ServiceResources.get_fd_usage()
-        sock_classes = ServiceResources.classify_sockets(self.http_port)
-        log_dict: Dict[str, Any] = {
-            "soft_limit": soft_limit,
-            "hard_limit": hard_limit,
-            "file_descriptors": fd_dict,
-            "sockets": sock_classes
-        }
-        self.logger.info({}, "Used: %s", json.dumps(log_dict, indent=4))
+        snapshot_dict: Dict[str, Any] = ServiceResources.get_resources_snapshot(self.http_port)
+        self.logger.info({}, "Used: %s", json.dumps(snapshot_dict, indent=4))
 
     async def run_resources_usage(self):
         """

--- a/neuro_san/service/utils/service_resources.py
+++ b/neuro_san/service/utils/service_resources.py
@@ -310,6 +310,23 @@ class ServiceResources:
         return mem_info.rss / (1024 * 1024), cls.max_memory_used_bytes / (1024 * 1024)
 
     @classmethod
+    def get_cpu_load(cls) -> float:
+        """
+        Get the current CPU load percentage of the process.
+        :return: CPU load percentage over a short interval (e.g., 0.1 seconds)
+                 in the range [0.0, 100.0]
+        """
+        if hasattr(os, "sched_getaffinity"):
+            # sched_getaffinity returns the set of CPUs the process is allowed to run on,
+            # which is more accurate for containerized environments.
+            denom = len(os.sched_getaffinity(0))
+        else:
+            denom = max(psutil.cpu_count(), 1)
+        cpu_load = psutil.Process().cpu_percent(interval=0.1)
+        cpu_load = min(cpu_load / denom, 100.0)
+        return cpu_load
+
+    @classmethod
     def get_snapshot_dict(cls, server_port: int) -> Dict[str, Any]:
         """
         Get a snapshot of current resource usage for logging or metrics.
@@ -319,6 +336,7 @@ class ServiceResources:
         # Get used file descriptors:
         fd_usage, soft_limit, hard_limit = cls.get_fd_usage()
         mem_used, mem_max = cls.get_memory_used_mbytes()
+        cpu_load: float = cls.get_cpu_load()
         snapshot: Dict[str, Any] = {
             "fd_usage": fd_usage,
             "fd_limits": {
@@ -329,6 +347,8 @@ class ServiceResources:
                 "current": mem_used,
                 "max_since_start": mem_max
             },
+            # Round CPU load to 3 decimal places for more compact output
+            "cpu_load": round(cpu_load, 3),
             "socket_usage": cls.classify_sockets(server_port)
         }
         return snapshot

--- a/neuro_san/service/utils/service_resources.py
+++ b/neuro_san/service/utils/service_resources.py
@@ -305,8 +305,7 @@ class ServiceResources:
         """
         p = psutil.Process()
         mem_info = p.memory_info()
-        if mem_info.rss > cls.max_memory_used_bytes:
-            cls.max_memory_used_bytes = mem_info.rss
+        cls.max_memory_used_bytes = max(cls.max_memory_used_bytes, mem_info.rss)
         # Return memory sizes in megabytes
         return mem_info.rss / (1024 * 1024), cls.max_memory_used_bytes / (1024 * 1024)
 

--- a/neuro_san/service/utils/service_resources.py
+++ b/neuro_san/service/utils/service_resources.py
@@ -310,6 +310,23 @@ class ServiceResources:
         return mem_info.rss / (1024 * 1024), cls.max_memory_used_bytes / (1024 * 1024)
 
     @classmethod
+    def get_cpu_load(cls) -> float:
+        """
+        Get the current CPU load percentage of the process.
+        :return: CPU load percentage over a short interval (e.g., 0.1 seconds)
+                 in the range [0.0, 100.0]
+        """
+        if hasattr(os, "sched_getaffinity"):
+            # sched_getaffinity returns the set of CPUs the process is allowed to run on,
+            # which is more accurate for containerized environments.
+            denom = len(os.sched_getaffinity(0))
+        else:
+            denom = max(psutil.cpu_count(), 1)
+        cpu_load = psutil.Process().cpu_percent(interval=0.1)
+        cpu_load = min(cpu_load / denom, 100.0)
+        return cpu_load
+
+    @classmethod
     def get_snapshot_dict(cls, server_port: int) -> Dict[str, Any]:
         """
         Get a snapshot of current resource usage for logging or metrics.
@@ -319,6 +336,7 @@ class ServiceResources:
         # Get used file descriptors:
         fd_usage, soft_limit, hard_limit = cls.get_fd_usage()
         mem_used, mem_max = cls.get_memory_used_mbytes()
+        cpu_load: float = cls.get_cpu_load()
         snapshot: Dict[str, Any] = {
             "fd_usage": fd_usage,
             "fd_limits": {
@@ -329,6 +347,7 @@ class ServiceResources:
                 "current": mem_used,
                 "max_since_start": mem_max
             },
+            "cpu_load": cpu_load,
             "socket_usage": cls.classify_sockets(server_port)
         }
         return snapshot

--- a/neuro_san/service/utils/service_resources.py
+++ b/neuro_san/service/utils/service_resources.py
@@ -292,3 +292,44 @@ class ServiceResources:
             "inbound_accepted": len(inbound_accepted_list),
             "outbound_tcp": cls.classify_outbound_sockets(outbound_list),
         }
+
+    # High watermark for memory usage in bytes since process start (for logging purposes)
+    max_memory_used_bytes: float = 0.0
+
+    @classmethod
+    def get_memory_used_mbytes(cls) -> Tuple[float, float]:
+        """
+        Get the current memory usage of the process in megabytes
+        and maximum memory used since process start, and update the maximum if current usage is higher.
+        :return: tuple of (current_memory_used_mbytes, max_memory_used_mbytes)
+        """
+        p = psutil.Process()
+        mem_info = p.memory_info()
+        if mem_info.rss > cls.max_memory_used_bytes:
+            cls.max_memory_used_bytes = mem_info.rss
+        # Return memory sizes in megabytes
+        return mem_info.rss / (1024 * 1024), cls.max_memory_used_bytes / (1024 * 1024)
+
+    @classmethod
+    def get_snapshot_dict(cls, server_port: int) -> Dict[str, Any]:
+        """
+        Get a snapshot of current resource usage for logging or metrics.
+        :param server_port: server port to classify sockets
+        :return: dictionary with resource usage information
+        """
+        # Get used file descriptors:
+        fd_usage, soft_limit, hard_limit = cls.get_fd_usage()
+        mem_used, mem_max = cls.get_memory_used_mbytes()
+        snapshot: Dict[str, Any] = {
+            "fd_usage": fd_usage,
+            "fd_limits": {
+                "soft": soft_limit,
+                "hard": hard_limit
+            },
+            "memory_usage_mbytes": {
+                "current": mem_used,
+                "max_since_start": mem_max
+            },
+            "socket_usage": cls.classify_sockets(server_port)
+        }
+        return snapshot

--- a/neuro_san/service/utils/service_resources.py
+++ b/neuro_san/service/utils/service_resources.py
@@ -48,6 +48,9 @@ class ServiceResources:
     on_macos: bool = sys.platform.startswith("darwin")
     on_windows: bool = sys.platform.startswith("win")
 
+    # High watermark for memory usage in bytes since process start (for logging purposes)
+    max_memory_used_bytes: float = 0.0
+
     # ---------------------------
     # POSIX helpers (Linux/macOS)
     # ---------------------------
@@ -292,9 +295,6 @@ class ServiceResources:
             "inbound_accepted": len(inbound_accepted_list),
             "outbound_tcp": cls.classify_outbound_sockets(outbound_list),
         }
-
-    # High watermark for memory usage in bytes since process start (for logging purposes)
-    max_memory_used_bytes: float = 0.0
 
     @classmethod
     def get_memory_used_mbytes(cls) -> Tuple[float, float]:


### PR DESCRIPTION
This PR adds an additional endpoint for neuro-san service: 
/snapshot
which will query the current state of system run-time resources and return it as a JSON dictionary.
This query can be used for external server monitoring/testing and works in parallel with internal system resources logging.

