### PR TITLE
Make the "Invoking" journal event diagnostic when a tool has no name

### DIFF
--- a/neuro_san/internals/run_context/langchain/journaling/journaling_callback_handler.py
+++ b/neuro_san/internals/run_context/langchain/journaling/journaling_callback_handler.py
@@ -162,8 +162,13 @@ class JournalingCallbackHandler(AsyncCallbackHandler):
             "params": tool_start_dict.get("tool_args")
         }
 
+        # Fall back to a placeholder label when the serialized tool has no name,
+        # so the journaled event stays diagnostic rather than an empty "Invoking: ``".
+        # The real value (or None) is still carried in invoked_agent_name above.
+        display_name: str = agent_name if agent_name else "<unnamed tool>"
+
         # Report that we are about to invoke a tool.
-        message: BaseMessage = AgentMessage(content=f"Invoking: `{agent_name}` with:",
+        message: BaseMessage = AgentMessage(content=f"Invoking: `{display_name}` with:",
                                             structure=caller_structure)
         await self.calling_agent_journal.write_message(message)
 

--- a/tests/neuro_san/internals/run_context/langchain/journaling/test_journaling_callback_handler.py
+++ b/tests/neuro_san/internals/run_context/langchain/journaling/test_journaling_callback_handler.py
@@ -1,0 +1,63 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+from neuro_san.internals.messages.agent_message import AgentMessage
+from neuro_san.internals.run_context.langchain.journaling.journaling_callback_handler import JournalingCallbackHandler
+
+
+class TestOnToolStartInvokingLabel:
+    """on_tool_start should journal a diagnostic "Invoking" label even when the
+    serialized tool carries no name."""
+
+    @staticmethod
+    def _make_handler():
+        """Build a handler whose calling-agent journal records written messages."""
+        calling_agent_journal = MagicMock()
+        calling_agent_journal.write_message = AsyncMock()
+        handler = JournalingCallbackHandler(
+            calling_agent_journal=calling_agent_journal,
+            base_journal=MagicMock(),
+            parent_origin=[],
+            origination=MagicMock(),
+        )
+        return handler, calling_agent_journal
+
+    @pytest.mark.asyncio
+    async def test_uses_tool_name_when_present(self):
+        """A serialized tool with a name is reported verbatim."""
+        handler, journal = self._make_handler()
+        await handler.on_tool_start({"name": "search"}, "input", run_id=uuid4(), tags=[], inputs={})
+        message = journal.write_message.call_args.args[0]
+        assert isinstance(message, AgentMessage)
+        assert message.content == "Invoking: `search` with:"
+        assert message.structure["invoked_agent_name"] == "search"
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_placeholder_when_name_missing(self):
+        """A serialized tool with no name yields a diagnostic placeholder label
+        instead of an empty "Invoking: ``"; the raw value is still reported."""
+        handler, journal = self._make_handler()
+        await handler.on_tool_start({}, "input", run_id=uuid4(), tags=[], inputs={})
+        message = journal.write_message.call_args.args[0]
+        assert message.content == "Invoking: `<unnamed tool>` with:"
+        assert message.structure["invoked_agent_name"] is None


### PR DESCRIPTION
## Problem

`JournalingCallbackHandler.on_tool_start` builds the journaled invocation label straight from `serialized.get("name")`:

```python
message = AgentMessage(content=f"Invoking: `{agent_name}` with:", ...)
```

When the serialized tool carries no name, this emits an uninformative `Invoking: `` with:` (empty backticks) plus a null `invoked_agent_name` — a decorative event with no indication of what was being invoked.

## Change

Fall back to a `<unnamed tool>` placeholder for the human-readable label when the name is missing, so the event stays diagnostic. The raw value (the real name, or `None`) is still carried unchanged in `structure.invoked_agent_name`, so downstream consumers are unaffected.

Behavior-preserving for the normal (named) case — only the missing-name path changes.

## Tests

Added `test_journaling_callback_handler.py`:

- named tool → label reports the name verbatim;
- missing name → label falls back to `<unnamed tool>` while `invoked_agent_name` stays `None`.
