### PR TITLE
Fix Gemini INVALID_ARGUMENT for tools without parameters

### DIFF
--- a/neuro_san/internals/run_context/langchain/core/base_model_dictionary_converter.py
+++ b/neuro_san/internals/run_context/langchain/core/base_model_dictionary_converter.py
@@ -96,7 +96,7 @@ class BaseModelDictionaryConverter(DictionaryConverter):
 
         # Get stuff from the object-level function dictionary
         # from the OpenAI function spec
-        properties: Dict[str, Any] = function_dict.get("properties")
+        properties: Dict[str, Any] = function_dict.get("properties", {})
         required: List[str] = []
         required = function_dict.get("required", required)
 

--- a/neuro_san/internals/run_context/langchain/core/langchain_openai_function_tool.py
+++ b/neuro_san/internals/run_context/langchain/core/langchain_openai_function_tool.py
@@ -159,13 +159,17 @@ It's function_json is described thusly:
         # to be an args_schema member which should be a pydantic BaseModel
         # for the objects that are passed as arguments.
         #
-        # If "parameters" is not None, create a pydantic BaseModel of the OpenAI function spec for the agent
-        # to satisfy that langchain need.  It's kind of a shame because this is just
-        # going to get converted back to an OpenAI function again later on in langchain
-        #  agent-land.
-        if use_function_json != function_json:
-            converter = BaseModelDictionaryConverter("parameters")
-            tool.args_schema = converter.from_dict(use_function_json)
+        # Always build an explicit args_schema from the OpenAI function spec.
+        # When no "parameters" block is declared, feed an empty dict to the
+        # converter so it produces an empty pydantic BaseModel. Without this,
+        # langchain's BaseTool auto-derives a schema from _arun(*args, **kwargs)
+        # which emits a property named "args" of type "array" with no "items"
+        # field — Gemini rejects that with INVALID_ARGUMENT. It's kind of a
+        # shame because this is just going to get converted back to an OpenAI
+        # function again later on in langchain agent-land.
+        converter = BaseModelDictionaryConverter("parameters")
+        schema_source: Dict[str, Any] = use_function_json if use_function_json != function_json else {}
+        tool.args_schema = converter.from_dict(schema_source)
 
         tool.tool_caller = tool_caller
 


### PR DESCRIPTION
When a tool's HOCON function block declared no "parameters", args_schema was left unset. LangChain's BaseTool then auto-derived a schema from _arun(*args, **kwargs), producing a property named "args" of type "array" with no "items" field. OpenAI and Claude accept this, but Gemini strictly validates and rejects it with INVALID_ARGUMENT.

Always build an explicit args_schema. When no "parameters" block is declared, feed an empty dict to the converter so it produces an empty pydantic BaseModel — preventing the broken auto-derivation. Tools with parameters go through the exact same converter call as before.

Also use .get("properties", {}) in the converter so an absent properties key is handled cleanly.

Fix #1050 