### PR TITLE
Reject None function_json with ValueError in create_function_tool

### DIFF
--- a/neuro_san/internals/run_context/langchain/core/base_tool_factory.py
+++ b/neuro_san/internals/run_context/langchain/core/base_tool_factory.py
@@ -273,6 +273,18 @@ class BaseToolFactory:
         # Also, most internal agents do not have a name identifier on their functional
         # JSON, which is required.  Use the agent name we are using for look-up for that
         # regardless of intent.
-        function_json["name"] = name
+        try:
+            function_json["name"] = name
+        except TypeError as exception:
+            # The function_json of external agent cannot be found.
+            # Assign "name" will trigger a TypeError since function_json is None.
+            message: str = f"""
+Could not create tool to call extenal agent {name}.
+It's function_json is described thusly:
+{function_json}
+"""
+            # ValueError is more appropriate here since the problem is with the value of function_json.
+            # This error will be caught in create_external_tool() and a message will be sent to the client.
+            raise ValueError(message) from exception
 
         return LangChainOpenAIFunctionTool.from_function_json(function_json, self.tool_caller)

--- a/neuro_san/internals/run_context/langchain/core/base_tool_factory.py
+++ b/neuro_san/internals/run_context/langchain/core/base_tool_factory.py
@@ -273,18 +273,13 @@ class BaseToolFactory:
         # Also, most internal agents do not have a name identifier on their functional
         # JSON, which is required.  Use the agent name we are using for look-up for that
         # regardless of intent.
-        try:
-            function_json["name"] = name
-        except TypeError as exception:
-            # The function_json of external agent cannot be found.
-            # Assign "name" will trigger a TypeError since function_json is None.
-            message: str = f"""
-Could not create tool to call external agent {name}.
-Its function_json is described thusly:
-{function_json}
-"""
-            # ValueError is more appropriate here since the problem is with the value of function_json.
-            # This error will be caught in create_external_tool() and a message will be sent to the client.
-            raise ValueError(message) from exception
+        if function_json is None:
+            # An external agent that couldn't be reached has no function_json.
+            # Raise ValueError so create_external_tool's existing handler turns this
+            # into a user-facing "Agent/tool X was unreachable" message instead of
+            # the TypeError that the assignment below would otherwise raise.
+            message: str = f"Could not create tool to call external agent '{name}'. Its function_json is None."
+            raise ValueError(message)
 
+        function_json["name"] = name
         return LangChainOpenAIFunctionTool.from_function_json(function_json, self.tool_caller)

--- a/neuro_san/internals/run_context/langchain/core/base_tool_factory.py
+++ b/neuro_san/internals/run_context/langchain/core/base_tool_factory.py
@@ -279,8 +279,8 @@ class BaseToolFactory:
             # The function_json of external agent cannot be found.
             # Assign "name" will trigger a TypeError since function_json is None.
             message: str = f"""
-Could not create tool to call extenal agent {name}.
-It's function_json is described thusly:
+Could not create tool to call external agent {name}.
+Its function_json is described thusly:
 {function_json}
 """
             # ValueError is more appropriate here since the problem is with the value of function_json.


### PR DESCRIPTION
When an external agent is unreachable, `ExternalToolAdapter.get_function_json` returns `None`. The next line in `create_function_tool`, `function_json["name"] = name`, then raised `TypeError: 'NoneType' object does not support item assignment`, which propagated past the `except ValueError` handler in `create_external_tool` and crashed instead of degrading gracefully.

Add an explicit `if function_json is None` guard at the top of
create_function_tool that raises ValueError with a message naming the agent.
The ValueError flows into the existing handler in create_external_tool,
which logs "Agent/tool {name} was unreachable." and writes an AgentMessage
to the journal — the same fallback already used when the adapter itself
raises ValueError.

Fix #1003 