### PR TITLE
Attach Checkmarx report to GitHub releases

### DIFF
--- a/.github/workflows/checkmarx.yml
+++ b/.github/workflows/checkmarx.yml
@@ -2,7 +2,7 @@
 name: Checkmarx One
 
 permissions:
-  contents: read
+  contents: write
   security-events: write
 
 on:
@@ -10,6 +10,9 @@ on:
     # M-F at 2 am UTC
     - cron: '0 2 * * 1-5'
   workflow_dispatch:
+  release:
+    types:
+      - published
 
 jobs:
   checkmarx-scan:
@@ -183,3 +186,13 @@ jobs:
           name: checkmarx-report-${{ github.run_id }}
           path: checkmarx-report.pdf
           retention-days: 90
+
+      - name: Attach report to release
+        if: github.event_name == 'release' && steps.report.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          gh release upload "${{ github.event.release.tag_name }}" \
+            checkmarx-report.pdf#checkmarx-sast-report.pdf \
+            --clobber

--- a/.github/workflows/checkmarx.yml
+++ b/.github/workflows/checkmarx.yml
@@ -187,7 +187,7 @@ jobs:
           retention-days: 90
 
   attach-to-release:
-    if: github.event_name == 'release'
+    if: always() && github.event_name == 'release'
     needs: checkmarx-scan
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/checkmarx.yml
+++ b/.github/workflows/checkmarx.yml
@@ -1,10 +1,6 @@
 ---
 name: Checkmarx One
 
-permissions:
-  contents: write
-  security-events: write
-
 on:
   schedule:
     # M-F at 2 am UTC
@@ -17,6 +13,9 @@ on:
 jobs:
   checkmarx-scan:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - name: Checkout repository
         # v6.0.2
@@ -187,12 +186,25 @@ jobs:
           path: checkmarx-report.pdf
           retention-days: 90
 
+  attach-to-release:
+    if: github.event_name == 'release'
+    needs: checkmarx-scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download report artifact
+        # v4.3.0
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: checkmarx-report-${{ github.run_id }}
+
       - name: Attach report to release
-        if: github.event_name == 'release' && steps.report.outcome == 'success'
         env:
           GH_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ github.event.release.tag_name }}
         shell: bash
         run: |
-          gh release upload "${{ github.event.release.tag_name }}" \
+          gh release upload "$TAG_NAME" \
             checkmarx-report.pdf#checkmarx-sast-report.pdf \
             --clobber


### PR DESCRIPTION
## Summary

Adds a `release: published` trigger to the Checkmarx workflow so a scan runs at release time and the PDF report is permanently attached as a release asset (no expiration, unlike workflow artifacts).

**Architecture:** Two jobs for least-privilege permissions:
- `checkmarx-scan` — `contents: read` — runs scan, generates report, uploads as workflow artifact
- `attach-to-release` — `contents: write` — only runs on release events, downloads artifact and attaches to the release via `gh release upload`

The `attach-to-release` job uses `always()` so the report is attached even if the scan fails due to threshold violations — useful while repos still have existing findings being cleaned up. The `--clobber` flag allows re-running without duplicate-asset errors.

Tag name is passed via env var (`TAG_NAME`) to prevent GitHub Actions script injection.

Link to Devin session: https://app.devin.ai/sessions/fa003ff86bb34485a399856794ea8d65
Requested by: @donn-leaf
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cognizant-ai-lab/neuro-san/pull/1049" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->