### PR TITLE
Allow for stop_on_error to return early from CompositeDictionaryValidator

### DIFF
--- a/neuro_san/internals/validation/common/composite_dictionary_validator.py
+++ b/neuro_san/internals/validation/common/composite_dictionary_validator.py
@@ -26,13 +26,19 @@ class CompositeDictionaryValidator(DictionaryValidator):
     Implementation of the DictionaryValidator interface that uses multiple validators
     """
 
-    def __init__(self, validators: List[DictionaryValidator]):
+    def __init__(self, validators: List[DictionaryValidator], stop_on_error: bool = False):
         """
         Constructor
 
         :param validators: A list of validators to use
+        :param stop_on_error: When True, return after the first validator that produces
+                errors instead of running every validator. Useful for ordering phases
+                where later validators assume earlier validators passed (e.g., shape
+                checks before semantic checks that would crash on malformed input).
+                Default False preserves the "collect all errors" behavior.
         """
         self.validators: List[DictionaryValidator] = validators
+        self.stop_on_error: bool = stop_on_error
 
     def validate(self, candidate: Dict[str, Any]) -> List[str]:
         """
@@ -52,6 +58,9 @@ class CompositeDictionaryValidator(DictionaryValidator):
             return errors
 
         for validator in self.validators:
-            errors.extend(validator.validate(candidate))
+            new_errors: List[str] = validator.validate(candidate)
+            errors.extend(new_errors)
+            if new_errors and self.stop_on_error:
+                break
 
         return errors

--- a/neuro_san/internals/validation/network/manifest_network_validator.py
+++ b/neuro_san/internals/validation/network/manifest_network_validator.py
@@ -29,44 +29,22 @@ class ManifestNetworkValidator(CompositeDictionaryValidator):
     """
     Implementation of CompositeDictionaryValidator interface that uses multiple specific validators
     to do some standard validation upon reading in an agent network description.
-
-    Validation runs in two phases. The first phase checks that `tools` is a list,
-    because structure validators iterate or concatenate it and would crash or
-    report nonsense on a malformed value. The second phase runs the remaining
-    keyword checks (empty instructions/description) together with all structure
-    checks so users see those errors in one pass.
     """
 
-    def __init__(
-            self,
-            external_network_names: List[str] = None,
-            mcp_servers: List[str] = None,
-            stop_on_error: bool = False
-    ):
+    def __init__(self, external_network_names: List[str] = None, mcp_servers: List[str] = None):
         """
         Constructor
 
         :param external_network_names: A list of external network names
         :param mcp_servers: A list of MCP servers, as read in from a mcp_info.hocon file
-        :param stop_on_error: When True, return after the first phase that produces
         """
-        # Phase 1: only the `tools`-shape check, because it's the one that crashes
-        # or silently corrupts results in downstream structure validators.
-        tools_shape_phase: CompositeDictionaryValidator = CompositeDictionaryValidator([
-            KeywordNetworkValidator(keywords=["tools"]),
-        ])
-
-        # Phase 2: remaining keyword checks and all structure checks. All errors are
-        # collected together so users see them in a single pass.
-        other_phase: CompositeDictionaryValidator = CompositeDictionaryValidator([
-            KeywordNetworkValidator(keywords=["instructions", "description"]),
+        validators: List[DictionaryValidator] = [
             # Note we do use the CyclesNetworkValidator here because cycles are actually OK.
+            KeywordNetworkValidator(),
             MissingNodesNetworkValidator(),
             UnreachableNodesNetworkValidator(),
             # No ToolBoxNetworkValidator yet.
             ToolNameNetworkValidator(),
             UrlNetworkValidator(external_network_names, mcp_servers),
-        ])
-
-        phases: List[DictionaryValidator] = [tools_shape_phase, other_phase]
-        super().__init__(phases, stop_on_error=stop_on_error)
+        ]
+        super().__init__(validators)

--- a/neuro_san/internals/validation/network/manifest_network_validator.py
+++ b/neuro_san/internals/validation/network/manifest_network_validator.py
@@ -38,7 +38,12 @@ class ManifestNetworkValidator(CompositeDictionaryValidator):
     stop_on_error=True so the second phase is skipped when the first phase fails.
     """
 
-    def __init__(self, external_network_names: List[str] = None, mcp_servers: List[str] = None):
+    def __init__(
+            self,
+            external_network_names: List[str] = None,
+            mcp_servers: List[str] = None,
+            stop_on_error: bool = False
+        ):
         """
         Constructor
 
@@ -64,4 +69,4 @@ class ManifestNetworkValidator(CompositeDictionaryValidator):
         ])
 
         phases: List[DictionaryValidator] = [tools_shape_phase, other_phase]
-        super().__init__(phases, stop_on_error=True)
+        super().__init__(phases, stop_on_error=stop_on_error)

--- a/neuro_san/internals/validation/network/manifest_network_validator.py
+++ b/neuro_san/internals/validation/network/manifest_network_validator.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 # END COPYRIGHT
-from typing import Any
-from typing import Dict
 from typing import List
 
 from neuro_san.internals.interfaces.dictionary_validator import DictionaryValidator
@@ -36,7 +34,8 @@ class ManifestNetworkValidator(CompositeDictionaryValidator):
     because structure validators iterate or concatenate it and would crash or
     report nonsense on a malformed value. The second phase runs the remaining
     keyword checks (empty instructions/description) together with all structure
-    checks so users see those errors in one pass.
+    checks so users see those errors in one pass. The outer composite uses
+    stop_on_error=True so the second phase is skipped when the first phase fails.
     """
 
     def __init__(self, external_network_names: List[str] = None, mcp_servers: List[str] = None):
@@ -46,12 +45,15 @@ class ManifestNetworkValidator(CompositeDictionaryValidator):
         :param external_network_names: A list of external network names
         :param mcp_servers: A list of MCP servers, as read in from a mcp_info.hocon file
         """
-        # Gate: only the `tools`-shape check, because it's the one that crashes
+        # Phase 1: only the `tools`-shape check, because it's the one that crashes
         # or silently corrupts results in downstream structure validators.
-        self._tools_shape_validators: List[DictionaryValidator] = [
+        tools_shape_phase: CompositeDictionaryValidator = CompositeDictionaryValidator([
             KeywordNetworkValidator(keywords=["tools"]),
-        ]
-        other_validators: List[DictionaryValidator] = [
+        ])
+
+        # Phase 2: remaining keyword checks and all structure checks. All errors are
+        # collected together so users see them in a single pass.
+        other_phase: CompositeDictionaryValidator = CompositeDictionaryValidator([
             KeywordNetworkValidator(keywords=["instructions", "description"]),
             # Note we do use the CyclesNetworkValidator here because cycles are actually OK.
             MissingNodesNetworkValidator(),
@@ -59,30 +61,7 @@ class ManifestNetworkValidator(CompositeDictionaryValidator):
             # No ToolBoxNetworkValidator yet.
             ToolNameNetworkValidator(),
             UrlNetworkValidator(external_network_names, mcp_servers),
-        ]
-        super().__init__(other_validators)
+        ])
 
-    def validate(self, candidate: Dict[str, Any]) -> List[str]:
-        """
-        Validate in two phases: `tools`-shape first, then everything else.
-
-        If `tools` is malformed (not a list), return the shape error immediately
-        without running the structure validators — they iterate or concatenate
-        `tools` and would crash or report nonsense.
-
-        :param candidate: The dictionary to validate
-        :return: A list of error messages
-        """
-        # Delegate empty/None handling to the parent so its "Nothing to validate."
-        # message is preserved instead of being overridden by per-validator messages.
-        if not candidate:
-            return super().validate(candidate)
-
-        errors: List[str] = []
-        for shape_validator in self._tools_shape_validators:
-            errors.extend(shape_validator.validate(candidate))
-        if errors:
-            return errors
-
-        errors.extend(super().validate(candidate))
-        return errors
+        phases: List[DictionaryValidator] = [tools_shape_phase, other_phase]
+        super().__init__(phases, stop_on_error=True)

--- a/neuro_san/internals/validation/network/manifest_network_validator.py
+++ b/neuro_san/internals/validation/network/manifest_network_validator.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 #
 # END COPYRIGHT
+from typing import Any
+from typing import Dict
 from typing import List
 
 from neuro_san.internals.interfaces.dictionary_validator import DictionaryValidator
@@ -29,6 +31,11 @@ class ManifestNetworkValidator(CompositeDictionaryValidator):
     """
     Implementation of CompositeDictionaryValidator interface that uses multiple specific validators
     to do some standard validation upon reading in an agent network description.
+
+    Validation runs in two phases. The keyword phase (KeywordNetworkValidator) checks field types
+    such as `tools` being a list. The structure phase (missing nodes, unreachable nodes, tool names,
+    URLs) only runs if the keyword phase produces no errors, because downstream validators assume
+    correct data types such as "tools" being a list and would otherwise crash.
     """
 
     def __init__(self, external_network_names: List[str] = None, mcp_servers: List[str] = None):
@@ -38,13 +45,35 @@ class ManifestNetworkValidator(CompositeDictionaryValidator):
         :param external_network_names: A list of external network names
         :param mcp_servers: A list of MCP servers, as read in from a mcp_info.hocon file
         """
-        validators: List[DictionaryValidator] = [
-            # Note we do use the CyclesNetworkValidator here because cycles are actually OK.
+        self._keyword_validators: List[DictionaryValidator] = [
             KeywordNetworkValidator(),
+        ]
+        structure_validators: List[DictionaryValidator] = [
+            # Note we do use the CyclesNetworkValidator here because cycles are actually OK.
             MissingNodesNetworkValidator(),
             UnreachableNodesNetworkValidator(),
             # No ToolBoxNetworkValidator yet.
             ToolNameNetworkValidator(),
             UrlNetworkValidator(external_network_names, mcp_servers),
         ]
-        super().__init__(validators)
+        super().__init__(structure_validators)
+
+    def validate(self, candidate: Dict[str, Any]) -> List[str]:
+        """
+        Validate the candidate in two phases: keyword first, then structure.
+
+        If any keyword validator reports errors, return those immediately without running
+        structure validators — they assume correct data types and would crash or report
+        misleading results on malformed input.
+
+        :param candidate: The dictionary to validate
+        :return: A list of error messages
+        """
+        errors: List[str] = []
+        for keyword_validator in self._keyword_validators:
+            errors.extend(keyword_validator.validate(candidate))
+        if errors:
+            return errors
+
+        errors.extend(super().validate(candidate))
+        return errors

--- a/neuro_san/internals/validation/network/manifest_network_validator.py
+++ b/neuro_san/internals/validation/network/manifest_network_validator.py
@@ -34,8 +34,7 @@ class ManifestNetworkValidator(CompositeDictionaryValidator):
     because structure validators iterate or concatenate it and would crash or
     report nonsense on a malformed value. The second phase runs the remaining
     keyword checks (empty instructions/description) together with all structure
-    checks so users see those errors in one pass. The outer composite uses
-    stop_on_error=True so the second phase is skipped when the first phase fails.
+    checks so users see those errors in one pass.
     """
 
     def __init__(
@@ -49,6 +48,7 @@ class ManifestNetworkValidator(CompositeDictionaryValidator):
 
         :param external_network_names: A list of external network names
         :param mcp_servers: A list of MCP servers, as read in from a mcp_info.hocon file
+        :param stop_on_error: When True, return after the first phase that produces
         """
         # Phase 1: only the `tools`-shape check, because it's the one that crashes
         # or silently corrupts results in downstream structure validators.

--- a/neuro_san/internals/validation/network/manifest_network_validator.py
+++ b/neuro_san/internals/validation/network/manifest_network_validator.py
@@ -32,10 +32,11 @@ class ManifestNetworkValidator(CompositeDictionaryValidator):
     Implementation of CompositeDictionaryValidator interface that uses multiple specific validators
     to do some standard validation upon reading in an agent network description.
 
-    Validation runs in two phases. The keyword phase (KeywordNetworkValidator) checks field types
-    such as `tools` being a list. The structure phase (missing nodes, unreachable nodes, tool names,
-    URLs) only runs if the keyword phase produces no errors, because downstream validators assume
-    correct data types such as "tools" being a list and would otherwise crash.
+    Validation runs in two phases. The first phase checks that `tools` is a list,
+    because structure validators iterate or concatenate it and would crash or
+    report nonsense on a malformed value. The second phase runs the remaining
+    keyword checks (empty instructions/description) together with all structure
+    checks so users see those errors in one pass.
     """
 
     def __init__(self, external_network_names: List[str] = None, mcp_servers: List[str] = None):
@@ -45,10 +46,13 @@ class ManifestNetworkValidator(CompositeDictionaryValidator):
         :param external_network_names: A list of external network names
         :param mcp_servers: A list of MCP servers, as read in from a mcp_info.hocon file
         """
-        self._keyword_validators: List[DictionaryValidator] = [
-            KeywordNetworkValidator(),
+        # Gate: only the `tools`-shape check, because it's the one that crashes
+        # or silently corrupts results in downstream structure validators.
+        self._tools_shape_validators: List[DictionaryValidator] = [
+            KeywordNetworkValidator(keywords=["tools"]),
         ]
-        structure_validators: List[DictionaryValidator] = [
+        other_validators: List[DictionaryValidator] = [
+            KeywordNetworkValidator(keywords=["instructions", "description"]),
             # Note we do use the CyclesNetworkValidator here because cycles are actually OK.
             MissingNodesNetworkValidator(),
             UnreachableNodesNetworkValidator(),
@@ -56,22 +60,22 @@ class ManifestNetworkValidator(CompositeDictionaryValidator):
             ToolNameNetworkValidator(),
             UrlNetworkValidator(external_network_names, mcp_servers),
         ]
-        super().__init__(structure_validators)
+        super().__init__(other_validators)
 
     def validate(self, candidate: Dict[str, Any]) -> List[str]:
         """
-        Validate the candidate in two phases: keyword first, then structure.
+        Validate in two phases: `tools`-shape first, then everything else.
 
-        If any keyword validator reports errors, return those immediately without running
-        structure validators — they assume correct data types and would crash or report
-        misleading results on malformed input.
+        If `tools` is malformed (not a list), return the shape error immediately
+        without running the structure validators — they iterate or concatenate
+        `tools` and would crash or report nonsense.
 
         :param candidate: The dictionary to validate
         :return: A list of error messages
         """
         errors: List[str] = []
-        for keyword_validator in self._keyword_validators:
-            errors.extend(keyword_validator.validate(candidate))
+        for shape_validator in self._tools_shape_validators:
+            errors.extend(shape_validator.validate(candidate))
         if errors:
             return errors
 

--- a/neuro_san/internals/validation/network/manifest_network_validator.py
+++ b/neuro_san/internals/validation/network/manifest_network_validator.py
@@ -73,6 +73,11 @@ class ManifestNetworkValidator(CompositeDictionaryValidator):
         :param candidate: The dictionary to validate
         :return: A list of error messages
         """
+        # Delegate empty/None handling to the parent so its "Nothing to validate."
+        # message is preserved instead of being overridden by per-validator messages.
+        if not candidate:
+            return super().validate(candidate)
+
         errors: List[str] = []
         for shape_validator in self._tools_shape_validators:
             errors.extend(shape_validator.validate(candidate))

--- a/neuro_san/internals/validation/network/manifest_network_validator.py
+++ b/neuro_san/internals/validation/network/manifest_network_validator.py
@@ -43,7 +43,7 @@ class ManifestNetworkValidator(CompositeDictionaryValidator):
             external_network_names: List[str] = None,
             mcp_servers: List[str] = None,
             stop_on_error: bool = False
-        ):
+    ):
         """
         Constructor
 


### PR DESCRIPTION
Fix #852 

When an agent spec has tools as a string instead of a list, `KeywordNetworkValidator` correctly emits the keyword error, but the composite keeps running and `UnreachableNodesNetworkValidator` then crashes on str + list, discarding the readable error. Add an opt-in `stop_on_error` flag to `CompositeDictionaryValidator` (default `False`, so `StructureNetworkValidator` is unaffected).

Similar fix was done on neuro-san-studio's AND https://github.com/cognizant-ai-lab/neuro-san-studio/pull/1052