### PR TITLE
Recurse into list elements in PydanticArgumentDictionaryConverter.to_dict

### DIFF
--- a/neuro_san/internals/run_context/langchain/core/pydantic_argument_dictionary_converter.py
+++ b/neuro_san/internals/run_context/langchain/core/pydantic_argument_dictionary_converter.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 from typing import Any
 from typing import Dict
+from typing import List
 
 from pydantic import BaseModel
 
@@ -44,17 +45,27 @@ class PydanticArgumentDictionaryConverter(DictionaryConverter):
         # Do the pydantic conversion to a dict
         base_dict: Dict[str, Any] = dict(obj)
 
-        # Loop through all the keys, converting any other
-        # sub-objects that are BaseModels to dictionaries as well.
+        # Loop through all the keys, recursively converting any sub-objects
+        # (dicts, pydantic objects, and list elements thereof) to dictionaries.
         new_dict: Dict[str, Any] = {}
         for key, value in base_dict.items():
-            new_value: Any = value
-            if isinstance(value, Dict) or self.is_pydantic_object(value):
-                new_value = self.to_dict(value)
-            # Note: We might need to go through list components, too.
-            new_dict[key] = new_value
+            new_dict[key] = self._convert_value(value)
 
         return new_dict
+
+    def _convert_value(self, value: Any) -> Any:
+        """
+        Recursively convert a single value, descending into dicts, pydantic
+        BaseModel instances, and lists thereof.
+        """
+        if isinstance(value, Dict) or self.is_pydantic_object(value):
+            return self.to_dict(value)
+        if isinstance(value, list):
+            converted_list: List = []
+            for item in value:
+                converted_list.append(self._convert_value(item))
+            return converted_list
+        return value
 
     def from_dict(self, obj_dict: Dict[str, Any]) -> BaseModel:
         """


### PR DESCRIPTION
Fix #997 

Extracted per-value conversion into a small `_convert_value` helper that handles three cases: dict / pydantic BaseModel (existing behavior), list (new — recurses into each element), primitives (passthrough). The top-level loop now delegates to it.