### PR TITLE
Redact pydantic ValidationError input values in API-key error paths

### DIFF
--- a/neuro_san/internals/run_context/langchain/core/run_context_runnable.py
+++ b/neuro_san/internals/run_context/langchain/core/run_context_runnable.py
@@ -207,7 +207,10 @@ class RunContextRunnable(NeuroSanRunnable):
                     }
                     # Log the error with technical details for debugging purposes,
                     # but we are returning a more user-friendly message to the client.
-                    self.logger.error("API KEY error detected: %s", str(api_error))
+                    # get_safe_log_message() redacts pydantic ValidationError input values
+                    # so user-supplied API key material can't leak into server logs.
+                    self.logger.error("API KEY error detected: %s",
+                                      ApiKeyErrorCheck.get_safe_log_message(api_error))
                     break
                 # Continue with regular retry logic:
                 self.logger.warning("retrying from %s", api_error.__class__.__name__)

--- a/neuro_san/internals/run_context/langchain/llms/default_llm_factory.py
+++ b/neuro_san/internals/run_context/langchain/llms/default_llm_factory.py
@@ -443,7 +443,8 @@ class DefaultLlmFactory(ContextTypeLlmFactory, LangChainLlmFactory):
                     #          following set in sly_data.llm_config:
                     #          anthropic_api_key
                     #
-                    self.logger.info("API KEY error detected: %s", str(exception))
+                    self.logger.error("API KEY error detected: %s",
+                                      ApiKeyErrorCheck.get_safe_log_message(exception))
                     raise ValueError(message) from exception
                 found_exception = exception
 

--- a/neuro_san/internals/run_context/langchain/util/api_key_error_check.py
+++ b/neuro_san/internals/run_context/langchain/util/api_key_error_check.py
@@ -89,7 +89,51 @@ Some things to try:
    on the same machine making this request.
 """
 
+        # No catalogue hit. If this is a pydantic ValidationError, the raw
+        # str(exception) can include `input_value=<the user's input>` — which
+        # would leak any user-supplied API key value. Rebuild the message from
+        # the structured .errors() data instead, omitting the raw input entirely.
+        if ApiKeyErrorCheck._is_pydantic_validation_error(exception):
+            return ApiKeyErrorCheck._format_redacted_pydantic_error(exception)
+
         return None
+
+    @staticmethod
+    def get_safe_log_message(exception: Exception) -> str:
+        """
+        Return a log-safe representation of the exception. For pydantic
+        ValidationErrors, returns the structured-error-derived message
+        (with `input` redacted) so user-supplied values can't leak into
+        server logs. For all other exception types, returns str(exception),
+        which preserves useful debug detail (status codes, request IDs).
+        """
+        if ApiKeyErrorCheck._is_pydantic_validation_error(exception):
+            return ApiKeyErrorCheck._format_redacted_pydantic_error(exception)
+        return str(exception)
+
+    @staticmethod
+    def _is_pydantic_validation_error(exception: Exception) -> bool:
+        """
+        Duck-typed check for pydantic_core.ValidationError to avoid a hard import
+        on pydantic_core from this util module.
+        """
+        cls = type(exception)
+        return cls.__name__ == "ValidationError" and cls.__module__.startswith("pydantic")
+
+    @staticmethod
+    def _format_redacted_pydantic_error(exception: Exception) -> str:
+        """
+        Build a message from a pydantic ValidationError using its structured
+        .errors() data, omitting the 'input' field entirely so user-supplied
+        values can't leak.
+        """
+        parts: List[str] = []
+        for err in exception.errors():
+            loc: str = ".".join(str(x) for x in err.get("loc", ()))
+            msg: str = err.get("msg", "")
+            err_type: str = err.get("type", "")
+            parts.append(f"{loc}: {msg} [type={err_type}, input=<redacted>]")
+        return f"{len(parts)} validation error(s): " + "; ".join(parts)
 
     @staticmethod
     def check_for_internal_error(exception_traceback: str) -> bool:

--- a/neuro_san/internals/run_context/langchain/util/api_key_error_check.py
+++ b/neuro_san/internals/run_context/langchain/util/api_key_error_check.py
@@ -17,6 +17,7 @@
 
 from typing import Dict
 from typing import List
+from typing import Optional
 
 # Dictionary with provider key env var -> strings to look for
 API_KEY_EXCEPTIONS: Dict[str, List] = {
@@ -52,7 +53,7 @@ class ApiKeyErrorCheck:
     """
 
     @staticmethod
-    def check_for_api_key_exception(exception: Exception) -> str:
+    def check_for_api_key_exception(exception: Exception) -> Optional[str]:
         """
         :param exception: An exception to check
         :return: A more helpful exception message if it relates to an API key or None
@@ -124,7 +125,7 @@ Some things to try:
     def _format_redacted_pydantic_error(exception: Exception) -> str:
         """
         Build a message from a pydantic ValidationError using its structured
-        .errors() data, omitting the 'input' field entirely so user-supplied
+        .errors() data, redacting the 'input' field entirely so user-supplied
         values can't leak.
         """
         parts: List[str] = []


### PR DESCRIPTION
Pydantic ValidationError instances stringify with `input_value=<the user's input>`, which can include user-supplied API key material — for example when sly_data carries a non-string value like a list for `*_api_key`. The substring-matching catalogue in ApiKeyErrorCheck templates known cases into env-var-name-only messages, but providers whose lowercase pydantic field name isn't catalogued (e.g. Google's `google_api_key`) would fall through and leak the raw input into both the user-facing ValueError and the corresponding server log line.

## Changes:

- ApiKeyErrorCheck.check_for_api_key_exception now falls back to a structured rebuild from `exception.errors()` for unmatched pydantic ValidationErrors. The rebuilt message uses loc/msg/type and replaces the input with `<redacted>`, so user-supplied values can no longer reach the chat client by this path.

- Added ApiKeyErrorCheck.get_safe_log_message() and replaced the `self.logger.*("API KEY error detected: %s", str(exception))` calls in default_llm_factory.py and run_context_runnable.py with calls through it, closing the same leak in server logs.

- Added _is_pydantic_validation_error() (duck-typed to avoid a hard pydantic_core import) and _format_redacted_pydantic_error() helpers.

Verified empirically with a non-string value via sly_data.