### PR TITLE
Limiting Dynamic Class Instantiation via Environment Variable in AuthorizerFactory

### DIFF
--- a/neuro_san/internals/authorization/factory/authorizer_factory.py
+++ b/neuro_san/internals/authorization/factory/authorizer_factory.py
@@ -30,6 +30,13 @@ class AuthorizerFactory:
     Factory class for getting the appropriate Authorizer instance
     """
 
+    ALLOWED_AUTHORIZERS = {
+        "neuro_san.internals.authorization.jwt.jwt_authorizer.JwtAuthorizer",
+        "neuro_san.internals.authorization.jwt.jwt_issuer.JwtIssuer",
+        "neuro_san.internals.authorization.null.always_no_authorizer.AlwaysNoAuthorizer",
+        "neuro_san.internals.authorization.null.always_yes_authorizer.AlwaysYesAuthorizer",
+    }
+
     @staticmethod
     def create_authorizer() -> Authorizer:
         """
@@ -39,6 +46,8 @@ class AuthorizerFactory:
 
         auth_classname: str = environ.get("AGENT_AUTHORIZER")
         if auth_classname is not None and len(auth_classname) > 0:
+            if auth_classname not in AuthorizerFactory.ALLOWED_AUTHORIZERS:
+                raise ValueError(f"Unauthorized authorizer class: {auth_classname}")
             # Note that this will raise an exception if the class is not found
             authorizer = ResolverUtil.create_instance(auth_classname, "AGENT_AUTHORIZER env var", Authorizer)
         else:


### PR DESCRIPTION
## Summary

Security: Dynamic Class Instantiation via Environment Variable in AuthorizerFactory

## Problem

**Severity**: `Critical` | **File**: `neuro_san/internals/authorization/factory/authorizer_factory.py:L33`

The AuthorizerFactory.create_authorizer() method uses ResolverUtil.create_instance() to dynamically instantiate a class based on the AGENT_AUTHORIZER environment variable. This is a code injection vulnerability where an attacker who can control the environment variable can cause arbitrary code execution. The method reads the class name from an environment variable and passes it directly to a reflection-based instantiation mechanism without validation.

## Solution

Implement a whitelist of allowed authorizer class names or use a registry pattern instead of dynamic class loading from environment variables. If dynamic loading is required, validate the class name against a strict allowlist before instantiation.

## Changes

- `neuro_san/internals/authorization/factory/authorizer_factory.py` (modified)