### PR TITLE
NS-1036 Silently remove fallbacks with no API_KEY set for them. Only error when nothing in fallbacks works.

### DIFF
--- a/neuro_san/internals/run_context/langchain/core/langchain_run_context.py
+++ b/neuro_san/internals/run_context/langchain/core/langchain_run_context.py
@@ -240,6 +240,7 @@ class LangChainRunContext(RunContext):
                 error += "\n".join(construction_errors) + "\n"
             raise ValueError(error)
 
+        self.llm_resources = main_llm_resources
         agent: Runnable = self.create_agent(instructions, main_llm_resources.get_model())
 
         return agent

--- a/neuro_san/internals/run_context/langchain/core/langchain_run_context.py
+++ b/neuro_san/internals/run_context/langchain/core/langchain_run_context.py
@@ -243,7 +243,8 @@ class LangChainRunContext(RunContext):
 
             api_key_errors: List[str] = error_dict.get("api_key_errors", [])
             if len(api_key_errors) > 0:
-                error += "\nThe following errors occurred while using API keys:\n"
+                error += "\nLLM operation for this agent requires certain API keys to be set as environment variables."
+                error += "\nThe following errors occurred while looking for LLM API keys:\n"
                 error += "\n    ".join(api_key_errors)
 
             raise ValueError(error)

--- a/neuro_san/internals/run_context/langchain/core/langchain_run_context.py
+++ b/neuro_san/internals/run_context/langchain/core/langchain_run_context.py
@@ -17,7 +17,6 @@
 from typing import Any
 from typing import Dict
 from typing import List
-from typing import Set
 from typing import Union
 
 import json
@@ -224,17 +223,18 @@ class LangChainRunContext(RunContext):
         llm_factory: ContextTypeLlmFactory = self.invocation_context.get_llm_factory()
         sly_data: Dict[str, Any] = self.tool_caller.get_sly_data()
 
-        main_llm_resources: LangChainLlmResources | List[Set[str]] = \
+        main_llm_resources: LangChainLlmResources | Dict[str, Any] = \
             llm_factory.create_llm_with_fallbacks(self.llm_config, sly_data)
 
-        if isinstance(main_llm_resources, list):
+        if isinstance(main_llm_resources, dict):
             error: str = "No fully-specified LLM found in llm_config or fallbacks."
-            required_llm_config: Set[str] = main_llm_resources.pop(0)
+            error_dict: Dict[str, Any] = main_llm_resources
+            required_llm_config: List[str] = error_dict.get("required_llm_config_errors", [])
             if len(required_llm_config) > 0:
                 error += "\nLLM operation for this agent requires at least one "
                 error += "of the following set in sly_data.llm_config:\n"
                 error += "\n".join(sorted(required_llm_config)) + "\n"
-            construction_errors: Set[str] = main_llm_resources.pop(0)
+            construction_errors: List[str] = error_dict.get("construction_errors", [])
             if len(construction_errors) > 0:
                 error += "\nThe following errors occurred while constructing LLMs:\n"
                 error += "\n".join(construction_errors) + "\n"

--- a/neuro_san/internals/run_context/langchain/core/langchain_run_context.py
+++ b/neuro_san/internals/run_context/langchain/core/langchain_run_context.py
@@ -223,70 +223,23 @@ class LangChainRunContext(RunContext):
         # Get the factory we will use
         llm_factory: ContextTypeLlmFactory = self.invocation_context.get_llm_factory()
 
-        # Prepare a list of fallbacks.  By default, the llm_config itself is a single-entry fallback list.
-        fallbacks: List[Dict[str, Any]] = [self.llm_config]
-        fallbacks = self.llm_config.get("fallbacks", fallbacks)
+        main_llm_resources: LangChainLlmResources | List[Set[str]] = \
+            llm_factory.create_llm_with_fallbacks(self.llm_config, self.sly_data)
 
-        # Get the sly data to see if there are any optional user llm_config (like API keys) to use
-        sly_data: Dict[str, Any] = self.tool_caller.get_sly_data()
-
-        # Initialize a list of chain fallbacks. This may or may not get filled.
-        chain_fallbacks: List[Runnable] = []
-        first_llm: bool = True
-        required_llm_config: Set[str] = set()
-
-        # Go through the list of fallbacks in the config.
-        construction_errors: List[str] = []
-        for fallback in fallbacks:
-
-            # Create a model we might use.
-            # If construction fails (e.g. missing API key in env), record the error and
-            # try the next fallback rather than aborting the whole loop.
-            try:
-                one_llm_resources: LangChainLlmResources | Set[str] = llm_factory.create_llm(fallback, sly_data)
-            except ValueError as exception:
-                construction_errors.append(str(exception))
-                continue
-
-            if one_llm_resources is None:
-                # Nothing to use or report.
-                # Skip for now, a fallback might still be fulfilled.
-                continue
-
-            if isinstance(one_llm_resources, set):
-                # Report later on which required llm_config are missing
-                # Skip for now, a fallback might still be fulfilled.
-                required_llm_config.update(one_llm_resources)
-                continue
-
-            one_agent: Runnable = self.create_agent(instructions, one_llm_resources.get_model())
-
-            if first_llm:
-                # The first fully-specified agent is the one we want to be our main guy.
-                agent = one_agent
-                # For now. Could be problems with different providers w/ token counting.
-                self.llm_resources = one_llm_resources
-                # Anything that comes later will not be the first
-                first_llm = False
-            else:
-                # Anything later than the first guy is considered a fallback. Add it to the list.
-                chain_fallbacks.append(one_agent)
-
-        if agent is None:
+        if isinstance(main_llm_resources, list):
             error: str = "No fully-specified LLM found in llm_config or fallbacks."
+            required_llm_config: Set[str] = main_llm_resources.pop(0)
             if len(required_llm_config) > 0:
                 error += "\nLLM operation for this agent requires at least one "
                 error += "of the following set in sly_data.llm_config:\n"
                 error += "\n".join(sorted(required_llm_config)) + "\n"
+            construction_errors: Set[str] = main_llm_resources.pop(0)
             if len(construction_errors) > 0:
                 error += "\nThe following errors occurred while constructing LLMs:\n"
                 error += "\n".join(construction_errors) + "\n"
             raise ValueError(error)
 
-        if len(chain_fallbacks) > 0:
-            # Set up fallbacks.
-            # See https://python.langchain.com/docs/how_to/tools_error/#tryexcept-tool-call
-            agent = agent.with_fallbacks(chain_fallbacks)
+        agent: Runnable = self.create_agent(instructions, main_llm_resources.get_model())
 
         return agent
 

--- a/neuro_san/internals/run_context/langchain/core/langchain_run_context.py
+++ b/neuro_san/internals/run_context/langchain/core/langchain_run_context.py
@@ -229,15 +229,23 @@ class LangChainRunContext(RunContext):
         if isinstance(main_llm_resources, dict):
             error: str = "No fully-specified LLM found in llm_config or fallbacks."
             error_dict: Dict[str, Any] = main_llm_resources
-            required_llm_config: List[str] = error_dict.get("required_llm_config_errors", [])
-            if len(required_llm_config) > 0:
+
+            required_sly_data: List[str] = error_dict.get("required_sly_data_errors", [])
+            if len(required_sly_data) > 0:
                 error += "\nLLM operation for this agent requires at least one "
                 error += "of the following set in sly_data.llm_config:\n"
-                error += "\n".join(sorted(required_llm_config)) + "\n"
+                error += "\n    ".join(sorted(required_sly_data)) + "\n"
+
             construction_errors: List[str] = error_dict.get("construction_errors", [])
             if len(construction_errors) > 0:
                 error += "\nThe following errors occurred while constructing LLMs:\n"
-                error += "\n".join(construction_errors) + "\n"
+                error += "\n    ".join(construction_errors) + "\n"
+
+            api_key_errors: List[str] = error_dict.get("api_key_errors", [])
+            if len(api_key_errors) > 0:
+                error += "\nThe following errors occurred while using API keys:\n"
+                error += "\n    ".join(api_key_errors)
+
             raise ValueError(error)
 
         self.llm_resources = main_llm_resources

--- a/neuro_san/internals/run_context/langchain/core/langchain_run_context.py
+++ b/neuro_san/internals/run_context/langchain/core/langchain_run_context.py
@@ -243,7 +243,8 @@ class LangChainRunContext(RunContext):
 
             api_key_errors: List[str] = error_dict.get("api_key_errors", [])
             if len(api_key_errors) > 0:
-                error += "\nLLM operation for this agent requires certain API keys to be set as environment variables."
+                error += "\n\nLLM operation for this agent requires at least one LLM provider API key"
+                error += " to be set as an environment variable."
                 error += "\nThe following errors occurred while looking for LLM API keys:\n"
                 error += "\n    ".join(api_key_errors)
 

--- a/neuro_san/internals/run_context/langchain/core/langchain_run_context.py
+++ b/neuro_san/internals/run_context/langchain/core/langchain_run_context.py
@@ -248,6 +248,11 @@ class LangChainRunContext(RunContext):
                 error += "\nThe following errors occurred while looking for LLM API keys:\n"
                 error += "\n    ".join(api_key_errors)
 
+                for api_key_error in api_key_errors:
+                    # Note: We are assuming the errors have already been filtered for
+                    # not dispensing secrets with ApiKeyErrorCheck.get_safe_log_message()
+                    self.logger.error("API KEY error detected: %s", api_key_error)
+
             raise ValueError(error)
 
         self.llm_resources = main_llm_resources

--- a/neuro_san/internals/run_context/langchain/core/langchain_run_context.py
+++ b/neuro_san/internals/run_context/langchain/core/langchain_run_context.py
@@ -222,9 +222,10 @@ class LangChainRunContext(RunContext):
 
         # Get the factory we will use
         llm_factory: ContextTypeLlmFactory = self.invocation_context.get_llm_factory()
+        sly_data: Dict[str, Any] = self.tool_caller.get_sly_data()
 
         main_llm_resources: LangChainLlmResources | List[Set[str]] = \
-            llm_factory.create_llm_with_fallbacks(self.llm_config, self.sly_data)
+            llm_factory.create_llm_with_fallbacks(self.llm_config, sly_data)
 
         if isinstance(main_llm_resources, list):
             error: str = "No fully-specified LLM found in llm_config or fallbacks."

--- a/neuro_san/internals/run_context/langchain/core/run_context_runnable.py
+++ b/neuro_san/internals/run_context/langchain/core/run_context_runnable.py
@@ -29,7 +29,6 @@ from pydantic import ConfigDict
 from langchain_classic.callbacks.tracers.logging import LoggingCallbackHandler
 from langchain_core.agents import AgentFinish
 from langchain_core.callbacks.base import BaseCallbackHandler
-from langchain_core.language_models.base import BaseLanguageModel
 from langchain_core.messages.ai import AIMessage
 from langchain_core.messages.base import BaseMessage
 from langchain_core.runnables.base import Runnable
@@ -76,6 +75,9 @@ class RunContextRunnable(NeuroSanRunnable):
     # is able to use JSON schema definitions to validate fields.
     agent_chain: Runnable
 
+    # This needs to be a Runnable because nowadays the primary LLM could be
+    # be a BaseLanguageModel with fallbacks attached to it, which ends up
+    # being a Runnable.
     primary_llm: Runnable
 
     journal: Journal

--- a/neuro_san/internals/run_context/langchain/core/run_context_runnable.py
+++ b/neuro_san/internals/run_context/langchain/core/run_context_runnable.py
@@ -76,7 +76,7 @@ class RunContextRunnable(NeuroSanRunnable):
     # is able to use JSON schema definitions to validate fields.
     agent_chain: Runnable
 
-    primary_llm: BaseLanguageModel
+    primary_llm: Runnable
 
     journal: Journal
 

--- a/neuro_san/internals/run_context/langchain/llms/default_llm_factory.py
+++ b/neuro_san/internals/run_context/langchain/llms/default_llm_factory.py
@@ -573,7 +573,7 @@ class DefaultLlmFactory(ContextTypeLlmFactory, LangChainLlmFactory):
 
     def create_llm_with_fallbacks(self, config: Dict[str, Any],
                                   sly_data: Dict[str, Any] = None,
-                                  num_fallbacks: int = None) -> LangChainLlmResources | Set[str]:
+                                  num_fallbacks: int = None) -> LangChainLlmResources | List[Set[str]]:
         """
         :param config: A dictionary which describes which LLM to use, perhaps with fallbacks specified.
         :param sly_data: A user-provided dictionary of private data,
@@ -636,7 +636,8 @@ class DefaultLlmFactory(ContextTypeLlmFactory, LangChainLlmFactory):
 
         if main_llm_resources is None:
             # Return all errors
-            return required_llm_config.union(construction_errors)
+            return [required_llm_config, construction_errors]
+
         if len(fallback_llm_resources) > 0:
             # Set up fallbacks.
             # See https://python.langchain.com/docs/how_to/tools_error/#tryexcept-tool-call

--- a/neuro_san/internals/run_context/langchain/llms/default_llm_factory.py
+++ b/neuro_san/internals/run_context/langchain/llms/default_llm_factory.py
@@ -592,8 +592,11 @@ class DefaultLlmFactory(ContextTypeLlmFactory, LangChainLlmFactory):
         # Initialize a list of chain fallbacks. This may or may not get filled.
         main_llm_resources: LangChainLlmResources = None
         fallback_llm_resources: List[LangChainLlmResources] = []
+
+        # Different kinds of errors we might encounter and report separately
         required_sly_data: Set[str] = set()
         api_key_errors: Set[str] = set()
+        construction_errors: Set[str] = set()
 
         # Trim the list of fallbacks.
         if num_fallbacks is not None:
@@ -605,7 +608,6 @@ class DefaultLlmFactory(ContextTypeLlmFactory, LangChainLlmFactory):
                 fallbacks = fallbacks[:num_fallbacks]
 
         # Go through the list of fallbacks in the config.
-        construction_errors: Set[str] = []
         for fallback in fallbacks:
 
             # Create a model we might use.

--- a/neuro_san/internals/run_context/langchain/llms/default_llm_factory.py
+++ b/neuro_san/internals/run_context/langchain/llms/default_llm_factory.py
@@ -653,9 +653,9 @@ class DefaultLlmFactory(ContextTypeLlmFactory, LangChainLlmFactory):
         if main_llm_resources is None:
             # Return all errors
             return {
-                "api_key_errors": list(api_key_errors),
-                "construction_errors": list(construction_errors),
-                "required_sly_data_errors": list(required_sly_data),
+                "api_key_errors": sorted(api_key_errors),
+                "construction_errors": sorted(construction_errors),
+                "required_sly_data_errors": sorted(required_sly_data),
             }
 
         if len(fallback_llm_resources) > 0:

--- a/neuro_san/internals/run_context/langchain/llms/default_llm_factory.py
+++ b/neuro_san/internals/run_context/langchain/llms/default_llm_factory.py
@@ -194,7 +194,7 @@ class DefaultLlmFactory(ContextTypeLlmFactory, LangChainLlmFactory):
         :return: The fully specified config with defaults filled in.
                 Can also return a set of strings describing any required sly_data API keys that are not provided.
         """
-        full_config: Dict[str, Any] = None
+        full_config: Dict[str, Any] | Set[str] = None
 
         class_from_llm_config: str = config.get("class")
         if class_from_llm_config:

--- a/neuro_san/internals/run_context/langchain/llms/default_llm_factory.py
+++ b/neuro_san/internals/run_context/langchain/llms/default_llm_factory.py
@@ -592,7 +592,8 @@ class DefaultLlmFactory(ContextTypeLlmFactory, LangChainLlmFactory):
         # Initialize a list of chain fallbacks. This may or may not get filled.
         main_llm_resources: LangChainLlmResources = None
         fallback_llm_resources: List[LangChainLlmResources] = []
-        required_llm_config: Set[str] = set()
+        required_sly_data: Set[str] = set()
+        api_key_errors: Set[str] = set()
 
         # Trim the list of fallbacks.
         if num_fallbacks is not None:
@@ -604,7 +605,7 @@ class DefaultLlmFactory(ContextTypeLlmFactory, LangChainLlmFactory):
                 fallbacks = fallbacks[:num_fallbacks]
 
         # Go through the list of fallbacks in the config.
-        construction_errors: List[str] = []
+        construction_errors: Set[str] = []
         for fallback in fallbacks:
 
             # Create a model we might use.
@@ -614,7 +615,17 @@ class DefaultLlmFactory(ContextTypeLlmFactory, LangChainLlmFactory):
             try:
                 one_llm_resources = self.create_llm(fallback, sly_data)
             except ValueError as exception:
-                construction_errors.append(str(exception))
+                if exception.__cause__ is not None:
+                    cause: Exception = exception.__cause__
+                    message: str = ApiKeyErrorCheck.check_for_api_key_exception(cause)
+                    if message is not None:
+                        # Make sure the message is fit for public consumption with no
+                        # explicit secrets in the text.
+                        message = ApiKeyErrorCheck.get_safe_log_message(exception)
+                        api_key_errors.add(message)
+                        continue
+
+                construction_errors.add(str(exception))
                 continue
 
             if one_llm_resources is None:
@@ -625,7 +636,7 @@ class DefaultLlmFactory(ContextTypeLlmFactory, LangChainLlmFactory):
             if isinstance(one_llm_resources, set):
                 # Report later on which required llm_config are missing
                 # Skip for now, a fallback might still be fulfilled.
-                required_llm_config.update(one_llm_resources)
+                required_sly_data.update(one_llm_resources)
                 continue
 
             if main_llm_resources is None:
@@ -638,8 +649,9 @@ class DefaultLlmFactory(ContextTypeLlmFactory, LangChainLlmFactory):
         if main_llm_resources is None:
             # Return all errors
             return {
-                "required_llm_config_errors": list(required_llm_config),
-                "construction_errors": construction_errors
+                "api_key_errors": list(api_key_errors),
+                "construction_errors": list(construction_errors),
+                "required_sly_data_errors": list(required_sly_data),
             }
 
         if len(fallback_llm_resources) > 0:

--- a/neuro_san/internals/run_context/langchain/llms/default_llm_factory.py
+++ b/neuro_san/internals/run_context/langchain/llms/default_llm_factory.py
@@ -443,8 +443,6 @@ class DefaultLlmFactory(ContextTypeLlmFactory, LangChainLlmFactory):
                     #          following set in sly_data.llm_config:
                     #          anthropic_api_key
                     #
-                    self.logger.error("API KEY error detected: %s",
-                                      ApiKeyErrorCheck.get_safe_log_message(exception))
                     raise ValueError(message) from exception
                 found_exception = exception
 

--- a/neuro_san/internals/run_context/langchain/llms/default_llm_factory.py
+++ b/neuro_san/internals/run_context/langchain/llms/default_llm_factory.py
@@ -571,6 +571,7 @@ class DefaultLlmFactory(ContextTypeLlmFactory, LangChainLlmFactory):
         """
         return {self.strip_outer_quotes(k): v for k, v in d.items()}
 
+    # pylint: disable=too-many-branches
     def create_llm_with_fallbacks(self, config: Dict[str, Any],
                                   sly_data: Dict[str, Any] = None,
                                   num_fallbacks: int = None) -> LangChainLlmResources | Dict[str, Any]:

--- a/neuro_san/internals/run_context/langchain/llms/default_llm_factory.py
+++ b/neuro_san/internals/run_context/langchain/llms/default_llm_factory.py
@@ -618,6 +618,9 @@ class DefaultLlmFactory(ContextTypeLlmFactory, LangChainLlmFactory):
             try:
                 one_llm_resources = self.create_llm(fallback, sly_data)
             except ValueError as exception:
+                # API Key errors get thrown as ValueErrors but have their
+                # "from" __cause__ set as the original exception.
+                # Examine that so we can report those separately.
                 if exception.__cause__ is not None:
                     cause: Exception = exception.__cause__
                     message: str = ApiKeyErrorCheck.check_for_api_key_exception(cause)

--- a/neuro_san/internals/run_context/langchain/llms/default_llm_factory.py
+++ b/neuro_san/internals/run_context/langchain/llms/default_llm_factory.py
@@ -573,16 +573,17 @@ class DefaultLlmFactory(ContextTypeLlmFactory, LangChainLlmFactory):
 
     def create_llm_with_fallbacks(self, config: Dict[str, Any],
                                   sly_data: Dict[str, Any] = None,
-                                  num_fallbacks: int = None) -> LangChainLlmResources | List[Set[str]]:
+                                  num_fallbacks: int = None) -> LangChainLlmResources | Dict[str, Any]:
         """
         :param config: A dictionary which describes which LLM to use, perhaps with fallbacks specified.
         :param sly_data: A user-provided dictionary of private data,
                 from which we might extract API keys to use for user billing.
                 Can be None indicating no API keys are provided at all and the system defaults will be used.
         :param num_fallbacks: The number of fallbacks to try. Default value of None implies all.
-        :return: A LangChainLlmResources instance or a set or error strings if no valid
-                llm was found.  If there were valid and useable fallbacks specified,
-                those will be set up as fallbacks for the model.
+        :return: A LangChainLlmResources instance or if no valid llm was found or
+                a dictionary whose keys are error types and whose values are lists of error strings
+                for that type.  If there were valid and useable fallbacks specified,
+                those will be set up as fallbacks for the model on the LlmResources object.
         """
         # Prepare a list of fallbacks.  By default, the llm_config itself is a single-entry fallback list.
         fallbacks: List[Dict[str, Any]] = [config]
@@ -636,7 +637,10 @@ class DefaultLlmFactory(ContextTypeLlmFactory, LangChainLlmFactory):
 
         if main_llm_resources is None:
             # Return all errors
-            return [required_llm_config, construction_errors]
+            return {
+                "required_llm_config_errors": list(required_llm_config),
+                "construction_errors": construction_errors
+            }
 
         if len(fallback_llm_resources) > 0:
             # Set up fallbacks.

--- a/neuro_san/internals/run_context/utils/activation_capsule.py
+++ b/neuro_san/internals/run_context/utils/activation_capsule.py
@@ -124,8 +124,8 @@ flag to your invocation.
         llm_resources = llm_factory.create_llm_with_fallbacks(llm_config, sly_data, num_fallbacks)
         if llm_resources is None:
             raise ValueError("Unable to create LLM from llm_config (missing required configuration and/or sly_data).")
-        if isinstance(llm_resources, set):
-            required = "\n".join(sorted(llm_resources))
+        if isinstance(llm_resources, list):
+            required = "\n".join(sorted(llm_resources[0]))
             raise ValueError(
                 "LLM operation for this agent requires at least one of the following set in sly_data.llm_config:\n"
                 f"{required}\n"

--- a/neuro_san/internals/run_context/utils/activation_capsule.py
+++ b/neuro_san/internals/run_context/utils/activation_capsule.py
@@ -125,10 +125,10 @@ flag to your invocation.
         if llm_resources is None:
             raise ValueError("Unable to create LLM from llm_config (missing required configuration and/or sly_data).")
         if isinstance(llm_resources, dict):
-            # For now, do not worry about the "construction_errors" key.
+            # For now, do not worry about the "construction_errors" or "api_key_errors" keys.
             # These are very likely to already be handled by the front man.
-            llm_config_errors: List[str] = llm_resources.get("required_llm_config_errors", [])
-            required = "\n".join(sorted(llm_config_errors))
+            required_sly_data: List[str] = llm_resources.get("required_sly_data_errors", [])
+            required = "\n".join(sorted(required_sly_data))
             raise ValueError(
                 "LLM operation for this agent requires at least one of the following set in sly_data.llm_config:\n"
                 f"{required}\n"

--- a/neuro_san/internals/run_context/utils/activation_capsule.py
+++ b/neuro_san/internals/run_context/utils/activation_capsule.py
@@ -124,8 +124,11 @@ flag to your invocation.
         llm_resources = llm_factory.create_llm_with_fallbacks(llm_config, sly_data, num_fallbacks)
         if llm_resources is None:
             raise ValueError("Unable to create LLM from llm_config (missing required configuration and/or sly_data).")
-        if isinstance(llm_resources, list):
-            required = "\n".join(sorted(llm_resources[0]))
+        if isinstance(llm_resources, dict):
+            # For now, do not worry about the "construction_errors" key.
+            # These are very likely to already be handled by the front man.
+            llm_config_errors: List[str] = llm_resources.get("required_llm_config_errors", [])
+            required = "\n".join(sorted(llm_config_errors))
             raise ValueError(
                 "LLM operation for this agent requires at least one of the following set in sly_data.llm_config:\n"
                 f"{required}\n"

--- a/tests/neuro_san/internals/run_context/langchain/core/test_langchain_run_context_llm_fallbacks.py
+++ b/tests/neuro_san/internals/run_context/langchain/core/test_langchain_run_context_llm_fallbacks.py
@@ -23,6 +23,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from neuro_san.internals.run_context.langchain.core.langchain_run_context import LangChainRunContext
+from neuro_san.internals.run_context.langchain.llms.default_llm_factory import DefaultLlmFactory
 
 
 # Both markers needed so conftest.py skips the OPENAI_API_KEY requirement:
@@ -38,8 +39,7 @@ class TestLangChainContextLlmFallbacks:
     and aggregates a final ValueError when no fallback succeeds.
     """
 
-    @staticmethod
-    def _make_run_context(llm_config: Dict[str, Any], create_llm_side_effect) -> LangChainRunContext:
+    def _make_run_context(self, llm_config: Dict[str, Any], create_llm_side_effect) -> LangChainRunContext:
         """
         Build a LangChainRunContext with the bare minimum wiring needed to exercise
         create_agent_with_fallbacks(), bypassing __init__ to avoid pulling in the
@@ -53,7 +53,7 @@ class TestLangChainContextLlmFallbacks:
         run_context.llm_config = llm_config
         run_context.llm_resources = None
 
-        llm_factory = MagicMock()
+        llm_factory = DefaultLlmFactory()
         llm_factory.create_llm = MagicMock(side_effect=create_llm_side_effect)
 
         invocation_context = MagicMock()
@@ -71,8 +71,7 @@ class TestLangChainContextLlmFallbacks:
 
         return run_context
 
-    @staticmethod
-    def _llm_resources_mock() -> MagicMock:
+    def _llm_resources_mock(self) -> MagicMock:
         """A stand-in for a successful LangChainLlmResources return value."""
         resources = MagicMock()
         resources.get_model.return_value = MagicMock(name="llm_model")

--- a/tests/neuro_san/internals/run_context/langchain/core/test_langchain_run_context_llm_fallbacks.py
+++ b/tests/neuro_san/internals/run_context/langchain/core/test_langchain_run_context_llm_fallbacks.py
@@ -39,7 +39,8 @@ class TestLangChainContextLlmFallbacks:
     and aggregates a final ValueError when no fallback succeeds.
     """
 
-    def _make_run_context(self, llm_config: Dict[str, Any], create_llm_side_effect) -> LangChainRunContext:
+    @staticmethod
+    def _make_run_context(llm_config: Dict[str, Any], create_llm_side_effect) -> LangChainRunContext:
         """
         Build a LangChainRunContext with the bare minimum wiring needed to exercise
         create_agent_with_fallbacks(), bypassing __init__ to avoid pulling in the
@@ -71,7 +72,8 @@ class TestLangChainContextLlmFallbacks:
 
         return run_context
 
-    def _llm_resources_mock(self) -> MagicMock:
+    @staticmethod
+    def _llm_resources_mock() -> MagicMock:
         """A stand-in for a successful LangChainLlmResources return value."""
         resources = MagicMock()
         resources.get_model.return_value = MagicMock(name="llm_model")


### PR DESCRIPTION
* Funnel all create_llm() calls in LangChainRunContext to create_llm_with_fallbacks()
* Have that create_llm_with_fallbacks() method return a dictionary with different error lists when nothing in the fallback list works at all.
* Have LangChainRunContext do the reporting of API Keys not working as well instead of lower. The idea is these can be deferred in a forward-looking fallback list scenario that @ofrancon shrewdly wants to entertain.
* Fix fallout

What @ofrancon wants to be able to do is to specify an llm_config like this:
```
    "llm_config": {
        "fallbacks": [
            {
                # Try OpenAI first
                "model_name": "gpt-5.2",
            },
            {
                # Fall back to Anthropic Claude if OpenAI is unavailable.
                "model_name": "claude-sonnet",
            },
            {
                # Fall back to Google Gemini if both OpenAI and Anthropic are unavailable.
                "model_name": "gemini-3-flash",
            },
        ]
    }
```
and not have to have every single key set for every LLM provider.
This is quite reasonable.   

Still, there are questions we need to answer about what a config looks like for devs vs our own production needs, but that is not for this PR. This PR is to enable the mechanism so that we can debate how to employ it.

With this PR, the system will take the subset of that llm_config fallbacks specification that will remotely work given the configuration and use that for the basis of agents.

@donn-leaf : There is a question for you about a reporting trade-off within this PR. Perhaps there is an env var afoot or an llm_config key to add to control preferences. Suggestions welcome.

Tested the above config manually with a bunch of different key configurations in hello_world.

