### PR TITLE
Surface OpenRouter API key / billing errors with friendly guidance

### DIFF
--- a/neuro_san/internals/run_context/langchain/core/run_context_runnable.py
+++ b/neuro_san/internals/run_context/langchain/core/run_context_runnable.py
@@ -55,6 +55,8 @@ RATE_LIMIT_ERROR_TYPES: Tuple[Type[Any], ...] = ResolverUtil.create_type_tuple([
                                             "openai.RateLimitError",
                                             "anthropic.RateLimitError",
                                             "google.genai._interactions.RateLimitError",
+                                            # OpenRouter SDK rate-limit error (HTTP 429)
+                                            "openrouter.errors.TooManyRequestsResponseError",
                                          ])
 
 # Lazily import specific errors from llm providers
@@ -62,6 +64,13 @@ API_ERROR_TYPES: Tuple[Type[Any], ...] = ResolverUtil.create_type_tuple([
                                             "openai.APIError",
                                             "anthropic.APIError",
                                             "langchain_google_genai.chat_models.ChatGoogleGenerativeAIError",
+                                            # Base class for all OpenRouter SDK HTTP errors (UnauthorizedResponseError,
+                                            # BadGatewayResponseError, ResponseValidationError, etc.). Routing these
+                                            # through this branch lets ApiKeyErrorCheck convert runtime 401s
+                                            # ("Missing Authentication header") into the friendly OPENROUTER_API_KEY
+                                            # message instead of letting them fall through to the generic
+                                            # `except Exception` retry.
+                                            "openrouter.errors.OpenRouterError",
                                          ])
 
 

--- a/neuro_san/internals/run_context/langchain/llms/default_llm_info.hocon
+++ b/neuro_san/internals/run_context/langchain/llms/default_llm_info.hocon
@@ -1358,6 +1358,9 @@
                 "presence_penalty": null,
                 "seed": null,
                 "stop": null,               # Maps to ChatOpenRouter `stop_sequences`
+                # streaming defaults to off; set "streaming": true in llm_config to enable.
+                # stream_usage tracks streaming, so it is enabled iff streaming is enabled.
+                "streaming": false,
 
                 # OpenRouter-specific options
                 # See https://openrouter.ai/docs

--- a/neuro_san/internals/run_context/langchain/llms/openrouter_llm_policy.py
+++ b/neuro_san/internals/run_context/langchain/llms/openrouter_llm_policy.py
@@ -23,6 +23,7 @@ from contextlib import suppress
 from langchain_core.language_models.base import BaseLanguageModel
 
 from neuro_san.internals.run_context.langchain.llms.llm_policy import LlmPolicy
+from neuro_san.internals.utils.config_util import ConfigUtil
 
 
 class OpenRouterLlmPolicy(LlmPolicy):
@@ -69,14 +70,15 @@ class OpenRouterLlmPolicy(LlmPolicy):
             presence_penalty=config.get("presence_penalty"),
             seed=config.get("seed"),
             stop_sequences=config.get("stop"),
-            # Disable streaming: neuro-san does not consume per-token chunks from the model,
-            # and disabling streaming reduces per-request LangChain pipeline overhead.
-            # Token usage is collected from AIMessage.usage_metadata in LlmTokenCallbackHandler.
-            # We set streaming explicitly (rather than relying on the False default) so that
-            # langchain_core._should_stream() recognizes it as opted-out
-            # even when a streaming-aware callback is attached.
-            streaming=False,
-            stream_usage=False,  # Don't even include token usage in the streaming response, since we're not streaming
+            # Streaming is configurable via the "streaming" key in llm_config; defaults
+            # to False so existing agents keep their long-standing non-streaming behavior.
+            # We pass streaming explicitly (rather than relying on LangChain's default) so
+            # that langchain_core._should_stream() picks up the configured value even when
+            # a streaming-aware callback is attached. Token usage is collected from
+            # AIMessage.usage_metadata in LlmTokenCallbackHandler regardless of streaming
+            # mode; stream_usage tracks streaming so usage frames flow only when streaming.
+            streaming=ConfigUtil.get_bool(config, "streaming"),
+            stream_usage=ConfigUtil.get_bool(config, "streaming"),
             reasoning=config.get("reasoning"),
             openrouter_provider=config.get("openrouter_provider"),
             route=config.get("route"),

--- a/neuro_san/internals/run_context/langchain/util/api_key_error_check.py
+++ b/neuro_san/internals/run_context/langchain/util/api_key_error_check.py
@@ -25,6 +25,24 @@ API_KEY_EXCEPTIONS: Dict[str, List] = {
     "ANTHROPIC_API_KEY": ["ANTHROPIC_API_KEY", "anthropic_api_key", "invalid x-api-key", "credit balance"],
     "GOOGLE_API_KEY": ["Application Default Credentials", "default credentials", "Gemini: 400 API key not valid"],
 
+    # OpenRouter surfaces a few distinct families of failures that the friendly
+    # OPENROUTER_API_KEY guidance addresses (matches the
+    # "1) double-check key / 2) get a key / 3) low credit balance" trio):
+    #   * Construction-time: ChatOpenRouter's pydantic validator raises with the
+    #     literal text "OPENROUTER_API_KEY must be set." (wrapped in a
+    #     pydantic_core.ValidationError, which is in API_KEY_ERRORS).
+    #   * Runtime 401 (UnauthorizedResponseError): str() is just the API's error
+    #     message — typically "Missing Authentication header" when no key was
+    #     sent and provider-defined strings (e.g. "No auth credentials found")
+    #     when one was sent but rejected.
+    #   * Runtime 402 (PaymentRequiredResponseError): "Insufficient credits..."
+    #     with a link to https://openrouter.ai/settings/credits. The same low-
+    #     balance bullet in the friendly message applies; matching "Insufficient
+    #     credits" plus the OpenRouter settings URL keeps the catch tight.
+    "OPENROUTER_API_KEY": ["OPENROUTER_API_KEY", "openrouter_api_key",
+                           "Missing Authentication header", "No auth credentials found",
+                           "Insufficient credits", "openrouter.ai/settings/credits"],
+
     # Azure OpenAI requires several parameters; all can be set via environment variables
     # except "deployment_name", which must be provided explicitly.
     "AZURE_OPENAI_API_KEY": ["invalid subscription key", "wrong API endpoint"],


### PR DESCRIPTION
Fix #1055 

When an OpenRouter-backed agent hit a runtime auth or billing failure, the openrouter SDK exceptions weren't routed through neuro-san's API-key error path, so users got the raw stack trace ("UnauthorizedResponseError: Missing Authentication header", "PaymentRequiredResponseError: Insufficient credits...") with no hint on how to fix it.

Changes:

* run_context_runnable.py: add openrouter.errors.OpenRouterError (base class for all OpenRouter HTTP errors) to API_ERROR_TYPES and openrouter.errors.TooManyRequestsResponseError to RATE_LIMIT_ERROR_TYPES. Subclassing handles every other 4xx/5xx the SDK raises (PaymentRequired, BadGateway, ResponseValidation, etc.) via the single base entry. Missing-module tolerant via ResolverUtil.create_type_tuple — no-ops when langchain-openrouter is not installed.

* api_key_error_check.py: add an OPENROUTER_API_KEY entry to API_KEY_EXCEPTIONS covering three failure modes:
    - Construction-time ("OPENROUTER_API_KEY must be set." from ChatOpenRouter's pydantic validator)
    - Runtime 401 ("Missing Authentication header" / "No auth credentials found")
    - Runtime 402 ("Insufficient credits" with the openrouter.ai/settings/credits link) All three now produce the existing "double-check key / get a key / check credit balance" guidance, matching how Anthropic's "credit balance" string is grouped.

Also in this branch: streaming is now configurable per-agent via a "streaming" key in llm_config (defaults to false, preserving existing behavior). Driven through ConfigUtil.get_bool so both ChatOpenRouter's streaming and stream_usage track the same flag.