### PR TITLE
#1021 Pin mcp >=1.23.0,<2.0 and tighten langchain-mcp-adapters ceiling to <0.2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -77,4 +77,18 @@ json-repair>=0.47.3,<1.0
 croniter>=6.2.2
 
 # MCP tools
-langchain-mcp-adapters>=0.1.7,<1.0
+# These two pins are coupled: langchain-mcp-adapters depends on the mcp package,
+# so changes in either can affect us. Keep the rationales in sync.
+
+# Ceiling <0.2.0: 0.2.0 ships langchain-ai/langchain-mcp-adapters#379, which
+# changed ToolMessage.content from a concatenated text string to a list of
+# LangChain content blocks. JournalingCallbackHandler.on_tool_end then calls
+# str() on .content and would log the raw list structure instead of the tool's
+# text output.
+langchain-mcp-adapters>=0.1.7,<0.2.0
+
+# Floor >=1.23.0: needed for MCP OAuth client_credentials grant, required by
+# the MCP Authentication work in cognizant-ai-lab/neuro-san#683.
+# Ceiling <2.0: avoid breaking changes from the upcoming 2.x line.
+# See https://github.com/modelcontextprotocol/python-sdk/releases/ for changelogs.
+mcp>=1.23.0,<2.0


### PR DESCRIPTION
- Add an explicit `mcp` pin (`>=1.23.0` for OAuth client_credentials, required by the MCP Authentication work in #683;` <2.0` to avoid the upcoming breaking 2.x release). Fix #1021

- Tighten `langchain-mcp-adapters` to `<0.2.0`. The `0.2.0` release ships `langchain-ai/langchain-mcp-adapters#379`, which changes `ToolMessage.content` from a concatenated text string to a list of LangChain content blocks. `JournalingCallbackHandler.on_tool_end` calls `str()` on `.content`, so the journal would log the raw list structure instead of the tool's text.