### PR TITLE
Fix hadolint lint errors in Dockerfile

### DIFF
--- a/neuro_san/deploy/Dockerfile
+++ b/neuro_san/deploy/Dockerfile
@@ -93,8 +93,8 @@ COPY --from=builder /install /usr/local
 # Note: The registries directory where agent definitions live is mandatory
 #       The coded_tools directory where agent code lives is optional
 #       [s] allows for registries/coded_tools from within client repo or neuro-san repo
-COPY ./neuro_san/registrie[s] ./registrie[s] ${APP_SOURCE}/registries
-COPY ./neuro_san/coded_tool[s] ./coded_tool[s] ${APP_SOURCE}/coded_tools
+COPY ./neuro_san/registrie[s] ./registrie[s] ${APP_SOURCE}/registries/
+COPY ./neuro_san/coded_tool[s] ./coded_tool[s] ${APP_SOURCE}/coded_tools/
 
 # Copy application code and necessary files if we are running within the neuro-san repo
 # [n] allows this to not have to be there for client repo builds.
@@ -384,4 +384,4 @@ ENV FGA_POLICY_FILE=
 ENV FGA_STORE_NAME=
 
 
-ENTRYPOINT "${APP_ENTRYPOINT}"
+ENTRYPOINT ["/bin/bash", "-c", "exec ${APP_ENTRYPOINT}"]


### PR DESCRIPTION
## Summary

Fix 3 hadolint findings in `neuro_san/deploy/Dockerfile`:

- **DL3021** (lines 96-97): COPY with more than 2 arguments requires the last argument to end with `/`. Added trailing slashes to the destination paths.
- **DL3025** (line 387): Use JSON notation for ENTRYPOINT. Converted from shell form `ENTRYPOINT "${APP_ENTRYPOINT}"` to exec form `ENTRYPOINT ["/bin/bash", "-c", "exec ${APP_ENTRYPOINT}"]`.

These fixes prepare the Dockerfile for hadolint CI enforcement via build-common's new `run-hadolint` action (cognizant-ai-lab/build-common#21).

## Review & Testing Checklist for Human
- [ ] Verify the ENTRYPOINT exec-form change preserves the same runtime behavior (variable expansion via bash, `exec` replaces the shell process)
- [ ] Confirm a Docker build still succeeds with the trailing-slash COPY changes

### Notes
- Verified locally with `docker run --rm -i hadolint/hadolint` — all 3 findings are resolved and no new issues.


Link to Devin session: https://app.devin.ai/sessions/6f9d53bc40ee45abad0d6007565b5bb0
Requested by: @donn-leaf
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cognizant-ai-lab/neuro-san/pull/946" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->