### PR TITLE
Fix Claude Opus 4.7 temperature 400 error

### DIFF
--- a/neuro_san/internals/interfaces/context_type_llm_factory.py
+++ b/neuro_san/internals/interfaces/context_type_llm_factory.py
@@ -31,7 +31,7 @@ class ContextTypeLlmFactory:
         "temperature"               A float "temperature" value with which to
                                     initialize the chat model.  In general,
                                     higher temperatures yield more random results.
-                                    Default if not specified is 0.7
+                                    Default if not specified is the provider's default.
 
         "prompt_token_fraction"     The fraction of total tokens (not necessarily words
                                     or letters) to use for a prompt. Each model_name

--- a/neuro_san/internals/run_context/langchain/llms/anthropic_llm_policy.py
+++ b/neuro_san/internals/run_context/langchain/llms/anthropic_llm_policy.py
@@ -53,6 +53,9 @@ class AnthropicLlmPolicy(LlmPolicy):
         llm = ChatAnthropic(
             model_name=model_name,
             max_tokens=config.get("max_tokens"),  # This is always for output
+            temperature=config.get("temperature"),
+            top_k=config.get("top_k"),
+            top_p=config.get("top_p"),
             default_request_timeout=config.get("default_request_timeout"),
             max_retries=config.get("max_retries"),
             stop_sequences=config.get("stop_sequences"),

--- a/neuro_san/internals/run_context/langchain/llms/anthropic_llm_policy.py
+++ b/neuro_san/internals/run_context/langchain/llms/anthropic_llm_policy.py
@@ -53,9 +53,6 @@ class AnthropicLlmPolicy(LlmPolicy):
         llm = ChatAnthropic(
             model_name=model_name,
             max_tokens=config.get("max_tokens"),  # This is always for output
-            temperature=config.get("temperature"),
-            top_k=config.get("top_k"),
-            top_p=config.get("top_p"),
             default_request_timeout=config.get("default_request_timeout"),
             max_retries=config.get("max_retries"),
             stop_sequences=config.get("stop_sequences"),

--- a/neuro_san/internals/run_context/langchain/llms/default_llm_factory.py
+++ b/neuro_san/internals/run_context/langchain/llms/default_llm_factory.py
@@ -63,7 +63,7 @@ class DefaultLlmFactory(ContextTypeLlmFactory, LangChainLlmFactory):
         "temperature"               A float "temperature" value with which to
                                     initialize the chat model.  In general,
                                     higher temperatures yield more random results.
-                                    Default if not specified is 0.7
+                                    Default if not specified is the provider's default.
 
         "prompt_token_fraction"     The fraction of total tokens (not necessarily words
                                     or letters) to use for a prompt. Each model_name

--- a/neuro_san/internals/run_context/langchain/llms/default_llm_factory.py
+++ b/neuro_san/internals/run_context/langchain/llms/default_llm_factory.py
@@ -257,11 +257,6 @@ class DefaultLlmFactory(ContextTypeLlmFactory, LangChainLlmFactory):
         full_config["class"] = chat_class_name
         full_config["model_name"] = llm_entry.get("use_model_name", use_model_name)
 
-        # Null out any parameters that the model's provider has deprecated.
-        deprecated_params: List[str] = llm_entry.get("deprecated_params", [])
-        for param in deprecated_params:
-            full_config[param] = None
-
         # Get any required api keys into the full config.
         full_config = self.replace_any_required_api_keys(full_config, sly_data)
         if full_config is not None and not isinstance(full_config, set):

--- a/neuro_san/internals/run_context/langchain/llms/default_llm_factory.py
+++ b/neuro_san/internals/run_context/langchain/llms/default_llm_factory.py
@@ -257,6 +257,11 @@ class DefaultLlmFactory(ContextTypeLlmFactory, LangChainLlmFactory):
         full_config["class"] = chat_class_name
         full_config["model_name"] = llm_entry.get("use_model_name", use_model_name)
 
+        # Null out any parameters that the model's provider has deprecated.
+        deprecated_params: List[str] = llm_entry.get("deprecated_params", [])
+        for param in deprecated_params:
+            full_config[param] = None
+
         # Get any required api keys into the full config.
         full_config = self.replace_any_required_api_keys(full_config, sly_data)
         if full_config is not None and not isinstance(full_config, set):

--- a/neuro_san/internals/run_context/langchain/llms/default_llm_info.hocon
+++ b/neuro_san/internals/run_context/langchain/llms/default_llm_info.hocon
@@ -600,10 +600,6 @@
         # https://platform.claude.com/docs/en/about-claude/pricing
         "price_per_1k_input_tokens": 0.005,
         "price_per_1k_output_tokens": 0.025,
-        # The Anthropic API returns a 400 error when temperature, top_k, or top_p is sent
-        # for this model. temperature is actively injected by default_config (0.7); top_k
-        # and top_p are already null but included here as a safety measure.
-        "deprecated_params": ["temperature", "top_k", "top_p"],
     }
 
 
@@ -1080,9 +1076,8 @@
                 # Note that we can only supply arguments that are "Just Data" in nature.
                 # See https://python.langchain.com/api_reference/anthropic/chat_models/langchain_anthropic.chat_models.ChatAnthropic.html#langchain_anthropic.chat_models.ChatAnthropic
                 "max_tokens": null,
-                "temperature": null,
-                "top_k": null,
-                "top_p": null,
+                # temperature, top_k, and top_p are not passed to ChatAnthropic;
+                # newer models (Opus 4.7+) reject them outright with a 400 error.
                 "default_request_timeout": null,
                 "max_retries": 2,
                 "stop_sequences": null,

--- a/neuro_san/internals/run_context/langchain/llms/default_llm_info.hocon
+++ b/neuro_san/internals/run_context/langchain/llms/default_llm_info.hocon
@@ -601,7 +601,8 @@
         "price_per_1k_input_tokens": 0.005,
         "price_per_1k_output_tokens": 0.025,
         # The Anthropic API returns a 400 error when temperature, top_k, or top_p is sent
-        # for this model.
+        # for this model. temperature is actively injected by default_config (0.7); top_k
+        # and top_p are already null but included here as a safety measure.
         "deprecated_params": ["temperature", "top_k", "top_p"],
     }
 

--- a/neuro_san/internals/run_context/langchain/llms/default_llm_info.hocon
+++ b/neuro_san/internals/run_context/langchain/llms/default_llm_info.hocon
@@ -600,6 +600,9 @@
         # https://platform.claude.com/docs/en/about-claude/pricing
         "price_per_1k_input_tokens": 0.005,
         "price_per_1k_output_tokens": 0.025,
+        # The Anthropic API returns a 400 error when temperature, top_k, or top_p is sent
+        # for this model.
+        "deprecated_params": ["temperature", "top_k", "top_p"],
     }
 
 

--- a/neuro_san/internals/run_context/langchain/llms/default_llm_info.hocon
+++ b/neuro_san/internals/run_context/langchain/llms/default_llm_info.hocon
@@ -1076,8 +1076,9 @@
                 # Note that we can only supply arguments that are "Just Data" in nature.
                 # See https://python.langchain.com/api_reference/anthropic/chat_models/langchain_anthropic.chat_models.ChatAnthropic.html#langchain_anthropic.chat_models.ChatAnthropic
                 "max_tokens": null,
-                # temperature, top_k, and top_p are not passed to ChatAnthropic;
-                # newer models (Opus 4.7+) reject them outright with a 400 error.
+                "temperature": null,
+                "top_k": null,
+                "top_p": null,
                 "default_request_timeout": null,
                 "max_retries": 2,
                 "stop_sequences": null,
@@ -1258,9 +1259,10 @@
 
         "model_name": "gpt-5.2",           # The string name of the default model to use.
 
-        "temperature": 0.7,                 # The default LLM temperature (randomness) to use.
+        "temperature": null,                 # The default LLM temperature (randomness) to use.
                                             # Values are floats between 0.0 (least random) to
                                             # 1.0 (most random).
+                                            # null means use the provider's default.
 
         "prompt_token_fraction": 1.0,       # The fraction of total tokens (not necessarily words
                                             # or letters) to use for a prompt. Each model_name

--- a/neuro_san/internals/run_context/langchain/llms/default_llm_info.hocon
+++ b/neuro_san/internals/run_context/langchain/llms/default_llm_info.hocon
@@ -1259,11 +1259,6 @@
 
         "model_name": "gpt-5.2",           # The string name of the default model to use.
 
-        "temperature": null,                 # The default LLM temperature (randomness) to use.
-                                            # Values are floats between 0.0 (least random) to
-                                            # 1.0 (most random).
-                                            # null means use the provider's default.
-
         "prompt_token_fraction": 1.0,       # The fraction of total tokens (not necessarily words
                                             # or letters) to use for a prompt. Each model_name
                                             # has a documented number of max_tokens it can handle

--- a/neuro_san/internals/run_context/langchain/llms/langchain_llm_factory.py
+++ b/neuro_san/internals/run_context/langchain/llms/langchain_llm_factory.py
@@ -38,7 +38,7 @@ class LangChainLlmFactory(EnvironmentConfiguration):
         "temperature"               A float "temperature" value with which to
                                     initialize the chat model.  In general,
                                     higher temperatures yield more random results.
-                                    Default if not specified is 0.7
+                                    Default if not specified is the provider's default.
 
         "max_tokens"                The maximum number of tokens to use in
                                     get_max_prompt_tokens(). By default this comes from

--- a/neuro_san/internals/run_context/langchain/llms/standard_langchain_llm_factory.py
+++ b/neuro_san/internals/run_context/langchain/llms/standard_langchain_llm_factory.py
@@ -45,7 +45,7 @@ class StandardLangChainLlmFactory(LangChainLlmFactory):
         "temperature"               A float "temperature" value with which to
                                     initialize the chat model.  In general,
                                     higher temperatures yield more random results.
-                                    Default if not specified is 0.7
+                                    Default if not specified is the provider's default.
 
         "max_tokens"                The maximum number of tokens to use in
                                     get_max_prompt_tokens(). By default, this comes from

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -2,7 +2,7 @@
 # necessary for operation to minimize the size of containers
 
 # Optional LLM Access
-langchain-anthropic>=1.4.1,<2.0
+langchain-anthropic>=1.4.3,<2.0
 langchain-aws>=1.0.0,<2.0
 langchain-google-genai>=4.1.2,<5.0
 langchain-nvidia-ai-endpoints>=1.0.0,<2.0

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -2,7 +2,7 @@
 # necessary for operation to minimize the size of containers
 
 # Optional LLM Access
-langchain-anthropic>=1.3.0,<2.0
+langchain-anthropic>=1.4.1,<2.0
 langchain-aws>=1.0.0,<2.0
 langchain-google-genai>=4.1.2,<5.0
 langchain-nvidia-ai-endpoints>=1.0.0,<2.0


### PR DESCRIPTION
## Summary

Claude Opus 4.7 rejects `temperature`, `top_k`, and `top_p` parameters with a 400 error. The Python `langchain-anthropic` SDK does not strip these automatically (unlike the TypeScript version), so any value passed to the `ChatAnthropic` constructor is forwarded to the API.

This PR:
1. Sets `"temperature": null` in the global `default_config` so it no longer injects `0.7` into every model's config.
2. Removes `temperature`, `top_k`, and `top_p` from the `ChatAnthropic` constructor in `anthropic_llm_policy.py` (newer Anthropic models reject them).
3. Bumps `langchain-anthropic` minimum to `>=1.4.3` for full Opus 4.7 feature support.
4. Updates doc comments that referenced the old `0.7` default.