### PR TITLE
968 replace psutil dependency with service resourcespy in load test

### DIFF
--- a/neuro_san/service/utils/service_resources.py
+++ b/neuro_san/service/utils/service_resources.py
@@ -402,6 +402,7 @@ class ServiceResources:
         cpu_load = cls._get_process(pid).cpu_percent(interval=0.1)
         cpu_load = min(cpu_load / denom, 100.0)
         return cpu_load
+
     @classmethod
     def get_thread_count(cls, pid: Optional[int] = None) -> int:
         """

--- a/neuro_san/service/utils/service_resources.py
+++ b/neuro_san/service/utils/service_resources.py
@@ -48,8 +48,9 @@ class ServiceResources:
     on_macos: bool = sys.platform.startswith("darwin")
     on_windows: bool = sys.platform.startswith("win")
 
-    # High watermark for memory usage in bytes since process start (for logging purposes)
-    max_memory_used_bytes: float = 0.0
+    # High watermark for memory usage in bytes since process start (for logging purposes).
+    # Keyed by PID; None key represents the current process.
+    _max_memory_used_bytes: Dict[Optional[int], float] = {}
 
     # ---------------------------
     # POSIX helpers (Linux/macOS)
@@ -60,15 +61,20 @@ class ServiceResources:
         Iterator over numeric FDs for a process (Unix/macOS).
         :param pid: target process ID, or None for the current process.
         """
-        # When monitoring an external process, read its /proc/<pid>/fd
-        if pid is not None:
+        if pid is not None and cls.on_unix:
+            # Linux: external process FDs are visible via /proc/<pid>/fd
             fd_dir = f"/proc/{pid}/fd"
+        elif pid is not None:
+            # macOS: /dev/fd only lists the current process's FDs;
+            # there is no /proc/<pid>/fd equivalent.
+            # Callers should fall back to psutil.Process(pid).num_fds().
+            return
         elif cls.on_unix:
-            # /proc/self/fd is a Linux procfs directory listing all open FDs
-            # for the calling process. See: https://man7.org/linux/man-pages/man5/proc.5.html
+            # Linux: /proc/self/fd is a procfs symlink to the current process's FDs.
+            # See: https://man7.org/linux/man-pages/man5/proc.5.html
             fd_dir = "/proc/self/fd"
         else:
-            # /dev/fd is the macOS equivalent of /proc/self/fd.
+            # macOS: /dev/fd lists the current process's open file descriptors.
             # See: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man4/fd.4.html
             fd_dir = "/dev/fd"
         try:
@@ -89,8 +95,25 @@ class ServiceResources:
         Returns counts by FD kind on Unix/macOS:
           regular_file, socket_inet, socket_unix, fifo_pipe, other, total
         :param pid: target process ID, or None for the current process.
+
+        For external PIDs on macOS, per-FD classification is not possible
+        (no /proc filesystem). Falls back to psutil.Process(pid).num_fds()
+        for a total count only.
         """
         p = cls._get_process(pid)
+
+        # On macOS with an external PID, we cannot enumerate individual FDs.
+        # Fall back to psutil for a simple total count.
+        if pid is not None and not cls.on_unix:
+            fd_dict: Dict[str, int] = {
+                "regular_file": 0,
+                "socket_inet": 0,
+                "socket_unix": 0,
+                "fifo_pipe": 0,
+                "other": 0,
+                "total": p.num_fds(),
+            }
+            return fd_dict
 
         # Maps of socket FDs to distinguish AF_INET vs AF_UNIX
         inet_fds = {c.fd for c in p.connections(kind="inet")}  # tcp/udp
@@ -101,7 +124,12 @@ class ServiceResources:
 
         for fd in cls._iter_fds_posix(pid=pid) or ():
             try:
-                st = os.fstat(fd)
+                if pid is not None:
+                    # For external processes, stat via /proc/<pid>/fd/<fd> path
+                    # because os.fstat(fd) would stat this process's own FD table.
+                    st = os.stat(f"/proc/{pid}/fd/{fd}")
+                else:
+                    st = os.fstat(fd)
             except OSError:
                 continue  # fd may have just closed
             mode = st.st_mode
@@ -207,11 +235,18 @@ class ServiceResources:
         """
         Returns (counts_dict, soft_limit, hard_limit).
 
-        * Unix/macOS: soft/hard are RLIMIT_NOFILE integers.
+        * Unix/macOS: soft/hard are RLIMIT_NOFILE integers for the current process.
         * Windows:    returns (counts_dict, None, None) since RLIMIT_NOFILE does not apply.
+        * External PID: returns (counts_dict, None, None) because resource.getrlimit
+          only reads the current process's limits, not the target's.
         :param pid: target process ID, or None for the current process.
         """
         counts = cls.classify_fds(pid=pid)
+
+        # resource.getrlimit returns limits for the current process only.
+        # For external PIDs, return None to avoid reporting misleading values.
+        if pid is not None:
+            return counts, None, None
 
         if (cls.on_unix or cls.on_macos) and resource is not None:
             soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
@@ -326,14 +361,18 @@ class ServiceResources:
         """
         Get the current memory usage of the process in megabytes
         and maximum memory used since process start, and update the maximum if current usage is higher.
+        High-water mark is tracked per PID to avoid cross-contamination
+        when monitoring multiple processes.
         :param pid: target process ID, or None for the current process.
         :return: tuple of (current_memory_used_mbytes, max_memory_used_mbytes)
         """
         p = cls._get_process(pid)
         mem_info = p.memory_info()
-        cls.max_memory_used_bytes = max(cls.max_memory_used_bytes, mem_info.rss)
+        prev_max = cls._max_memory_used_bytes.get(pid, 0.0)
+        new_max = max(prev_max, mem_info.rss)
+        cls._max_memory_used_bytes[pid] = new_max
         # Return memory sizes in megabytes
-        return mem_info.rss / (1024 * 1024), cls.max_memory_used_bytes / (1024 * 1024)
+        return mem_info.rss / (1024 * 1024), new_max / (1024 * 1024)
 
     @classmethod
     def get_cpu_load(cls, pid: Optional[int] = None) -> float:

--- a/neuro_san/service/utils/service_resources.py
+++ b/neuro_san/service/utils/service_resources.py
@@ -162,6 +162,11 @@ class ServiceResources:
     # ---------------------------
     # Public API (cross-platform)
     # ---------------------------
+    @staticmethod
+    def _get_process(pid: Optional[int] = None) -> psutil.Process:
+        """Return a psutil.Process for the given PID, or the current process."""
+        return psutil.Process(pid) if pid is not None else psutil.Process()
+    
     @classmethod
     def classify_fds(cls) -> Dict[str, int]:
         """

--- a/neuro_san/service/utils/service_resources.py
+++ b/neuro_san/service/utils/service_resources.py
@@ -49,8 +49,9 @@ class ServiceResources:
     on_windows: bool = sys.platform.startswith("win")
 
     # High watermark for memory usage in bytes since process start (for logging purposes).
-    # Keyed by PID; None key represents the current process.
-    _max_memory_used_bytes: Dict[Optional[int], float] = {}
+    # Keyed by (PID, create_time) to handle PID reuse correctly.
+    # None key represents the current process.
+    _max_memory_used_bytes: Dict[Optional[Tuple[int, float]], float] = {}
 
     # ---------------------------
     # POSIX helpers (Linux/macOS)
@@ -362,16 +363,18 @@ class ServiceResources:
         """
         Get the current memory usage of the process in megabytes
         and maximum memory used since process start, and update the maximum if current usage is higher.
-        High-water mark is tracked per PID to avoid cross-contamination
-        when monitoring multiple processes.
+        High-water mark is tracked per (PID, create_time) to handle PID reuse
+        and avoid cross-contamination when monitoring multiple processes.
         :param pid: target process ID, or None for the current process.
         :return: tuple of (current_memory_used_mbytes, max_memory_used_mbytes)
         """
         p = cls._get_process(pid)
         mem_info = p.memory_info()
-        prev_max = cls._max_memory_used_bytes.get(pid, 0.0)
+        # Key by (pid, create_time) so a recycled PID starts fresh.
+        key = (p.pid, p.create_time()) if pid is not None else None
+        prev_max = cls._max_memory_used_bytes.get(key, 0.0)
         new_max = max(prev_max, mem_info.rss)
-        cls._max_memory_used_bytes[pid] = new_max
+        cls._max_memory_used_bytes[key] = new_max
         # Return memory sizes in megabytes
         return mem_info.rss / (1024 * 1024), new_max / (1024 * 1024)
 

--- a/neuro_san/service/utils/service_resources.py
+++ b/neuro_san/service/utils/service_resources.py
@@ -174,7 +174,7 @@ class ServiceResources:
         Returns a simplified breakdown on Windows using psutil:
 
           regular_file   -> len(Process.open_files())
-          socket_inet    -> len(Process.connections(kind="inet"))
+          socket_inet    -> len(Process.net_connections(kind="inet"))
           other_handles  -> num_handles - above_known
           total_handles  -> Process.num_handles()
 
@@ -191,7 +191,12 @@ class ServiceResources:
             total_handles = 0
         files = len(p.open_files())
         # TCP/UDP INET sockets for this process
-        inet_conns = p.connections(kind="inet")
+        # Use net_connections() for psutil>=7.0.0 compatibility;
+        # fall back to deprecated connections() for older versions.
+        try:
+            inet_conns = p.net_connections(kind="inet")
+        except (AttributeError, Exception):  # pylint: disable=broad-exception-caught
+            inet_conns = p.connections(kind="inet")
         socket_inet = len(inet_conns)
 
         # We can't see AF_UNIX on Windows (not applicable), FIFO pipes classification requires WinAPI.

--- a/neuro_san/service/utils/service_resources.py
+++ b/neuro_san/service/utils/service_resources.py
@@ -64,8 +64,12 @@ class ServiceResources:
         if pid is not None:
             fd_dir = f"/proc/{pid}/fd"
         elif cls.on_unix:
+            # /proc/self/fd is a Linux procfs directory listing all open FDs
+            # for the calling process. See: https://man7.org/linux/man-pages/man5/proc.5.html
             fd_dir = "/proc/self/fd"
         else:
+            # /dev/fd is the macOS equivalent of /proc/self/fd.
+            # See: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man4/fd.4.html
             fd_dir = "/dev/fd"
         try:
             names = os.listdir(fd_dir)

--- a/neuro_san/service/utils/service_resources.py
+++ b/neuro_san/service/utils/service_resources.py
@@ -62,6 +62,10 @@ class ServiceResources:
         Iterator over numeric FDs for a process (Unix/macOS).
         :param pid: target process ID, or None for the current process.
         """
+        if cls.on_windows:
+            # Windows does not have /dev/fd or /proc; FD enumeration is
+            # handled by _classify_handles_windows via the classify_fds router.
+            return
         if pid is not None and cls.on_unix:
             # Linux: external process FDs are visible via /proc/<pid>/fd
             fd_dir = f"/proc/{pid}/fd"

--- a/neuro_san/service/utils/service_resources.py
+++ b/neuro_san/service/utils/service_resources.py
@@ -389,15 +389,19 @@ class ServiceResources:
         """
         target_pid = pid if pid is not None else 0
         if hasattr(os, "sched_getaffinity"):
-            # sched_getaffinity(pid) returns the set of CPUs the process is allowed
-            # to run on. Passing 0 means the current process.
-            denom = len(os.sched_getaffinity(target_pid))
+            try:
+                # sched_getaffinity(pid) returns the set of CPUs the process is allowed
+                # to run on. Passing 0 means the current process.
+                denom = len(os.sched_getaffinity(target_pid))
+            except (ProcessLookupError, PermissionError, OSError):
+                # Target process may have exited or be inaccessible.
+                # Fall back to system-wide CPU count.
+                denom = max(psutil.cpu_count(), 1)
         else:
             denom = max(psutil.cpu_count(), 1)
         cpu_load = cls._get_process(pid).cpu_percent(interval=0.1)
         cpu_load = min(cpu_load / denom, 100.0)
         return cpu_load
-
     @classmethod
     def get_thread_count(cls, pid: Optional[int] = None) -> int:
         """

--- a/neuro_san/service/utils/service_resources.py
+++ b/neuro_san/service/utils/service_resources.py
@@ -66,8 +66,8 @@ class ServiceResources:
             # Linux: external process FDs are visible via /proc/<pid>/fd
             fd_dir = f"/proc/{pid}/fd"
         elif pid is not None:
-            # macOS: /dev/fd only lists the current process's FDs;
-            # there is no /proc/<pid>/fd equivalent.
+            # Non-Linux (macOS, BSD, etc.): /dev/fd only lists the current
+            # process's FDs; there is no /proc/<pid>/fd equivalent.
             # Callers should fall back to psutil.Process(pid).num_fds().
             return
         elif cls.on_unix:
@@ -75,7 +75,9 @@ class ServiceResources:
             # See: https://man7.org/linux/man-pages/man5/proc.5.html
             fd_dir = "/proc/self/fd"
         else:
-            # macOS: /dev/fd lists the current process's open file descriptors.
+            # Non-Linux POSIX (macOS, BSD, etc.): /dev/fd lists the current
+            # process's open file descriptors. On unsupported platforms, the
+            # os.listdir below will fail and the except clause returns gracefully.
             # See: https://developer.apple.com/library/archive/documentation/
             #   System/Conceptual/ManPages_iPhoneOS/man4/fd.4.html
             fd_dir = "/dev/fd"

--- a/neuro_san/service/utils/service_resources.py
+++ b/neuro_san/service/utils/service_resources.py
@@ -55,11 +55,18 @@ class ServiceResources:
     # POSIX helpers (Linux/macOS)
     # ---------------------------
     @classmethod
-    def _iter_fds_posix(cls):
+    def _iter_fds_posix(cls, pid: Optional[int] = None):
         """
-        Iterator over numeric FDs for the current process (Unix/macOS).
+        Iterator over numeric FDs for a process (Unix/macOS).
+        :param pid: target process ID, or None for the current process.
         """
-        fd_dir = "/proc/self/fd" if cls.on_unix else "/dev/fd"
+        # When monitoring an external process, read its /proc/<pid>/fd
+        if pid is not None:
+            fd_dir = f"/proc/{pid}/fd"
+        elif cls.on_unix:
+            fd_dir = "/proc/self/fd"
+        else:
+            fd_dir = "/dev/fd"
         try:
             names = os.listdir(fd_dir)
         except Exception:  # pylint: disable=broad-exception-caught
@@ -73,12 +80,13 @@ class ServiceResources:
             yield fd
 
     @classmethod
-    def _classify_fds_posix(cls) -> Dict[str, int]:
+    def _classify_fds_posix(cls, pid: Optional[int] = None) -> Dict[str, int]:
         """
         Returns counts by FD kind on Unix/macOS:
           regular_file, socket_inet, socket_unix, fifo_pipe, other, total
+        :param pid: target process ID, or None for the current process.
         """
-        p = psutil.Process()
+        p = cls._get_process(pid)
 
         # Maps of socket FDs to distinguish AF_INET vs AF_UNIX
         inet_fds = {c.fd for c in p.connections(kind="inet")}  # tcp/udp
@@ -87,7 +95,7 @@ class ServiceResources:
         fd_dict: Dict[str, int] = {}
         total_fds = 0
 
-        for fd in cls._iter_fds_posix() or ():
+        for fd in cls._iter_fds_posix(pid=pid) or ():
             try:
                 st = os.fstat(fd)
             except OSError:
@@ -121,7 +129,7 @@ class ServiceResources:
     # Windows helpers
     # ---------------------------
     @classmethod
-    def _classify_handles_windows(cls) -> Dict[str, int]:
+    def _classify_handles_windows(cls, pid: Optional[int] = None) -> Dict[str, int]:
         """
         Returns a simplified breakdown on Windows using psutil:
 
@@ -133,8 +141,9 @@ class ServiceResources:
         Notes:
           * Windows does not expose POSIX FDs; we count OS handles instead.
           * We cannot reliably enumerate every handle type without native WinAPI.
+        :param pid: target process ID, or None for the current process.
         """
-        p = psutil.Process()
+        p = cls._get_process(pid)
 
         try:
             total_handles = p.num_handles()  # all handles owned by this process
@@ -164,36 +173,41 @@ class ServiceResources:
     # ---------------------------
     @staticmethod
     def _get_process(pid: Optional[int] = None) -> psutil.Process:
-        """Return a psutil.Process for the given PID, or the current process."""
+        """
+        Return a psutil.Process for the given PID, or the current process.
+        :param pid: target process ID, or None for the current process.
+        """
         return psutil.Process(pid) if pid is not None else psutil.Process()
-    
+
     @classmethod
-    def classify_fds(cls) -> Dict[str, int]:
+    def classify_fds(cls, pid: Optional[int] = None) -> Dict[str, int]:
         """
         Cross-platform classification:
           * Unix/macOS: returns per-FD kinds + "total"
           * Windows:    returns per-handle kinds + "total_handles"
+        :param pid: target process ID, or None for the current process.
         """
         if cls.on_unix or cls.on_macos:
-            return cls._classify_fds_posix()
+            return cls._classify_fds_posix(pid=pid)
         if cls.on_windows:
-            return cls._classify_handles_windows()
+            return cls._classify_handles_windows(pid=pid)
         # Fallback: try POSIX path; if not, return minimal info
         try:
-            return cls._classify_fds_posix()
+            return cls._classify_fds_posix(pid=pid)
         except Exception:  # pylint: disable=broad-exception-caught
-            p = psutil.Process()
+            p = cls._get_process(pid)
             return {"total_unknown": getattr(p, "num_fds", lambda: 0)()}
 
     @classmethod
-    def get_fd_usage(cls) -> Tuple[Dict[str, int], Optional[int], Optional[int]]:
+    def get_fd_usage(cls, pid: Optional[int] = None) -> Tuple[Dict[str, int], Optional[int], Optional[int]]:
         """
         Returns (counts_dict, soft_limit, hard_limit).
 
         * Unix/macOS: soft/hard are RLIMIT_NOFILE integers.
         * Windows:    returns (counts_dict, None, None) since RLIMIT_NOFILE does not apply.
+        :param pid: target process ID, or None for the current process.
         """
-        counts = cls.classify_fds()
+        counts = cls.classify_fds(pid=pid)
 
         if (cls.on_unix or cls.on_macos) and resource is not None:
             soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
@@ -202,14 +216,15 @@ class ServiceResources:
         # Windows / unknown
         return counts, None, None
 
-    # --- internal helper: get this process's TCP connections, psutil-6-safe ---
+    # --- internal helper: get a process's TCP connections, psutil-6-safe ---
     @classmethod
-    def _proc_tcp_conns(cls) -> List[Any]:
+    def _proc_tcp_conns(cls, pid: Optional[int] = None) -> List[Any]:
         """
-        Return TCP connections for the current process, with a fallback that
+        Return TCP connections for a process, with a fallback that
         is compatible with psutil 6.x where Process.connections may be deprecated.
+        :param pid: target process ID, or None for the current process.
         """
-        p = psutil.Process()
+        p = cls._get_process(pid)
         try:
             # Works on psutil <= 5.x and (for now) also on many 6.x installs
             return p.connections(kind="tcp")
@@ -258,10 +273,11 @@ class ServiceResources:
         return result
 
     @classmethod
-    def classify_sockets(cls, server_port: int) -> Dict[str, Any]:
+    def classify_sockets(cls, server_port: int, pid: Optional[int] = None) -> Dict[str, Any]:
         """
         Classify active sockets bound to the given server port.
         :param server_port: server port
+        :param pid: target process ID, or None for the current process.
         :return: dictionary with keys:
            "inbound_listen": number of inbound listening sockets;
            "inbound_accepted": number of accepted inbound connections;
@@ -272,7 +288,7 @@ class ServiceResources:
           * Dual-stack listeners typically appear as separate IPv4/IPv6 LISTEN sockets.
           * Multi-process servers (Tornado server.start(N)) must call this in each worker PID.
         """
-        tcp = cls._proc_tcp_conns()
+        tcp = cls._proc_tcp_conns(pid=pid)
 
         inbound_listen = 0
         inbound_accepted_list: list = []
@@ -302,22 +318,24 @@ class ServiceResources:
         }
 
     @classmethod
-    def get_memory_used_mbytes(cls) -> Tuple[float, float]:
+    def get_memory_used_mbytes(cls, pid: Optional[int] = None) -> Tuple[float, float]:
         """
         Get the current memory usage of the process in megabytes
         and maximum memory used since process start, and update the maximum if current usage is higher.
+        :param pid: target process ID, or None for the current process.
         :return: tuple of (current_memory_used_mbytes, max_memory_used_mbytes)
         """
-        p = psutil.Process()
+        p = cls._get_process(pid)
         mem_info = p.memory_info()
         cls.max_memory_used_bytes = max(cls.max_memory_used_bytes, mem_info.rss)
         # Return memory sizes in megabytes
         return mem_info.rss / (1024 * 1024), cls.max_memory_used_bytes / (1024 * 1024)
 
     @classmethod
-    def get_cpu_load(cls) -> float:
+    def get_cpu_load(cls, pid: Optional[int] = None) -> float:
         """
         Get the current CPU load percentage of the process.
+        :param pid: target process ID, or None for the current process.
         :return: CPU load percentage over a short interval (e.g., 0.1 seconds)
                  in the range [0.0, 100.0]
         """
@@ -327,21 +345,22 @@ class ServiceResources:
             denom = len(os.sched_getaffinity(0))
         else:
             denom = max(psutil.cpu_count(), 1)
-        cpu_load = psutil.Process().cpu_percent(interval=0.1)
+        cpu_load = cls._get_process(pid).cpu_percent(interval=0.1)
         cpu_load = min(cpu_load / denom, 100.0)
         return cpu_load
 
     @classmethod
-    def get_snapshot_dict(cls, server_port: int) -> Dict[str, Any]:
+    def get_snapshot_dict(cls, server_port: int, pid: Optional[int] = None) -> Dict[str, Any]:
         """
         Get a snapshot of current resource usage for logging or metrics.
         :param server_port: server port to classify sockets
+        :param pid: target process ID, or None for the current process.
         :return: dictionary with resource usage information
         """
         # Get used file descriptors:
-        fd_usage, soft_limit, hard_limit = cls.get_fd_usage()
-        mem_used, mem_max = cls.get_memory_used_mbytes()
-        cpu_load: float = cls.get_cpu_load()
+        fd_usage, soft_limit, hard_limit = cls.get_fd_usage(pid=pid)
+        mem_used, mem_max = cls.get_memory_used_mbytes(pid=pid)
+        cpu_load: float = cls.get_cpu_load(pid=pid)
         snapshot: Dict[str, Any] = {
             "fd_usage": fd_usage,
             "fd_limits": {
@@ -354,6 +373,6 @@ class ServiceResources:
             },
             # Round CPU load to 3 decimal places for more compact output
             "cpu_load": round(cpu_load, 3),
-            "socket_usage": cls.classify_sockets(server_port)
+            "socket_usage": cls.classify_sockets(server_port, pid=pid)
         }
         return snapshot

--- a/neuro_san/service/utils/service_resources.py
+++ b/neuro_san/service/utils/service_resources.py
@@ -124,8 +124,14 @@ class ServiceResources:
             return fd_dict
 
         # Maps of socket FDs to distinguish AF_INET vs AF_UNIX
-        inet_fds = {c.fd for c in p.connections(kind="inet")}  # tcp/udp
-        unix_fds = {c.fd for c in p.connections(kind="unix")}  # unix sockets
+        try:
+            inet_fds = {c.fd for c in p.net_connections(kind="inet")}
+        except (AttributeError, Exception):  # pylint: disable=broad-exception-caught
+            inet_fds = {c.fd for c in p.connections(kind="inet")}
+        try:
+            unix_fds = {c.fd for c in p.net_connections(kind="unix")}
+        except (AttributeError, Exception):  # pylint: disable=broad-exception-caught
+            unix_fds = {c.fd for c in p.connections(kind="unix")}
 
         fd_dict: Dict[str, int] = {}
         total_fds = 0

--- a/neuro_san/service/utils/service_resources.py
+++ b/neuro_san/service/utils/service_resources.py
@@ -350,6 +350,36 @@ class ServiceResources:
         return cpu_load
 
     @classmethod
+    def get_thread_count(cls, pid: Optional[int] = None) -> int:
+        """
+        Get the number of threads for the process.
+        :param pid: target process ID, or None for the current process.
+        :return: number of threads
+        """
+        p = cls._get_process(pid)
+        return p.num_threads()
+
+    @classmethod
+    def get_connection_count(cls, pid: Optional[int] = None) -> int:
+        """
+        Get the number of network connections for the process.
+        :param pid: target process ID, or None for the current process.
+        :return: number of network connections
+        """
+        p = cls._get_process(pid)
+        return len(p.net_connections())
+
+    @classmethod
+    def get_child_count(cls, pid: Optional[int] = None) -> int:
+        """
+        Get the number of child processes.
+        :param pid: target process ID, or None for the current process.
+        :return: number of child processes
+        """
+        p = cls._get_process(pid)
+        return len(p.children())
+
+    @classmethod
     def get_snapshot_dict(cls, server_port: int, pid: Optional[int] = None) -> Dict[str, Any]:
         """
         Get a snapshot of current resource usage for logging or metrics.

--- a/neuro_san/service/utils/service_resources.py
+++ b/neuro_san/service/utils/service_resources.py
@@ -402,9 +402,9 @@ class ServiceResources:
             except (ProcessLookupError, PermissionError, OSError):
                 # Target process may have exited or be inaccessible.
                 # Fall back to system-wide CPU count.
-                denom = max(psutil.cpu_count(), 1)
+                denom = max(psutil.cpu_count() or 1, 1)
         else:
-            denom = max(psutil.cpu_count(), 1)
+            denom = max(psutil.cpu_count() or 1, 1)
         cpu_load = cls._get_process(pid).cpu_percent(interval=0.1)
         cpu_load = min(cpu_load / denom, 100.0)
         return cpu_load

--- a/neuro_san/service/utils/service_resources.py
+++ b/neuro_san/service/utils/service_resources.py
@@ -75,7 +75,8 @@ class ServiceResources:
             fd_dir = "/proc/self/fd"
         else:
             # macOS: /dev/fd lists the current process's open file descriptors.
-            # See: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man4/fd.4.html
+            # See: https://developer.apple.com/library/archive/documentation/
+            #   System/Conceptual/ManPages_iPhoneOS/man4/fd.4.html
             fd_dir = "/dev/fd"
         try:
             names = os.listdir(fd_dir)
@@ -90,7 +91,7 @@ class ServiceResources:
             yield fd
 
     @classmethod
-    def _classify_fds_posix(cls, pid: Optional[int] = None) -> Dict[str, int]:
+    def _classify_fds_posix(cls, pid: Optional[int] = None) -> Dict[str, int]:  # pylint: disable=too-many-branches
         """
         Returns counts by FD kind on Unix/macOS:
           regular_file, socket_inet, socket_unix, fifo_pipe, other, total

--- a/neuro_san/service/utils/service_resources.py
+++ b/neuro_san/service/utils/service_resources.py
@@ -379,14 +379,16 @@ class ServiceResources:
     def get_cpu_load(cls, pid: Optional[int] = None) -> float:
         """
         Get the current CPU load percentage of the process.
+        Uses the target process's CPU affinity for normalization when available.
         :param pid: target process ID, or None for the current process.
         :return: CPU load percentage over a short interval (e.g., 0.1 seconds)
                  in the range [0.0, 100.0]
         """
+        target_pid = pid if pid is not None else 0
         if hasattr(os, "sched_getaffinity"):
-            # sched_getaffinity returns the set of CPUs the process is allowed to run on,
-            # which is more accurate for containerized environments.
-            denom = len(os.sched_getaffinity(0))
+            # sched_getaffinity(pid) returns the set of CPUs the process is allowed
+            # to run on. Passing 0 means the current process.
+            denom = len(os.sched_getaffinity(target_pid))
         else:
             denom = max(psutil.cpu_count(), 1)
         cpu_load = cls._get_process(pid).cpu_percent(interval=0.1)

--- a/neuro_san/service/utils/service_resources.py
+++ b/neuro_san/service/utils/service_resources.py
@@ -236,7 +236,9 @@ class ServiceResources:
             return cls._classify_fds_posix(pid=pid)
         except Exception:  # pylint: disable=broad-exception-caught
             p = cls._get_process(pid)
-            return {"total_unknown": getattr(p, "num_fds", lambda: 0)()}
+            if hasattr(p, "num_fds"):
+                return {"total_unknown": p.num_fds()}
+            return {"total_unknown": 0}
 
     @classmethod
     def get_fd_usage(cls, pid: Optional[int] = None) -> Tuple[Dict[str, int], Optional[int], Optional[int]]:

--- a/tests/load_tests/load_test_mock_llm_service.py
+++ b/tests/load_tests/load_test_mock_llm_service.py
@@ -56,6 +56,8 @@ from typing import Tuple
 
 import psutil
 
+from neuro_san.service.utils.service_resources import ServiceResources
+
 logging.basicConfig(level=logging.INFO, format="%(message)s")
 logger = logging.getLogger(__name__)
 
@@ -197,16 +199,24 @@ class MockLlmLoadTest:  # pylint: disable=too-many-instance-attributes
 
     @staticmethod
     def _snapshot(proc) -> Optional[Dict[str, Any]]:
-        """Capture a point-in-time resource snapshot of a process."""
+        """
+        Capture a point-in-time resource snapshot of a process.
+        Uses ServiceResources to centralize all psutil resource monitoring.
+        """
         try:
-            mem = proc.memory_info()
+            pid = proc.pid
+            # Memory: returns (current_mb, max_mb); we only need current
+            mem_current, _ = ServiceResources.get_memory_used_mbytes(pid=pid)
+            # FD count: returns dict with "total" key on Unix
+            fd_counts = ServiceResources.classify_fds(pid=pid)
+            fd_total = fd_counts.get("total", fd_counts.get("total_handles", 0))
             return {
-                "rss": mem.rss / 1024 / 1024,
-                "fds": proc.num_fds(),
-                "threads": proc.num_threads(),
-                "connections": len(proc.net_connections()),
-                "children": len(proc.children()),
-                "cpu": proc.cpu_percent(interval=0.1),
+                "rss": mem_current,
+                "fds": fd_total,
+                "threads": ServiceResources.get_thread_count(pid=pid),
+                "connections": ServiceResources.get_connection_count(pid=pid),
+                "children": ServiceResources.get_child_count(pid=pid),
+                "cpu": ServiceResources.get_cpu_load(pid=pid),
             }
         except (psutil.NoSuchProcess, psutil.AccessDenied):
             return None


### PR DESCRIPTION
This PR replaced the direct `psutil` dependency for resource monitoring in
`tests/load_tests/load_test_mock_llm_service.py` with the existing
`ServiceResources` class from `neuro_san/service/utils/service_resources.py`.

- All resource monitoring in `_snapshot()` (memory, FDs, threads,
connections, children, CPU) now goes through `ServiceResources`.

- The remaining `psutil` usage in the load test is retained for
concerns unrelated to `ServiceResources`: process discovery
(`psutil.process_iter` in `_find_process`, `psutil.Process(pid)`
in `_auto_start_servers`) and exception types (`psutil.NoSuchProcess`,
`psutil.AccessDenied`). These are outside the scope of the resource
monitoring and do not belong in `ServiceResources`.