### PR TITLE
Add OpenRouter as an LLM provider

### DIFF
--- a/docs/agent_hocon_reference.md
+++ b/docs/agent_hocon_reference.md
@@ -211,12 +211,25 @@ to use LLMs from various providers.
 | NVidia        | NVIDIA_API_KEY                                 |
 | Ollma         | &lt;None required&gt;                          |
 | OpenAI        | OPENAI_API_KEY                                 |
+| OpenRouter    | OPENROUTER_API_KEY                             |
 
 **Anthropic Model Names:** The model names `claude-haiku`, `claude-sonnet`, `claude-opus`, and `claude-fable`
 are aliases that automatically reference the latest versions of their respective Anthropic model lines.
 This aliasing is recommended because Anthropic frequently deprecates older model versions. For information
 on current models and deprecation schedules, see the
 [Anthropic model deprecations documentation](https://platform.claude.com/docs/en/about-claude/model-deprecations).
+
+**OpenRouter Model Names:** [OpenRouter](https://openrouter.ai/) is a unified API gateway that fronts
+hundreds of models from many providers (OpenAI, Anthropic, Google, Meta, etc.) behind a single endpoint.
+With the `openrouter` class, the `model_name` follows OpenRouter's `provider/model` convention, e.g.
+`anthropic/claude-sonnet-4-5` or `openai/gpt-4o`. OpenRouter also exposes "meta-router" models such as
+`openrouter/free` and `openrouter/auto` that select an underlying model at request time based on the
+capabilities the request needs (image understanding, tool calling, structured outputs, etc.). Because
+the underlying model is not known ahead of time for these routers, their `max_output_tokens` is left
+unset in `default_llm_info.hocon` — see the
+[llm_info_hocon_reference](./llm_info_hocon_reference.md#max_output_tokens) for what that means in practice.
+This integration requires the [`langchain-openrouter`](https://docs.langchain.com/oss/python/integrations/chat/openrouter)
+package, which neuro-san lazy-installs on first use.
 
 **Security Best Practice:** _We strongly recommend to **not** set secrets as values within any source file._
 These files tend to creep into source control repos, and it is **very** bad practice
@@ -280,6 +293,7 @@ Set the `class` key to one of the values listed below, then specify the model us
 | NVidia        | nvidiea       |
 | Ollma         | ollama        |
 | OpenAI        | openai        |
+| OpenRouter    | openrouter    |
 
 You may only provide parameters that are explicitly defined for that provider's class under the
 `classes.<class>.args` section of

--- a/docs/llm_info_hocon_reference.md
+++ b/docs/llm_info_hocon_reference.md
@@ -144,6 +144,15 @@ While it is possible to specify a smaller max_output_tokens in a given [classes]
 configuration, it is not possible to simply list a new larger value and have it
 magically manifest itself.  This is a matter of how the LLM was trained.
 
+**`null` is allowed** for entries whose true output ceiling is not known ahead of time.
+The motivating case is OpenRouter's meta-router models (e.g. `openrouter/free`,
+`openrouter/auto`), which pick an underlying model at request time, so the real
+`max_output_tokens` varies per request. When `max_output_tokens` is `null`, neuro-san
+skips the `prompt_token_fraction` multiplication and leaves the resulting `max_tokens`
+unset on the LLM, letting the provider's own default take over. Concrete numeric values
+are still preferred whenever the model has a known fixed ceiling — `null` should be
+reserved for the cases above.
+
 #### `knowledge_cutoff`
 
 String date indicating the origination date of the last piece of training data.

--- a/neuro_san/internals/run_context/langchain/llms/default_llm_factory.py
+++ b/neuro_san/internals/run_context/langchain/llms/default_llm_factory.py
@@ -514,7 +514,7 @@ class DefaultLlmFactory(ContextTypeLlmFactory, LangChainLlmFactory):
         # Unpack user_config  into llm constructor
         return llm_class(**user_config)
 
-    def get_max_prompt_tokens(self, config: Dict[str, Any]) -> int | None:
+    def get_max_prompt_tokens(self, config: Dict[str, Any]) -> Optional[int]:
         """
         :param config: A dictionary which describes which LLM to use.
         :return: The maximum number of tokens given the 'model_name' in the

--- a/neuro_san/internals/run_context/langchain/llms/default_llm_factory.py
+++ b/neuro_san/internals/run_context/langchain/llms/default_llm_factory.py
@@ -18,6 +18,7 @@
 from typing import Any
 from typing import Dict
 from typing import List
+from typing import Optional
 from typing import Set
 from typing import Type
 from typing import Tuple
@@ -513,30 +514,42 @@ class DefaultLlmFactory(ContextTypeLlmFactory, LangChainLlmFactory):
         # Unpack user_config  into llm constructor
         return llm_class(**user_config)
 
-    def get_max_prompt_tokens(self, config: Dict[str, Any]) -> int:
+    def get_max_prompt_tokens(self, config: Dict[str, Any]) -> int | None:
         """
         :param config: A dictionary which describes which LLM to use.
         :return: The maximum number of tokens given the 'model_name' in the
-                config dictionary.
+                config dictionary, or None if the llm entry does not declare a
+                fixed max_output_tokens (e.g. OpenRouter meta-routers where the
+                underlying model is chosen per-request).
         """
 
-        model_name = config.get("model_name")
+        model_name: str = config.get("model_name")
 
-        llm_entry = self.llm_infos.get(model_name)
+        llm_entry: Dict[str, Any] = self.llm_infos.get(model_name)
         if llm_entry is None:
             raise ValueError(f"No llm entry for model_name {model_name}")
 
-        use_model_name = llm_entry.get("use_model_name", model_name)
+        use_model_name: str = llm_entry.get("use_model_name", model_name)
         if len(llm_entry.keys()) <= 2 and use_model_name is not None:
             # We effectively have an alias. Switch out the llm entry.
             llm_entry = self.llm_infos.get(use_model_name)
 
-        entry_max_tokens = llm_entry.get("max_output_tokens")
-        prompt_token_fraction = config.get("prompt_token_fraction")
-        use_max_tokens = int(entry_max_tokens * prompt_token_fraction)
+        entry_max_tokens: Optional[int] = llm_entry.get("max_output_tokens")
+        prompt_token_fraction: Optional[float] = config.get("prompt_token_fraction")
+
+        # Both factors must be concrete numbers for the multiplication to work —
+        # entry_max_tokens is intentionally null in llm_info for models whose true
+        # max_output_tokens is unknown until the underlying model is selected at
+        # request time (e.g. openrouter/free, openrouter/auto). Without this guard,
+        # int(None * fraction) raises TypeError, which has been observed to surface
+        # as a hang upstream. Returning None lets callers fall back to the model's
+        # own default.
+        use_max_tokens: Optional[int] = None
+        if entry_max_tokens is not None and prompt_token_fraction is not None:
+            use_max_tokens = int(entry_max_tokens * prompt_token_fraction)
 
         # Allow the actual value for max_tokens to come from the config, if there
-        max_prompt_tokens = config.get("max_tokens", use_max_tokens)
+        max_prompt_tokens: Optional[int] = config.get("max_tokens", use_max_tokens)
         if max_prompt_tokens is None:
             max_prompt_tokens = use_max_tokens
 

--- a/neuro_san/internals/run_context/langchain/llms/default_llm_info.hocon
+++ b/neuro_san/internals/run_context/langchain/llms/default_llm_info.hocon
@@ -1151,9 +1151,8 @@
         },
         "capabilities": [ "tools" ],
         # Like openrouter/free, the underlying model is chosen per-request, so the
-        # true context window varies. OpenRouter's model page does not publish a
-        # nominal window for the router itself, so we follow the same 200k figure
-        # used for openrouter/free as a reasonable default for prompt-token math.
+        # true context window varies. OpenRouter's model page advertises 2m, so we go
+        # with that as the nominal value used for prompt-token math.
         "context_window_size": 2000000,
         # max_output_tokens depends on which model the router picks; leave null so
         # the underlying model's default applies.

--- a/neuro_san/internals/run_context/langchain/llms/default_llm_info.hocon
+++ b/neuro_san/internals/run_context/langchain/llms/default_llm_info.hocon
@@ -1107,6 +1107,60 @@
         "knowledge_cutoff": "03/2025",
     },
 
+    # OpenRouter
+    # https://openrouter.ai/
+    #
+    # OpenRouter is a unified API gateway that fronts hundreds of models from many
+    # providers (OpenAI, Anthropic, Google, Meta, etc.) behind a single
+    # OpenAI-compatible endpoint. Models are addressed as "provider/model", e.g.
+    # "anthropic/claude-sonnet-4-5". A few "meta" router models (like openrouter/free
+    # and openrouter/auto) pick an underlying model at request time based on the
+    # capabilities your prompt needs.
+
+    "openrouter/free": {
+        # openrouter/free is a router that selects free models at random from the models available on OpenRouter.
+        # The router smartly filters for models that support features needed for your request
+        # such as image understanding, tool calling, structured outputs and more.
+        "class": "openrouter",
+        "model_info_url": "https://openrouter.ai/openrouter/free",
+        "modalities": {
+            "input": [ "text", "image" ],
+            "output": [ "text" ],
+        },
+        "capabilities": [ "tools" ],
+        # The underlying model is chosen at request time, so the true context window
+        # also varies per request. OpenRouter's model page advertises 200k, so we go
+        # with that as the nominal value used for prompt-token math.
+        "context_window_size": 200000,
+        # max_output_tokens likewise depends on which model the router picks, so we
+        # leave it null and let the underlying model's default apply.
+        "max_output_tokens": null,
+        "knowledge_cutoff": "unknown",
+    },
+
+    "openrouter/auto": {
+        # openrouter/auto is a paid auto-router that uses a meta-model to analyze the
+        # incoming prompt and pick one of dozens of candidate models for quality.
+        # Pricing matches whichever underlying model handles the request — there is
+        # no premium routing fee. See https://openrouter.ai/openrouter/auto
+        "class": "openrouter",
+        "model_info_url": "https://openrouter.ai/openrouter/auto",
+        "modalities": {
+            "input": [ "text", "image" ],
+            "output": [ "text" ],
+        },
+        "capabilities": [ "tools" ],
+        # Like openrouter/free, the underlying model is chosen per-request, so the
+        # true context window varies. OpenRouter's model page does not publish a
+        # nominal window for the router itself, so we follow the same 200k figure
+        # used for openrouter/free as a reasonable default for prompt-token math.
+        "context_window_size": 2000000,
+        # max_output_tokens depends on which model the router picks; leave null so
+        # the underlying model's default applies.
+        "max_output_tokens": null,
+        "knowledge_cutoff": "unknown",
+    },
+
     # These are data for each LLM class, so they don't have to be repeated for each
     # LLM info entry above.
     "classes": {
@@ -1285,6 +1339,38 @@
                 "stop": null,
                 "nvidia_api_key": null,
                 "nvidia_base_url": null,
+            }
+        },
+        "openrouter": {
+            "args": {
+                # Note that we can only supply arguments that are "Just Data" in nature.
+                # See https://docs.langchain.com/oss/python/integrations/chat/openrouter
+                "openrouter_api_key": null,
+                "openrouter_api_base": null,
+                "request_timeout": null,    # In milliseconds; maps to ChatOpenRouter `timeout`
+                "max_retries": 2,
+                "temperature": null,
+                "max_tokens": null,         # This is always for output
+                "top_p": null,
+                "frequency_penalty": null,
+                "presence_penalty": null,
+                "seed": null,
+                "stop": null,               # Maps to ChatOpenRouter `stop_sequences`
+
+                # OpenRouter-specific options
+                # See https://openrouter.ai/docs
+
+                # Reasoning settings, e.g. {"effort": "high", "summary": "auto"}
+                "reasoning": null,
+                # Provider routing preferences, e.g. {"order": ["Anthropic", "OpenAI"]}
+                "openrouter_provider": null,
+                # Route preference, e.g. "fallback"
+                "route": null,
+                # Session id used by OpenRouter to group related requests for observability.
+                # Falls back to OPENROUTER_SESSION_ID env var when null.
+                "session_id": null,
+                # Trace metadata forwarded to broadcast destinations (Langfuse, LangSmith, ...).
+                "trace": null,
             }
         },
         "gemini": {

--- a/neuro_san/internals/run_context/langchain/llms/openrouter_llm_policy.py
+++ b/neuro_san/internals/run_context/langchain/llms/openrouter_llm_policy.py
@@ -1,0 +1,125 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+from typing import Any
+from typing import Dict
+
+from contextlib import suppress
+
+from langchain_core.language_models.base import BaseLanguageModel
+
+from neuro_san.internals.run_context.langchain.llms.llm_policy import LlmPolicy
+
+
+class OpenRouterLlmPolicy(LlmPolicy):
+    """
+    Implementation of the LlmPolicy for OpenRouter chat models.
+
+    OpenRouter is a unified API that fronts hundreds of models from many
+    providers (OpenAI, Anthropic, Google, Meta, etc.). Models are addressed
+    as "provider/model", e.g. "anthropic/claude-sonnet-4-5".
+
+    ChatOpenRouter builds its own openrouter SDK client internally and does
+    not allow for passing in an externally managed async web client.
+    """
+
+    def create_llm(self, config: Dict[str, Any], model_name: str, client: Any) -> BaseLanguageModel:
+        """
+        Create a BaseLanguageModel instance from the fully-specified llm config
+        for the llm class that the implementation supports.  Chat models are usually
+        per-provider, where the specific model itself is an argument to its constructor.
+
+        :param config: The fully specified llm config
+        :param model_name: The name of the model
+        :param client: The web client to use (if any)
+        :return: A BaseLanguageModel (can be Chat or LLM)
+        """
+        # Use lazy loading to prevent installing the world
+        # pylint: disable=invalid-name
+        ChatOpenRouter = self.resolver.resolve_class_in_module("ChatOpenRouter",
+                                                               module_name="langchain_openrouter.chat_models",
+                                                               install_if_missing="langchain-openrouter")
+
+        llm = ChatOpenRouter(
+            model=model_name,
+            api_key=self.get_value_or_env(config, "openrouter_api_key",
+                                          "OPENROUTER_API_KEY"),
+            base_url=self.get_value_or_env(config, "openrouter_api_base",
+                                           "OPENROUTER_API_BASE"),
+            timeout=config.get("request_timeout"),
+            max_retries=config.get("max_retries"),
+            temperature=config.get("temperature"),
+            max_tokens=config.get("max_tokens"),
+            top_p=config.get("top_p"),
+            frequency_penalty=config.get("frequency_penalty"),
+            presence_penalty=config.get("presence_penalty"),
+            seed=config.get("seed"),
+            stop_sequences=config.get("stop"),
+            # Disable streaming: neuro-san does not consume per-token chunks from the model,
+            # and disabling streaming reduces per-request LangChain pipeline overhead.
+            # Token usage is collected from AIMessage.usage_metadata in LlmTokenCallbackHandler.
+            # We set streaming explicitly (rather than relying on the False default) so that
+            # langchain_core._should_stream() recognizes it as opted-out
+            # even when a streaming-aware callback is attached.
+            streaming=False,
+            stream_usage=False,  # Don't even include token usage in the streaming response, since we're not streaming
+            reasoning=config.get("reasoning"),
+            openrouter_provider=config.get("openrouter_provider"),
+            route=config.get("route"),
+            session_id=config.get("session_id"),
+            trace=config.get("trace"),
+            # If omitted, this defaults to the global verbose value,
+            # accessible via langchain_core.globals.get_verbose():
+            # https://github.com/langchain-ai/langchain/blob/master/libs/core/langchain_core/globals.py#L53
+            #
+            # However, accessing the global verbose value during concurrent initialization
+            # can trigger the following warning:
+            #
+            # UserWarning: Importing verbose from langchain root module is no longer supported.
+            # Please use langchain.globals.set_verbose() / langchain.globals.get_verbose() instead.
+            # old_verbose = langchain.verbose
+            #
+            # To prevent this, we explicitly set verbose=False here (which matches the default
+            # global verbose value) so that the warning is never triggered.
+            verbose=False,
+        )
+        return llm
+
+    async def delete_resources(self):
+        """
+        Release the run-time resources used by the model
+        """
+        if self.llm is None:
+            return
+
+        # Do the necessary reach-ins to successfully shut down the web client.
+        # ChatOpenRouter wraps an openrouter.OpenRouter SDK client which itself
+        # owns the httpx clients. Best-effort close, since the SDK's close API
+        # is not part of LangChain's public contract.
+        sdk_client: Any = getattr(self.llm, "client", None)
+        if sdk_client is not None:
+            for attr in ("aclose", "close"):
+                method = getattr(sdk_client, attr, None)
+                if method is None:
+                    continue
+                with suppress(Exception):
+                    result = method()
+                    if hasattr(result, "__await__"):
+                        await result
+                break
+
+        self.llm = None

--- a/neuro_san/internals/run_context/langchain/llms/standard_langchain_llm_factory.py
+++ b/neuro_san/internals/run_context/langchain/llms/standard_langchain_llm_factory.py
@@ -31,6 +31,7 @@ from neuro_san.internals.run_context.langchain.llms.langchain_llm_resources impo
 from neuro_san.internals.run_context.langchain.llms.nvidia_llm_policy import NvidiaLlmPolicy
 from neuro_san.internals.run_context.langchain.llms.ollama_llm_policy import OllamaLlmPolicy
 from neuro_san.internals.run_context.langchain.llms.openai_llm_policy import OpenAILlmPolicy
+from neuro_san.internals.run_context.langchain.llms.openrouter_llm_policy import OpenRouterLlmPolicy
 
 
 class StandardLangChainLlmFactory(LangChainLlmFactory):
@@ -75,6 +76,7 @@ class StandardLangChainLlmFactory(LangChainLlmFactory):
                 "gemini": GeminiLlmPolicy,
                 "nvidia": NvidiaLlmPolicy,
                 "openai": OpenAILlmPolicy,
+                "openrouter": OpenRouterLlmPolicy,
                 "ollama": OllamaLlmPolicy,
             }
 

--- a/neuro_san/registries/manifest.hocon
+++ b/neuro_san/registries/manifest.hocon
@@ -47,6 +47,7 @@
     "music_nerd_pro_llm_ollama.hocon": true,
     "music_nerd_pro_multi_agents.hocon": true,
     "music_nerd_pro_llm_bedrock_claude.hocon": true,
+    "music_nerd_pro_llm_openrouter.hocon": true,
 
     # This is an example of summarization middleware.
     "music_nerd_summarize.hocon": true,

--- a/neuro_san/registries/music_nerd_pro_llm_openrouter.hocon
+++ b/neuro_san/registries/music_nerd_pro_llm_openrouter.hocon
@@ -95,7 +95,7 @@ Then answer with a JSON message that has two keys:
             "function": {
                 "description": """
 You are an API that keeps track of the running cost of the MusicNerdPro service. Pass the current running cost
-to the API to get the updated running cost. If no running cost it known, pass 0.00.
+to the API to get the updated running cost. If no running cost is known, pass 0.00.
                 """,
                 "parameters": {
                     "type": "object",

--- a/neuro_san/registries/music_nerd_pro_llm_openrouter.hocon
+++ b/neuro_san/registries/music_nerd_pro_llm_openrouter.hocon
@@ -1,0 +1,114 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+# The schema specifications for this file are documented here:
+# https://github.com/cognizant-ai-lab/neuro-san/blob/main/docs/agent_hocon_reference.md
+
+{
+    # Optional metadata describing this agent network
+    "metadata": {
+        "description": "Simple agent network using a single OpenRouter-based agent and a single CodedTool",
+        "tags": ["example", "llm_tests"],
+        "sample_queries": [
+            "Which band wrote Yellow Submarine?",
+            "Where are they from?",
+        ]
+    },
+    "llm_config": {
+        # OpenRouter exposes models under a "provider/model" naming convention
+        # (e.g. "anthropic/claude-sonnet-4-5", "openai/gpt-4o"). The two entries
+        # below — "openrouter/free" and "openrouter/auto" — are meta-routers that
+        # pick the underlying model at request time. Using a specific
+        # "provider/model" id pins to that exact model.
+        #
+        # The model_name only resolves to the openrouter class because
+        # default_llm_info.hocon has an entry for it. To use any other OpenRouter
+        # model without adding an llm_info entry, also set "class": "openrouter".
+        "model_name": "openrouter/free",
+    },
+    "tools": [
+        # This first agent definition is regarded as the "Front Man", which
+        # does all the talking to the outside world/client.
+        #
+        # Some disqualifications from being a front man:
+        #   1) Cannot use a CodedTool "class" definition
+        #   2) Cannot use a Tool "toolbox" definition
+        #
+        # Besides the first agent being the front man, these tool definitions
+        # do not have to be in any particular order. How they are linked and
+        # call each other is defined within their own specs.
+        # This could be a graph, potentially even with cycles.
+        {
+            "name": "MusicNerdPro",
+
+            # Note that there are no parameters defined for this guy's "function" key.
+            # This is the primary way to identify this tool as a front-man,
+            # distinguishing it from the rest of the tools.
+
+            "function": {
+
+                # The description acts as an initial prompt. 
+                "description": """
+I can help with music-related inquiries.
+"""
+            },
+
+            "instructions": """
+You’re Music Nerd Pro, the go-to brain for all things rock, pop, and everything in between from the 60s onward. You live for liner notes, B-sides, lost demos, and legendary live sets. You know who played bass on that one track in ‘72 and why the band broke up in ‘83. People come to you with questions like:
+	•	“What’s the story behind this song?”
+	•	“Which album should I start with?”
+	•	“Who influenced this band’s sound?”
+	•	“Is there a deeper meaning in these lyrics?”
+	•	“What’s a hidden gem I probably missed?”
+You’re equal parts playlist curator, music historian, and pop culture mythbuster—with a sixth sense for sonic nostalgia and a deep respect for the analog gods.
+
+- You must call the Accountant tool exactly once per user question — no more, no less.
+- You must not estimate, guess, or invent the cost under any circumstance.
+- You must not skip calling the Accountant tool — it is required once for every question.
+
+For each question you receive, call your Accountant agent to calculate the running cost. Otherwise you won't get paid!
+Then answer with a JSON message that has two keys:
+1. An "answer" key whose value has the answer to the question
+2. A "running_cost" key whose value has the running cost computed by the Accountant agent.
+""",
+            "tools": ["Accountant"]
+
+            # Parse any JSON in responses into the structure field of the ChatMessage.
+            "structure_formats": "json"
+        },
+        {
+            "name": "Accountant",
+            "function": {
+                "description": """
+You are an API that keeps track of the running cost of the MusicNerdPro service. Pass the current running cost
+to the API to get the updated running cost. If no running cost it known, pass 0.00.
+                """,
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "running_cost": {
+                            "type": "float",
+                            "description": "The current running total of the service cost."
+                        },
+                    },
+                    "required": ["running_cost"]
+                }
+            },
+            "class": "accountant.Accountant"
+        },
+    ]
+}

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -7,6 +7,7 @@ langchain-aws>=1.0.0,<2.0
 langchain-google-genai>=4.1.2,<5.0
 langchain-nvidia-ai-endpoints>=1.0.0,<2.0
 langchain-ollama>=1.0.0,<2.0
+langchain-openrouter>=0.2.3,<1.0
 
 # Optional Authorization
 openfga-sdk

--- a/tests/fixtures/music_nerd_pro_llm_openrouter/combination_responses_with_history_direct.hocon
+++ b/tests/fixtures/music_nerd_pro_llm_openrouter/combination_responses_with_history_direct.hocon
@@ -25,7 +25,7 @@
     "timeout_in_seconds": 180,
 
     # success_ratio is useful for passing to the assessor to find out why
-    # a test is intermitently failing. Sometimes it's the agent prompt, but
+    # a test is intermittently failing. Sometimes it's the agent prompt, but
     # sometimes it's the test itself.
     "success_ratio": "1/1",
 

--- a/tests/fixtures/music_nerd_pro_llm_openrouter/combination_responses_with_history_direct.hocon
+++ b/tests/fixtures/music_nerd_pro_llm_openrouter/combination_responses_with_history_direct.hocon
@@ -1,0 +1,77 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+# This file defines everything necessary for a data-driven test.
+{
+    # Describes what agent to test against.
+    "agent": "music_nerd_pro_llm_openrouter",
+
+    # Timeout for the entire test.
+    # It's also possible to have a timeout_in_seconds on a per-interaction basis.
+    "timeout_in_seconds": 180,
+
+    # success_ratio is useful for passing to the assessor to find out why
+    # a test is intermitently failing. Sometimes it's the agent prompt, but
+    # sometimes it's the test itself.
+    "success_ratio": "1/1",
+
+    # Connect to the agent via a server
+    "connections": ["direct"],
+
+    # Interactions are a series of dictionaries with request elements paired with
+    # descriptions of response checks.
+    "interactions": [
+        {
+            # This is what we send as input to streaming_chat()
+            "text": "Who did Yellow Submarine?",
+
+            # The response block treats how we are going to test what comes back
+            "response": {
+                # Structure block says how we are going to examine the structure
+                # (dictionary) returned as part of the response.
+                "structure": {
+                    # "answer" is a key that is supposed to be in the dictionary.
+                    "answer": {
+                        # Keywords says we are going to look for exact matches for each
+                        # element in a list of strings.  All elements need to show up
+                        # in order to pass.
+                        "keywords": "Beatles"
+                    },
+                    "running_cost": {
+                        "value": 3.0
+                    }
+                }
+            }
+        },
+        {
+            # This next interaction block tests the ability for an agent
+            # to continue its conversation with the context from the previous
+            # interaction.
+            "text": "Where were they from?",
+            "response": {
+                "structure": {
+                    "answer": {
+                        "keywords": "Liverpool"
+                    },
+                    "running_cost": {
+                        "value": 6.0
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/tests/neuro_san/zzz_hocons/test_smoke_test_hocons.py
+++ b/tests/neuro_san/zzz_hocons/test_smoke_test_hocons.py
@@ -48,6 +48,8 @@ class TestSmokeTestHocons(TestCase):
             "Issue #910: disabled until #909 is resolved.",
         "music_nerd_pro_llm_anthropic/combination_responses_with_history_direct.hocon":
             "Issue #936: disabled until #909 is resolved.",
+        "music_nerd_pro_llm_openrouter/combination_responses_with_history_direct.hocon":
+            "Disabled until OPENROUTER_API_KEY is added to the GitHub Actions secrets.",
     }
 
     def _skip_if_disabled(self, test_hocon: str) -> None:
@@ -122,6 +124,7 @@ class TestSmokeTestHocons(TestCase):
         "music_nerd_pro_llm_gemini/combination_responses_with_history_direct.hocon",
         "music_nerd_pro_llm_azure/combination_responses_with_history_direct.hocon",
         "music_nerd_pro_llm_bedrock_claude/combination_responses_with_history_direct.hocon",
+        "music_nerd_pro_llm_openrouter/combination_responses_with_history_direct.hocon",
 
         # List more hocon files as they become available here.
     ]), skip_on_empty=True)


### PR DESCRIPTION
OpenRouter is a unified API gateway that fronts hundreds of models from many providers behind a single OpenAI-compatible endpoint. Models are addressed as "provider/model" (e.g. "anthropic/claude-sonnet-4-5"), and meta-routers like "openrouter/free" and "openrouter/auto" pick the underlying model at request time.

Changes:
- New `OpenRouterLlmPolicy` backed by `langchain-openrouter`'s `ChatOpenRouter`, wired into `StandardLangChainLlmFactory` under the `"openrouter"` class.
- Add the `"openrouter"` class args plus `"openrouter/free"` and `"openrouter/auto"` entries in `default_llm_info.hocon`. Both router entries use `max_output_tokens=null` since the chosen model is unknown until request time.
- Guard `get_max_prompt_tokens` against `null` `max_output_tokens`; without this, `int(None * fraction)` raised `TypeError`, which surfaced as a hang.
- Add `langchain-openrouter` to `requirements-build.txt`.
- New `music_nerd_pro_llm_openrouter` registry + smoke-test fixture (currently in `DISABLED_HOCONS` pending `OPENROUTER_API_KEY` in CI secrets).
- Document the new provider in `agent_hocon_reference.md` and the `max_output_tokens=null` behavior in `llm_info_hocon_reference.md`.

Fix #980 