### PR TITLE
Fix setup-python-env action path in publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Setup Python environment
         # 1.0.4
-        uses: cognizant-ai-lab/build-common/actions/python-setup-env@f5836555ee8e04413a8f9b313a431ab36337045b
+        uses: cognizant-ai-lab/build-common/actions/setup-python-env@f5836555ee8e04413a8f9b313a431ab36337045b
         with:
           python-version: '3.10'
           requirements-file: ''


### PR DESCRIPTION
## Summary
The "Publish to PyPI" workflow ([failed run](https://github.com/cognizant-ai-lab/neuro-san/actions/runs/25891553329)) referenced the build-common action as `actions/python-setup-env`, but the actual directory in build-common is `actions/setup-python-env`. 

Link to Devin session: https://app.devin.ai/sessions/9e745bf111e14cf8845e591c4cd8e8e8
Requested by: @donn-leaf
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cognizant-ai-lab/neuro-san/pull/940" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->