### PR TITLE
Fix Checkmarx threshold minimum value

### DIFF
--- a/.github/workflows/checkmarx.yml
+++ b/.github/workflows/checkmarx.yml
@@ -10,9 +10,6 @@ on:
     # M-F at 2 am UTC
     - cron: '0 2 * * 1-5'
   workflow_dispatch:
-  push:
-    branches:
-      - devin/1781205319-fix-cx-threshold
 
 jobs:
   checkmarx-scan:

--- a/.github/workflows/checkmarx.yml
+++ b/.github/workflows/checkmarx.yml
@@ -10,9 +10,6 @@ on:
     # M-F at 2 am UTC
     - cron: '0 2 * * 1-5'
   workflow_dispatch:
-  push:
-    branches:
-      - devin/1781205319-fix-cx-threshold
 
 jobs:
   checkmarx-scan:
@@ -33,7 +30,7 @@ jobs:
           cx-tenant: ${{ vars.CX_TENANT }}
           cx-client-id: ${{ vars.CX_CLIENT_ID }}
           cx-client-secret: ${{ secrets.CX_CLIENT_SECRET }}
-          scan-params: '--sast-preset-name "Checkmarx Default" --threshold "sast-critical=1;sast-high=1;sast-medium=1"'
+          scan-params: '--sast-preset-name "Checkmarx Default" --threshold "sast-critical=1;sast-high=1"'
 
       - name: Generate and download Checkmarx report
         id: report

--- a/.github/workflows/checkmarx.yml
+++ b/.github/workflows/checkmarx.yml
@@ -10,6 +10,9 @@ on:
     # M-F at 2 am UTC
     - cron: '0 2 * * 1-5'
   workflow_dispatch:
+  push:
+    branches:
+      - devin/1781205319-fix-cx-threshold
 
 jobs:
   checkmarx-scan:

--- a/.github/workflows/checkmarx.yml
+++ b/.github/workflows/checkmarx.yml
@@ -30,7 +30,7 @@ jobs:
           cx-tenant: ${{ vars.CX_TENANT }}
           cx-client-id: ${{ vars.CX_CLIENT_ID }}
           cx-client-secret: ${{ secrets.CX_CLIENT_SECRET }}
-          scan-params: '--sast-preset-name "Checkmarx Default" --threshold "sast-critical=0;sast-high=0"'
+          scan-params: '--sast-preset-name "Checkmarx Default" --threshold "sast-critical=1;sast-high=1"'
 
       - name: Generate and download Checkmarx report
         id: report

--- a/.github/workflows/checkmarx.yml
+++ b/.github/workflows/checkmarx.yml
@@ -10,6 +10,9 @@ on:
     # M-F at 2 am UTC
     - cron: '0 2 * * 1-5'
   workflow_dispatch:
+  push:
+    branches:
+      - devin/1781205319-fix-cx-threshold
 
 jobs:
   checkmarx-scan:
@@ -30,7 +33,7 @@ jobs:
           cx-tenant: ${{ vars.CX_TENANT }}
           cx-client-id: ${{ vars.CX_CLIENT_ID }}
           cx-client-secret: ${{ secrets.CX_CLIENT_SECRET }}
-          scan-params: '--sast-preset-name "Checkmarx Default" --threshold "sast-critical=1;sast-high=1"'
+          scan-params: '--sast-preset-name "Checkmarx Default" --threshold "sast-critical=1;sast-high=1;sast-medium=1"'
 
       - name: Generate and download Checkmarx report
         id: report


### PR DESCRIPTION
## Summary

The Checkmarx One CLI requires `--threshold` values to be >= 1. The previous `sast-critical=0;sast-high=0` caused:
```
Invalid value for threshold limit sast-critical. Threshold should be greater or equal to 1.
Invalid value for threshold limit sast-high. Threshold should be greater or equal to 1.
```

Changed to `sast-critical=1;sast-high=1` — build fails if 1 or more Critical or High SAST findings exist.

We tested the pass and fail cases, which work as expected, and the report is generated in either case, as desired.

Link to Devin session: https://app.devin.ai/sessions/fa003ff86bb34485a399856794ea8d65
Requested by: @donn-leaf