### PR TITLE
Get observability parenting correct for langfuse (and others)

### DIFF
--- a/neuro_san/internals/run_context/langchain/core/run_context_runnable.py
+++ b/neuro_san/internals/run_context/langchain/core/run_context_runnable.py
@@ -32,6 +32,8 @@ from langchain_core.language_models.base import BaseLanguageModel
 from langchain_core.messages.ai import AIMessage
 from langchain_core.messages.base import BaseMessage
 from langchain_core.runnables.base import Runnable
+from langchain_core.runnables.config import ensure_config
+from langchain_core.runnables.config import merge_configs
 from langchain_core.runnables.utils import Input
 from langchain_core.runnables.utils import Output
 
@@ -148,8 +150,12 @@ class RunContextRunnable(NeuroSanRunnable):
             # to the logs.  Add this because some people are interested in it.
             callbacks.append(LoggingCallbackHandler(self.logger))
 
+        # Prepare our own runnable config
         runnable_config: Dict[str, Any] = self.prepare_runnable_config(callbacks=callbacks,
                                                                        recursion_limit=max_steps)
+        # Need to merge in the existing config with the one that we just created so the notion
+        # of "parent_run_id" gets preserved.
+        runnable_config = merge_configs(ensure_config(), runnable_config)
 
         # Attempt to count tokens/costs while invoking the agent.
         token_counter = LangChainTokenCounter(self.primary_llm, self.invocation_context, self.journal, self.origin)

--- a/neuro_san/internals/run_context/langchain/tracing/langfuse_tracing_context.py
+++ b/neuro_san/internals/run_context/langchain/tracing/langfuse_tracing_context.py
@@ -195,7 +195,7 @@ If you didn't mean to use langfuse for observability, you can do this:
 
         elif run_name is not None:
             # Add .agent to the end to get langfuse to display the agent icon
-            new_name: str = f"{run_name}.agent"
+            new_name: str = f"{run_name} (agent)"
             runnable_config["run_name"] = new_name
 
         request_metadata["langfuse_user_id"] = user_id

--- a/neuro_san/internals/run_context/langchain/tracing/langfuse_tracing_context.py
+++ b/neuro_san/internals/run_context/langchain/tracing/langfuse_tracing_context.py
@@ -175,13 +175,13 @@ If you didn't mean to use langfuse for observability, you can do this:
         empty: Dict[str, Any] = {}
         request_metadata: Dict[str, Any] = runnable_config.get("metadata", empty)
         user_id: str = request_metadata.get("user_id", "<Unknown>")
+        run_name = runnable_config.get("run_name")
 
         # Find the right session_id to use for the session components
         self.session_id: str = self.get_parent_session_id()
         if self.session_id is None:
 
             # Get pieces of the session_id to construct
-            run_name = runnable_config.get("run_name")
             request_id: str = request_metadata.get("request_id", "<Unknown>")
 
             # It's possible we should move the addition of hostname up to the services infra.
@@ -192,6 +192,11 @@ If you didn't mean to use langfuse for observability, you can do this:
 
             # Create a session_id for the trace.
             self.session_id: str = f"{run_name}@{request_id}@{hostname}@{now_str}"
+
+        elif run_name is not None:
+            # Add .agent to the end to get langfuse to display the agent icon
+            new_name: str = f"{run_name}.agent"
+            runnable_config["run_name"] = new_name
 
         request_metadata["langfuse_user_id"] = user_id
         request_metadata["langfuse_session_id"] = self.session_id


### PR DESCRIPTION

Get the langchain parent_run_id correct by using merge_configs() and ensure_config()  from the langchain depths in RunContextRunnable.  This was a genius insight from @Noravee 

Extra bonus: For langfuse, get the chains that delimit agent boundaries to show up with the agent icon as well.

Langfuse looks like this now:

<img width="945" height="902" alt="Screenshot 2026-05-26 at 3 36 22 PM" src="https://github.com/user-attachments/assets/cea16edc-59e1-4ccb-b722-041cfe276548" />