### PR TITLE
NS-1038 Add keep-alive AGENT_PROGRESS messages to streaming_chat requests.

### DIFF
--- a/neuro_san/client/thinking_file_message_processor.py
+++ b/neuro_san/client/thinking_file_message_processor.py
@@ -75,6 +75,13 @@ class ThinkingFileMessageProcessor(MessageProcessor):
         if text is None and structure is None:
             return
 
+        # An AGENT_PROGRESS message with empty text and no structure is the server's
+        # HTTP heartbeat keepalive frame (sent to keep proxies / clients from dropping
+        # an otherwise quiet streaming connection). It carries no real progress info,
+        # so don't pollute the thinking file with empty entries per tick.
+        if message_type == ChatMessageType.AGENT_PROGRESS and not text and structure is None:
+            return
+
         origin: List[str] = chat_message_dict.get("origin")
         test_origin_str: str = Origination.get_full_name_from_origin(origin)
 

--- a/neuro_san/deploy/Dockerfile
+++ b/neuro_san/deploy/Dockerfile
@@ -278,15 +278,15 @@ ENV AGENT_HTTP_SERVER_INSTANCES="1"
 # Logging period is specified in seconds.
 ENV AGENT_HTTP_RESOURCES_MONITOR_INTERVAL="0"
 
-# Interval in seconds between HTTP heartbeat writes sent to streaming clients
+# Interval in seconds between HTTP keep-alive messages sent to streaming clients
 # to keep the connection alive during long quiet periods. This is important
 # when intermediaries (nginx, load balancers, AWS ALB) or clients would otherwise
 # drop an idle HTTP connection (commonly after ~60s) before the agent produces
-# its next streamed message. The heartbeat only fires when the stream has been
-# quiet for the full interval; real message traffic suppresses it.
-# A value of 0 (the default) disables the heartbeat entirely.
+# its next streamed message. The keep-alive message only fires when the stream has been
+# quiet for approximately the full interval; real message traffic suppresses it.
+# A value of 0 (the default) disables the keep-alive messages entirely.
 # Typical production value is 25-30 (under the 60s defaults of common proxies).
-ENV AGENT_HTTP_SERVER_HEARTBEAT_INTERVAL=0
+ENV AGENT_STREAM_KEEP_ALIVE_WITH_PROGRESS_INTERVAL=0
 
 # Optional URL describing how the server is to be referenced by the outside world.
 # This is useful when a server is behind a load-balancer as part of a larger cluster.

--- a/neuro_san/deploy/Dockerfile
+++ b/neuro_san/deploy/Dockerfile
@@ -286,7 +286,7 @@ ENV AGENT_HTTP_RESOURCES_MONITOR_INTERVAL="0"
 # quiet for approximately the full interval; real message traffic suppresses it.
 # A value of 0 (the default) disables the keep-alive messages entirely.
 # Typical production value is 25-30 (under the 60s defaults of common proxies).
-ENV AGENT_STREAM_KEEP_ALIVE_WITH_PROGRESS_INTERVAL=0
+ENV AGENT_STREAM_KEEP_ALIVE_WITH_PROGRESS_INTERVAL_SECONDS=0
 
 # Optional URL describing how the server is to be referenced by the outside world.
 # This is useful when a server is behind a load-balancer as part of a larger cluster.

--- a/neuro_san/deploy/Dockerfile
+++ b/neuro_san/deploy/Dockerfile
@@ -288,13 +288,6 @@ ENV AGENT_HTTP_RESOURCES_MONITOR_INTERVAL="0"
 # Typical production value is 25-30 (under the 60s defaults of common proxies).
 ENV AGENT_HTTP_SERVER_HEARTBEAT_INTERVAL=0
 
-# Payload written for each heartbeat tick. This is the exact wire shape of an
-# empty AGENT_PROGRESS message (ChatMessageType.AGENT_PROGRESS), so any
-# client already handling AGENT_PROGRESS messages will accept it as a no-op
-# tick: empty text, no structure, no origin.
-# Only consulted when AGENT_HTTP_SERVER_HEARTBEAT_INTERVAL > 0.
-ENV AGENT_HTTP_SERVER_HEARTBEAT_PAYLOAD='{"type": "AGENT_PROGRESS", "text": ""}'
-
 # Optional URL describing how the server is to be referenced by the outside world.
 # This is useful when a server is behind a load-balancer as part of a larger cluster.
 ENV AGENT_EXTERNAL_SERVER_URL=""

--- a/neuro_san/deploy/Dockerfile
+++ b/neuro_san/deploy/Dockerfile
@@ -278,6 +278,23 @@ ENV AGENT_HTTP_SERVER_INSTANCES="1"
 # Logging period is specified in seconds.
 ENV AGENT_HTTP_RESOURCES_MONITOR_INTERVAL="0"
 
+# Interval in seconds between HTTP heartbeat writes sent to streaming clients
+# to keep the connection alive during long quiet periods. This is important
+# when intermediaries (nginx, load balancers, AWS ALB) or clients would otherwise
+# drop an idle HTTP connection (commonly after ~60s) before the agent produces
+# its next streamed message. The heartbeat only fires when the stream has been
+# quiet for the full interval; real message traffic suppresses it.
+# A value of 0 (the default) disables the heartbeat entirely.
+# Typical production value is 25-30 (under the 60s defaults of common proxies).
+ENV AGENT_HTTP_SERVER_HEARTBEAT_INTERVAL=0
+
+# Payload written for each heartbeat tick. This is the exact wire shape of an
+# empty AGENT_PROGRESS message (ChatMessageType.AGENT_PROGRESS), so any
+# client already handling AGENT_PROGRESS messages will accept it as a no-op
+# tick: empty text, no structure, no origin.
+# Only consulted when AGENT_HTTP_SERVER_HEARTBEAT_INTERVAL > 0.
+ENV AGENT_HTTP_SERVER_HEARTBEAT_PAYLOAD='{"type": "AGENT_PROGRESS", "text": ""}'
+
 # Optional URL describing how the server is to be referenced by the outside world.
 # This is useful when a server is behind a load-balancer as part of a larger cluster.
 ENV AGENT_EXTERNAL_SERVER_URL=""

--- a/neuro_san/service/http/config/http_server_config.py
+++ b/neuro_san/service/http/config/http_server_config.py
@@ -36,4 +36,4 @@ class HttpServerConfig:
         self.http_server_instances: int = DEFAULT_HTTP_SERVER_INSTANCES
         self.http_port: int = 80
         self.http_server_monitor_interval_seconds: int = DEFAULT_HTTP_SERVER_MONITOR_INTERVAL_SECONDS
-        self.http_server_heartbeat_interval_seconds: int = DEFAULT_KEEP_ALIVE_INTERVAL_SECONDS
+        self.stream_keep_alive_with_progress_interval_seconds: int = DEFAULT_KEEP_ALIVE_INTERVAL_SECONDS

--- a/neuro_san/service/http/config/http_server_config.py
+++ b/neuro_san/service/http/config/http_server_config.py
@@ -17,17 +17,12 @@
 """
 See class comment for details
 """
-from neuro_san.internals.messages.chat_message_type import ChatMessageType
 
 DEFAULT_HTTP_CONNECTIONS_BACKLOG: int = 128
 DEFAULT_HTTP_IDLE_CONNECTIONS_TIMEOUT_SECONDS: int = 3600
 DEFAULT_HTTP_SERVER_INSTANCES: int = 1
 DEFAULT_HTTP_SERVER_MONITOR_INTERVAL_SECONDS: int = 0
 DEFAULT_HTTP_SERVER_HEARTBEAT_INTERVAL_SECONDS: int = 0
-# Payload to send as heartbeat message.
-# Default is a JSON string with serialized AGENT_PROGRESS message with empty text.
-DEFAULT_HTTP_SERVER_HEARTBEAT_PAYLOAD: str = \
-    f'{{"type": "{ChatMessageType.to_string(ChatMessageType.AGENT_PROGRESS)}", "text": ""}}'
 
 
 class HttpServerConfig:
@@ -42,4 +37,3 @@ class HttpServerConfig:
         self.http_port: int = 80
         self.http_server_monitor_interval_seconds: int = DEFAULT_HTTP_SERVER_MONITOR_INTERVAL_SECONDS
         self.http_server_heartbeat_interval_seconds: int = DEFAULT_HTTP_SERVER_HEARTBEAT_INTERVAL_SECONDS
-        self.http_server_heartbeat_payload: str = DEFAULT_HTTP_SERVER_HEARTBEAT_PAYLOAD

--- a/neuro_san/service/http/config/http_server_config.py
+++ b/neuro_san/service/http/config/http_server_config.py
@@ -17,11 +17,17 @@
 """
 See class comment for details
 """
+from neuro_san.internals.messages.chat_message_type import ChatMessageType
 
 DEFAULT_HTTP_CONNECTIONS_BACKLOG: int = 128
 DEFAULT_HTTP_IDLE_CONNECTIONS_TIMEOUT_SECONDS: int = 3600
 DEFAULT_HTTP_SERVER_INSTANCES: int = 1
 DEFAULT_HTTP_SERVER_MONITOR_INTERVAL_SECONDS: int = 0
+DEFAULT_HTTP_SERVER_HEARTBEAT_INTERVAL_SECONDS: int = 0
+# Payload to send as heartbeat message.
+# Default is a JSON string with serialized AGENT_PROGRESS message with empty text.
+DEFAULT_HTTP_SERVER_HEARTBEAT_PAYLOAD: str = \
+    f'{{"type": "{ChatMessageType.to_string(ChatMessageType.AGENT_PROGRESS)}", "text": ""}}'
 
 
 class HttpServerConfig:
@@ -35,3 +41,5 @@ class HttpServerConfig:
         self.http_server_instances: int = DEFAULT_HTTP_SERVER_INSTANCES
         self.http_port: int = 80
         self.http_server_monitor_interval_seconds: int = DEFAULT_HTTP_SERVER_MONITOR_INTERVAL_SECONDS
+        self.http_server_heartbeat_interval_seconds: int = DEFAULT_HTTP_SERVER_HEARTBEAT_INTERVAL_SECONDS
+        self.http_server_heartbeat_payload: str = DEFAULT_HTTP_SERVER_HEARTBEAT_PAYLOAD

--- a/neuro_san/service/http/config/http_server_config.py
+++ b/neuro_san/service/http/config/http_server_config.py
@@ -22,7 +22,7 @@ DEFAULT_HTTP_CONNECTIONS_BACKLOG: int = 128
 DEFAULT_HTTP_IDLE_CONNECTIONS_TIMEOUT_SECONDS: int = 3600
 DEFAULT_HTTP_SERVER_INSTANCES: int = 1
 DEFAULT_HTTP_SERVER_MONITOR_INTERVAL_SECONDS: int = 0
-DEFAULT_HTTP_SERVER_HEARTBEAT_INTERVAL_SECONDS: int = 0
+DEFAULT_KEEP_ALIVE_INTERVAL_SECONDS: int = 0
 
 
 class HttpServerConfig:
@@ -36,4 +36,4 @@ class HttpServerConfig:
         self.http_server_instances: int = DEFAULT_HTTP_SERVER_INSTANCES
         self.http_port: int = 80
         self.http_server_monitor_interval_seconds: int = DEFAULT_HTTP_SERVER_MONITOR_INTERVAL_SECONDS
-        self.http_server_heartbeat_interval_seconds: int = DEFAULT_HTTP_SERVER_HEARTBEAT_INTERVAL_SECONDS
+        self.http_server_heartbeat_interval_seconds: int = DEFAULT_KEEP_ALIVE_INTERVAL_SECONDS

--- a/neuro_san/service/http/handlers/streaming_chat_handler.py
+++ b/neuro_san/service/http/handlers/streaming_chat_handler.py
@@ -151,7 +151,6 @@ class StreamingChatHandler(BaseRequestHandler):
                     if flush_ok:
                         # Some flush was successful. This is good.
                         flushed_first_result = True
-                        # Register the time of the last successful flush, so that we can adjust our heartbeat timing.
                     else:
                         # We tried flushing the result to no avail
                         if self._is_client_close_a_problem(is_event, flushed_first_result):

--- a/neuro_san/service/http/handlers/streaming_chat_handler.py
+++ b/neuro_san/service/http/handlers/streaming_chat_handler.py
@@ -30,10 +30,9 @@ from json.decoder import JSONDecodeError
 import time
 import tornado
 
+from neuro_san.internals.messages.chat_message_type import ChatMessageType
 from neuro_san.service.generic.async_agent_service import AsyncAgentService
-from neuro_san.service.http.config.http_server_config import DEFAULT_HTTP_SERVER_HEARTBEAT_PAYLOAD
 from neuro_san.service.http.handlers.base_request_handler import BaseRequestHandler
-from neuro_san.service.utils.request_util import RequestUtil
 
 
 class StreamingChatHandler(BaseRequestHandler):
@@ -47,17 +46,15 @@ class StreamingChatHandler(BaseRequestHandler):
         This method is called by Tornado framework to allow
         injecting service-specific data into local handler context.
         :param kwargs: dictionary of named parameters, including:
-            "heartbeat_interval_seconds" - heartbeat protocol message interval in seconds;
-            "heartbeat_payload" - string containing the heartbeat ChatMessage
-                (e.g. an empty AGENT_PROGRESS) that will be wrapped in the standard
-                ChatResponse envelope before being sent on the wire.
+            "heartbeat_interval_seconds" - heartbeat protocol message interval
+                in seconds. The heartbeat payload itself is fixed (see
+                _build_heartbeat_frame()); only the interval is configurable.
         """
         super().initialize(**kwargs)
         self.heartbeat_interval_seconds = kwargs.get("heartbeat_interval_seconds", 0)
-        # Pre-build the on-the-wire heartbeat frame once so each tick only needs to
-        # write bytes -- no per-tick JSON parsing or string-concat.
-        heartbeat_payload: str = kwargs.get("heartbeat_payload", DEFAULT_HTTP_SERVER_HEARTBEAT_PAYLOAD)
-        self.heartbeat_frame: str = self._build_heartbeat_frame(heartbeat_payload)
+        # Build the on-the-wire heartbeat frame once at initialize() time so
+        # each tick only needs to write bytes -- no per-tick JSON serialization.
+        self.heartbeat_frame: str = self._build_heartbeat_frame()
         self.last_send_ts = 0.0
 
         if self.heartbeat_interval_seconds > 0:
@@ -66,33 +63,24 @@ class StreamingChatHandler(BaseRequestHandler):
             asyncio.create_task(self.run_heartbeat())
 
     @staticmethod
-    def _build_heartbeat_frame(configured_payload: str) -> str:
+    def _build_heartbeat_frame() -> str:
         """
-        Build the exact wire frame to write for each heartbeat tick.
+        Build the exact wire frame to write for each heartbeat tick: an empty
+        AGENT_PROGRESS ChatMessage wrapped in the standard ChatResponse
+        envelope -- {"response": <chat-message>} -- so clients see the same
+        shape as real chat responses. A newline is appended so JSON-Lines
+        parsers see a clean frame boundary even when the heartbeat lands
+        between two real messages.
 
-        The configured payload is expected to be a JSON ChatMessage dictionary
-        (e.g. an empty AGENT_PROGRESS), which is wrapped here in the standard
-        ChatResponse envelope -- {"response": <chat-message>} -- so that
-        clients see the same shape they see for real chat responses. A newline
-        is appended so JSON-Lines parsers see a clean frame boundary even
-        when the heartbeat lands between two real messages.
+        The contents are not user-configurable; only the heartbeat interval is.
 
-        If the configured payload is not valid JSON (legacy callers that pass
-        raw bytes such as "\\n"), it is sent as-is with a trailing newline
-        ensured -- preserving backward-compatible behavior.
-
-        :param configured_payload: The value of the heartbeat_payload kwarg,
-                typically sourced from AGENT_HTTP_SERVER_HEARTBEAT_PAYLOAD.
         :return: The exact string to write per heartbeat tick.
         """
-        try:
-            chat_message: Dict[str, Any] = json.loads(configured_payload)
-        except (JSONDecodeError, TypeError):
-            # Not JSON -- pass through, ensuring a trailing newline for framing.
-            if not configured_payload.endswith("\n"):
-                configured_payload = configured_payload + "\n"
-            return RequestUtil.safe_message(configured_payload)
-        return RequestUtil.safe_message(json.dumps({"response": chat_message}) + "\n")
+        chat_message: Dict[str, Any] = {
+            "type": ChatMessageType.to_string(ChatMessageType.AGENT_PROGRESS),
+            "text": "",
+        }
+        return json.dumps({"response": chat_message}) + "\n"
 
     # pylint: disable=too-many-statements
     # pylint: disable=too-many-branches

--- a/neuro_san/service/http/handlers/streaming_chat_handler.py
+++ b/neuro_san/service/http/handlers/streaming_chat_handler.py
@@ -56,11 +56,12 @@ class StreamingChatHandler(BaseRequestHandler):
         # each tick only needs to write bytes -- no per-tick JSON serialization.
         self.heartbeat_frame: str = self._build_heartbeat_frame()
         self.last_send_ts = 0.0
+        self.heartbeat_task: asyncio.Task = None
 
         if self.heartbeat_interval_seconds > 0:
             # If heartbeat is enabled,
             # start the heartbeat task in the background, so it can run concurrently with the main request processing.
-            asyncio.create_task(self.run_heartbeat())
+            self.heartbeat_task = asyncio.create_task(self.run_heartbeat())
 
     @staticmethod
     def _build_heartbeat_frame() -> str:
@@ -179,6 +180,11 @@ class StreamingChatHandler(BaseRequestHandler):
                 self.process_exception(exc)
 
         finally:
+            # If we started a heartbeat task, cancel it now to clean up resources.
+            if self.heartbeat_task is not None:
+                self.heartbeat_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await self.heartbeat_task
             await self._finish_request(result_generator, metadata, agent_name)
 
     async def run_heartbeat(self):
@@ -209,7 +215,7 @@ class StreamingChatHandler(BaseRequestHandler):
                 # self.heartbeat_frame already includes the ChatResponse envelope
                 # and a trailing newline (see _build_heartbeat_frame()).
                 self.write(self.heartbeat_frame)
-                self.flush()
+                await self.flush()
                 self.last_send_ts = time.monotonic()
                 time_to_sleep = self.heartbeat_interval_seconds
             except tornado.iostream.StreamClosedError:

--- a/neuro_san/service/http/handlers/streaming_chat_handler.py
+++ b/neuro_san/service/http/handlers/streaming_chat_handler.py
@@ -134,7 +134,8 @@ class StreamingChatHandler(BaseRequestHandler):
             # If heartbeat is enabled, time to start it here:
             if self.heartbeat_interval_seconds > 0:
                 # If heartbeat is enabled,
-                # start the heartbeat task in the background, so it can run concurrently with the main request processing.
+                # start the heartbeat task in the background,
+                # so it can run concurrently with the main request processing.
                 self.heartbeat_task = asyncio.create_task(self.run_heartbeat())
 
             # Now process the result stream

--- a/neuro_san/service/http/handlers/streaming_chat_handler.py
+++ b/neuro_san/service/http/handlers/streaming_chat_handler.py
@@ -27,9 +27,11 @@ import asyncio
 import contextlib
 import json
 from json.decoder import JSONDecodeError
+import time
 import tornado
 
 from neuro_san.service.generic.async_agent_service import AsyncAgentService
+from neuro_san.service.http.config.http_server_config import DEFAULT_HTTP_SERVER_HEARTBEAT_PAYLOAD
 from neuro_san.service.http.handlers.base_request_handler import BaseRequestHandler
 
 
@@ -37,6 +39,59 @@ class StreamingChatHandler(BaseRequestHandler):
     """
     Handler class for neuro-san streaming chat API call.
     """
+
+    # pylint: disable=attribute-defined-outside-init
+    def initialize(self, **kwargs):
+        """
+        This method is called by Tornado framework to allow
+        injecting service-specific data into local handler context.
+        :param kwargs: dictionary of named parameters, including:
+            "heartbeat_interval_seconds" - heartbeat protocol message interval in seconds;
+            "heartbeat_payload" - string containing the heartbeat ChatMessage
+                (e.g. an empty AGENT_PROGRESS) that will be wrapped in the standard
+                ChatResponse envelope before being sent on the wire.
+        """
+        super().initialize(**kwargs)
+        self.heartbeat_interval_seconds = kwargs.get("heartbeat_interval_seconds", 0)
+        # Pre-build the on-the-wire heartbeat frame once so each tick only needs to
+        # write bytes -- no per-tick JSON parsing or string-concat.
+        heartbeat_payload: str = kwargs.get("heartbeat_payload", DEFAULT_HTTP_SERVER_HEARTBEAT_PAYLOAD)
+        self.heartbeat_frame: str = self._build_heartbeat_frame(heartbeat_payload)
+        self.last_send_ts = 0.0
+
+        if self.heartbeat_interval_seconds > 0:
+            # If heartbeat is enabled,
+            # start the heartbeat task in the background, so it can run concurrently with the main request processing.
+            asyncio.create_task(self.run_heartbeat())
+
+    @staticmethod
+    def _build_heartbeat_frame(configured_payload: str) -> str:
+        """
+        Build the exact wire frame to write for each heartbeat tick.
+
+        The configured payload is expected to be a JSON ChatMessage dictionary
+        (e.g. an empty AGENT_PROGRESS), which is wrapped here in the standard
+        ChatResponse envelope -- {"response": <chat-message>} -- so that
+        clients see the same shape they see for real chat responses. A newline
+        is appended so JSON-Lines parsers see a clean frame boundary even
+        when the heartbeat lands between two real messages.
+
+        If the configured payload is not valid JSON (legacy callers that pass
+        raw bytes such as "\\n"), it is sent as-is with a trailing newline
+        ensured -- preserving backward-compatible behavior.
+
+        :param configured_payload: The value of the heartbeat_payload kwarg,
+                typically sourced from AGENT_HTTP_SERVER_HEARTBEAT_PAYLOAD.
+        :return: The exact string to write per heartbeat tick.
+        """
+        try:
+            chat_message: Dict[str, Any] = json.loads(configured_payload)
+        except (JSONDecodeError, TypeError):
+            # Not JSON -- pass through, ensuring a trailing newline for framing.
+            if configured_payload.endswith("\n"):
+                return configured_payload
+            return configured_payload + "\n"
+        return json.dumps({"response": chat_message}) + "\n"
 
     # pylint: disable=too-many-statements
     # pylint: disable=too-many-branches
@@ -100,6 +155,8 @@ class StreamingChatHandler(BaseRequestHandler):
                     if flush_ok:
                         # Some flush was successful. This is good.
                         flushed_first_result = True
+                        # Register the time of the last successful flush, so that we can adjust our heartbeat timing.
+                        self.last_send_ts = time.monotonic()
                     else:
                         # We tried flushing the result to no avail
                         if self._is_client_close_a_problem(is_event, flushed_first_result):
@@ -134,6 +191,40 @@ class StreamingChatHandler(BaseRequestHandler):
 
         finally:
             await self._finish_request(result_generator, metadata, agent_name)
+
+    async def run_heartbeat(self):
+        """
+        Background task driving the HTTP heartbeat: every
+        heartbeat_interval_seconds (and only when no real traffic has been
+        flushed within that window), write the pre-built heartbeat frame
+        to keep proxies/clients from dropping the streaming connection.
+        Exits when the request finishes or the client disconnects.
+        """
+        metadata: Dict[str, Any] = self.get_metadata()
+        self.logger.info(metadata, "Starting heartbeat generator with interval %d seconds",
+                         self.heartbeat_interval_seconds)
+        time_to_sleep: float = self.heartbeat_interval_seconds
+        while True:
+            await asyncio.sleep(time_to_sleep)
+            time_now: float = time.monotonic()
+            time_to_sleep = self.heartbeat_interval_seconds - (time_now - self.last_send_ts)
+            if time_to_sleep > 0.5:
+                # We have seen some request traffic recently, so we can delay our heartbeat a bit.
+                # Time to sleep is long enough - so go sleep
+                continue
+            if self._finished:
+                # No need to send heartbeats if we are already finished.
+                # Time to exit and end the heartbeat task.
+                return
+            try:
+                # self.heartbeat_frame already includes the ChatResponse envelope
+                # and a trailing newline (see _build_heartbeat_frame()).
+                self.write(self.heartbeat_frame)
+                self.flush()
+                self.last_send_ts = time.monotonic()
+                time_to_sleep = self.heartbeat_interval_seconds
+            except tornado.iostream.StreamClosedError:
+                return  # client gone; main loop's next flush will see it too
 
     def _is_client_close_a_problem(self, is_event: bool, flushed_first_result: bool) -> bool:
         """

--- a/neuro_san/service/http/handlers/streaming_chat_handler.py
+++ b/neuro_san/service/http/handlers/streaming_chat_handler.py
@@ -51,16 +51,16 @@ class StreamingChatHandler(BaseRequestHandler):
                 _build_heartbeat_frame()); only the interval is configurable.
         """
         super().initialize(**kwargs)
-        self.heartbeat_interval_seconds = kwargs.get("heartbeat_interval_seconds", 0)
+        self.keep_alive_interval_seconds = kwargs.get("keep_alive_interval_seconds", 0)
         # Build the on-the-wire heartbeat frame once at initialize() time so
         # each tick only needs to write bytes -- no per-tick JSON serialization.
-        self.heartbeat_frame: str = self._build_heartbeat_frame()
+        self.keep_alive_frame: str = self._build_keep_alive_frame()
         self.last_send_ts = 0.0
-        self.heartbeat_task: asyncio.Task = None
+        self.keep_alive_task: asyncio.Task = None
         self.lock: asyncio.Lock = asyncio.Lock()  # protects request writes to output stream and last_send_ts updates
 
     @staticmethod
-    def _build_heartbeat_frame() -> str:
+    def _build_keep_alive_frame() -> str:
         """
         Build the exact wire frame to write for each heartbeat tick: an empty
         AGENT_PROGRESS ChatMessage wrapped in the standard ChatResponse
@@ -133,11 +133,11 @@ class StreamingChatHandler(BaseRequestHandler):
 
             # We are now ready to start processing the request and streaming results back to the client.
             # If heartbeat is enabled, time to start it here:
-            if self.heartbeat_interval_seconds > 0:
+            if self.keep_alive_interval_seconds > 0:
                 # If heartbeat is enabled,
                 # start the heartbeat task in the background,
                 # so it can run concurrently with the main request processing.
-                self.heartbeat_task = asyncio.create_task(self.run_heartbeat())
+                self.keep_alive_task = asyncio.create_task(self.run_heartbeat())
 
             # Now process the result stream
             async with asyncio.timeout(request_timeout):
@@ -185,10 +185,10 @@ class StreamingChatHandler(BaseRequestHandler):
 
         finally:
             # If we started a heartbeat task, cancel it now to clean up resources.
-            if self.heartbeat_task is not None:
-                self.heartbeat_task.cancel()
+            if self.keep_alive_task is not None:
+                self.keep_alive_task.cancel()
                 with contextlib.suppress(asyncio.CancelledError):
-                    await self.heartbeat_task
+                    await self.keep_alive_task
             await self._finish_request(result_generator, metadata, agent_name)
 
     async def run_heartbeat(self):
@@ -201,12 +201,12 @@ class StreamingChatHandler(BaseRequestHandler):
         """
         metadata: Dict[str, Any] = self.get_metadata()
         self.logger.info(metadata, "Starting heartbeat generator with interval %d seconds",
-                         self.heartbeat_interval_seconds)
-        time_to_sleep: float = self.heartbeat_interval_seconds
+                         self.keep_alive_interval_seconds)
+        time_to_sleep: float = self.keep_alive_interval_seconds
         while True:
             await asyncio.sleep(time_to_sleep)
             time_now: float = time.monotonic()
-            time_to_sleep = self.heartbeat_interval_seconds - (time_now - self.last_send_ts)
+            time_to_sleep = self.keep_alive_interval_seconds - (time_now - self.last_send_ts)
             if time_to_sleep > 0.5:
                 # We have seen some request traffic recently, so we can delay our heartbeat a bit.
                 # Time to sleep is long enough - so go sleep
@@ -215,7 +215,7 @@ class StreamingChatHandler(BaseRequestHandler):
                 # self.heartbeat_frame already includes the ChatResponse envelope
                 # and a trailing newline (see _build_heartbeat_frame()).
                 async with self.lock:
-                    self.write(self.heartbeat_frame)
+                    self.write(self.keep_alive_frame)
                     flush_ok = await self.do_flush()
                     self.last_send_ts = time.monotonic()
                 if not flush_ok:
@@ -223,7 +223,7 @@ class StreamingChatHandler(BaseRequestHandler):
                     # (most probably because connection is closed by a client).
                     # Finish heartbeat task
                     return
-                time_to_sleep = self.heartbeat_interval_seconds
+                time_to_sleep = self.keep_alive_interval_seconds
             except tornado.iostream.StreamClosedError:
                 return  # client gone; main loop's next flush will see it too
 

--- a/neuro_san/service/http/handlers/streaming_chat_handler.py
+++ b/neuro_san/service/http/handlers/streaming_chat_handler.py
@@ -207,10 +207,6 @@ class StreamingChatHandler(BaseRequestHandler):
                 # We have seen some request traffic recently, so we can delay our heartbeat a bit.
                 # Time to sleep is long enough - so go sleep
                 continue
-            if self._finished:
-                # No need to send heartbeats if we are already finished.
-                # Time to exit and end the heartbeat task.
-                return
             try:
                 # self.heartbeat_frame already includes the ChatResponse envelope
                 # and a trailing newline (see _build_heartbeat_frame()).

--- a/neuro_san/service/http/handlers/streaming_chat_handler.py
+++ b/neuro_san/service/http/handlers/streaming_chat_handler.py
@@ -57,6 +57,7 @@ class StreamingChatHandler(BaseRequestHandler):
         self.heartbeat_frame: str = self._build_heartbeat_frame()
         self.last_send_ts = 0.0
         self.heartbeat_task: asyncio.Task = None
+        self.lock: asyncio.Lock = asyncio.Lock()  # protects request writes to output stream and last_send_ts updates
 
     @staticmethod
     def _build_heartbeat_frame() -> str:
@@ -143,13 +144,14 @@ class StreamingChatHandler(BaseRequestHandler):
                 result_generator = service.streaming_chat(request_dict, metadata)
                 async for result_dict in result_generator:
                     result_str: str = json.dumps(result_dict) + "\n"
-                    self.write(result_str)
-                    flush_ok = await self.do_flush()
+                    async with self.lock:
+                        self.write(result_str)
+                        flush_ok = await self.do_flush()
+                        self.last_send_ts = time.monotonic()
                     if flush_ok:
                         # Some flush was successful. This is good.
                         flushed_first_result = True
                         # Register the time of the last successful flush, so that we can adjust our heartbeat timing.
-                        self.last_send_ts = time.monotonic()
                     else:
                         # We tried flushing the result to no avail
                         if self._is_client_close_a_problem(is_event, flushed_first_result):
@@ -213,14 +215,15 @@ class StreamingChatHandler(BaseRequestHandler):
             try:
                 # self.heartbeat_frame already includes the ChatResponse envelope
                 # and a trailing newline (see _build_heartbeat_frame()).
-                self.write(self.heartbeat_frame)
-                flush_ok = await self.do_flush()
+                async with self.lock:
+                    self.write(self.heartbeat_frame)
+                    flush_ok = await self.do_flush()
+                    self.last_send_ts = time.monotonic()
                 if not flush_ok:
                     # We tried flushing the heartbeat with no success
                     # (most probably because connection is closed by a client).
                     # Finish heartbeat task
                     return
-                self.last_send_ts = time.monotonic()
                 time_to_sleep = self.heartbeat_interval_seconds
             except tornado.iostream.StreamClosedError:
                 return  # client gone; main loop's next flush will see it too

--- a/neuro_san/service/http/handlers/streaming_chat_handler.py
+++ b/neuro_san/service/http/handlers/streaming_chat_handler.py
@@ -33,6 +33,7 @@ import tornado
 from neuro_san.service.generic.async_agent_service import AsyncAgentService
 from neuro_san.service.http.config.http_server_config import DEFAULT_HTTP_SERVER_HEARTBEAT_PAYLOAD
 from neuro_san.service.http.handlers.base_request_handler import BaseRequestHandler
+from neuro_san.service.utils.request_util import RequestUtil
 
 
 class StreamingChatHandler(BaseRequestHandler):
@@ -88,10 +89,10 @@ class StreamingChatHandler(BaseRequestHandler):
             chat_message: Dict[str, Any] = json.loads(configured_payload)
         except (JSONDecodeError, TypeError):
             # Not JSON -- pass through, ensuring a trailing newline for framing.
-            if configured_payload.endswith("\n"):
-                return configured_payload
-            return configured_payload + "\n"
-        return json.dumps({"response": chat_message}) + "\n"
+            if not configured_payload.endswith("\n"):
+                configured_payload = configured_payload + "\n"
+            return RequestUtil.safe_message(configured_payload)
+        return RequestUtil.safe_message(json.dumps({"response": chat_message}) + "\n")
 
     # pylint: disable=too-many-statements
     # pylint: disable=too-many-branches

--- a/neuro_san/service/http/handlers/streaming_chat_handler.py
+++ b/neuro_san/service/http/handlers/streaming_chat_handler.py
@@ -58,11 +58,6 @@ class StreamingChatHandler(BaseRequestHandler):
         self.last_send_ts = 0.0
         self.heartbeat_task: asyncio.Task = None
 
-        if self.heartbeat_interval_seconds > 0:
-            # If heartbeat is enabled,
-            # start the heartbeat task in the background, so it can run concurrently with the main request processing.
-            self.heartbeat_task = asyncio.create_task(self.run_heartbeat())
-
     @staticmethod
     def _build_heartbeat_frame() -> str:
         """
@@ -134,6 +129,13 @@ class StreamingChatHandler(BaseRequestHandler):
                 # most probably it's because connection is closed by a client.
                 # Raise accordingly - we will handle this exception:
                 raise tornado.iostream.StreamClosedError()
+
+            # We are now ready to start processing the request and streaming results back to the client.
+            # If heartbeat is enabled, time to start it here:
+            if self.heartbeat_interval_seconds > 0:
+                # If heartbeat is enabled,
+                # start the heartbeat task in the background, so it can run concurrently with the main request processing.
+                self.heartbeat_task = asyncio.create_task(self.run_heartbeat())
 
             # Now process the result stream
             async with asyncio.timeout(request_timeout):
@@ -211,7 +213,12 @@ class StreamingChatHandler(BaseRequestHandler):
                 # self.heartbeat_frame already includes the ChatResponse envelope
                 # and a trailing newline (see _build_heartbeat_frame()).
                 self.write(self.heartbeat_frame)
-                await self.flush()
+                flush_ok = await self.do_flush()
+                if not flush_ok:
+                    # We tried flushing the heartbeat with no success
+                    # (most probably because connection is closed by a client).
+                    # Finish heartbeat task
+                    return
                 self.last_send_ts = time.monotonic()
                 time_to_sleep = self.heartbeat_interval_seconds
             except tornado.iostream.StreamClosedError:

--- a/neuro_san/service/http/server/http_server.py
+++ b/neuro_san/service/http/server/http_server.py
@@ -318,5 +318,5 @@ class HttpServer(AgentStateListener):
             "openapi_service_spec": open_api_dict,
             "server_context": self.server_context,
             "logging_config": self.logging_config,
-            "heartbeat_interval_seconds": self.server_config.http_server_heartbeat_interval_seconds,
+            "keep_alive_interval_seconds": self.server_config.stream_keep_alive_with_progress_interval_seconds,
         }

--- a/neuro_san/service/http/server/http_server.py
+++ b/neuro_san/service/http/server/http_server.py
@@ -317,5 +317,7 @@ class HttpServer(AgentStateListener):
             "forwarded_request_metadata": self.forwarded_request_metadata,
             "openapi_service_spec": open_api_dict,
             "server_context": self.server_context,
-            "logging_config": self.logging_config
+            "logging_config": self.logging_config,
+            "heartbeat_interval_seconds": self.server_config.http_server_heartbeat_interval_seconds,
+            "heartbeat_payload": self.server_config.http_server_heartbeat_payload
         }

--- a/neuro_san/service/http/server/http_server.py
+++ b/neuro_san/service/http/server/http_server.py
@@ -319,5 +319,4 @@ class HttpServer(AgentStateListener):
             "server_context": self.server_context,
             "logging_config": self.logging_config,
             "heartbeat_interval_seconds": self.server_config.http_server_heartbeat_interval_seconds,
-            "heartbeat_payload": self.server_config.http_server_heartbeat_payload
         }

--- a/neuro_san/service/main_loop/server_main_loop.py
+++ b/neuro_san/service/main_loop/server_main_loop.py
@@ -140,7 +140,7 @@ class ServerMainLoop:
                                 help="Http server resources monitoring/logging interval in seconds "
                                      "0 means no logging")
         arg_parser.add_argument("--stream_keep_alive_with_progress_interval_seconds", type=int,
-                                default=int(os.environ.get("AGENT_STREAM_KEEP_ALIVE_WITH_PROGRESS_INTERVAL",
+                                default=int(os.environ.get("AGENT_STREAM_KEEP_ALIVE_WITH_PROGRESS_INTERVAL_SECONDS",
                                                            DEFAULT_KEEP_ALIVE_INTERVAL_SECONDS)),
                                 help="Http server heartbeat interval in seconds "
                                      "0 means no heartbeat")
@@ -202,7 +202,8 @@ class ServerMainLoop:
         self.http_server_config.http_server_instances = args.http_server_instances
         self.http_server_config.http_server_monitor_interval_seconds = args.http_resources_monitor_interval_seconds
         self.http_server_config.http_port = args.http_port
-        self.http_server_config.http_server_heartbeat_interval_seconds = args.http_server_heartbeat_interval_seconds
+        self.http_server_config.stream_keep_alive_with_progress_interval_seconds =\
+            args.stream_keep_alive_with_progress_interval_seconds
 
         self.server_context.set_temp_storage_max_items(args.max_temp_networks)
 

--- a/neuro_san/service/main_loop/server_main_loop.py
+++ b/neuro_san/service/main_loop/server_main_loop.py
@@ -35,7 +35,7 @@ from neuro_san.service.http.config.http_server_config import DEFAULT_HTTP_CONNEC
 from neuro_san.service.http.config.http_server_config import DEFAULT_HTTP_IDLE_CONNECTIONS_TIMEOUT_SECONDS
 from neuro_san.service.http.config.http_server_config import DEFAULT_HTTP_SERVER_INSTANCES
 from neuro_san.service.http.config.http_server_config import DEFAULT_HTTP_SERVER_MONITOR_INTERVAL_SECONDS
-from neuro_san.service.http.config.http_server_config import DEFAULT_HTTP_SERVER_HEARTBEAT_INTERVAL_SECONDS
+from neuro_san.service.http.config.http_server_config import DEFAULT_KEEP_ALIVE_INTERVAL_SECONDS
 from neuro_san.service.http.config.http_server_config import HttpServerConfig
 from neuro_san.service.http.logging.logging_config_restorer import LoggingConfigRestorer
 from neuro_san.service.http.server.http_server import DEFAULT_SERVER_NAME
@@ -139,9 +139,9 @@ class ServerMainLoop:
                                                            DEFAULT_HTTP_SERVER_MONITOR_INTERVAL_SECONDS)),
                                 help="Http server resources monitoring/logging interval in seconds "
                                      "0 means no logging")
-        arg_parser.add_argument("--http_server_heartbeat_interval_seconds", type=int,
-                                default=int(os.environ.get("AGENT_HTTP_SERVER_HEARTBEAT_INTERVAL",
-                                                           DEFAULT_HTTP_SERVER_HEARTBEAT_INTERVAL_SECONDS)),
+        arg_parser.add_argument("--stream_keep_alive_with_progress_interval_seconds", type=int,
+                                default=int(os.environ.get("AGENT_STREAM_KEEP_ALIVE_WITH_PROGRESS_INTERVAL",
+                                                           DEFAULT_KEEP_ALIVE_INTERVAL_SECONDS)),
                                 help="Http server heartbeat interval in seconds "
                                      "0 means no heartbeat")
         arg_parser.add_argument("--max_temp_networks", type=int,

--- a/neuro_san/service/main_loop/server_main_loop.py
+++ b/neuro_san/service/main_loop/server_main_loop.py
@@ -36,7 +36,6 @@ from neuro_san.service.http.config.http_server_config import DEFAULT_HTTP_IDLE_C
 from neuro_san.service.http.config.http_server_config import DEFAULT_HTTP_SERVER_INSTANCES
 from neuro_san.service.http.config.http_server_config import DEFAULT_HTTP_SERVER_MONITOR_INTERVAL_SECONDS
 from neuro_san.service.http.config.http_server_config import DEFAULT_HTTP_SERVER_HEARTBEAT_INTERVAL_SECONDS
-from neuro_san.service.http.config.http_server_config import DEFAULT_HTTP_SERVER_HEARTBEAT_PAYLOAD
 from neuro_san.service.http.config.http_server_config import HttpServerConfig
 from neuro_san.service.http.logging.logging_config_restorer import LoggingConfigRestorer
 from neuro_san.service.http.server.http_server import DEFAULT_SERVER_NAME
@@ -145,10 +144,6 @@ class ServerMainLoop:
                                                            DEFAULT_HTTP_SERVER_HEARTBEAT_INTERVAL_SECONDS)),
                                 help="Http server heartbeat interval in seconds "
                                      "0 means no heartbeat")
-        arg_parser.add_argument("--http_server_heartbeat_payload", type=str,
-                                default=os.environ.get("AGENT_HTTP_SERVER_HEARTBEAT_PAYLOAD",
-                                                       DEFAULT_HTTP_SERVER_HEARTBEAT_PAYLOAD),
-                                help="Http server heartbeat payload as a string")
         arg_parser.add_argument("--max_temp_networks", type=int,
                                 default=int(os.environ.get("AGENT_MAX_TEMP_NETWORKS", "0")),
                                 help="Maximum number of temporary agent networks to keep in memory. "
@@ -208,7 +203,6 @@ class ServerMainLoop:
         self.http_server_config.http_server_monitor_interval_seconds = args.http_resources_monitor_interval_seconds
         self.http_server_config.http_port = args.http_port
         self.http_server_config.http_server_heartbeat_interval_seconds = args.http_server_heartbeat_interval_seconds
-        self.http_server_config.http_server_heartbeat_payload = args.http_server_heartbeat_payload
 
         self.server_context.set_temp_storage_max_items(args.max_temp_networks)
 

--- a/neuro_san/service/main_loop/server_main_loop.py
+++ b/neuro_san/service/main_loop/server_main_loop.py
@@ -35,6 +35,8 @@ from neuro_san.service.http.config.http_server_config import DEFAULT_HTTP_CONNEC
 from neuro_san.service.http.config.http_server_config import DEFAULT_HTTP_IDLE_CONNECTIONS_TIMEOUT_SECONDS
 from neuro_san.service.http.config.http_server_config import DEFAULT_HTTP_SERVER_INSTANCES
 from neuro_san.service.http.config.http_server_config import DEFAULT_HTTP_SERVER_MONITOR_INTERVAL_SECONDS
+from neuro_san.service.http.config.http_server_config import DEFAULT_HTTP_SERVER_HEARTBEAT_INTERVAL_SECONDS
+from neuro_san.service.http.config.http_server_config import DEFAULT_HTTP_SERVER_HEARTBEAT_PAYLOAD
 from neuro_san.service.http.config.http_server_config import HttpServerConfig
 from neuro_san.service.http.logging.logging_config_restorer import LoggingConfigRestorer
 from neuro_san.service.http.server.http_server import DEFAULT_SERVER_NAME
@@ -138,6 +140,15 @@ class ServerMainLoop:
                                                            DEFAULT_HTTP_SERVER_MONITOR_INTERVAL_SECONDS)),
                                 help="Http server resources monitoring/logging interval in seconds "
                                      "0 means no logging")
+        arg_parser.add_argument("--http_server_heartbeat_interval_seconds", type=int,
+                                default=int(os.environ.get("AGENT_HTTP_SERVER_HEARTBEAT_INTERVAL",
+                                                           DEFAULT_HTTP_SERVER_HEARTBEAT_INTERVAL_SECONDS)),
+                                help="Http server heartbeat interval in seconds "
+                                     "0 means no heartbeat")
+        arg_parser.add_argument("--http_server_heartbeat_payload", type=str,
+                                default=os.environ.get("AGENT_HTTP_SERVER_HEARTBEAT_PAYLOAD",
+                                                       DEFAULT_HTTP_SERVER_HEARTBEAT_PAYLOAD),
+                                help="Http server heartbeat payload as a string")
         arg_parser.add_argument("--max_temp_networks", type=int,
                                 default=int(os.environ.get("AGENT_MAX_TEMP_NETWORKS", "0")),
                                 help="Maximum number of temporary agent networks to keep in memory. "
@@ -196,6 +207,8 @@ class ServerMainLoop:
         self.http_server_config.http_server_instances = args.http_server_instances
         self.http_server_config.http_server_monitor_interval_seconds = args.http_resources_monitor_interval_seconds
         self.http_server_config.http_port = args.http_port
+        self.http_server_config.http_server_heartbeat_interval_seconds = args.http_server_heartbeat_interval_seconds
+        self.http_server_config.http_server_heartbeat_payload = args.http_server_heartbeat_payload
 
         self.server_context.set_temp_storage_max_items(args.max_temp_networks)
 

--- a/tests/neuro_san/client/test_thinking_file_message_processor_heartbeat.py
+++ b/tests/neuro_san/client/test_thinking_file_message_processor_heartbeat.py
@@ -1,0 +1,120 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+"""
+Unit tests for ThinkingFileMessageProcessor's handling of AGENT_PROGRESS
+heartbeat messages emitted by the neuro-san HTTP server.
+
+The server may emit empty-text AGENT_PROGRESS messages as keepalive ticks
+to prevent intermediate proxies and clients from dropping idle streaming
+connections during long quiet periods. The CLI's thinking-file logger
+must treat those as no-ops; real AGENT_PROGRESS messages with content
+must continue to be written.
+"""
+
+from pathlib import Path
+
+from neuro_san.client.thinking_file_message_processor import ThinkingFileMessageProcessor
+from neuro_san.internals.messages.chat_message_type import ChatMessageType
+
+
+class TestThinkingFileMessageProcessorHeartbeat:
+    """
+    Verifies that the thinking-file logger silently drops empty-content
+    AGENT_PROGRESS heartbeats and still writes real AGENT_PROGRESS messages.
+    """
+
+    def _make_processor(self, thinking_dir: Path) -> ThinkingFileMessageProcessor:
+        # thinking_file=None forces the per-origin file path under thinking_dir.
+        return ThinkingFileMessageProcessor(thinking_file=None, thinking_dir=str(thinking_dir))
+
+    def test_heartbeat_with_empty_text_is_skipped(self, tmp_path):
+        """
+        A heartbeat message (AGENT_PROGRESS, text="", no structure, no origin)
+        should produce no files in the thinking_dir.
+        """
+        processor = self._make_processor(tmp_path)
+        heartbeat = {"type": "AGENT_PROGRESS", "text": ""}
+
+        processor.process_message(heartbeat, ChatMessageType.AGENT_PROGRESS)
+
+        assert not list(tmp_path.iterdir()), (
+            "Expected the thinking_dir to remain empty after a heartbeat; "
+            f"got {[p.name for p in tmp_path.iterdir()]}."
+        )
+
+    def test_heartbeat_without_text_field_is_skipped(self, tmp_path):
+        """
+        An AGENT_PROGRESS frame missing the text field altogether is also a
+        no-op tick and must be skipped.
+        """
+        processor = self._make_processor(tmp_path)
+        heartbeat = {"type": "AGENT_PROGRESS"}
+
+        processor.process_message(heartbeat, ChatMessageType.AGENT_PROGRESS)
+
+        assert not list(tmp_path.iterdir()), (
+            "Expected the thinking_dir to remain empty after a heartbeat with "
+            f"no text field; got {[p.name for p in tmp_path.iterdir()]}."
+        )
+
+    def test_real_agent_progress_message_is_still_written(self, tmp_path):
+        """
+        A real AGENT_PROGRESS message with non-empty text and an origin must
+        still produce an entry in the thinking_dir.
+        """
+        processor = self._make_processor(tmp_path)
+        real = {
+            "type": "AGENT_PROGRESS",
+            "text": "halfway done",
+            "origin": [{"tool": "calculator", "instantiation_index": 0}],
+        }
+
+        processor.process_message(real, ChatMessageType.AGENT_PROGRESS)
+
+        files = list(tmp_path.iterdir())
+        assert len(files) == 1, (
+            f"Expected one file for a real AGENT_PROGRESS message; got {files}."
+        )
+        contents = files[0].read_text()
+        assert "halfway done" in contents, (
+            f"Expected the progress text to appear in the thinking file; got:\n{contents}"
+        )
+        assert "AGENT_PROGRESS" in contents
+
+    def test_agent_progress_with_structure_only_is_still_written(self, tmp_path):
+        """
+        An AGENT_PROGRESS message with a structure payload but no text is a
+        real progress report (e.g. from AgentProgressReporter.async_report_progress)
+        and must be written even though the text is absent.
+        """
+        processor = self._make_processor(tmp_path)
+        real = {
+            "type": "AGENT_PROGRESS",
+            "structure": {"step": 3, "total": 7},
+            "origin": [{"tool": "planner", "instantiation_index": 0}],
+        }
+
+        processor.process_message(real, ChatMessageType.AGENT_PROGRESS)
+
+        files = list(tmp_path.iterdir())
+        assert len(files) == 1, (
+            f"Expected one file for a structured progress message; got {files}."
+        )
+        contents = files[0].read_text()
+        assert '"step": 3' in contents, (
+            f"Expected the structure JSON to appear in the thinking file; got:\n{contents}"
+        )

--- a/tests/neuro_san/service/http/handlers/test_streaming_chat_handler_heartbeat_frame.py
+++ b/tests/neuro_san/service/http/handlers/test_streaming_chat_handler_heartbeat_frame.py
@@ -42,7 +42,7 @@ class TestStreamingChatHandlerHeartbeatFrame:
 
     def test_frame_ends_with_newline(self):
         """JSON-Lines framing requires a trailing newline on each frame."""
-        frame: str = StreamingChatHandler._build_heartbeat_frame()
+        frame: str = StreamingChatHandler._build_keep_alive_frame()
         assert frame.endswith("\n"), (
             f"Heartbeat frame must end with a newline for JSON-Lines framing; got {frame!r}."
         )
@@ -52,7 +52,7 @@ class TestStreamingChatHandlerHeartbeatFrame:
         The frame parses as a ChatResponse: a top-level "response" key
         whose value is the ChatMessage.
         """
-        parsed = json.loads(StreamingChatHandler._build_heartbeat_frame().rstrip("\n"))
+        parsed = json.loads(StreamingChatHandler._build_keep_alive_frame().rstrip("\n"))
         assert "response" in parsed, (
             f"Expected the heartbeat frame to use the ChatResponse envelope; got {parsed}."
         )
@@ -64,7 +64,7 @@ class TestStreamingChatHandlerHeartbeatFrame:
         CLI's ThinkingFileMessageProcessor heartbeat-skip recognizes)
         with empty text and no structure / origin.
         """
-        parsed = json.loads(StreamingChatHandler._build_heartbeat_frame().rstrip("\n"))
+        parsed = json.loads(StreamingChatHandler._build_keep_alive_frame().rstrip("\n"))
         chat_message = parsed["response"]
         expected_type_name: str = ChatMessageType.to_string(ChatMessageType.AGENT_PROGRESS)
 
@@ -77,7 +77,7 @@ class TestStreamingChatHandlerHeartbeatFrame:
         The frame must contain exactly one newline (the terminator) so
         clients reading line-by-line see one frame per tick.
         """
-        frame: str = StreamingChatHandler._build_heartbeat_frame()
+        frame: str = StreamingChatHandler._build_keep_alive_frame()
         assert frame.count("\n") == 1, (
             f"Heartbeat frame must contain exactly one newline; got {frame!r}."
         )
@@ -87,8 +87,8 @@ class TestStreamingChatHandlerHeartbeatFrame:
         The builder is deterministic: calling it twice yields the same
         bytes, so it's safe to call once at initialize() time and reuse.
         """
-        first: str = StreamingChatHandler._build_heartbeat_frame()
-        second: str = StreamingChatHandler._build_heartbeat_frame()
+        first: str = StreamingChatHandler._build_keep_alive_frame()
+        second: str = StreamingChatHandler._build_keep_alive_frame()
         assert first == second, (
             f"Heartbeat frame must be stable across calls; got {first!r} vs {second!r}."
         )

--- a/tests/neuro_san/service/http/handlers/test_streaming_chat_handler_heartbeat_frame.py
+++ b/tests/neuro_san/service/http/handlers/test_streaming_chat_handler_heartbeat_frame.py
@@ -1,0 +1,114 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+"""
+Unit tests for StreamingChatHandler._build_heartbeat_frame().
+
+The handler pre-builds the heartbeat wire frame once at initialize() time
+and writes it verbatim per tick. The frame must:
+  - wrap a JSON ChatMessage payload in the {"response": ...} envelope so
+    clients see the same shape as real chat responses;
+  - end in a newline so JSON-Lines framing remains intact even when the
+    heartbeat lands between two real messages;
+  - fall back to passing non-JSON payloads through with a trailing newline,
+    preserving the legacy "\\n" default's behavior.
+"""
+
+import json
+
+from neuro_san.service.http.handlers.streaming_chat_handler import StreamingChatHandler
+
+
+# These tests exercise a deliberately-internal helper directly; suppress
+# protected-access warnings file-wide rather than at each call site.
+# pylint: disable=protected-access
+class TestStreamingChatHandlerHeartbeatFrame:
+    """
+    Direct tests for the static frame builder. No Tornado runtime is
+    required because the method does not touch instance state.
+    """
+
+    # ---- JSON ChatMessage payloads (the primary path) -----------------------
+
+    def test_agent_progress_payload_is_wrapped_in_response_envelope(self):
+        """
+        The Dockerfile-default AGENT_PROGRESS payload is wrapped in
+        {"response": ...} and a trailing newline is appended.
+        """
+        configured = '{"type": 104, "text": ""}'
+        frame = StreamingChatHandler._build_heartbeat_frame(configured)
+
+        assert frame.endswith("\n"), "Heartbeat frame must end with a newline for JSON-Lines framing."
+        # Parsing the line (minus the newline) must yield a ChatResponse-shaped dict.
+        parsed = json.loads(frame.rstrip("\n"))
+        assert parsed == {"response": {"type": 104, "text": ""}}, (
+            f"Expected the configured ChatMessage to be wrapped in 'response'; got {parsed}."
+        )
+
+    def test_string_type_agent_progress_payload_is_wrapped(self):
+        """
+        The string-name form of the type field (matching what
+        ChatMessageConverter emits for real messages) is wrapped the same way.
+        """
+        configured = '{"type": "AGENT_PROGRESS", "text": ""}'
+        frame = StreamingChatHandler._build_heartbeat_frame(configured)
+
+        parsed = json.loads(frame.rstrip("\n"))
+        assert parsed == {"response": {"type": "AGENT_PROGRESS", "text": ""}}
+
+    def test_payload_with_extra_fields_is_wrapped_verbatim(self):
+        """
+        Extra fields on the configured ChatMessage are passed through into
+        the wrapped envelope unchanged -- the builder must not strip them.
+        """
+        configured = '{"type": "AGENT_PROGRESS", "text": "ping", "structure": {"k": 1}}'
+        frame = StreamingChatHandler._build_heartbeat_frame(configured)
+
+        parsed = json.loads(frame.rstrip("\n"))
+        assert parsed == {
+            "response": {"type": "AGENT_PROGRESS", "text": "ping", "structure": {"k": 1}}
+        }
+
+    # ---- Legacy / fallback non-JSON payloads --------------------------------
+
+    def test_legacy_newline_payload_passes_through(self):
+        """
+        The historical default heartbeat payload of "\\n" must be sent on
+        the wire unchanged, since it is already a valid JSON-Lines frame
+        (a blank line that all JSON-Lines parsers tolerate).
+        """
+        assert StreamingChatHandler._build_heartbeat_frame("\n") == "\n"
+
+    def test_non_json_string_gets_newline_appended(self):
+        """
+        A non-JSON heartbeat payload (e.g. a plain string sentinel) is
+        passed through with a newline appended for framing.
+        """
+        assert StreamingChatHandler._build_heartbeat_frame("ping") == "ping\n"
+
+    def test_non_json_string_with_trailing_newline_is_not_double_terminated(self):
+        """
+        A non-JSON payload that already ends in a newline must not get a
+        second newline appended.
+        """
+        assert StreamingChatHandler._build_heartbeat_frame("ping\n") == "ping\n"
+
+    def test_empty_string_payload_is_terminated(self):
+        """
+        Empty configured payload -- which json.loads treats as invalid --
+        yields a single newline frame.
+        """
+        assert StreamingChatHandler._build_heartbeat_frame("") == "\n"

--- a/tests/neuro_san/service/http/handlers/test_streaming_chat_handler_heartbeat_frame.py
+++ b/tests/neuro_san/service/http/handlers/test_streaming_chat_handler_heartbeat_frame.py
@@ -17,98 +17,78 @@
 """
 Unit tests for StreamingChatHandler._build_heartbeat_frame().
 
-The handler pre-builds the heartbeat wire frame once at initialize() time
-and writes it verbatim per tick. The frame must:
-  - wrap a JSON ChatMessage payload in the {"response": ...} envelope so
-    clients see the same shape as real chat responses;
-  - end in a newline so JSON-Lines framing remains intact even when the
-    heartbeat lands between two real messages;
-  - fall back to passing non-JSON payloads through with a trailing newline,
-    preserving the legacy "\\n" default's behavior.
+The heartbeat payload is no longer user-configurable: only the heartbeat
+interval is. The handler calls _build_heartbeat_frame() once at
+initialize() time and writes that frame verbatim for every tick. These
+tests pin the frame's wire shape so future refactors of how it is built
+do not silently change what clients see.
 """
 
 import json
 
+from neuro_san.internals.messages.chat_message_type import ChatMessageType
 from neuro_san.service.http.handlers.streaming_chat_handler import StreamingChatHandler
 
 
-# These tests exercise a deliberately-internal helper directly; suppress
-# protected-access warnings file-wide rather than at each call site.
+# These tests access a deliberately-internal helper directly; suppress
+# protected-access warnings file-wide.
 # pylint: disable=protected-access
 class TestStreamingChatHandlerHeartbeatFrame:
     """
-    Direct tests for the static frame builder. No Tornado runtime is
-    required because the method does not touch instance state.
+    Pins the wire-format invariants of the constant heartbeat frame:
+    it must be a ChatResponse-shaped JSON line carrying an empty
+    AGENT_PROGRESS ChatMessage and terminated with a newline.
     """
 
-    # ---- JSON ChatMessage payloads (the primary path) -----------------------
-
-    def test_agent_progress_payload_is_wrapped_in_response_envelope(self):
-        """
-        The Dockerfile-default AGENT_PROGRESS payload is wrapped in
-        {"response": ...} and a trailing newline is appended.
-        """
-        configured = '{"type": 104, "text": ""}'
-        frame = StreamingChatHandler._build_heartbeat_frame(configured)
-
-        assert frame.endswith("\n"), "Heartbeat frame must end with a newline for JSON-Lines framing."
-        # Parsing the line (minus the newline) must yield a ChatResponse-shaped dict.
-        parsed = json.loads(frame.rstrip("\n"))
-        assert parsed == {"response": {"type": 104, "text": ""}}, (
-            f"Expected the configured ChatMessage to be wrapped in 'response'; got {parsed}."
+    def test_frame_ends_with_newline(self):
+        """JSON-Lines framing requires a trailing newline on each frame."""
+        frame: str = StreamingChatHandler._build_heartbeat_frame()
+        assert frame.endswith("\n"), (
+            f"Heartbeat frame must end with a newline for JSON-Lines framing; got {frame!r}."
         )
 
-    def test_string_type_agent_progress_payload_is_wrapped(self):
+    def test_frame_wraps_chat_message_in_response_envelope(self):
         """
-        The string-name form of the type field (matching what
-        ChatMessageConverter emits for real messages) is wrapped the same way.
+        The frame parses as a ChatResponse: a top-level "response" key
+        whose value is the ChatMessage.
         """
-        configured = '{"type": "AGENT_PROGRESS", "text": ""}'
-        frame = StreamingChatHandler._build_heartbeat_frame(configured)
+        parsed = json.loads(StreamingChatHandler._build_heartbeat_frame().rstrip("\n"))
+        assert "response" in parsed, (
+            f"Expected the heartbeat frame to use the ChatResponse envelope; got {parsed}."
+        )
+        assert isinstance(parsed["response"], dict)
 
-        parsed = json.loads(frame.rstrip("\n"))
-        assert parsed == {"response": {"type": "AGENT_PROGRESS", "text": ""}}
+    def test_frame_is_an_empty_agent_progress_message(self):
+        """
+        The wrapped ChatMessage is an AGENT_PROGRESS (matching what the
+        CLI's ThinkingFileMessageProcessor heartbeat-skip recognizes)
+        with empty text and no structure / origin.
+        """
+        parsed = json.loads(StreamingChatHandler._build_heartbeat_frame().rstrip("\n"))
+        chat_message = parsed["response"]
+        expected_type_name: str = ChatMessageType.to_string(ChatMessageType.AGENT_PROGRESS)
 
-    def test_payload_with_extra_fields_is_wrapped_verbatim(self):
-        """
-        Extra fields on the configured ChatMessage are passed through into
-        the wrapped envelope unchanged -- the builder must not strip them.
-        """
-        configured = '{"type": "AGENT_PROGRESS", "text": "ping", "structure": {"k": 1}}'
-        frame = StreamingChatHandler._build_heartbeat_frame(configured)
+        assert chat_message == {"type": expected_type_name, "text": ""}, (
+            f"Heartbeat ChatMessage must be exactly an empty AGENT_PROGRESS; got {chat_message}."
+        )
 
-        parsed = json.loads(frame.rstrip("\n"))
-        assert parsed == {
-            "response": {"type": "AGENT_PROGRESS", "text": "ping", "structure": {"k": 1}}
-        }
+    def test_frame_is_a_single_json_line(self):
+        """
+        The frame must contain exactly one newline (the terminator) so
+        clients reading line-by-line see one frame per tick.
+        """
+        frame: str = StreamingChatHandler._build_heartbeat_frame()
+        assert frame.count("\n") == 1, (
+            f"Heartbeat frame must contain exactly one newline; got {frame!r}."
+        )
 
-    # ---- Legacy / fallback non-JSON payloads --------------------------------
-
-    def test_legacy_newline_payload_passes_through(self):
+    def test_repeated_calls_yield_identical_frames(self):
         """
-        The historical default heartbeat payload of "\\n" must be sent on
-        the wire unchanged, since it is already a valid JSON-Lines frame
-        (a blank line that all JSON-Lines parsers tolerate).
+        The builder is deterministic: calling it twice yields the same
+        bytes, so it's safe to call once at initialize() time and reuse.
         """
-        assert StreamingChatHandler._build_heartbeat_frame("\n") == "\n"
-
-    def test_non_json_string_gets_newline_appended(self):
-        """
-        A non-JSON heartbeat payload (e.g. a plain string sentinel) is
-        passed through with a newline appended for framing.
-        """
-        assert StreamingChatHandler._build_heartbeat_frame("ping") == "ping\n"
-
-    def test_non_json_string_with_trailing_newline_is_not_double_terminated(self):
-        """
-        A non-JSON payload that already ends in a newline must not get a
-        second newline appended.
-        """
-        assert StreamingChatHandler._build_heartbeat_frame("ping\n") == "ping\n"
-
-    def test_empty_string_payload_is_terminated(self):
-        """
-        Empty configured payload -- which json.loads treats as invalid --
-        yields a single newline frame.
-        """
-        assert StreamingChatHandler._build_heartbeat_frame("") == "\n"
+        first: str = StreamingChatHandler._build_heartbeat_frame()
+        second: str = StreamingChatHandler._build_heartbeat_frame()
+        assert first == second, (
+            f"Heartbeat frame must be stable across calls; got {first!r} vs {second!r}."
+        )


### PR DESCRIPTION
This PR adds periodic heartbeat message generation for every streaming chat request our service is processing.
Heart rate is configured by cmd line parameter or env variable, default being 0 == no heart beat.
Message itself is neuro-san AGENT_PROGRESS message with no contents,
clients should be able to safely ignore it. 
