### PR TITLE
NS-956 Slightly better langfuse reporting

### DIFF
--- a/neuro_san/internals/run_context/langchain/tracing/langfuse_tracing_context.py
+++ b/neuro_san/internals/run_context/langchain/tracing/langfuse_tracing_context.py
@@ -18,14 +18,15 @@ from __future__ import annotations
 
 from typing import Any
 from typing import Dict
-from typing import List
 from typing import Type
 
+from contextvars import ContextVar
 from datetime import datetime
 from socket import gethostname
 
 from langchain_core.callbacks.base import BaseCallbackHandler
 from langchain_core.runnables.base import Runnable
+from langchain_core.tracers.context import register_configure_hook
 
 from leaf_common.config.resolver_util import ResolverUtil
 
@@ -38,6 +39,31 @@ class LangfuseTracingContext(LangChainTracingContext):
     """
     TracingContext implementation for runs that use Langfuse.
     """
+
+    @staticmethod
+    def register():
+        """
+        Globally egister the Langfuse CallbackHandler, if available
+        """
+
+        context_var = ContextVar("langfuse_handler", default=None)
+
+        # See if we can create a new langfuse handler instance.
+        callback_handler_type: Type[BaseCallbackHandler] = None
+        callback_handler_type = ResolverUtil.create_type("langfuse.langchain.CallbackHandler",
+                                                         raise_if_not_found=False)
+        if callback_handler_type is not None:
+
+            callback_handler: BaseCallbackHandler = callback_handler_type()
+
+            context_var.set(callback_handler)
+            register_configure_hook(context_var, inheritable=True)
+
+        return context_var
+
+    # Global context variable for the langfuse callback handler.
+    # Do the register() once at class load time.
+    HANDLER_CONTEXT_VAR: ContextVar = register()
 
     def __init__(self, run_target: RunTarget,
                  config: Dict[str, Any],
@@ -52,7 +78,6 @@ class LangfuseTracingContext(LangChainTracingContext):
         super().__init__(run_target=run_target, config=config)
 
         self.parent_context: LangfuseTracingContext = parent_context
-        self.callback_handler: BaseCallbackHandler = None
         self.main_span: Any = None
 
         # See if we can get a langfuse handler instance.
@@ -84,6 +109,47 @@ If you didn't mean to use langfuse for observability, you can do this:
         :param inputs: The inputs to the chain
         :param runnable_config: The config for the runnable
         """
+        # According to langfuse docs, this should be safe for use in async code.
+        if self.main_span is not None:
+            with self.main_span:
+                await super().ainvoke(chain, inputs, runnable_config)
+        else:
+            await super().ainvoke(chain, inputs, runnable_config)
+
+    def create_main_span(self, runnable_config: Dict[str, Any]):
+        """
+        Create the main span for the run
+        :param runnable_config: The config for the runnable
+        """
+
+        if self.main_span is not None:
+            return
+
+        if self.parent_context is not None:
+            return
+
+        run_name: str = runnable_config.get("run_name")
+
+        # No need to ResolverUtil absolutely everything, but we still need to locally import
+        # for the rest of the system to behave without langfuse installed.
+
+        # pylint: disable=import-outside-toplevel
+        from langfuse import get_client
+
+        # Get the langfuse client
+        langfuse_client: Any = get_client()
+        self.main_span = langfuse_client.start_as_current_observation(as_type="agent", name=run_name)
+
+    def augment_config(self, runnable_config: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Augment the configuration however the implementation sees fit (if at all).
+        :param runnable_config: The config for the runnable
+        :return: The augmented config
+        """
+        self.create_main_span(runnable_config)
+
+        runnable_config["neuro_san_tracing_context"] = self
+
         # Get the user_id for the trace
         empty: Dict[str, Any] = {}
         request_metadata: Dict[str, Any] = runnable_config.get("metadata", empty)
@@ -97,81 +163,9 @@ If you didn't mean to use langfuse for observability, you can do this:
         hostname: str = gethostname()
         session_id: str = f"{session_id}@{hostname}"
 
-        # pylint: disable=import-outside-toplevel
-        from langfuse import propagate_attributes
-
-        # According to langfuse docs, this should be safe for use in async code.
-        with self.main_span:
-            propagate_attributes(user_id=user_id, session_id=session_id)
-            await super().ainvoke(chain, inputs, runnable_config)
-
-    def create_main_span(self, runnable_config: Dict[str, Any]):
-        """
-        Create the main span for the run
-        :param runnable_config: The config for the runnable
-        """
-
-        if self.main_span is not None:
-            return
-
-        run_name: str = runnable_config.get("run_name")
-
-        # We have a handler, therefore we have langfuse installed.
-        # No need to ResolverUtil absolutely everything, but we still need to locally import
-        # for the rest of the system to behave without langfuse installed.
-
-        # pylint: disable=import-outside-toplevel
-        from langfuse import get_client
-
-        if self.parent_context is not None:
-            # Get the langfuse client
-            langfuse_client: Any = get_client()
-            self.main_span = langfuse_client.start_as_current_observation(as_type="span", name=run_name)
-        else:
-            # Get the langfuse client
-            langfuse_client: Any = get_client()
-            self.main_span = langfuse_client.start_as_current_observation(as_type="agent", name=run_name)
-
-    def maybe_create_handler(self, runnable_config: Dict[str, Any]):
-        """
-        If the tracing config doesn't have a handler, create it.
-        """
-        self.create_main_span(runnable_config)
-
-        if self.callback_handler is None and self.parent_context is not None:
-            self.callback_handler = self.parent_context.callback_handler
-
-        if self.callback_handler is None:
-
-            # See if we can create a new langfuse handler instance.
-            callback_handler_type: Type[BaseCallbackHandler] = None
-            callback_handler_type = ResolverUtil.create_type("langfuse.langchain.CallbackHandler",
-                                                             raise_if_not_found=False)
-            if callback_handler_type is None:
-                # Nothing we can do. Skip.
-                self.callback_handler = None
-                return
-
-            self.callback_handler = callback_handler_type()
-
-    def augment_config(self, runnable_config: Dict[str, Any]) -> Dict[str, Any]:
-        """
-        Augment the configuration however the implementation sees fit (if at all).
-        :param runnable_config: The config for the runnable
-        :return: The augmented config
-        """
-        self.maybe_create_handler(runnable_config)
-        if self.callback_handler is None:
-            # Nothing we can do. Skip.
-            return runnable_config
-
-        # Set the callbacks per the langfuse docs
-        callbacks: List[BaseCallbackHandler] = runnable_config.get("callbacks", [])
-        if self.callback_handler not in callbacks:
-            callbacks.append(self.callback_handler)
-        runnable_config["callbacks"] = callbacks
-
-        runnable_config["neuro_san_tracing_context"] = self
+        request_metadata["langfuse_user_id"] = user_id
+        request_metadata["langfuse_session_id"] = session_id
+        runnable_config["metadata"] = request_metadata
 
         return runnable_config
 

--- a/neuro_san/internals/run_context/langchain/tracing/langfuse_tracing_context.py
+++ b/neuro_san/internals/run_context/langchain/tracing/langfuse_tracing_context.py
@@ -81,7 +81,10 @@ class LangfuseTracingContext(LangChainTracingContext):
         """
         super().__init__(run_target=run_target, config=config)
 
+        # Keep a reference to the parent context
         self.parent_context: LangfuseTracingContext = parent_context
+
+        # Keep a session_id for any child TracingContext to use in its langfuse config for the run.
         self.session_id: str = None
 
         # See if we can get a langfuse handler instance.
@@ -97,6 +100,8 @@ If you really wanted to use langfuse for observability, you can install it with
 If you didn't mean to use langfuse for observability, you can do this:
     export LANGFUSE_ENABLED=false
 """)
+
+        # Keep track of some Langfuse state
 
         # No need to ResolverUtil absolutely everything, but we still need to locally import
         # for the rest of the system to behave without langfuse installed.

--- a/neuro_san/internals/run_context/langchain/tracing/langfuse_tracing_context.py
+++ b/neuro_san/internals/run_context/langchain/tracing/langfuse_tracing_context.py
@@ -151,8 +151,10 @@ If you didn't mean to use langfuse for observability, you can do this:
             # Langfuse is not enabled
             return
 
-        # According to langfuse docs, this should be safe for use in async code.
         run_name: str = runnable_config.get("run_name")
+
+        # This "agent" type gets us the nice little icon in the langfuse UI
+        # According to langfuse docs, this should be safe for use in async code.
         self.main_span = self.langfuse_client.start_as_current_observation(as_type="agent", name=run_name)
 
     def augment_config(self, runnable_config: Dict[str, Any]) -> Dict[str, Any]:

--- a/neuro_san/internals/run_context/langchain/tracing/langfuse_tracing_context.py
+++ b/neuro_san/internals/run_context/langchain/tracing/langfuse_tracing_context.py
@@ -106,7 +106,7 @@ If you didn't mean to use langfuse for observability, you can do this:
         from opentelemetry.util._decorator import _AgnosticContextManager
 
         self.langfuse_client: Langfuse = get_client()
-        self.main_span: _AgnosticContextManager = None
+        self.main_span: _AgnosticContextManager[Any] = None
 
     def clone(self) -> TracingContext:
         """
@@ -143,6 +143,11 @@ If you didn't mean to use langfuse for observability, you can do this:
             return
 
         if self.langfuse_client is None:
+            # Langfuse is not enabled
+            return
+
+        if self.parent_context is not None:
+            # This is a child run
             return
 
         # According to langfuse docs, this should be safe for use in async code.

--- a/neuro_san/internals/run_context/langchain/tracing/langfuse_tracing_context.py
+++ b/neuro_san/internals/run_context/langchain/tracing/langfuse_tracing_context.py
@@ -43,9 +43,11 @@ class LangfuseTracingContext(LangChainTracingContext):
     @staticmethod
     def register():
         """
-        Globally egister the Langfuse CallbackHandler, if available
+        Globally register the Langfuse CallbackHandler, if available
+        This is really the only way we can do this with langchain managing span parentage.
         """
 
+        # Create a context variable for the langfuse handler
         context_var = ContextVar("langfuse_handler", default=None)
 
         # See if we can create a new langfuse handler instance.
@@ -54,8 +56,10 @@ class LangfuseTracingContext(LangChainTracingContext):
                                                          raise_if_not_found=False)
         if callback_handler_type is not None:
 
+            # Create the callback handler instance
             callback_handler: BaseCallbackHandler = callback_handler_type()
 
+            # Register the callback handler via the context variable
             context_var.set(callback_handler)
             register_configure_hook(context_var, inheritable=True)
 
@@ -78,11 +82,13 @@ class LangfuseTracingContext(LangChainTracingContext):
         super().__init__(run_target=run_target, config=config)
 
         self.parent_context: LangfuseTracingContext = parent_context
+        self.langfuse_client: Any = None
         self.main_span: Any = None
 
         # See if we can get a langfuse handler instance.
-        handler_type = ResolverUtil.create_type("langfuse.langchain.CallbackHandler", raise_if_not_found=False)
-        if handler_type is None:
+        # handler_type = ResolverUtil.create_type("langfuse.langchain.CallbackHandler", raise_if_not_found=False)
+        # if handler_type is None:
+        if self.HANDLER_CONTEXT_VAR.get() is None:
             raise ValueError("""
 Failed to create Langfuse CallbackHandler. Try one of the following:
 
@@ -92,6 +98,14 @@ If you really wanted to use langfuse for observability, you can install it with
 If you didn't mean to use langfuse for observability, you can do this:
     export LANGFUSE_ENABLED=false
 """)
+
+        # No need to ResolverUtil absolutely everything, but we still need to locally import
+        # for the rest of the system to behave without langfuse installed.
+
+        # Get the langfuse client
+        # pylint: disable=import-outside-toplevel
+        from langfuse import get_client
+        self.langfuse_client = get_client()
 
     def clone(self) -> TracingContext:
         """
@@ -109,7 +123,6 @@ If you didn't mean to use langfuse for observability, you can do this:
         :param inputs: The inputs to the chain
         :param runnable_config: The config for the runnable
         """
-        # According to langfuse docs, this should be safe for use in async code.
         if self.main_span is not None:
             with self.main_span:
                 await super().ainvoke(chain, inputs, runnable_config)
@@ -130,15 +143,9 @@ If you didn't mean to use langfuse for observability, you can do this:
 
         run_name: str = runnable_config.get("run_name")
 
-        # No need to ResolverUtil absolutely everything, but we still need to locally import
-        # for the rest of the system to behave without langfuse installed.
-
-        # pylint: disable=import-outside-toplevel
-        from langfuse import get_client
-
-        # Get the langfuse client
-        langfuse_client: Any = get_client()
-        self.main_span = langfuse_client.start_as_current_observation(as_type="agent", name=run_name)
+        # According to langfuse docs, this should be safe for use in async code.
+        if self.langfuse_client is not None:
+            self.main_span = self.langfuse_client.start_as_current_observation(as_type="agent", name=run_name)
 
     def augment_config(self, runnable_config: Dict[str, Any]) -> Dict[str, Any]:
         """
@@ -173,7 +180,5 @@ If you didn't mean to use langfuse for observability, you can do this:
         """
         Flush the tracing context.
         """
-        # pylint: disable=import-outside-toplevel
-        from langfuse import get_client
-        langfuse_client: Any = get_client()
-        langfuse_client.flush()
+        if self.langfuse_client is not None:
+            self.langfuse_client.flush()

--- a/neuro_san/internals/run_context/langchain/tracing/langfuse_tracing_context.py
+++ b/neuro_san/internals/run_context/langchain/tracing/langfuse_tracing_context.py
@@ -146,10 +146,6 @@ If you didn't mean to use langfuse for observability, you can do this:
             # Langfuse is not enabled
             return
 
-        if self.parent_context is not None:
-            # This is a child run
-            return
-
         # According to langfuse docs, this should be safe for use in async code.
         run_name: str = runnable_config.get("run_name")
         self.main_span = self.langfuse_client.start_as_current_observation(as_type="agent", name=run_name)

--- a/neuro_san/internals/run_context/langchain/tracing/langfuse_tracing_context.py
+++ b/neuro_san/internals/run_context/langchain/tracing/langfuse_tracing_context.py
@@ -21,7 +21,6 @@ from typing import Dict
 from typing import Type
 
 from contextvars import ContextVar
-from datetime import datetime
 from socket import gethostname
 
 from langchain_core.callbacks.base import BaseCallbackHandler
@@ -82,8 +81,8 @@ class LangfuseTracingContext(LangChainTracingContext):
         super().__init__(run_target=run_target, config=config)
 
         self.parent_context: LangfuseTracingContext = parent_context
-        self.langfuse_client: Any = None
-        self.main_span: Any = None
+        self.hostname: str = gethostname()
+        self.session_run_name: str = None
 
         # See if we can get a langfuse handler instance.
         # handler_type = ResolverUtil.create_type("langfuse.langchain.CallbackHandler", raise_if_not_found=False)
@@ -101,11 +100,13 @@ If you didn't mean to use langfuse for observability, you can do this:
 
         # No need to ResolverUtil absolutely everything, but we still need to locally import
         # for the rest of the system to behave without langfuse installed.
-
-        # Get the langfuse client
         # pylint: disable=import-outside-toplevel
+        from langfuse import Langfuse
         from langfuse import get_client
-        self.langfuse_client = get_client()
+        from opentelemetry.util._decorator import _AgnosticContextManager
+
+        self.langfuse_client: Langfuse = get_client()
+        self.main_span: _AgnosticContextManager = None
 
     def clone(self) -> TracingContext:
         """
@@ -124,6 +125,8 @@ If you didn't mean to use langfuse for observability, you can do this:
         :param runnable_config: The config for the runnable
         """
         if self.main_span is not None:
+            # We have a main span. Use it as the context.
+            # pylint: disable=not-context-manager
             with self.main_span:
                 await super().ainvoke(chain, inputs, runnable_config)
         else:
@@ -136,16 +139,15 @@ If you didn't mean to use langfuse for observability, you can do this:
         """
 
         if self.main_span is not None:
+            # Already done
             return
 
-        if self.parent_context is not None:
+        if self.langfuse_client is None:
             return
-
-        run_name: str = runnable_config.get("run_name")
 
         # According to langfuse docs, this should be safe for use in async code.
-        if self.langfuse_client is not None:
-            self.main_span = self.langfuse_client.start_as_current_observation(as_type="agent", name=run_name)
+        run_name: str = runnable_config.get("run_name")
+        self.main_span = self.langfuse_client.start_as_current_observation(as_type="agent", name=run_name)
 
     def augment_config(self, runnable_config: Dict[str, Any]) -> Dict[str, Any]:
         """
@@ -162,19 +164,33 @@ If you didn't mean to use langfuse for observability, you can do this:
         request_metadata: Dict[str, Any] = runnable_config.get("metadata", empty)
         user_id: str = request_metadata.get("user_id", "<Unknown>")
 
+        # Find the right run_name to use for the session components
+        self.session_run_name: str = self.get_parent_session_run_name()
+        if self.session_run_name is None:
+            self.session_run_name = runnable_config.get("run_name")
+
         # Create a session_id for the trace.
         # It's possible we should move the addition of hostname up to the services infra.
         request_id: str = request_metadata.get("request_id", "<Unknown>")
-        now: datetime = datetime.now()
-        session_id: str = f"{request_id}@{now.strftime('%Y-%m-%d-%H:%M:%S.%f')}"
-        hostname: str = gethostname()
-        session_id: str = f"{session_id}@{hostname}"
+        session_id: str = f"{self.session_run_name}@{request_id}@{self.hostname}"
 
         request_metadata["langfuse_user_id"] = user_id
         request_metadata["langfuse_session_id"] = session_id
         runnable_config["metadata"] = request_metadata
 
         return runnable_config
+
+    def get_parent_session_run_name(self):
+        """
+        Get the parent session run name.
+        We want the component of the session_id to be consistent for any depth of trace.
+
+        :return: The parent session run name
+        """
+        if self.parent_context is not None:
+            return self.parent_context.get_parent_session_run_name()
+
+        return self.session_run_name
 
     async def flush(self):
         """

--- a/neuro_san/internals/run_context/langchain/tracing/langfuse_tracing_context.py
+++ b/neuro_san/internals/run_context/langchain/tracing/langfuse_tracing_context.py
@@ -151,6 +151,10 @@ If you didn't mean to use langfuse for observability, you can do this:
             # Langfuse is not enabled
             return
 
+        if self.parent_context is not None and self.parent_context.main_span is not None:
+            # We have a parent context with a main_span. Dont do anything.
+            return
+
         run_name: str = runnable_config.get("run_name")
 
         # This "agent" type gets us the nice little icon in the langfuse UI

--- a/neuro_san/internals/run_context/langchain/tracing/langfuse_tracing_context.py
+++ b/neuro_san/internals/run_context/langchain/tracing/langfuse_tracing_context.py
@@ -82,7 +82,6 @@ class LangfuseTracingContext(LangChainTracingContext):
         super().__init__(run_target=run_target, config=config)
 
         self.parent_context: LangfuseTracingContext = parent_context
-        self.hostname: str = gethostname()
         self.session_id: str = None
 
         # See if we can get a langfuse handler instance.
@@ -170,15 +169,18 @@ If you didn't mean to use langfuse for observability, you can do this:
         self.session_id: str = self.get_parent_session_id()
         if self.session_id is None:
 
+            # Get pieces of the session_id to construct
             run_name = runnable_config.get("run_name")
+            request_id: str = request_metadata.get("request_id", "<Unknown>")
+
+            # It's possible we should move the addition of hostname up to the services infra.
+            hostname: str = gethostname()
 
             # We use the time to distiguish sessions on a restarted server on the same host.
             now_str: str = datetime.now().strftime('%Y-%m-%d-%H:%M:%S.%f')
 
             # Create a session_id for the trace.
-            # It's possible we should move the addition of hostname up to the services infra.
-            request_id: str = request_metadata.get("request_id", "<Unknown>")
-            self.session_id: str = f"{run_name}@{request_id}@{self.hostname}@{now_str}"
+            self.session_id: str = f"{run_name}@{request_id}@{hostname}@{now_str}"
 
         request_metadata["langfuse_user_id"] = user_id
         request_metadata["langfuse_session_id"] = self.session_id

--- a/neuro_san/internals/run_context/langchain/tracing/langfuse_tracing_context.py
+++ b/neuro_san/internals/run_context/langchain/tracing/langfuse_tracing_context.py
@@ -21,6 +21,7 @@ from typing import Dict
 from typing import Type
 
 from contextvars import ContextVar
+from datetime import datetime
 from socket import gethostname
 
 from langchain_core.callbacks.base import BaseCallbackHandler
@@ -168,12 +169,16 @@ If you didn't mean to use langfuse for observability, you can do this:
         # Find the right session_id to use for the session components
         self.session_id: str = self.get_parent_session_id()
         if self.session_id is None:
+
             run_name = runnable_config.get("run_name")
+
+            # We use the time to distiguish sessions on a restarted server on the same host.
+            now_str: str = datetime.now().strftime('%Y-%m-%d-%H:%M:%S.%f')
 
             # Create a session_id for the trace.
             # It's possible we should move the addition of hostname up to the services infra.
             request_id: str = request_metadata.get("request_id", "<Unknown>")
-            self.session_id: str = f"{run_name}@{request_id}@{self.hostname}"
+            self.session_id: str = f"{run_name}@{request_id}@{self.hostname}@{now_str}"
 
         request_metadata["langfuse_user_id"] = user_id
         request_metadata["langfuse_session_id"] = self.session_id

--- a/neuro_san/internals/run_context/langchain/tracing/langfuse_tracing_context.py
+++ b/neuro_san/internals/run_context/langchain/tracing/langfuse_tracing_context.py
@@ -82,7 +82,7 @@ class LangfuseTracingContext(LangChainTracingContext):
 
         self.parent_context: LangfuseTracingContext = parent_context
         self.hostname: str = gethostname()
-        self.session_run_name: str = None
+        self.session_id: str = None
 
         # See if we can get a langfuse handler instance.
         # handler_type = ResolverUtil.create_type("langfuse.langchain.CallbackHandler", raise_if_not_found=False)
@@ -165,33 +165,33 @@ If you didn't mean to use langfuse for observability, you can do this:
         request_metadata: Dict[str, Any] = runnable_config.get("metadata", empty)
         user_id: str = request_metadata.get("user_id", "<Unknown>")
 
-        # Find the right run_name to use for the session components
-        self.session_run_name: str = self.get_parent_session_run_name()
-        if self.session_run_name is None:
-            self.session_run_name = runnable_config.get("run_name")
+        # Find the right session_id to use for the session components
+        self.session_id: str = self.get_parent_session_id()
+        if self.session_id is None:
+            run_name = runnable_config.get("run_name")
 
-        # Create a session_id for the trace.
-        # It's possible we should move the addition of hostname up to the services infra.
-        request_id: str = request_metadata.get("request_id", "<Unknown>")
-        session_id: str = f"{self.session_run_name}@{request_id}@{self.hostname}"
+            # Create a session_id for the trace.
+            # It's possible we should move the addition of hostname up to the services infra.
+            request_id: str = request_metadata.get("request_id", "<Unknown>")
+            self.session_id: str = f"{run_name}@{request_id}@{self.hostname}"
 
         request_metadata["langfuse_user_id"] = user_id
-        request_metadata["langfuse_session_id"] = session_id
+        request_metadata["langfuse_session_id"] = self.session_id
         runnable_config["metadata"] = request_metadata
 
         return runnable_config
 
-    def get_parent_session_run_name(self):
+    def get_parent_session_id(self):
         """
-        Get the parent session run name.
-        We want the component of the session_id to be consistent for any depth of trace.
+        Get the parent session id.
+        We want the to be consistent for any depth of trace in the request.
 
-        :return: The parent session run name
+        :return: The parent session id
         """
         if self.parent_context is not None:
-            return self.parent_context.get_parent_session_run_name()
+            return self.parent_context.get_parent_session_id()
 
-        return self.session_run_name
+        return self.session_id
 
     async def flush(self):
         """


### PR DESCRIPTION
Slightly better langfuse reporting. Simpler. Uses the ContextVar like the plugin does.

The parentage of chains is still not good, but you can start to figure out what belongs to what when you look at the timeline view.   RunnableWithFallbacks (which should probably be attached to RunContextRunnalbe) and LangGraph (which should probably be attached to RunnableWithFallbacks) are still attaching themselves to the main observation from the TracingContext parent and not to what called them.

I've spent enough time on this for now. There are still some tricks to play with setting explicit parent_run_ids, but they get hackier and wackier.
Might pick this up again later when there isn't as many other things that need attention.

With this the plugin should not be necessary any more.