### PR TITLE
Pass --repo to gh release upload in checkmarx workflow

### DIFF
--- a/.github/workflows/checkmarx.yml
+++ b/.github/workflows/checkmarx.yml
@@ -207,4 +207,5 @@ jobs:
         run: |
           gh release upload "$TAG_NAME" \
             checkmarx-report.pdf#checkmarx-sast-report.pdf \
+            --repo "${{ github.repository }}" \
             --clobber


### PR DESCRIPTION
## Summary

The `attach-to-release` job in `checkmarx.yml` fails with:

```
fatal: not a git repository (or any of the parent directories): .git
```

The job downloads the report artifact but never checks out the repo, so `gh release upload` cannot infer the repository from a local `.git` directory. Adding `--repo "${{ github.repository }}"` lets `gh` resolve the target release without needing a clone.

Failed run: https://github.com/cognizant-ai-lab/neuro-san/actions/runs/27641444714/job/81742669458

Link to Devin session: https://app.devin.ai/sessions/a61eb3300dcc42b0a1bfe8b9a1e3e9c3
Requested by: @donn-leaf
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cognizant-ai-lab/neuro-san/pull/1060" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->