### PR TITLE
A little extra for Medium-level CheckMarx false-positive vulnerability

### DIFF
--- a/neuro_san/deploy/Dockerfile
+++ b/neuro_san/deploy/Dockerfile
@@ -333,6 +333,12 @@ ENV AGENT_MCP_ENABLE="true"
 # while disabling neuro-san own http API.
 ENV AGENT_MCP_ONLY="false"
 
+# When set, this parameter requires https for internal agent session communication
+# The default is false, to allow developers to get their work done without going
+# through the rigamarole of getting certificates for simple local development.
+# Strongly consider turning this on for your production deployments.
+ENV AGENT_SESSION_REQUIRE_HTTPS="false"
+
 #
 # Authorization
 #

--- a/neuro_san/deploy/Dockerfile
+++ b/neuro_san/deploy/Dockerfile
@@ -333,10 +333,9 @@ ENV AGENT_MCP_ENABLE="true"
 # while disabling neuro-san own http API.
 ENV AGENT_MCP_ONLY="false"
 
-# When set, this parameter requires https for internal agent session communication
-# The default is false, to allow developers to get their work done without going
-# through the rigamarole of getting certificates for simple local development.
-# Strongly consider turning this on for your production deployments.
+# When set to "true", this parameter requires https for internal agent session communication.
+# The default is "false", to allow developers to work locally without acquiring certificates.
+# Strongly consider turning this on for production deployments.
 ENV AGENT_SESSION_REQUIRE_HTTPS="false"
 
 #

--- a/neuro_san/deploy/entrypoint.sh
+++ b/neuro_san/deploy/entrypoint.sh
@@ -42,6 +42,8 @@ ${PIP} freeze
 PACKAGE_INSTALL=${PACKAGE_INSTALL:-.}
 echo "PACKAGE_INSTALL is ${PACKAGE_INSTALL}"
 
+echo "AGENT_SESSION_REQUIRE_HTTPS = ${AGENT_SESSION_REQUIRE_HTTPS}"
+
 echo "Starting service with args '$1'..."
 ${PYTHON} "${PACKAGE_INSTALL}"/neuro_san/service/main_loop/server_main_loop.py "$@"
 

--- a/neuro_san/session/abstract_http_service_agent_session.py
+++ b/neuro_san/session/abstract_http_service_agent_session.py
@@ -100,7 +100,7 @@ class AbstractHttpServiceAgentSession(AgentSessionConstants):
         require_https: bool = getenv("AGENT_SESSION_REQUIRE_HTTPS", "false").lower() == "true"
         if require_https and scheme != "https":
             raise ValueError(
-                "AGENT_SESSION_REQUIRE_HTTPS=true requires https; configure the session for https (e.g., provide security_cfg)"
+                f"AGENT_SESSION_REQUIRE_HTTPS=true requires https. Configure the {self.__class__.__name__} accordingly"
             )
 
         if self.agent_name is None:

--- a/neuro_san/session/abstract_http_service_agent_session.py
+++ b/neuro_san/session/abstract_http_service_agent_session.py
@@ -85,14 +85,12 @@ class AbstractHttpServiceAgentSession(AgentSessionConstants):
         :param method: The method endpoint we wish to reach
         :return: The full URL for accessing the method, given the host, port and agent_name.
         """
-        # CheckMarx false positive
-        # The following line is a single source for 3 different Medium-level "Commuinication over HTTP"
-        # vulnerabilities. It sees "http" below an freaks out because absoultely everything is not going
-        # over https.  Reasonable for production, but not reasonable for development. While http
-        # communication is indeed a possibility, the choice of communication protocol is entirely up to
-        # the client code.  Agent network developers cannot start from a fully locked down https position
-        # because at that point no one has certificates, so this http possibility always needs to be
-        # here so that people can get their initial work done.
+        # CheckMarx false positive:
+        # CheckMarx flags the literal "http" below as a medium-level "Communication over HTTP" issue.
+        # This method only builds the URL; the caller decides whether to use https by providing
+        # appropriate session/security configuration. HTTP support is kept for ease of local
+        # development where certificates are often unavailable.
+        # For production, set AGENT_SESSION_REQUIRE_HTTPS=true (and configure https) to forbid http.
         scheme: str = "http"
         if self.security_cfg is not None:
             scheme = "https"

--- a/neuro_san/session/abstract_http_service_agent_session.py
+++ b/neuro_san/session/abstract_http_service_agent_session.py
@@ -18,6 +18,8 @@
 from typing import Any
 from typing import Dict
 
+from os import getenv
+
 from leaf_common.time.timeout import Timeout
 
 from neuro_san.interfaces.agent_session_constants import AgentSessionConstants
@@ -83,9 +85,24 @@ class AbstractHttpServiceAgentSession(AgentSessionConstants):
         :param method: The method endpoint we wish to reach
         :return: The full URL for accessing the method, given the host, port and agent_name.
         """
+        # CheckMarx false positive
+        # The following line is a single source for 3 different Medium-level "Commuinication over HTTP"
+        # vulnerabilities. It sees "http" below an freaks out because absoultely everything is not going
+        # over https.  Reasonable for production, but not reasonable for development. While http
+        # communication is indeed a possibility, the choice of communication protocol is entirely up to
+        # the client code.  Agent network developers cannot start from a fully locked down https position
+        # because at that point no one has certificates, so this http possibility always needs to be
+        # here so that people can get their initial work done.
         scheme: str = "http"
         if self.security_cfg is not None:
             scheme = "https"
+
+        # By default, be permissive so developers can get work done.
+        # Servers can turn this on to be more strict within their systems.
+        env_setting: str = getenv("AGENT_SESSION_REQUIRE_HTTPS", "false").lower()
+        allow_http: bool = env_setting in ["false", "0", "no", "off", "disable", "disabled", ""]
+        if not allow_http:
+            raise ValueError("Session is only configured to allow https communication, not http")
 
         if self.agent_name is None:
             return f"{scheme}://{self.use_host}:{self.use_port}/api/v1/{method}"

--- a/neuro_san/session/abstract_http_service_agent_session.py
+++ b/neuro_san/session/abstract_http_service_agent_session.py
@@ -99,10 +99,11 @@ class AbstractHttpServiceAgentSession(AgentSessionConstants):
 
         # By default, be permissive so developers can get work done.
         # Servers can turn this on to be more strict within their systems.
-        env_setting: str = getenv("AGENT_SESSION_REQUIRE_HTTPS", "false").lower()
-        allow_http: bool = env_setting in ["false", "0", "no", "off", "disable", "disabled", ""]
-        if not allow_http:
-            raise ValueError("Session is only configured to allow https communication, not http")
+        require_https: bool = getenv("AGENT_SESSION_REQUIRE_HTTPS", "false").lower() == "true"
+        if require_https and scheme != "https":
+            raise ValueError(
+                "AGENT_SESSION_REQUIRE_HTTPS=true requires https; configure the session for https (e.g., provide security_cfg)"
+            )
 
         if self.agent_name is None:
             return f"{scheme}://{self.use_host}:{self.use_port}/api/v1/{method}"


### PR DESCRIPTION
The new CheckMarx scans complain of a medium-level vulnerability where we are using http within the AbstractHttpServiceAgentSession.  This isn't really worrisome because it's up to the client code eventually calling this class to specify https in their urls and security configuration for the Session.  Nevertheless, there are a couple things we can do to assuage this warning:

1) Add a comment right by the CheckMarx source line explaining the situation - we don't want to require new developers to have to go off and get certs to do the simplest things.

2) Allow for a new AGENT_SESSION_REQUIRE_HTTPS env var so that production uses can expressly forbid the http behavior if they wish.  In the Dockerfile we recommend people turn this on for production.