### PR TITLE
Fix three latent bugs in ConnectivityReporter.assemble_tool_list

### DIFF
--- a/neuro_san/internals/chat/connectivity_reporter.py
+++ b/neuro_san/internals/chat/connectivity_reporter.py
@@ -25,6 +25,7 @@ from neuro_san.internals.interfaces.context_type_toolbox_factory import ContextT
 from neuro_san.internals.run_context.factory.master_toolbox_factory import MasterToolboxFactory
 from neuro_san.internals.run_context.interfaces.agent_network_inspector import AgentNetworkInspector
 from neuro_san.internals.run_context.utils.external_agent_parsing import ExternalAgentParsing
+from neuro_san.internals.validation.network.abstract_network_validator import AbstractNetworkValidator
 
 
 class ConnectivityReporter:
@@ -182,36 +183,22 @@ class ConnectivityReporter:
             # Nothing to report
             return tool_list
 
-        extractor = DictionaryExtractor(agent_spec)
+        # Combine the traditional `tools` field with `args.tools` (the coded-tool
+        # convention). coerce_* keep the result tolerant to malformed shapes;
+        # remove_dictionary_tools drops non-string entries (e.g., inline MCP
+        # configs) so the dedup set sees only agent-name strings.
+        combined: List[Any] = (
+            AbstractNetworkValidator.coerce_tools(agent_spec) +
+            AbstractNetworkValidator.coerce_args_tools(agent_spec)
+        )
 
         # Keep a set of the combined sources of tools,
         # so connectivity only gets reported once.
         tool_set: Set[str] = set()
-
-        # First check the tools of the run-of-the-mill agent spec
-        empty_list: List[str] = []
-        spec_tools: List[str] = extractor.get("tools", empty_list)
-
-        # Add to our list in order, but without repeats
-        for tool in spec_tools:
+        for tool in AbstractNetworkValidator.remove_dictionary_tools(combined):
             if tool not in tool_set:
                 tool_set.add(tool)
                 tool_list.append(tool)
-
-        # Next check a special case convention where a coded tool takes a dictionary of
-        # key/value pairs mapping function -> tool name.
-        empty_dict: Dict[str, Any] = {}
-        args_tools = extractor.get("args.tools", empty_dict)
-
-        if isinstance(args_tools, Dict):
-            args_tools = args_tools.values()
-
-        if isinstance(args_tools, List):
-            # Add to our list in order, but without repeats
-            for tool in args_tools:
-                if tool not in tool_set:
-                    tool_set.add(tool)
-                    tool_list.append(tool)
 
         return tool_list
 

--- a/tests/neuro_san/internals/chat/test_connectivity_reporter.py
+++ b/tests/neuro_san/internals/chat/test_connectivity_reporter.py
@@ -76,3 +76,40 @@ class TestConnectivityReporter(TestCase):
         tools: List[str] = connectivity.get("tools")
         self.assertIsNotNone(tools)
         self.assertEqual(len(tools), 0)
+
+    def test_assemble_tool_list_args_tools_dict(self):
+        """
+        Tests that an agent referencing downstream agents via `args.tools`
+        as a dict (the coded-tool convention) has those references included
+        in the assembled tool list. Previously the dict.values() result was
+        a dict_values view that failed the isinstance(args_tools, List)
+        check, silently dropping all coded-tool down-chains.
+        """
+        agent_spec: Dict[str, Any] = {
+            "args": {"tools": {"helper": "agent_a", "fallback": "agent_b"}},
+        }
+        tools: List[str] = ConnectivityReporter.assemble_tool_list(agent_spec)
+        self.assertEqual(sorted(tools), ["agent_a", "agent_b"])
+
+    def test_assemble_tool_list_tools_as_string_does_not_iterate_chars(self):
+        """
+        Tests that a malformed `tools` field (string instead of list) does
+        not silently iterate the string character-by-character. coerce_tools
+        treats it as empty.
+        """
+        agent_spec: Dict[str, Any] = {"tools": "agent_a"}
+        tools: List[str] = ConnectivityReporter.assemble_tool_list(agent_spec)
+        self.assertEqual([], tools)
+
+    def test_assemble_tool_list_dict_element_does_not_crash(self):
+        """
+        Tests that a dict element in `tools` (e.g., an inline MCP server
+        config) is filtered out instead of raising TypeError: unhashable
+        type: 'dict' when added to the dedup set. Other string entries are
+        retained.
+        """
+        agent_spec: Dict[str, Any] = {
+            "tools": ["agent_a", {"server": "mcp_server"}, "agent_b"],
+        }
+        tools: List[str] = ConnectivityReporter.assemble_tool_list(agent_spec)
+        self.assertEqual(tools, ["agent_a", "agent_b"])


### PR DESCRIPTION
Fix #957 

Replace the inline tool-list assembly with calls to the shared `AbstractNetworkValidator.coerce_tools`, `coerce_args_tools`, and `remove_dictionary_tools` helpers introduced for the validation chain. Same external contract — ordered list of unique agent-name strings, traditional `tools` first then `args.tools` — but correct on three previously-broken inputs:

  1. `args.tools` as a dict: `dict.values()` returned a dict_values view that failed `isinstance(args_tools, List)`, silently dropping all coded-tool down-chains from the connectivity report.
  2. `tools` as a string: the for-loop iterated the string character-by-character, emitting individual letters as fake tool names.
  3. dict element in `tools` (e.g., inline MCP server config): adding the unhashable dict to the dedup set raised `TypeError: unhashable type: 'dict'` instead of being filtered.

Add tests for each of the three scenarios.