### PR TITLE
Set Anthropic test case to skip

### DIFF
--- a/tests/neuro_san/zzz_hocons/test_smoke_test_hocons.py
+++ b/tests/neuro_san/zzz_hocons/test_smoke_test_hocons.py
@@ -43,9 +43,11 @@ class TestSmokeTestHocons(TestCase):
     # resolved.
     DISABLED_HOCONS = {
         "music_nerd_pro_llm_azure/combination_responses_with_history_direct.hocon":
-            "Issue #910: disabled until #909 (Anthropic API key) is resolved.",
+            "Issue #910: disabled until #909 is resolved.",
         "music_nerd_pro_llm_bedrock_claude/combination_responses_with_history_direct.hocon":
-            "Issue #910: disabled until #909 (Anthropic API key) is resolved.",
+            "Issue #910: disabled until #909 is resolved.",
+        "music_nerd_pro_llm_anthropic/combination_responses_with_history_direct.hocon":
+            "Issue #936: disabled until #909 is resolved.",
     }
 
     def _skip_if_disabled(self, test_hocon: str) -> None:


### PR DESCRIPTION
This PR temporarily disables the _**Anthropic test**_ case in our Neuro-san's smoke test until @donn-leaf helps. This issue is most likely due to the API key fund being zero.

A total of 3 test cases are set to skip:
`tests/neuro_san/zzz_hocons/test_smoke_test_hocons.py::TestSmokeTestHocons::test_hocon_with_non_default_llm_2_music_nerd_pro_llm_azure_combination_responses_with_history_direct 
[gw0] SKIPPED tests/neuro_san/zzz_hocons/test_smoke_test_hocons.py::TestSmokeTestHocons::test_hocon_with_non_default_llm_0_music_nerd_pro_llm_anthropic_combination_responses_with_history_direct 
[gw1] SKIPPED 
tests/neuro_san/zzz_hocons/test_smoke_test_hocons.py::TestSmokeTestHocons::test_hocon_with_non_default_llm_1_music_nerd_pro_llm_gemini_combination_responses_with_history_direct 
[gw1] SKIPPED `
