### PR TITLE
Notify client when agent exceeds max_execution_seconds

### DIFF
--- a/neuro_san/internals/run_context/langchain/core/run_context_runnable.py
+++ b/neuro_san/internals/run_context/langchain/core/run_context_runnable.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 # END COPYRIGHT
+from asyncio import TimeoutError as AsyncTimeout
 from typing import Any
 from typing import Dict
 from typing import List
@@ -163,8 +164,18 @@ class RunContextRunnable(NeuroSanRunnable):
 
         # Attempt to count tokens/costs while invoking the agent.
         token_counter = LangChainTokenCounter(self.primary_llm, self.invocation_context, self.journal, self.origin)
-        await token_counter.count_tokens(self.invoke_agent_chain(inputs, runnable_config, max_attempts),
-                                         max_execution_seconds)
+        try:
+            await token_counter.count_tokens(self.invoke_agent_chain(inputs, runnable_config, max_attempts),
+                                             max_execution_seconds)
+        except AsyncTimeout:
+            # The token counter already wrote the final AIMessage to the journal
+            # (before its token-accounting messages, to preserve message order).
+            # Here we only need to surface the timeout in server logs.
+            self.logger.warning(
+                "Agent '%s' exceeded max_execution_seconds=%ss and was cancelled.",
+                Origination.get_full_name_from_origin(self.origin),
+                max_execution_seconds,
+            )
 
         return inputs
 

--- a/neuro_san/internals/run_context/langchain/core/run_context_runnable.py
+++ b/neuro_san/internals/run_context/langchain/core/run_context_runnable.py
@@ -172,7 +172,7 @@ class RunContextRunnable(NeuroSanRunnable):
             # (before its token-accounting messages, to preserve message order).
             # Here we only need to surface the timeout in server logs.
             self.logger.warning(
-                "Agent '%s' exceeded max_execution_seconds=%ss and was cancelled.",
+                "Agent '%s' timed out: exceeded max_execution_seconds=%ss and was cancelled.",
                 Origination.get_full_name_from_origin(self.origin),
                 max_execution_seconds,
             )

--- a/neuro_san/internals/run_context/langchain/token_counting/langchain_token_counter.py
+++ b/neuro_san/internals/run_context/langchain/token_counting/langchain_token_counter.py
@@ -32,6 +32,7 @@ from time import time
 from langchain_core.callbacks import AsyncCallbackHandler
 from langchain_core.callbacks.base import BaseCallbackHandler
 from langchain_core.language_models.base import BaseLanguageModel
+from langchain_core.messages.ai import AIMessage
 
 from leaf_common.asyncio.asyncio_executor import AsyncioExecutor
 from neuro_san.internals.interfaces.context_type_llm_factory import ContextTypeLlmFactory
@@ -124,6 +125,7 @@ class LangChainTokenCounter:
         #   are now limited to the calling agent only, and no longer include those
         #   from downstream (chained) agents. However, `models_token_dict` is added
         #   to the `LlmTokenCallbackHandler` to collect token stats of each model call.
+        timed_out: bool = False
         with get_llm_token_callback(llm_infos) as callback:
             # Create a new context for different ContextVar values
             # and use the create_task() to run within that context.
@@ -132,14 +134,31 @@ class LangChainTokenCounter:
             try:
                 retval = await wait_for(task, max_execution_seconds)
             except AsyncTimeout:
-                # Per docs for wait_for(), the task is already cancelled.
+                # Per docs for wait_for(), the task is already cancelled, so the
+                # task's own final journal.write_message(AIMessage(...)) never ran.
+                # Synthesize that final AIMessage here — before report() below — so
+                # the journal order matches the normal-completion path:
+                #   streamed events -> final AIMessage -> token accounting.
+                timeout_output: str = (
+                    f"Agent stopped: max_execution_seconds={max_execution_seconds}s exceeded."
+                )
+                if self.journal is not None:
+                    await self.journal.write_message(AIMessage(timeout_output))
                 retval = None
+                timed_out = True
 
         # Figure out how much time our agent took.
         end_time: float = time()
         time_taken_in_seconds: float = end_time - start_time
 
         await self.report(callback, time_taken_in_seconds)
+
+        if timed_out:
+            # Re-raise so the caller can synthesize a final AIMessage and update chat history.
+            # Partial token accounting was already reported above.
+            raise AsyncTimeout(
+                f"Agent '{origin_str}' exceeded max_execution_seconds={max_execution_seconds}s"
+            )
 
         return retval
 

--- a/neuro_san/internals/run_context/langchain/token_counting/langchain_token_counter.py
+++ b/neuro_san/internals/run_context/langchain/token_counting/langchain_token_counter.py
@@ -140,7 +140,7 @@ class LangChainTokenCounter:
                 # the journal order matches the normal-completion path:
                 #   streamed events -> final AIMessage -> token accounting.
                 timeout_output: str = (
-                    f"Agent stopped: max_execution_seconds={max_execution_seconds}s exceeded."
+                    f"Agent timed out: max_execution_seconds={max_execution_seconds}s exceeded."
                 )
                 if self.journal is not None:
                     await self.journal.write_message(AIMessage(timeout_output))

--- a/neuro_san/internals/run_context/langchain/token_counting/langchain_token_counter.py
+++ b/neuro_san/internals/run_context/langchain/token_counting/langchain_token_counter.py
@@ -154,7 +154,7 @@ class LangChainTokenCounter:
         await self.report(callback, time_taken_in_seconds)
 
         if timed_out:
-            # Re-raise so the caller can synthesize a final AIMessage and update chat history.
+            # Re-raise so the caller can handle/log the timeout.
             # Partial token accounting was already reported above.
             raise AsyncTimeout(
                 f"Agent '{origin_str}' exceeded max_execution_seconds={max_execution_seconds}s"

--- a/neuro_san/internals/run_context/langchain/token_counting/langchain_token_counter.py
+++ b/neuro_san/internals/run_context/langchain/token_counting/langchain_token_counter.py
@@ -155,7 +155,6 @@ class LangChainTokenCounter:
 
         if timed_out:
             # Re-raise so the caller can handle/log the timeout.
-            # Partial token accounting was already reported above.
             raise AsyncTimeout(
                 f"Agent '{origin_str}' exceeded max_execution_seconds={max_execution_seconds}s"
             )

--- a/tests/neuro_san/internals/run_context/langchain/token_counting/test_langchain_token_counter.py
+++ b/tests/neuro_san/internals/run_context/langchain/token_counting/test_langchain_token_counter.py
@@ -15,9 +15,18 @@
 #
 # END COPYRIGHT
 
+import asyncio
+from contextlib import contextmanager
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
 from unittest.mock import Mock
+from unittest.mock import patch
+
 import pytest
 
+from langchain_core.messages.ai import AIMessage
+
+from neuro_san.internals.messages.agent_message import AgentMessage
 from neuro_san.internals.run_context.langchain.token_counting.langchain_token_counter import LangChainTokenCounter
 
 
@@ -377,6 +386,88 @@ class TestLangChainTokenCounter:
         # Result should be different from originals
         assert result != dict_1
         assert result != dict_2
+
+    @pytest.mark.asyncio
+    async def test_count_tokens_timeout_writes_aimessage_before_token_accounting_and_raises(self):
+        """
+        On AsyncTimeout, count_tokens should:
+        1. Write a final AIMessage to the journal BEFORE report() writes its
+           token-accounting AgentMessages, so the journal stream order matches
+           the normal-completion path.
+        2. Re-raise AsyncTimeout so the caller (RunContextRunnable.run_it) can
+           log/handle it.
+        """
+        # Capture journal.write_message arguments in call order.
+        written_messages = []
+
+        async def record(msg, *_args, **_kwargs):
+            written_messages.append(msg)
+
+        mock_journal = MagicMock()
+        mock_journal.write_message = AsyncMock(side_effect=record)
+
+        # Mock the invocation_context dependencies that count_tokens / report touch.
+        mock_invocation_context = MagicMock()
+        mock_invocation_context.get_llm_factory.return_value.llm_infos = {}
+        mock_invocation_context.get_request_reporting.return_value = {}
+
+        # The executor wraps the awaitable in a real asyncio.Task so
+        # asyncio.wait_for() actually times out and cancels it.
+        mock_executor = MagicMock()
+        mock_executor.create_task.side_effect = (
+            lambda awaitable, _origin_str: asyncio.create_task(awaitable)
+        )
+        mock_invocation_context.get_asyncio_executor.return_value = mock_executor
+
+        counter = LangChainTokenCounter(
+            llm=MagicMock(),
+            invocation_context=mock_invocation_context,
+            journal=mock_journal,
+            # Single-element origin -> no "." in the full name, so report()
+            # exercises both the per-agent and network token-message branches.
+            origin=[{"tool": "test_agent", "instantiation_index": 0}],
+        )
+
+        async def slow_awaitable():
+            await asyncio.sleep(10)
+
+        @contextmanager
+        def fake_callback_cm(_llm_infos):
+            cb = MagicMock()
+            cb.models_token_dict = {}
+            cb.total_tokens = 0
+            cb.prompt_tokens = 0
+            cb.completion_tokens = 0
+            cb.successful_requests = 0
+            cb.total_cost = 0.0
+            yield cb
+
+        callback_path = (
+            "neuro_san.internals.run_context.langchain.token_counting."
+            "langchain_token_counter.get_llm_token_callback"
+        )
+
+        with patch(callback_path, fake_callback_cm):
+            with pytest.raises(asyncio.TimeoutError):
+                await counter.count_tokens(slow_awaitable(), max_execution_seconds=0.05)
+
+        # 1) First journal write must be the synthesized timeout AIMessage.
+        assert written_messages, "Expected at least the timeout AIMessage on the journal"
+        first = written_messages[0]
+        assert isinstance(first, AIMessage), (
+            f"First journal message should be AIMessage, got {type(first).__name__}"
+        )
+        assert "max_execution_seconds" in first.content
+
+        # 2) Any subsequent messages should be token-accounting AgentMessages
+        #    (report() writes per-agent and, for the frontman, network token messages).
+        assert len(written_messages) >= 2, (
+            "Expected token-accounting AgentMessage(s) after the timeout AIMessage"
+        )
+        for msg in written_messages[1:]:
+            assert isinstance(msg, AgentMessage), (
+                f"Expected AgentMessage after AIMessage, got {type(msg).__name__}"
+            )
 
     def test_merge_dicts_complex_token_scenario(self, token_counter):
         """Test merging with a realistic token counting scenario."""


### PR DESCRIPTION
Previously when `wait_for()` in `LangChainTokenCounter.count_tokens` timed out, the cancelled task never reached its final `journal.write_message`, and the `AsyncTimeout` was swallowed silently — the client saw no error, no final message, and nothing was logged.

Now on timeout, `count_tokens` writes a final `AIMessage` to the journal before `report()` runs (preserving the normal-completion order of streamed events -> final `AIMessage` -> token accounting) and re-raises `AsyncTimeout` so the caller can react. `RunContextRunnable.run_it` catches the re-raised `AsyncTimeout` and logs a warning with the agent origin and configured timeout.

Fix #1017 