### PR TITLE
Document expanded MCP server URL recognition rules

### DIFF
--- a/docs/agent_hocon_reference.md
+++ b/docs/agent_hocon_reference.md
@@ -597,7 +597,25 @@ This enables entire ecosystems of agent webs.
 #### MCP Servers
 
 Agents can call tools exposed by external Model Context Protocol (MCP) servers.
-MCP server URLs must either start with `https://mcp` or end with `/mcp`.
+
+MCP server URLs are recognized when they conform to the
+[MCP canonical server URI specification](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#canonical-server-uri):
+they must use the `http` or `https` scheme, must include a host, and must not contain a fragment.
+To distinguish MCP server URLs from other external agent URLs, the literal `mcp` must appear either
+as a label in the hostname (e.g. `mcp.example.com`) or as any segment of the URL path
+(e.g. `/mcp`, `/mcp/free`, `/server/mcp`, `/v1/mcp/server`).
+
+Examples of URLs that are recognized as MCP servers:
+
+- `https://mcp.example.com/mcp`
+- `https://mcp.example.com`
+- `https://mcp.example.com:8443`
+- `https://example.com/mcp/free`
+- `https://example.com/v1/mcp/server`
+- `http://localhost:8000/mcp/`
+
+If a URL you want to use does not satisfy these rules, fall back to the dictionary form below,
+which is always treated as an MCP reference regardless of URL shape.
 
 MCP servers can be configured in two formats:
 

--- a/neuro_san/internals/run_context/langchain/core/base_tool_factory.py
+++ b/neuro_san/internals/run_context/langchain/core/base_tool_factory.py
@@ -142,8 +142,10 @@ class BaseToolFactory:
         Create MCP tools from the provided MCP configuration.
 
         The configuration can be one of:
-        - **String**: A URL to an MCP server.
-        Valid values start with "https://mcp" or end with "/mcp" or "/mcp/".
+        - **String**: A canonical MCP server URI (see
+          https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#canonical-server-uri).
+          Must use http(s), no fragment, with "mcp" appearing either as a host label
+          (e.g. "mcp.example.com") or as a path segment (e.g. "/mcp", "/mcp/free", "/server/mcp").
         - **Dictionary**:
             - "server" (str): MCP server URL.
             - "tools" (List[str], optional): List of tool names to allow from the server.

--- a/neuro_san/internals/run_context/langchain/core/base_tool_factory.py
+++ b/neuro_san/internals/run_context/langchain/core/base_tool_factory.py
@@ -147,7 +147,7 @@ class BaseToolFactory:
           Must use http(s), no fragment, with "mcp" appearing either as a host label
           (e.g. "mcp.example.com") or as a path segment (e.g. "/mcp", "/mcp/free", "/server/mcp").
         - **Dictionary**:
-            - "server" (str): MCP server URL.
+            - "url" (str): MCP server URL.
             - "tools" (List[str], optional): List of tool names to allow from the server.
 
         :param mcp_info: MCP server URL (string) or a configuration dictionary

--- a/neuro_san/registries/mcp_deepwiki_str.hocon
+++ b/neuro_san/registries/mcp_deepwiki_str.hocon
@@ -43,8 +43,11 @@
             },
             # Only support streamable http protocal
             # For other modes of transport, use coded tool implementation
-            # Moreover, if the URL does not start with "https://mcp" or end with "/mcp" or "/mcp/",
-            # use dictionary format: {"url": "https://example.com"} instead.
+            # The URL must be a canonical MCP server URI (see
+            # https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#canonical-server-uri):
+            # http(s) scheme, no fragment, with "mcp" as a host label (e.g. "mcp.example.com")
+            # or as a path segment (e.g. "/mcp", "/mcp/free", "/server/mcp").
+            # Otherwise, use dictionary format: {"url": "https://example.com"} instead.
             "tools": ["https://mcp.deepwiki.com/mcp"]
             
             # For authentication, see https://github.com/cognizant-ai-lab/neuro-san/blob/main/docs/agent_hocon_reference.md#authentication

--- a/neuro_san/registries/mcp_deepwiki_str.hocon
+++ b/neuro_san/registries/mcp_deepwiki_str.hocon
@@ -41,7 +41,7 @@
             "function": {
                 "description": "Assist user with answer from deepwiki."
             },
-            # Only support streamable http protocal
+            # Only support streamable HTTP(S) protocol
             # For other modes of transport, use coded tool implementation
             # The URL must be a canonical MCP server URI (see
             # https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#canonical-server-uri):


### PR DESCRIPTION
The `is_mcp_tool URL` recognizer now follows the MCP canonical server URI spec (https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#canonical-server-uri) and matches any http(s) URL containing "mcp" as a host label or as any path segment — not just URLs that start with "https://mcp" or end with "/mcp" / "/mcp/". Update the user-facing doc and the two inline references that still described the old narrower rule:

- `docs/agent_hocon_reference.md`: rewrite the MCP Servers section to describe the canonical-URI rule, link to the spec, list example URLs that now match, and note that the dictionary form is the escape hatch for URLs that don't fit.

- `base_tool_factory.py`: update the create_mcp_tool docstring to match.

- `registries/mcp_deepwiki_str.hocon`: update the sample-registry comment that pointed users at the dictionary form when their URL didn't match the old rule.

Fix #1012