### PR TITLE
Bump build-common to 1.0.5

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,8 +12,8 @@ jobs:
   test:
     # don't run this job in sync'd clones
     if: github.repository == 'cognizant-ai-lab/neuro-san'
-    # 1.0.0
-    uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@455db3cc40e9ed6a0fb9bbaf8188888c1ae315c2
+    # 1.0.5
+    uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@550f3d7338e598c813b9580a238141328f7baaaa
     with:
       python-version: '3.12'
       lint-command-override: 'true'  # no lint in this workflow

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,8 +23,8 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Setup Python environment
-        # 1.0.4
-        uses: cognizant-ai-lab/build-common/actions/setup-python-env@f5836555ee8e04413a8f9b313a431ab36337045b
+        # 1.0.5
+        uses: cognizant-ai-lab/build-common/actions/setup-python-env@550f3d7338e598c813b9580a238141328f7baaaa
         with:
           python-version: '3.10'
           requirements-file: ''
@@ -40,8 +40,8 @@ jobs:
 
       - name: Notify Slack
         if: ${{ !cancelled() }}
-        # 1.0.4
-        uses: cognizant-ai-lab/build-common/actions/slack-notify@f5836555ee8e04413a8f9b313a431ab36337045b
+        # 1.0.5
+        uses: cognizant-ai-lab/build-common/actions/slack-notify@550f3d7338e598c813b9580a238141328f7baaaa
         with:
           status: ${{ job.status }}
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -96,8 +96,8 @@ jobs:
 
       - name: Notify Slack
         if: ${{ !cancelled() }}
-        # 1.0.4
-        uses: cognizant-ai-lab/build-common/actions/slack-notify@f5836555ee8e04413a8f9b313a431ab36337045b
+        # 1.0.5
+        uses: cognizant-ai-lab/build-common/actions/slack-notify@550f3d7338e598c813b9580a238141328f7baaaa
         with:
           status: ${{ job.status }}
           details: ${{ steps.smoke.outputs.summary }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,8 +16,8 @@ jobs:
     if: >
       (github.event_name == 'push' && github.ref != 'refs/heads/main') ||
       (github.event_name == 'pull_request' && github.base_ref == 'main')
-    # 1.0.0
-    uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@455db3cc40e9ed6a0fb9bbaf8188888c1ae315c2
+    # 1.0.5
+    uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@550f3d7338e598c813b9580a238141328f7baaaa
     with:
       python-version: '3.12'
       lint-toolchain: 'legacy'  # flake8 only (black/isort are opt-in)


### PR DESCRIPTION
## Summary

Bumps all `cognizant-ai-lab/build-common` action references from 1.0.0/1.0.4 to 1.0.5 (`550f3d73`). This keeps the repo on the latest released version of the shared CI infrastructure.

## Review & Testing Checklist for Human

Low risk — SHA-only change in workflow files.

- [ ] Verify CI passes on this PR (the Test workflow exercises the updated quality gate)

### Notes

Affected workflows: `integration.yml`, `publish.yml`, `smoke.yml`, `tests.yml` (5 action references updated).

Link to Devin session: https://app.devin.ai/sessions/9ee54c143bc24badad28c3ab8e2f8dba
Requested by: @donn-leaf