### PR TITLE
Apply defensive coerce_tools to MissingNodes/Cycles/Url validators

### DIFF
--- a/neuro_san/internals/validation/network/cycles_network_validator.py
+++ b/neuro_san/internals/validation/network/cycles_network_validator.py
@@ -117,8 +117,11 @@ class CyclesNetworkValidator(AbstractNetworkValidator):
         path.append(agent)
 
         # Step 5: Get all child agents (down_chains) of current agent
+        # coerce_tools treats a malformed `tools` (non-list) as empty so this
+        # validator does not iterate the characters of a string. The shape
+        # error itself is reported separately by ToolsShapeValidator.
         agent_spec: Dict[str, Any] = name_to_spec.get(agent, {})
-        down_chains: List[str] = agent_spec.get("tools", [])
+        down_chains: List[Any] = self.coerce_tools(agent_spec)
         safe_down_chains: List[str] = self.remove_dictionary_tools(down_chains)
 
         # Step 6: Recursively visit each child agent

--- a/neuro_san/internals/validation/network/missing_nodes_network_validator.py
+++ b/neuro_san/internals/validation/network/missing_nodes_network_validator.py
@@ -75,7 +75,10 @@ class MissingNodesNetworkValidator(AbstractNetworkValidator):
         # Iterate through all agents in the network
         for agent_name, agent_data in name_to_spec.items():
 
-            tools: List[str] = agent_data.get("tools", [])
+            # coerce_tools treats a malformed `tools` (non-list) as empty so this
+            # validator does not iterate the characters of a string. The shape
+            # error itself is reported separately by ToolsShapeValidator.
+            tools: List[Any] = self.coerce_tools(agent_data)
             safe_tools: List[str] = self.remove_dictionary_tools(tools)
 
             # Check each tool in the agent's tools list

--- a/neuro_san/internals/validation/network/url_network_validator.py
+++ b/neuro_san/internals/validation/network/url_network_validator.py
@@ -61,11 +61,13 @@ class UrlNetworkValidator(AbstractNetworkValidator):
         self.logger.info("Validating URLs for MCP tools and subnetwork...")
 
         for agent_name, agent in name_to_spec.items():
-            if agent.get("tools"):
-                tools: List[str] = agent.get("tools")
-                if tools:
-                    safe_tools: List[str] = self.remove_dictionary_tools(tools)
-                    self.check_safe_urls(agent_name, safe_tools, urls, errors)
+            # coerce_tools treats a malformed `tools` (non-list) as empty so this
+            # validator does not iterate the characters of a string. The shape
+            # error itself is reported separately by ToolsShapeValidator.
+            tools: List[Any] = self.coerce_tools(agent)
+            if tools:
+                safe_tools: List[str] = self.remove_dictionary_tools(tools)
+                self.check_safe_urls(agent_name, safe_tools, urls, errors)
 
         return errors
 

--- a/tests/neuro_san/internals/validation/network/test_cycles_validator.py
+++ b/tests/neuro_san/internals/validation/network/test_cycles_validator.py
@@ -53,3 +53,22 @@ class TestCyclesNetworkValidator(TestCase, AbstractNetworkValidatorTest):
         errors: List[str] = validator.validate(config)
 
         self.assertEqual(1, len(errors), errors[-1])
+
+    def test_tools_as_string_does_not_iterate_chars(self):
+        """
+        Tests that a malformed `tools` field (string instead of list) does
+        not silently iterate the string character-by-character. coerce_tools
+        treats it as empty; the shape error is reported separately by
+        ToolsShapeValidator.
+        """
+        validator: DictionaryValidator = self.create_validator()
+
+        config: Dict[str, Any] = self.restore("hello_world.hocon")
+        # announcer's tools as a string instead of a list
+        config["tools"][0]["tools"] = "synonymizer"
+
+        errors: List[str] = validator.validate(config)
+        # With char-iteration we'd traverse chars and possibly hit cycles by accident.
+        # With defensive coercion, the cycle detection runs on empty down-chains
+        # for this agent and finds no cycle.
+        self.assertEqual(0, len(errors), errors)

--- a/tests/neuro_san/internals/validation/network/test_missing_nodes_validator.py
+++ b/tests/neuro_san/internals/validation/network/test_missing_nodes_validator.py
@@ -52,3 +52,21 @@ class TestMissingNodesNetworkValidator(TestCase, AbstractNetworkValidatorTest):
         errors: List[str] = validator.validate(config)
 
         self.assertEqual(1, len(errors), errors[-1])
+
+    def test_tools_as_string_does_not_iterate_chars(self):
+        """
+        Tests that a malformed `tools` field (string instead of list) does
+        not silently iterate the string character-by-character, which would
+        flag each character as a missing node. coerce_tools treats it as
+        empty; the shape error is reported separately by ToolsShapeValidator.
+        """
+        validator: DictionaryValidator = self.create_validator()
+
+        config: Dict[str, Any] = self.restore("hello_world.hocon")
+        # announcer's tools as a string referring to an existing agent
+        config["tools"][0]["tools"] = "synonymizer"
+
+        errors: List[str] = validator.validate(config)
+        # If we iterated chars, each char would be reported as missing.
+        # With defensive coercion, no missing-node errors are reported.
+        self.assertEqual(0, len(errors), errors)

--- a/tests/neuro_san/internals/validation/network/test_url_network_validator.py
+++ b/tests/neuro_san/internals/validation/network/test_url_network_validator.py
@@ -57,3 +57,22 @@ class TestUrlNetworkValidator(TestCase, AbstractNetworkValidatorTest):
 
         errors: List[str] = validator.validate(config)
         self.assertEqual(1, len(errors))
+
+    def test_tools_as_string_does_not_iterate_chars(self):
+        """
+        Tests that a malformed `tools` field (string instead of list) does
+        not silently iterate the string character-by-character through
+        check_safe_urls. coerce_tools treats it as empty; the shape error
+        is reported separately by ToolsShapeValidator.
+        """
+        validator: DictionaryValidator = self.create_validator()
+
+        config: Dict[str, Any] = self.restore("math_guy_passthrough.hocon")
+        # Replace a list with a bare string URL.
+        config["tools"][0]["tools"] = "/math_guy"
+
+        errors: List[str] = validator.validate(config)
+        # With char-iteration each char would be checked against the URL list.
+        # With defensive coercion, the field is treated as empty and no URL
+        # check runs for this agent.
+        self.assertEqual(0, len(errors), errors)


### PR DESCRIPTION
Three downstream validators previously read `tools` directly with `agent.get("tools", [])`, then iterated the result. When the field is a string instead of a list (the #852 scenario), the for-loop iterates characters one by one — silently producing nonsense results (each character flagged as a missing node, treated as an unrecognized URL, or accidentally creating a cycle). Replace the direct read with `self.coerce_tools(agent)` (inherited from AbstractNetworkValidator) so malformed values are treated as empty; the shape error itself is already reported by ToolsShapeValidator.

ToolboxNetworkValidator is intentionally left unchanged — its check is pure truthiness with no iteration over tools, so it does not suffer this bug.

Add regression tests for each of the three fixed validators.

Fix #1009 