### PR TITLE
Bump build-common to 1.0.6

### DIFF
--- a/.github/workflows/checkmarx.yml
+++ b/.github/workflows/checkmarx.yml
@@ -21,8 +21,8 @@ jobs:
           fetch-depth: 0
 
       - name: Run Checkmarx One scan
-        # build-common 1.0.5
-        uses: cognizant-ai-lab/build-common/actions/checkmarx-one@550f3d7338e598c813b9580a238141328f7baaaa
+        # build-common 1.0.6
+        uses: cognizant-ai-lab/build-common/actions/checkmarx-one@e5f749a7ba5de8bb8106cb172e89f21ca581a697
         with:
           base-uri: ${{ vars.CX_BASE_URI }}
           cx-tenant: ${{ vars.CX_TENANT }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,8 +12,8 @@ jobs:
   test:
     # don't run this job in sync'd clones
     if: github.repository == 'cognizant-ai-lab/neuro-san'
-    # 1.0.5
-    uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@550f3d7338e598c813b9580a238141328f7baaaa
+    # 1.0.6
+    uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@e5f749a7ba5de8bb8106cb172e89f21ca581a697
     with:
       python-version: '3.12'
       lint-command-override: 'true'  # no lint in this workflow

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,8 +23,8 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Setup Python environment
-        # 1.0.5
-        uses: cognizant-ai-lab/build-common/actions/setup-python-env@550f3d7338e598c813b9580a238141328f7baaaa
+        # 1.0.6
+        uses: cognizant-ai-lab/build-common/actions/setup-python-env@e5f749a7ba5de8bb8106cb172e89f21ca581a697
         with:
           python-version: '3.10'
           requirements-file: ''
@@ -40,8 +40,8 @@ jobs:
 
       - name: Notify Slack
         if: ${{ !cancelled() }}
-        # 1.0.5
-        uses: cognizant-ai-lab/build-common/actions/slack-notify@550f3d7338e598c813b9580a238141328f7baaaa
+        # 1.0.6
+        uses: cognizant-ai-lab/build-common/actions/slack-notify@e5f749a7ba5de8bb8106cb172e89f21ca581a697
         with:
           status: ${{ job.status }}
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -96,8 +96,8 @@ jobs:
 
       - name: Notify Slack
         if: ${{ !cancelled() }}
-        # 1.0.5
-        uses: cognizant-ai-lab/build-common/actions/slack-notify@550f3d7338e598c813b9580a238141328f7baaaa
+        # 1.0.6
+        uses: cognizant-ai-lab/build-common/actions/slack-notify@e5f749a7ba5de8bb8106cb172e89f21ca581a697
         with:
           status: ${{ job.status }}
           details: ${{ steps.smoke.outputs.summary }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,8 +16,8 @@ jobs:
     if: >
       (github.event_name == 'push' && github.ref != 'refs/heads/main') ||
       (github.event_name == 'pull_request' && github.base_ref == 'main')
-    # 1.0.5
-    uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@550f3d7338e598c813b9580a238141328f7baaaa
+    # 1.0.6
+    uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@e5f749a7ba5de8bb8106cb172e89f21ca581a697
     with:
       python-version: '3.12'
       lint-toolchain: 'legacy'  # flake8 only (black/isort are opt-in)


### PR DESCRIPTION
## Summary
Bump all `cognizant-ai-lab/build-common` references from 1.0.5 (`550f3d7`) to 1.0.6 (`e5f749a`) across all workflow files.

## Review & Testing Checklist for Human
- [ ] Verify CI passes with the new build-common version
- [ ] Spot-check that no other action SHAs were modified

### Notes
Files updated: `checkmarx.yml`, `integration.yml`, `publish.yml`, `smoke.yml`, `tests.yml`

Link to Devin session: https://app.devin.ai/sessions/153b9da083644778ba2a708663d92ec0
Requested by: @donn-leaf
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cognizant-ai-lab/neuro-san/pull/1000" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->