### PR TITLE
NS-982 max_attempts setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Neuro SAN also offers:
 * cloud-agnostic server-readiness at scale - run where you want
 * enabling distributed agent webs that call each other to work together, wherever they are hosted.
 * security-by-default - you set what private data is to be shared downstream/upstream
-* Out-of-the-box support for Observability/tracing data feeds for apps like LangSmith, Arize Phoenix and HoneyHive.
+* Out-of-the-box support for Observability/tracing data feeds for apps like LangSmith, Langfuse, Arize Phoenix and HoneyHive.
 * test infrastructure for your agent networks, including:
     * data-driven test cases
     * the ability for LLMs to test your agent networks

--- a/docs/agent_hocon_reference.md
+++ b/docs/agent_hocon_reference.md
@@ -36,6 +36,7 @@ Items in ***bold*** are essentials. Try to understand these first.
     - [max_steps](#max_steps)
     - [max_iterations](#max_iterations)
     - [max_execution_seconds](#max_execution_seconds)
+    - [max_retries](#max_retries)
     - [metadata](#metadata)
         - [description](#description)
         - [tags](#tags)
@@ -79,6 +80,7 @@ Items in ***bold*** are essentials. Try to understand these first.
     - [max_steps](#max_steps-1)
     - [max_iterations](#max_iterations-1)
     - [max_execution_seconds](#max_execution_seconds-1)
+    - [max_retries](#max_retries-1)
     - [error_formatter](#error_formatter-1)
     - [error_fragments](#error_fragments-1)
     - [structure_formats](#structure_formats)
@@ -340,6 +342,13 @@ Deprecated. Use [max_steps](#max_steps) instead.
 An integer controlling the maximum amount of wall clock time (in seconds) to spend in the langchain
 [AgentExecutor](https://api.python.langchain.com/en/latest/agents/langchain.agents.agent.AgentExecutor.html)
 used for the agent.  Default is set for 2 minutes.
+
+### max_retries
+
+A positive integer indicating the maximum number of times to retry a failed agent run.
+This is different from [max_steps](#max_steps) in that it specfically relates to retrying on errors encounted
+during agent execution as opposed to limiting the number of super-steps.
+The default setting is to use 3 retry attempts.
 
 ### request_timeout_seconds
 
@@ -909,6 +918,11 @@ Deprecated. Use [max_steps](#max_steps-1) instead.
 ### max_execution_seconds
 
 Same as top-level [max_execution_seconds](#max_execution_seconds), except at single-agent scope.
+
+<!--- pyml disable-next-line no-duplicate-heading -->
+### max_retries
+
+Same as top-level [max_retries](#max_retries), except at single-agent scope.
 
 <!--- pyml disable-next-line no-duplicate-heading -->
 ### error_formatter

--- a/docs/agent_hocon_reference.md
+++ b/docs/agent_hocon_reference.md
@@ -345,7 +345,7 @@ used for the agent.  Default is set for 2 minutes.
 
 ### max_retries
 
-A positive integer indicating the maximum number of times to retry a failed agent run.
+A positive integer (i.e. >= 1) indicating the maximum number of times to retry a failed agent run.
 This is different from [max_steps](#max_steps) in that it specfically relates to retrying on errors encounted
 during agent execution as opposed to limiting the number of super-steps.
 The default setting is to use 3 retry attempts.

--- a/docs/agent_hocon_reference.md
+++ b/docs/agent_hocon_reference.md
@@ -346,7 +346,7 @@ used for the agent.  Default is set for 2 minutes.
 ### max_attempts
 
 A positive integer (i.e. >= 1) indicating the maximum number of times to attempt an agent run given any failures.
-This is different from [max_steps](#max_steps) in that it specifically relates to errors encounted
+This is different from [max_steps](#max_steps) in that it specifically relates to errors encountered
 during agent execution as opposed to limiting the number of super-steps.
 The default setting is to use 3 attempts.
 

--- a/docs/agent_hocon_reference.md
+++ b/docs/agent_hocon_reference.md
@@ -346,7 +346,7 @@ used for the agent.  Default is set for 2 minutes.
 ### max_retries
 
 A positive integer (i.e. >= 1) indicating the maximum number of times to retry a failed agent run.
-This is different from [max_steps](#max_steps) in that it specfically relates to retrying on errors encounted
+This is different from [max_steps](#max_steps) in that it specifically relates to retrying on errors encounted
 during agent execution as opposed to limiting the number of super-steps.
 The default setting is to use 3 retry attempts.
 

--- a/docs/agent_hocon_reference.md
+++ b/docs/agent_hocon_reference.md
@@ -346,8 +346,14 @@ used for the agent.  Default is set for 2 minutes.
 ### max_attempts
 
 A positive integer (i.e. >= 1) indicating the maximum number of times to attempt an agent run given any failures.
-This is different from [max_steps](#max_steps) in that it specifically relates to errors encountered
+This is different from [max_steps](#max_steps) in that it specifically relates to retryable errors encountered
 during agent execution as opposed to limiting the number of super-steps.
+
+A "retryable" error here includes LLM provider API errors pertaining to rate limits, timeouts,
+and other temporary failures.  Failures which are known to be non-retryable are not re-attempted.
+These include API_KEY errors, ValueErrors from tools, and other unexpected exceptions; the idea
+being: these errors would just happen again anyway so why waste the tokens?
+
 The default setting is to use 3 attempts.
 
 ### request_timeout_seconds

--- a/docs/agent_hocon_reference.md
+++ b/docs/agent_hocon_reference.md
@@ -36,7 +36,7 @@ Items in ***bold*** are essentials. Try to understand these first.
     - [max_steps](#max_steps)
     - [max_iterations](#max_iterations)
     - [max_execution_seconds](#max_execution_seconds)
-    - [max_retries](#max_retries)
+    - [max_attempts](#max_attempts)
     - [metadata](#metadata)
         - [description](#description)
         - [tags](#tags)
@@ -80,7 +80,7 @@ Items in ***bold*** are essentials. Try to understand these first.
     - [max_steps](#max_steps-1)
     - [max_iterations](#max_iterations-1)
     - [max_execution_seconds](#max_execution_seconds-1)
-    - [max_retries](#max_retries-1)
+    - [max_attempts](#max_attempts-1)
     - [error_formatter](#error_formatter-1)
     - [error_fragments](#error_fragments-1)
     - [structure_formats](#structure_formats)
@@ -343,12 +343,12 @@ An integer controlling the maximum amount of wall clock time (in seconds) to spe
 [AgentExecutor](https://api.python.langchain.com/en/latest/agents/langchain.agents.agent.AgentExecutor.html)
 used for the agent.  Default is set for 2 minutes.
 
-### max_retries
+### max_attempts
 
-A positive integer (i.e. >= 1) indicating the maximum number of times to retry a failed agent run.
-This is different from [max_steps](#max_steps) in that it specifically relates to retrying on errors encounted
+A positive integer (i.e. >= 1) indicating the maximum number of times to attempt an agent run given any failures.
+This is different from [max_steps](#max_steps) in that it specifically relates to errors encounted
 during agent execution as opposed to limiting the number of super-steps.
-The default setting is to use 3 retry attempts.
+The default setting is to use 3 attempts.
 
 ### request_timeout_seconds
 
@@ -920,9 +920,9 @@ Deprecated. Use [max_steps](#max_steps-1) instead.
 Same as top-level [max_execution_seconds](#max_execution_seconds), except at single-agent scope.
 
 <!--- pyml disable-next-line no-duplicate-heading -->
-### max_retries
+### max_attempts
 
-Same as top-level [max_retries](#max_retries), except at single-agent scope.
+Same as top-level [max_attempts](#max_attempts), except at single-agent scope.
 
 <!--- pyml disable-next-line no-duplicate-heading -->
 ### error_formatter

--- a/neuro_san/internals/graph/filters/defaults_config_filter.py
+++ b/neuro_san/internals/graph/filters/defaults_config_filter.py
@@ -48,7 +48,7 @@ class DefaultsConfigFilter(ConfigFilter):
         # It should be removed in the future.
         "max_iterations": None,
         "max_execution_seconds": None,
-        "max_retries": None,
+        "max_attempts": None,
         "error_formatter": None,
         "error_fragments": None,
     }

--- a/neuro_san/internals/graph/filters/defaults_config_filter.py
+++ b/neuro_san/internals/graph/filters/defaults_config_filter.py
@@ -48,6 +48,7 @@ class DefaultsConfigFilter(ConfigFilter):
         # It should be removed in the future.
         "max_iterations": None,
         "max_execution_seconds": None,
+        "max_retries": None,
         "error_formatter": None,
         "error_fragments": None,
     }

--- a/neuro_san/internals/run_context/langchain/core/run_context_runnable.py
+++ b/neuro_san/internals/run_context/langchain/core/run_context_runnable.py
@@ -150,6 +150,11 @@ class RunContextRunnable(NeuroSanRunnable):
             # to the logs.  Add this because some people are interested in it.
             callbacks.append(LoggingCallbackHandler(self.logger))
 
+        # Get the number of retries from the spec.
+        max_retries: int = agent_spec.get("max_retries", 3)
+        if max_retries < 1:
+            max_retries = 1
+
         # Prepare our own runnable config
         runnable_config: Dict[str, Any] = self.prepare_runnable_config(callbacks=callbacks,
                                                                        recursion_limit=max_steps)
@@ -159,20 +164,22 @@ class RunContextRunnable(NeuroSanRunnable):
 
         # Attempt to count tokens/costs while invoking the agent.
         token_counter = LangChainTokenCounter(self.primary_llm, self.invocation_context, self.journal, self.origin)
-        await token_counter.count_tokens(self.invoke_agent_chain(inputs, runnable_config), max_execution_seconds)
+        await token_counter.count_tokens(self.invoke_agent_chain(inputs, runnable_config, max_retries),
+                                         max_execution_seconds)
 
         return inputs
 
     # pylint: disable=too-many-locals,too-many-statements
-    async def invoke_agent_chain(self, inputs: Dict[str, Any], runnable_config: Dict[str, Any]):
+    async def invoke_agent_chain(self, inputs: Dict[str, Any], runnable_config: Dict[str, Any], max_retries: int):
         """
         Set the agent in motion
 
         :param inputs: The inputs to the agent_executor
         :param runnable_config: The runnable_config to send to the agent_executor
+        :param max_retries: The maximum number of retries to attempt if there is an error of any kind.
         """
         chain_result: Union[Dict[str, Any], AgentFinish, AIMessage] = None
-        retries: int = 3
+        retries: int = max_retries
         exception: Exception = None
         backtrace: str = None
         while chain_result is None and retries > 0:

--- a/neuro_san/internals/run_context/langchain/core/run_context_runnable.py
+++ b/neuro_san/internals/run_context/langchain/core/run_context_runnable.py
@@ -152,8 +152,7 @@ class RunContextRunnable(NeuroSanRunnable):
 
         # Get the number of retries from the spec.
         max_retries: int = agent_spec.get("max_retries", 3)
-        if max_retries < 1:
-            max_retries = 1
+        max_retries = max(max_retries, 1)
 
         # Prepare our own runnable config
         runnable_config: Dict[str, Any] = self.prepare_runnable_config(callbacks=callbacks,

--- a/neuro_san/internals/run_context/langchain/core/run_context_runnable.py
+++ b/neuro_san/internals/run_context/langchain/core/run_context_runnable.py
@@ -150,9 +150,9 @@ class RunContextRunnable(NeuroSanRunnable):
             # to the logs.  Add this because some people are interested in it.
             callbacks.append(LoggingCallbackHandler(self.logger))
 
-        # Get the number of retries from the spec.
-        max_retries: int = agent_spec.get("max_retries", 3)
-        max_retries = max(max_retries, 1)
+        # Get the number of attempts from the spec.
+        max_attempts: int = agent_spec.get("max_attempts", 3)
+        max_attempts = max(max_attempts, 1)
 
         # Prepare our own runnable config
         runnable_config: Dict[str, Any] = self.prepare_runnable_config(callbacks=callbacks,
@@ -163,32 +163,32 @@ class RunContextRunnable(NeuroSanRunnable):
 
         # Attempt to count tokens/costs while invoking the agent.
         token_counter = LangChainTokenCounter(self.primary_llm, self.invocation_context, self.journal, self.origin)
-        await token_counter.count_tokens(self.invoke_agent_chain(inputs, runnable_config, max_retries),
+        await token_counter.count_tokens(self.invoke_agent_chain(inputs, runnable_config, max_attempts),
                                          max_execution_seconds)
 
         return inputs
 
     # pylint: disable=too-many-locals,too-many-statements
-    async def invoke_agent_chain(self, inputs: Dict[str, Any], runnable_config: Dict[str, Any], max_retries: int):
+    async def invoke_agent_chain(self, inputs: Dict[str, Any], runnable_config: Dict[str, Any], max_attempts: int):
         """
         Set the agent in motion
 
         :param inputs: The inputs to the agent_executor
         :param runnable_config: The runnable_config to send to the agent_executor
-        :param max_retries: The maximum number of retries to attempt if there is an error of any kind.
+        :param max_attempts: The maximum number of attempts to make allowing for errors of any kind.
         """
         chain_result: Union[Dict[str, Any], AgentFinish, AIMessage] = None
-        retries: int = max_retries
+        attempts: int = max_attempts
         exception: Exception = None
         backtrace: str = None
-        while chain_result is None and retries > 0:
+        while chain_result is None and attempts > 0:
             try:
                 chain_result: Dict[str, Any] = await self.agent_chain.ainvoke(input=inputs, config=runnable_config)
             except RATE_LIMIT_ERROR_TYPES as rate_limit_error:
                 self.logger.warning("retrying from RateLimit error %s(%s)",
                                     rate_limit_error.__class__.__name__,
                                     str(rate_limit_error))
-                retries = retries - 1
+                attempts = attempts - 1
                 exception = rate_limit_error
             except API_ERROR_TYPES as api_error:
                 backtrace = traceback.format_exc()
@@ -211,11 +211,11 @@ class RunContextRunnable(NeuroSanRunnable):
                     break
                 # Continue with regular retry logic:
                 self.logger.warning("retrying from %s", api_error.__class__.__name__)
-                retries = retries - 1
+                attempts = attempts - 1
                 exception = api_error
             except KeyError as key_error:
                 self.logger.warning("retrying from KeyError")
-                retries = retries - 1
+                attempts = attempts - 1
                 exception = key_error
                 backtrace = traceback.format_exc()
             except ValueError as value_error:
@@ -234,7 +234,7 @@ class RunContextRunnable(NeuroSanRunnable):
                     }
                 else:
                     self.logger.warning("retrying from ValueError")
-                    retries = retries - 1
+                    attempts = attempts - 1
                     exception = value_error
                     backtrace = traceback.format_exc()
             # pylint: disable=broad-exception-caught
@@ -245,7 +245,7 @@ class RunContextRunnable(NeuroSanRunnable):
                                   exception_error,
                                   )
                 # These are likely real issues and non-retryable.
-                retries = 0
+                attempts = 0
                 exception = exception_error
                 backtrace = traceback.format_exc()
 


### PR DESCRIPTION
Add a max_attempts setting at global and per-agent scope.
This had been hard-coded before at 3, and that is still the default, but now this is adjustable.

Part of the motivation here is that we might want to be able to tune this for high-volume agents to fail sooner,
for instance: AND during a hosted vibing event.