### PR TITLE
NS-930 Remove OpenAI dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,6 @@ langchain>=1.2.0,<2.0
 langchain-core>=1.2.5,<2.0
 langchain-classic>=1.0.0,<2.0
 langchain-community>=0.4,<1.0
-openai>=1.54.1,<2.0
 bs4>=0.0.2,<0.1
 pydantic>=2.9.2,<3.0
 


### PR DESCRIPTION
We should depend on langchain-openai and its versions, not OpenAI directly.

As of now, at the end of this exercise, we get openai==2.37.0