### PR TITLE
Nest agent_chain spans under RunContextRunnable in traces

### DIFF
--- a/neuro_san/internals/run_context/langchain/core/run_context_runnable.py
+++ b/neuro_san/internals/run_context/langchain/core/run_context_runnable.py
@@ -32,6 +32,8 @@ from langchain_core.language_models.base import BaseLanguageModel
 from langchain_core.messages.ai import AIMessage
 from langchain_core.messages.base import BaseMessage
 from langchain_core.runnables.base import Runnable
+from langchain_core.runnables.config import ensure_config
+from langchain_core.runnables.config import merge_configs
 from langchain_core.runnables.utils import Input
 from langchain_core.runnables.utils import Output
 
@@ -148,8 +150,13 @@ class RunContextRunnable(NeuroSanRunnable):
             # to the logs.  Add this because some people are interested in it.
             callbacks.append(LoggingCallbackHandler(self.logger))
 
-        runnable_config: Dict[str, Any] = self.prepare_runnable_config(callbacks=callbacks,
-                                                                       recursion_limit=max_steps)
+        # Merge with the inherited config from var_child_runnable_config so the parent
+        # RunContextRunnable's AsyncCallbackManager (and its parent_run_id) is preserved.
+        # Without this, our local callbacks list would clobber the inherited manager in
+        # ensure_config(), detaching the agent_chain's spans from the parent trace.
+        local_config: Dict[str, Any] = self.prepare_runnable_config(callbacks=callbacks,
+                                                                    recursion_limit=max_steps)
+        runnable_config: Dict[str, Any] = merge_configs(ensure_config(), local_config)
 
         # Attempt to count tokens/costs while invoking the agent.
         token_counter = LangChainTokenCounter(self.primary_llm, self.invocation_context, self.journal, self.origin)

--- a/neuro_san/internals/run_context/langchain/tracing/neuro_san_runnable.py
+++ b/neuro_san/internals/run_context/langchain/tracing/neuro_san_runnable.py
@@ -96,10 +96,13 @@ class NeuroSanRunnable(RunnablePassthrough, RunTarget):
         **kwargs: Any | None,
     ) -> Other:
 
-        # Called by langchain infrastruture when a chain is invoked.
-        # Calling the super here means that run_it() below will be called
-        # as part of the RunnablePassthrough infrastructure.
-        _: Other = await super().ainvoke(input, config, **kwargs)
+        # Run afunc (run_it) inside _acall_with_config so it gets a real run_manager.
+        # RunnablePassthrough.ainvoke invokes afunc raw and only wraps a no-op identity
+        # in _acall_with_config, which leaves child ainvoke calls inside run_it() (the
+        # agent_chain, etc.) without a parent_run_id pointing at this runnable. Wrapping
+        # afunc directly collapses the empty wrapper span and lets children nest under
+        # this runnable in the trace.
+        await self._acall_with_config(self.afunc, input, config, **kwargs)
 
         # Collect intercepted outputs to report back to the tracing infrastructure.
         outputs: Dict[str, Any] = self.get_intercepted_outputs()


### PR DESCRIPTION
## Issue
`NeuroSanRunnable` inherits from `RunnablePassthrough`, whose `ainvoke` calls `afunc=run_it` raw and then wraps a no-op `aidentity` in `_acall_with_config`. That meant the span named `"RunContextRunnable"` wrapped the identity function (~0ms, empty), while `run_it` itself ran outside any span this runnable owned. As a result, child spans created inside `run_it` (notably the `agent_chain` / `LangGraph`) inherited `parent_run_id` from the surrounding `RunnableSequence` and showed up in the trace as siblings of `RunContextRunnable` rather than its children.

## Fix
Override `ainvoke` to call `_acall_with_config(self.afunc, ...)` directly so `run_it` itself runs inside the wrap. `run_it` now gets a real `run_manager`, `var_child_runnable_config` carries this runnable's `parent_run_id`, and `agent_chain` spans nest under `RunContextRunnable` in the trace.

Note that there is no functional change to neuro-san's agent execution — purely a tracing
fix. `run_it` is invoked with the same arguments, returns the same value, and journaling / token counting are unaffected.
