### PR TITLE
Try next fallback when LLM construction raises ValueError

### DIFF
--- a/neuro_san/internals/run_context/langchain/core/langchain_run_context.py
+++ b/neuro_san/internals/run_context/langchain/core/langchain_run_context.py
@@ -257,6 +257,7 @@ class LangChainRunContext(RunContext):
                 error += "of the following set in sly_data.llm_config:\n"
                 error += "\n".join(sorted(required_llm_config)) + "\n"
             if len(construction_errors) > 0:
+                error += "\nThe following errors occurred while constructing LLMs:\n"
                 error += "\n".join(construction_errors) + "\n"
             raise ValueError(error)
 

--- a/neuro_san/internals/run_context/langchain/core/langchain_run_context.py
+++ b/neuro_san/internals/run_context/langchain/core/langchain_run_context.py
@@ -214,10 +214,18 @@ class LangChainRunContext(RunContext):
         required_llm_config: Set[str] = set()
 
         # Go through the list of fallbacks in the config.
+        construction_errors: List[str] = []
         for fallback in fallbacks:
 
             # Create a model we might use.
-            one_llm_resources: LangChainLlmResources | Set[str] = llm_factory.create_llm(fallback, sly_data)
+            # If construction fails (e.g. missing API key in env), record the error and
+            # try the next fallback rather than aborting the whole loop.
+            try:
+                one_llm_resources: LangChainLlmResources | Set[str] = llm_factory.create_llm(fallback, sly_data)
+            except ValueError as exception:
+                construction_errors.append(str(exception))
+                continue
+
             if one_llm_resources is None:
                 # Nothing to use or report.
                 # Skip for now, a fallback might still be fulfilled.
@@ -248,6 +256,8 @@ class LangChainRunContext(RunContext):
                 error += "\nLLM operation for this agent requires at least one "
                 error += "of the following set in sly_data.llm_config:\n"
                 error += "\n".join(sorted(required_llm_config)) + "\n"
+            if len(construction_errors) > 0:
+                error += "\n".join(construction_errors) + "\n"
             raise ValueError(error)
 
         if len(chain_fallbacks) > 0:

--- a/neuro_san/internals/run_context/langchain/llms/default_llm_factory.py
+++ b/neuro_san/internals/run_context/langchain/llms/default_llm_factory.py
@@ -405,16 +405,44 @@ class DefaultLlmFactory(ContextTypeLlmFactory, LangChainLlmFactory):
                     # fallback path, while still being on by default in most deployments
                     # so the trail isn't lost.
                     #
+                    # Scope of this check: only failures that fire at LLM *construction*
+                    # time land here — i.e. the key is missing (None) or of the wrong
+                    # data type (e.g. list/dict supplied via sly_data where a string is
+                    # expected). A key that is structurally a string but rejected by the
+                    # provider (wrong/expired/over-quota) doesn't fail construction; it
+                    # fails at *runtime* on the first API call, and is handled by the
+                    # analogous check in RunContextRunnable.invoke_agent_chain()
+                    # (see run_context_runnable.py).
+                    #
                     # The user-friendly `message` we raise is still reported to the user.
-                    # Two cases to consider:
+                    # The raised ValueError is collected by the fallback loop in
+                    # LangChainRunContext.create_agent_with_fallbacks() and, if no
+                    # fallback succeeds, aggregated into a final ValueError surfaced
+                    # to the caller. Two cases to consider:
+                    #
                     #   a) Env var missing / misconfigured — server-side fix.
                     #      The aggregated ValueError lands in server output (the operator
                     #      sees it), and this log line provides the technical detail to
-                    #      diagnose it.
+                    #      diagnose it. The surfaced text looks like:
+                    #
+                    #          No fully-specified LLM found in llm_config or fallbacks.
+                    #          The following errors occurred while constructing LLMs:
+                    #
+                    #          A value for the OPENAI_API_KEY environment variable must be
+                    #          correctly set in the neuro-san server or run-time environment
+                    #          in order to use this agent network.
+                    #          ...
+                    #
                     #   b) sly_data was supposed to supply the key — client-side fix.
                     #      The aggregated ValueError surfaces to the chat client so the
                     #      end user (or calling system) knows to provide the key in
-                    #      sly_data.llm_config.
+                    #      sly_data.llm_config. The surfaced text looks like:
+                    #
+                    #          No fully-specified LLM found in llm_config or fallbacks.
+                    #          LLM operation for this agent requires at least one of the
+                    #          following set in sly_data.llm_config:
+                    #          anthropic_api_key
+                    #
                     self.logger.info("API KEY error detected: %s", str(exception))
                     raise ValueError(message) from exception
                 found_exception = exception

--- a/neuro_san/internals/run_context/langchain/llms/default_llm_factory.py
+++ b/neuro_san/internals/run_context/langchain/llms/default_llm_factory.py
@@ -401,7 +401,7 @@ class DefaultLlmFactory(ContextTypeLlmFactory, LangChainLlmFactory):
                 if message is not None:
                     # Log the error with technical details for debugging purposes,
                     # but we are returning a more user-friendly message to the client.
-                    self.logger.error("API KEY error detected: %s", str(exception))
+                    self.logger.debug("API KEY error detected: %s", str(exception))
                     raise ValueError(message) from exception
                 found_exception = exception
 

--- a/neuro_san/internals/run_context/langchain/llms/default_llm_factory.py
+++ b/neuro_san/internals/run_context/langchain/llms/default_llm_factory.py
@@ -399,9 +399,23 @@ class DefaultLlmFactory(ContextTypeLlmFactory, LangChainLlmFactory):
                 # also provide some more helpful failure text.
                 message: str = ApiKeyErrorCheck.check_for_api_key_exception(exception)
                 if message is not None:
-                    # Log the error with technical details for debugging purposes,
-                    # but we are returning a more user-friendly message to the client.
-                    self.logger.debug("API KEY error detected: %s", str(exception))
+                    # Log the error with technical details so a sysadmin can correlate
+                    # user-visible failures with the underlying provider error. INFO
+                    # level (rather than ERROR) avoids alarming on the recovered-via-
+                    # fallback path, while still being on by default in most deployments
+                    # so the trail isn't lost.
+                    #
+                    # The user-friendly `message` we raise is still reported to the user.
+                    # Two cases to consider:
+                    #   a) Env var missing / misconfigured — server-side fix.
+                    #      The aggregated ValueError lands in server output (the operator
+                    #      sees it), and this log line provides the technical detail to
+                    #      diagnose it.
+                    #   b) sly_data was supposed to supply the key — client-side fix.
+                    #      The aggregated ValueError surfaces to the chat client so the
+                    #      end user (or calling system) knows to provide the key in
+                    #      sly_data.llm_config.
+                    self.logger.info("API KEY error detected: %s", str(exception))
                     raise ValueError(message) from exception
                 found_exception = exception
 

--- a/tests/neuro_san/internals/run_context/langchain/core/test_langchain_run_context.py
+++ b/tests/neuro_san/internals/run_context/langchain/core/test_langchain_run_context.py
@@ -1,0 +1,212 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+from typing import Any
+from typing import Dict
+from typing import List
+from unittest.mock import MagicMock
+
+import pytest
+
+from neuro_san.internals.run_context.langchain.core.langchain_run_context import LangChainRunContext
+
+
+# Both markers needed so conftest.py skips the OPENAI_API_KEY requirement:
+# these tests fully mock the LLM factory, so no real provider key is required.
+pytestmark = [pytest.mark.non_default_llm_provider, pytest.mark.ollama]
+
+
+class TestLangChainRunContext:
+    """Tests for the LangChainRunContext class."""
+
+    @staticmethod
+    def _make_run_context(llm_config: Dict[str, Any], create_llm_side_effect) -> LangChainRunContext:
+        """
+        Build a LangChainRunContext with the bare minimum wiring needed to exercise
+        create_agent_with_fallbacks(), bypassing __init__ to avoid pulling in the
+        full RunContext / invocation_context machinery.
+
+        :param llm_config: The llm_config dict (may contain a "fallbacks" list).
+        :param create_llm_side_effect: Iterable of values/exceptions for the mocked
+            llm_factory.create_llm calls, one per fallback iteration.
+        """
+        run_context = LangChainRunContext.__new__(LangChainRunContext)
+        run_context.llm_config = llm_config
+        run_context.llm_resources = None
+
+        llm_factory = MagicMock()
+        llm_factory.create_llm = MagicMock(side_effect=create_llm_side_effect)
+
+        invocation_context = MagicMock()
+        invocation_context.get_llm_factory.return_value = llm_factory
+
+        tool_caller = MagicMock()
+        tool_caller.get_sly_data.return_value = {}
+
+        run_context.invocation_context = invocation_context
+        run_context.tool_caller = tool_caller
+
+        # Replace create_agent so we don't drag in langchain's create_agent and
+        # middleware machinery — calling the mock returns a Runnable-like MagicMock.
+        run_context.create_agent = MagicMock()
+
+        return run_context
+
+    @staticmethod
+    def _llm_resources_mock() -> MagicMock:
+        """A stand-in for a successful LangChainLlmResources return value."""
+        resources = MagicMock()
+        resources.get_model.return_value = MagicMock(name="llm_model")
+        return resources
+
+    def test_failing_first_fallback_continues_to_next(self):
+        """
+        If create_llm raises ValueError on the first fallback, the loop should
+        record the error, continue to the next fallback, and return its agent.
+        """
+        llm_config: Dict[str, Any] = {
+            "fallbacks": [
+                {"class": "anthropic", "model_name": "claude-sonnet-4-6"},
+                {"class": "openai", "model_name": "gpt-5.2"},
+            ]
+        }
+        side_effect: List[Any] = [
+            ValueError("anthropic_api_key missing"),
+            self._llm_resources_mock(),
+        ]
+        run_context = self._make_run_context(llm_config, side_effect)
+
+        agent = run_context.create_agent_with_fallbacks("dummy instructions")
+
+        assert agent is not None
+        # Both fallbacks were attempted (the first raised, the second succeeded).
+        create_llm = run_context.invocation_context.get_llm_factory().create_llm
+        assert create_llm.call_count == 2
+        # create_agent only got invoked once — for the successful (openai) fallback.
+        assert run_context.create_agent.call_count == 1
+
+    def test_sly_data_missing_keys_continues_to_next_fallback(self):
+        """
+        If a fallback reports missing sly_data keys (set return from create_llm),
+        the loop should continue to the next fallback and return its agent.
+        """
+        llm_config: Dict[str, Any] = {
+            "fallbacks": [
+                {"class": "anthropic", "model_name": "claude-sonnet-4-6",
+                 "anthropic_api_key": "sly_data"},
+                {"class": "openai", "model_name": "gpt-5.2"},
+            ]
+        }
+        side_effect: List[Any] = [
+            {"anthropic_api_key"},
+            self._llm_resources_mock(),
+        ]
+        run_context = self._make_run_context(llm_config, side_effect)
+
+        agent = run_context.create_agent_with_fallbacks("dummy instructions")
+
+        assert agent is not None
+        create_llm = run_context.invocation_context.get_llm_factory().create_llm
+        assert create_llm.call_count == 2
+        # create_agent only got invoked once — for the successful (openai) fallback.
+        assert run_context.create_agent.call_count == 1
+
+    def test_all_fallbacks_missing_sly_data_surfaces_required_keys(self):
+        """
+        When every fallback reports missing sly_data keys, the final ValueError
+        should list the union of required sly_data.llm_config keys under the
+        appropriate section header.
+        """
+        llm_config: Dict[str, Any] = {
+            "fallbacks": [
+                {"class": "anthropic", "model_name": "claude-sonnet-4-6",
+                 "anthropic_api_key": "sly_data"},
+                {"class": "openai", "model_name": "gpt-5.2",
+                 "openai_api_key": "sly_data"},
+            ]
+        }
+        side_effect: List[Any] = [
+            {"anthropic_api_key"},
+            {"openai_api_key"},
+        ]
+        run_context = self._make_run_context(llm_config, side_effect)
+
+        with pytest.raises(ValueError) as excinfo:
+            run_context.create_agent_with_fallbacks("dummy instructions")
+
+        message: str = str(excinfo.value)
+        assert "No fully-specified LLM found in llm_config or fallbacks." in message
+        assert "requires at least one of the following set in sly_data.llm_config:" in message
+        assert "anthropic_api_key" in message
+        assert "openai_api_key" in message
+
+    def test_mixed_sly_data_and_construction_failures_surface_both(self):
+        """
+        When one fallback reports missing sly_data keys and another raises a
+        ValueError during construction, the final error message should include
+        both the required-key section and the construction-errors section.
+        """
+        llm_config: Dict[str, Any] = {
+            "fallbacks": [
+                {"class": "anthropic", "model_name": "claude-sonnet-4-6",
+                 "anthropic_api_key": "sly_data"},
+                {"class": "openai", "model_name": "gpt-5.2"},
+            ]
+        }
+        side_effect: List[Any] = [
+            {"anthropic_api_key"},
+            ValueError("openai_api_key missing"),
+        ]
+        run_context = self._make_run_context(llm_config, side_effect)
+
+        with pytest.raises(ValueError) as excinfo:
+            run_context.create_agent_with_fallbacks("dummy instructions")
+
+        message: str = str(excinfo.value)
+        assert "requires at least one of the following set in sly_data.llm_config:" in message
+        assert "anthropic_api_key" in message
+        assert "The following errors occurred while constructing LLMs:" in message
+        assert "openai_api_key missing" in message
+
+    def test_all_fallbacks_failing_surfaces_collected_errors(self):
+        """
+        When every fallback raises ValueError during construction, the final
+        ValueError should list all collected construction errors under a clear
+        section header so the operator can see why each candidate failed.
+        """
+        llm_config: Dict[str, Any] = {
+            "fallbacks": [
+                {"class": "anthropic", "model_name": "claude-sonnet-4-6"},
+                {"class": "openai", "model_name": "gpt-5.2"},
+            ]
+        }
+        side_effect: List[Any] = [
+            ValueError("anthropic_api_key missing"),
+            ValueError("openai_api_key missing"),
+        ]
+        run_context = self._make_run_context(llm_config, side_effect)
+
+        with pytest.raises(ValueError) as excinfo:
+            run_context.create_agent_with_fallbacks("dummy instructions")
+
+        message: str = str(excinfo.value)
+        assert "No fully-specified LLM found in llm_config or fallbacks." in message
+        assert "The following errors occurred while constructing LLMs:" in message
+        assert "anthropic_api_key missing" in message
+        assert "openai_api_key missing" in message
+        # Construction errors should be on their own line, not glued onto the base sentence.
+        assert "fallbacks.anthropic_api_key" not in message

--- a/tests/neuro_san/internals/run_context/langchain/core/test_langchain_run_context_llm_fallbacks.py
+++ b/tests/neuro_san/internals/run_context/langchain/core/test_langchain_run_context_llm_fallbacks.py
@@ -30,8 +30,13 @@ from neuro_san.internals.run_context.langchain.core.langchain_run_context import
 pytestmark = [pytest.mark.non_default_llm_provider, pytest.mark.ollama]
 
 
-class TestLangChainRunContext:
-    """Tests for the LangChainRunContext class."""
+class TestLangChainContextLlmFallbacks:
+    """
+    Tests covering the LLM-fallback slice of LangChainRunContext —
+    specifically create_agent_with_fallbacks(), which iterates over llm_config
+    fallbacks, tolerates construction failures and missing-sly_data outcomes,
+    and aggregates a final ValueError when no fallback succeeds.
+    """
 
     @staticmethod
     def _make_run_context(llm_config: Dict[str, Any], create_llm_side_effect) -> LangChainRunContext:


### PR DESCRIPTION
The fallback loop in `LangChainRunContext` handled two non-fatal outcomes per iteration (`None` and `Set[str]-of-missing-keys`), but treated a `ValueError` from `create_llm` as fatal — aborting the loop and preventing later fallbacks from being attempted.

This meant a config like:

```json
  "fallbacks": [
    { "class": "anthropic", "model_name": "claude-sonnet-4-6" },
    { "class": "openai",    "model_name": "gpt-5.2" }
  ]
```

would fail outright when `ANTHROPIC_API_KEY` was unset, even if `OPENAI_API_KEY` was available — because `ChatAnthropic` construction raised an API-key error (re-raised as `ValueError` by `DefaultLlmFactory`) and the openai fallback was never tried.

## Changes

- `LangChainRunContext.create_agent_with_fallbacks`: Wrap `create_llm` in `try/except ValueError`, record the message in a `construction_errors` list, and continue to the next fallback. When no fallback succeeds, the final raised `ValueError` includes the collected construction errors under a clear section header ("The following errors occurred while constructing LLMs:") so the operator can see why each candidate failed.

- `DefaultLlmFactory`: demote API-key error log from `ERROR` to `INFO`. Previously, a per-attempt API-key failure was logged at `ERROR` level — which made sense when an API-key failure was always fatal. Now that the fallback loop can recover from such a failure by trying the next fallback, leaving the log at `ERROR` produced noisy/misleading `"API KEY error detected: …"` lines even on the recovered (successful) path. Demoting to `INFO` keeps the technical details available for debugging without alarming operators when a fallback transparently saves the day. The all-fallbacks-failed case still surfaces a clear, aggregated `ValueError` to the caller, so visibility of true failures isn't lost.

- Added unit tests in `tests/neuro_san/internals/run_context/langchain/core/test_langchain_run_context.py`

Fix #948 