### PR TITLE
NS-1026 Bump default of max_execution_seconds up to 5 minutes

### DIFF
--- a/docs/agent_hocon_reference.md
+++ b/docs/agent_hocon_reference.md
@@ -341,7 +341,7 @@ Deprecated. Use [max_steps](#max_steps) instead.
 
 An integer controlling the maximum amount of wall clock time (in seconds) to spend in the langchain
 [AgentExecutor](https://api.python.langchain.com/en/latest/agents/langchain.agents.agent.AgentExecutor.html)
-used for the agent.  Default is set for 2 minutes.
+used for the agent.  Default is set for 5 minutes.
 
 ### max_attempts
 

--- a/neuro_san/internals/run_context/langchain/core/run_context_runnable.py
+++ b/neuro_san/internals/run_context/langchain/core/run_context_runnable.py
@@ -106,7 +106,7 @@ class RunContextRunnable(NeuroSanRunnable):
         # as input.
         agent_spec: Dict[str, Any] = self.tool_caller.get_agent_tool_spec()
 
-        max_execution_seconds: float = agent_spec.get("max_execution_seconds", 2.0 * MINUTES)
+        max_execution_seconds: float = agent_spec.get("max_execution_seconds", 5.0 * MINUTES)
 
         # Langchain `create_agent` uses LangGraph under the hood, which has a default recursion limit of 10,000.
         # Even though it is called "recursion limit", it is actually more of a step ("super-step") limit for


### PR DESCRIPTION
By popular demand