### PR TITLE
Asd ns 966 threads stats01

### DIFF
--- a/neuro_san/service/generic/async_agent_service.py
+++ b/neuro_san/service/generic/async_agent_service.py
@@ -268,7 +268,7 @@ class AsyncAgentService:
             self.queues.sync_q.put(reservationist.get_queue())
 
         # Prepare
-        factory = ExternalAgentSessionFactory(use_direct=True)
+        factory = ExternalAgentSessionFactory(use_direct=False)
         invocation_context = SessionInvocationContext(
             self.agent_name,
             factory,

--- a/neuro_san/service/generic/async_agent_service.py
+++ b/neuro_san/service/generic/async_agent_service.py
@@ -268,7 +268,7 @@ class AsyncAgentService:
             self.queues.sync_q.put(reservationist.get_queue())
 
         # Prepare
-        factory = ExternalAgentSessionFactory(use_direct=False)
+        factory = ExternalAgentSessionFactory(use_direct=True)
         invocation_context = SessionInvocationContext(
             self.agent_name,
             factory,

--- a/neuro_san/service/main_loop/server_main_loop.py
+++ b/neuro_san/service/main_loop/server_main_loop.py
@@ -49,6 +49,7 @@ from neuro_san.service.watcher.main_loop.storage_watcher import StorageWatcher
 from neuro_san.service.watcher.temp_networks.temp_network_storage_updater import TempNetworkStorageUpdater
 from neuro_san.service.utils.server_status import ServerStatus
 from neuro_san.service.utils.server_context import ServerContext
+from neuro_san.service.utils.service_resources import ServiceResources
 
 
 # pylint: disable=too-many-instance-attributes
@@ -74,6 +75,8 @@ class ServerMainLoop:
         self.service_openapi_spec_file: str = self._get_default_openapi_spec_path()
         self.http_server: HttpServer = None
         self.server_context = ServerContext()
+        ServiceResources.set_server_context(self.server_context)
+
         self.http_server_config = HttpServerConfig()
         self.watcher_config: Dict[str, Any] = {}
         self.logging_config: Dict[str, Any] = {}

--- a/neuro_san/service/utils/service_resources.py
+++ b/neuro_san/service/utils/service_resources.py
@@ -20,8 +20,6 @@ See class definition for comments.
 import os
 import sys
 import stat
-import threading
-import traceback
 from typing import Any
 from typing import Dict
 from typing import Iterable
@@ -341,22 +339,6 @@ class ServiceResources:
         return cpu_load
 
     @classmethod
-    def dump_pool_threads(cls, prefix=""):
-        pool_threads = {
-            t.ident: t for t in threading.enumerate()
-            if t.name.startswith(prefix)
-        }
-        frames = sys._current_frames()
-        for tid, t in pool_threads.items():
-            frame = frames.get(tid)
-            if frame is None:
-                continue
-            print(f"\n>>>>>> {t.name} (tid={tid}, daemon={t.daemon}) ---")
-            traceback.print_stack(frame)
-            print(f"<<<<<< end of {t.name} stack ---\n")
-
-
-    @classmethod
     def get_snapshot_dict(cls, server_port: int) -> Dict[str, Any]:
         """
         Get a snapshot of current resource usage for logging or metrics.
@@ -383,8 +365,6 @@ class ServiceResources:
         }
         if cls.server_context is not None:
             snapshot["executor_threads"] = cls.server_context.get_executor_pool().get_threads_metrics()
-
-        #cls.dump_pool_threads(prefix="aaa")  # dump threads in executors for debugging
 
         snapshot["total_threads"] = psutil.Process().num_threads()
         return snapshot

--- a/neuro_san/service/utils/service_resources.py
+++ b/neuro_san/service/utils/service_resources.py
@@ -20,6 +20,8 @@ See class definition for comments.
 import os
 import sys
 import stat
+import threading
+import traceback
 from typing import Any
 from typing import Dict
 from typing import Iterable
@@ -339,6 +341,22 @@ class ServiceResources:
         return cpu_load
 
     @classmethod
+    def dump_pool_threads(cls, prefix=""):
+        pool_threads = {
+            t.ident: t for t in threading.enumerate()
+            if t.name.startswith(prefix)
+        }
+        frames = sys._current_frames()
+        for tid, t in pool_threads.items():
+            frame = frames.get(tid)
+            if frame is None:
+                continue
+            print(f"\n>>>>>> {t.name} (tid={tid}, daemon={t.daemon}) ---")
+            traceback.print_stack(frame)
+            print(f"<<<<<< end of {t.name} stack ---\n")
+
+
+    @classmethod
     def get_snapshot_dict(cls, server_port: int) -> Dict[str, Any]:
         """
         Get a snapshot of current resource usage for logging or metrics.
@@ -365,5 +383,8 @@ class ServiceResources:
         }
         if cls.server_context is not None:
             snapshot["executor_threads"] = cls.server_context.get_executor_pool().get_threads_metrics()
+
+        #cls.dump_pool_threads(prefix="aaa")  # dump threads in executors for debugging
+
         snapshot["total_threads"] = psutil.Process().num_threads()
         return snapshot

--- a/neuro_san/service/utils/service_resources.py
+++ b/neuro_san/service/utils/service_resources.py
@@ -28,6 +28,8 @@ from typing import Optional
 from typing import Tuple
 import psutil
 
+from neuro_san.service.utils.server_context import ServerContext
+
 # Unix-only
 try:
     # pylint: disable=invalid-name
@@ -50,6 +52,16 @@ class ServiceResources:
 
     # High watermark for memory usage in bytes since process start (for logging purposes)
     max_memory_used_bytes: float = 0.0
+
+    server_context: Optional[ServerContext] = None  # service ServerContext object for obtaining run-time metrics
+
+    @classmethod
+    def set_server_context(cls, context: ServerContext):
+        """
+        Set the ServerContext for this class, which can be used to obtain run-time metrics.
+        :param context: ServerContext instance
+        """
+        cls.server_context = context
 
     # ---------------------------
     # POSIX helpers (Linux/macOS)
@@ -338,17 +350,20 @@ class ServiceResources:
         mem_used, mem_max = cls.get_memory_used_mbytes()
         cpu_load: float = cls.get_cpu_load()
         snapshot: Dict[str, Any] = {
-            "fd_usage": fd_usage,
-            "fd_limits": {
-                "soft": soft_limit,
-                "hard": hard_limit
-            },
+            # "fd_usage": fd_usage,
+            # "fd_limits": {
+            #     "soft": soft_limit,
+            #     "hard": hard_limit
+            # },
             "memory_usage_mbytes": {
                 "current": mem_used,
                 "max_since_start": mem_max
             },
             # Round CPU load to 3 decimal places for more compact output
-            "cpu_load": round(cpu_load, 3),
-            "socket_usage": cls.classify_sockets(server_port)
+            # "cpu_load": round(cpu_load, 3),
+            # "socket_usage": cls.classify_sockets(server_port)
         }
+        if cls.server_context is not None:
+            snapshot["executor_threads"] = cls.server_context.get_executor_pool().get_threads_metrics()
+        snapshot["total_threads"] = psutil.Process().num_threads()
         return snapshot

--- a/neuro_san/service/utils/service_resources.py
+++ b/neuro_san/service/utils/service_resources.py
@@ -350,18 +350,18 @@ class ServiceResources:
         mem_used, mem_max = cls.get_memory_used_mbytes()
         cpu_load: float = cls.get_cpu_load()
         snapshot: Dict[str, Any] = {
-            # "fd_usage": fd_usage,
-            # "fd_limits": {
-            #     "soft": soft_limit,
-            #     "hard": hard_limit
-            # },
+            "fd_usage": fd_usage,
+            "fd_limits": {
+                "soft": soft_limit,
+                "hard": hard_limit
+            },
             "memory_usage_mbytes": {
                 "current": mem_used,
                 "max_since_start": mem_max
             },
             # Round CPU load to 3 decimal places for more compact output
-            # "cpu_load": round(cpu_load, 3),
-            # "socket_usage": cls.classify_sockets(server_port)
+            "cpu_load": round(cpu_load, 3),
+            "socket_usage": cls.classify_sockets(server_port)
         }
         if cls.server_context is not None:
             snapshot["executor_threads"] = cls.server_context.get_executor_pool().get_threads_metrics()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 # requirements-build.txt
 
 # In-house dependencies
-leaf-common>=1.2.40
+leaf-common>=1.2.41
 leaf-server-common>=0.1.24
 
 # These are needed for generating code from .proto files and for the


### PR DESCRIPTION
This PR adds run-time metrics for threads from AsyncioExecutors own thread pools.
Turns out we can have quite a lot of them when running high requests loads,
and though each thread object is not that big (~ 1Mb maybe), they can quickly add up.
