### PR TITLE
Don't hang when loading MCP servers info config fails

### DIFF
--- a/neuro_san/internals/graph/persistence/registry_manifest_restorer.py
+++ b/neuro_san/internals/graph/persistence/registry_manifest_restorer.py
@@ -284,7 +284,10 @@ class RegistryManifestRestorer(Restorer):
             message: str = f"Failed to restore registry item {manifest_key}. Skipping. - {str(exception)}"
             self.logger.error(message)
             agent_network = None
-        except (ParseException, ParseSyntaxException, JSONDecodeError) as exception:
+        except (ParseException, ParseSyntaxException, JSONDecodeError, ValueError) as exception:
+            # ValueError is the wrapper type raised by AbstractAsyncConfigRestorer for any
+            # parse / substitution / config-load failure; the other types are kept for
+            # belt-and-suspenders in case a future code path raises one directly.
 
             # Be sure we spit out the right exception message with relevant parsing
             # information as the error.  If not, we don't get enough good information
@@ -316,7 +319,10 @@ class RegistryManifestRestorer(Restorer):
             message: str = f"Failed to restore registry item {manifest_key}. Skipping. - {str(exception)}"
             self.logger.error(message)
             agent_network = None
-        except (ParseException, ParseSyntaxException, JSONDecodeError) as exception:
+        except (ParseException, ParseSyntaxException, JSONDecodeError, ValueError) as exception:
+            # ValueError is the wrapper type raised by AbstractAsyncConfigRestorer for any
+            # parse / substitution / config-load failure; the other types are kept for
+            # belt-and-suspenders in case a future code path raises one directly.
 
             # Be sure we spit out the right exception message with relevant parsing
             # information as the error.  If not, we don't get enough good information

--- a/neuro_san/internals/persistence/abstract_async_config_restorer.py
+++ b/neuro_san/internals/persistence/abstract_async_config_restorer.py
@@ -168,12 +168,31 @@ class AbstractAsyncConfigRestorer(Restorer, ConfigFilter):
         try:
             config = serialization.to_object(bytes_file)
         except (ParseException, ParseSyntaxException, JSONDecodeError, ConfigException) as exception:
-            message: str = f"""
-There was an error parsing {self.file_purpose} file "{file_path}".
-See the accompanying exception (above) for clues as to what might be
-syntactically incorrect in that file.
-"""
-            raise ParseException(message) from exception
+            # Re-raise as ValueError, not pyparsing.ParseException, for two reasons:
+            #
+            # 1. Not all caught errors are parse errors. ConfigException covers post-parse
+            #    failures like ConfigSubstitutionException (unresolved ${VAR} references)
+            #    and ConfigMissingException — re-raising those as a "parse exception" is
+            #    semantically misleading.
+            #
+            # 2. pyparsing.ParseBaseException.__str__ unconditionally appends
+            #    "  (at char {loc}), (line:{lineno}, col:{col})" to its string form.
+            #    For a wrapper exception that has no real source location, this prints
+            #    "(at char 0), (line:1, col:1)" regardless of where the actual error is,
+            #    which actively misleads anyone reading the log. There is no way to
+            #    suppress that suffix without subclassing ParseException and overriding
+            #    __str__; using ValueError sidesteps the problem entirely.
+            #
+            # We embed the underlying exception's type and message directly in the wrapper
+            # text so the real cause surfaces via str(e). Without this, callers that log
+            # "%s" % e see only the wrapper and lose the root cause — `from exception`
+            # only attaches the original via __cause__, which is rendered in tracebacks
+            # but not in str().
+            message: str = (
+                f'There was an error loading {self.file_purpose} file "{file_path}".\n'
+                f"Underlying error ({type(exception).__name__}): {exception}"
+            )
+            raise ValueError(message) from exception
 
         return config
 

--- a/neuro_san/internals/run_context/langchain/mcp/langchain_mcp_adapter.py
+++ b/neuro_san/internals/run_context/langchain/mcp/langchain_mcp_adapter.py
@@ -50,17 +50,21 @@ class LangChainMcpAdapter:
         """
         Loads MCP servers information from a configuration file if not already loaded.
         """
-        with self._mcp_info_lock:
-            if self._mcp_servers_info is None:
+        # Write through the class so the cache stays shared across instances.
+        # `self._mcp_servers_info = ...` would create an instance attribute that shadows
+        # the class attribute, leaving the class-level cache stuck at None and causing
+        # every new LangChainMcpAdapter to reload (and re-log) the config.
+        with LangChainMcpAdapter._mcp_info_lock:
+            if LangChainMcpAdapter._mcp_servers_info is None:
                 try:
-                    self._mcp_servers_info = McpServersInfoRestorer().restore()
+                    LangChainMcpAdapter._mcp_servers_info = McpServersInfoRestorer().restore()
                 except ValueError as value_error:
                     self.logger.warning("Error occurred while loading MCP servers info: %s", value_error)
                     self.logger.info("Proceeding with empty MCP servers info.")
-                if self._mcp_servers_info is None:
+                if LangChainMcpAdapter._mcp_servers_info is None:
                     # Something went wrong reading the file.
                     # Prevent further attempts to load info.
-                    self._mcp_servers_info = {}
+                    LangChainMcpAdapter._mcp_servers_info = {}
 
     async def get_mcp_tools(
             self,

--- a/neuro_san/internals/run_context/langchain/mcp/langchain_mcp_adapter.py
+++ b/neuro_san/internals/run_context/langchain/mcp/langchain_mcp_adapter.py
@@ -46,18 +46,21 @@ class LangChainMcpAdapter:
         self.client_allowed_tools: List[str] = []
         self.logger: Logger = getLogger(self.__class__.__name__)
 
-    @staticmethod
-    def _load_mcp_servers_info():
+    def _load_mcp_servers_info(self):
         """
         Loads MCP servers information from a configuration file if not already loaded.
         """
-        with LangChainMcpAdapter._mcp_info_lock:
-            if LangChainMcpAdapter._mcp_servers_info is None:
-                LangChainMcpAdapter._mcp_servers_info = McpServersInfoRestorer().restore()
-                if LangChainMcpAdapter._mcp_servers_info is None:
+        with self._mcp_info_lock:
+            if self._mcp_servers_info is None:
+                try:
+                    self._mcp_servers_info = McpServersInfoRestorer().restore()
+                except ValueError as value_error:
+                    self.logger.warning("Error occurred while loading MCP servers info: %s", value_error)
+                    self.logger.info("Proceeding with empty MCP servers info.")
+                if self._mcp_servers_info is None:
                     # Something went wrong reading the file.
                     # Prevent further attempts to load info.
-                    LangChainMcpAdapter._mcp_servers_info = {}
+                    self._mcp_servers_info = {}
 
     async def get_mcp_tools(
             self,

--- a/tests/neuro_san/internals/persistence/test_abstract_async_config_restorer.py
+++ b/tests/neuro_san/internals/persistence/test_abstract_async_config_restorer.py
@@ -19,11 +19,13 @@ import json
 import logging
 import shutil
 from pathlib import Path
-from typing import Any, Awaitable, Dict, TypeVar
+from typing import Any
+from typing import Awaitable
+from typing import Dict
+from typing import TypeVar
 from unittest.mock import patch
 
 import pytest
-from pyparsing.exceptions import ParseException
 
 from neuro_san.internals.persistence.abstract_async_config_restorer import AbstractAsyncConfigRestorer
 
@@ -222,28 +224,28 @@ class TestAbstractAsyncConfigRestorer:
         with pytest.raises(ValueError, match="must be a .json or .hocon file"):
             r.deserialize_file_contents("config.yaml", b'{}')
 
-    def test_deserialize_raises_parse_exception_on_invalid_json(self) -> None:
-        """A ParseException is raised when JSON content is syntactically invalid."""
+    def test_deserialize_raises_value_error_on_invalid_json(self) -> None:
+        """A ValueError is raised when JSON content is syntactically invalid."""
         r: ConcreteRestorer = self.make_restorer()
-        with pytest.raises(ParseException):
+        with pytest.raises(ValueError):
             r.deserialize_file_contents(
                 str(FIXTURES_DIR / "invalid.json"),
                 (FIXTURES_DIR / "invalid.json").read_bytes(),
             )
 
-    def test_deserialize_raises_parse_exception_on_invalid_hocon(self) -> None:
-        """A ParseException is raised when HOCON content is syntactically invalid."""
+    def test_deserialize_raises_value_error_on_invalid_hocon(self) -> None:
+        """A ValueError is raised when HOCON content is syntactically invalid."""
         r: ConcreteRestorer = self.make_restorer()
-        with pytest.raises(ParseException):
+        with pytest.raises(ValueError):
             r.deserialize_file_contents(
                 str(FIXTURES_DIR / "invalid.hocon"),
                 (FIXTURES_DIR / "invalid.hocon").read_bytes(),
             )
 
-    def test_deserialize_parse_exception_wraps_original(self) -> None:
-        """The raised ParseException chains the original parsing error as its cause."""
+    def test_deserialize_value_error_wraps_original(self) -> None:
+        """The raised ValueError chains the original parsing error as its cause."""
         r: ConcreteRestorer = self.make_restorer()
-        with pytest.raises(ParseException) as exc_info:
+        with pytest.raises(ValueError) as exc_info:
             r.deserialize_file_contents(
                 str(FIXTURES_DIR / "invalid.json"),
                 (FIXTURES_DIR / "invalid.json").read_bytes(),
@@ -345,18 +347,18 @@ class TestAbstractAsyncConfigRestorer:
             r.restore(path)
         mock_filter.assert_called_once()
 
-    def test_restore_raises_parse_exception_on_malformed_json(self, tmp_path: Path) -> None:
-        """A ParseException is raised when a .json file contains invalid content."""
+    def test_restore_raises_value_error_on_malformed_json(self, tmp_path: Path) -> None:
+        """A ValueError is raised when a .json file contains invalid content."""
         path: str = self.copy_fixture(tmp_path, "invalid.json")
         r: ConcreteRestorer = self.make_restorer()
-        with pytest.raises(ParseException):
+        with pytest.raises(ValueError):
             r.restore(path)
 
-    def test_restore_raises_parse_exception_on_malformed_hocon(self, tmp_path: Path) -> None:
-        """A ParseException is raised when a .hocon file contains invalid content."""
+    def test_restore_raises_value_error_on_malformed_hocon(self, tmp_path: Path) -> None:
+        """A ValueError is raised when a .hocon file contains invalid content."""
         path: str = self.copy_fixture(tmp_path, "invalid.hocon")
         r: ConcreteRestorer = self.make_restorer()
-        with pytest.raises(ParseException):
+        with pytest.raises(ValueError):
             r.restore(path)
 
     def test_restore_raises_value_error_on_unsupported_extension(self, tmp_path: Path) -> None:
@@ -414,16 +416,16 @@ class TestAbstractAsyncConfigRestorer:
         r: ConcreteRestorer = self.make_restorer(env_var="MY_CFG")
         assert self.run(r.async_restore())["key"] == "value"
 
-    def test_async_restore_raises_parse_exception_on_malformed_json(self, tmp_path: Path) -> None:
-        """A ParseException is raised when an async-read .json file is invalid."""
+    def test_async_restore_raises_value_error_on_malformed_json(self, tmp_path: Path) -> None:
+        """A ValueError is raised when an async-read .json file is invalid."""
         path: str = self.copy_fixture(tmp_path, "invalid.json")
         r: ConcreteRestorer = self.make_restorer()
-        with pytest.raises(ParseException):
+        with pytest.raises(ValueError):
             self.run(r.async_restore(path))
 
-    def test_async_restore_raises_parse_exception_on_malformed_hocon(self, tmp_path: Path) -> None:
-        """A ParseException is raised when an async-read .hocon file is invalid."""
+    def test_async_restore_raises_value_error_on_malformed_hocon(self, tmp_path: Path) -> None:
+        """A ValueError is raised when an async-read .hocon file is invalid."""
         path: str = self.copy_fixture(tmp_path, "invalid.hocon")
         r: ConcreteRestorer = self.make_restorer()
-        with pytest.raises(ParseException):
+        with pytest.raises(ValueError):
             self.run(r.async_restore(path))

--- a/tests/neuro_san/internals/run_context/langchain/mcp/test_langchain_mcp_adapter.py
+++ b/tests/neuro_san/internals/run_context/langchain/mcp/test_langchain_mcp_adapter.py
@@ -212,3 +212,32 @@ class TestLangChainMcpAdapter:
 
         for tool in result:
             assert "langchain_tool" in tool.tags
+
+    @pytest.mark.asyncio
+    @patch('neuro_san.internals.run_context.langchain.mcp.langchain_mcp_adapter.McpServersInfoRestorer')
+    @patch('neuro_san.internals.run_context.langchain.mcp.langchain_mcp_adapter.MultiServerMCPClient')
+    async def test_get_mcp_tools_proceeds_when_restore_raises_value_error(
+        self, mock_client_class, mock_restorer_class, adapter, mock_mcp_tool, caplog
+    ):
+        """A malformed mcp_info config (restore() raising ValueError) must not hang or
+        propagate; get_mcp_tools should log a warning and proceed with an empty servers
+        info dict."""
+        # pylint: disable=protected-access
+        mock_restorer = mock_restorer_class.return_value
+        mock_restorer.restore.side_effect = ValueError(
+            'There was an error loading MCP servers info file "mcp_info.hocon".\n'
+            "Underlying error (ConfigSubstitutionException): "
+            "Cannot resolve variable ${YDC_API_KEY} (line: 68, col: 39)"
+        )
+
+        mock_client = mock_client_class.return_value
+        mock_client.get_tools = AsyncMock(return_value=[mock_mcp_tool])
+
+        tools = await adapter.get_mcp_tools("https://mcp.example.com/mcp")
+
+        # The tool fetch still completes — the load failure does not propagate.
+        assert len(tools) == 1
+        # Fallback to the empty dict so subsequent lookups don't blow up.
+        assert LangChainMcpAdapter._mcp_servers_info == {}
+        # The real underlying cause is surfaced in the log so users can diagnose.
+        assert "Cannot resolve variable ${YDC_API_KEY}" in caplog.text


### PR DESCRIPTION
Loading `mcp_info.hocon` with a config error (e.g. an unresolved ${VAR} reference) caused the system to hang. The exception from `McpServersInfoRestorer().restore()` propagated unhandled out of `LangChainMcpAdapter._load_mcp_servers_info()`, leaving callers stuck waiting on an MCP servers info dict that never arrived.
#1002 

Fix:

- `langchain_mcp_adapter`: catch `ValueError` around the `restore()` call, log a warning, and proceed with an empty MCP servers info dict so startup completes. Convert the method from `@staticmethod` to an instance method so it can use `self.logger`.

- `abstract_async_config_restorer`: while diagnosing the hang, the wrapped exception was nearly impossible to read — it discarded the underlying cause's message (`"see accompanying exception (above)"` while the caller only logged str(e)) and the `pyparsing.ParseException` wrapper's __str__ unconditionally appended `"(at char 0), (line:1, col:1)"` boilerplate that wrongly suggested line-1 syntax errors. Re-raise as `ValueError` with the underlying exception's type and message embedded in the wrapper text so str(e) surfaces the real cause (e.g. "ConfigSubstitutionException: Cannot resolve variable ${YDC_API_KEY} (line: 68, col: 39)").

- `registry_manifest_restorer`: the exception-type change above would otherwise break `restore_one_agent_network()` / `async_restore_one_agent_network()`, which catch parse/JSON errors to log-and-skip malformed registry entries. Added ValueError to both except tuples so malformed agent network configs continue to be skipped (with their underlying-cause message logged) instead of aborting manifest loading.

- Update tests in `test_abstract_async_config_restorer` to expect `ValueError` instead of `ParseException`.