### PR TITLE
Add dedicated health check server on separate port

### DIFF
--- a/neuro_san/service/http/server/health_server.py
+++ b/neuro_san/service/http/server/health_server.py
@@ -1,0 +1,99 @@
+
+# Copyright (C) 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+"""
+Dedicated health check server that runs on a separate port and thread
+so that Kubernetes liveness/readiness probes are never blocked by
+heavy request processing on the main event loop.
+"""
+
+import asyncio
+import logging
+import threading
+
+import tornado.httpserver
+import tornado.ioloop
+import tornado.web
+
+from neuro_san.service.http.handlers.health_check_handler import HealthCheckHandler
+from neuro_san.service.utils.server_status import ServerStatus
+
+logger = logging.getLogger(__name__)
+
+
+class HealthServer:
+    """
+    A lightweight HTTP server dedicated to serving health check endpoints
+    (/livez, /readyz) on a separate port in its own thread. This prevents
+    Kubernetes probes from being starved when the main application event
+    loop is saturated with long-running LLM requests.
+    """
+
+    def __init__(self, port: int, server_status: ServerStatus):
+        """
+        :param port: TCP port for the dedicated health server
+        :param server_status: ServerStatus instance to query for readiness/liveness
+        """
+        self.port = port
+        self.server_status = server_status
+        self._thread: threading.Thread = None
+
+    def start(self):
+        """
+        Start the health check server in a daemon thread.
+        """
+        self._thread = threading.Thread(
+            target=self._run,
+            name="health-server",
+            daemon=True
+        )
+        self._thread.start()
+        logger.info("Health check server started on port %d", self.port)
+
+    def _run(self):
+        """
+        Entry point for the health server thread. Creates its own
+        asyncio event loop and Tornado IOLoop so it is fully independent
+        of the main application event loop.
+        """
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+
+        forwarded_request_metadata = []
+        logging_config = {}
+
+        live_data = {
+            "forwarded_request_metadata": forwarded_request_metadata,
+            "server_status": self.server_status,
+            "op": "live",
+            "logging_config": logging_config
+        }
+        ready_data = {
+            "forwarded_request_metadata": forwarded_request_metadata,
+            "server_status": self.server_status,
+            "op": "ready",
+            "logging_config": logging_config
+        }
+
+        app = tornado.web.Application([
+            ("/", HealthCheckHandler, ready_data),
+            ("/livez", HealthCheckHandler, live_data),
+            ("/readyz", HealthCheckHandler, ready_data),
+        ])
+
+        server = tornado.httpserver.HTTPServer(app)
+        server.listen(self.port)
+        tornado.ioloop.IOLoop.current().start()

--- a/neuro_san/service/main_loop/server_main_loop.py
+++ b/neuro_san/service/main_loop/server_main_loop.py
@@ -37,6 +37,7 @@ from neuro_san.service.http.config.http_server_config import DEFAULT_HTTP_SERVER
 from neuro_san.service.http.config.http_server_config import DEFAULT_HTTP_SERVER_MONITOR_INTERVAL_SECONDS
 from neuro_san.service.http.config.http_server_config import HttpServerConfig
 from neuro_san.service.http.logging.logging_config_restorer import LoggingConfigRestorer
+from neuro_san.service.http.server.health_server import HealthServer
 from neuro_san.service.http.server.http_server import DEFAULT_SERVER_NAME
 from neuro_san.service.http.server.http_server import DEFAULT_SERVER_NAME_FOR_LOGS
 from neuro_san.service.http.server.http_server import DEFAULT_MAX_CONCURRENT_REQUESTS
@@ -63,6 +64,7 @@ class ServerMainLoop:
         Constructor
         """
         self.http_port: int = 0
+        self.health_port: int = 0
 
         self.agent_networks: Dict[str, Dict[str, AgentNetwork]] = {}
 
@@ -149,6 +151,12 @@ class ServerMainLoop:
         arg_parser.add_argument("--mcp_only", type=str,
                                 default=os.environ.get("AGENT_MCP_ONLY", "false"),
                                 help="'true' if only MCP protocol service will be run (no HTTP service)")
+        arg_parser.add_argument("--health_port", type=int,
+                                default=int(os.environ.get("AGENT_HEALTH_PORT", "0")),
+                                help="Port for dedicated health check server. "
+                                     "When set, /livez and /readyz are served on a separate "
+                                     "thread so K8s probes are never blocked by request load. "
+                                     "0 disables the dedicated server.")
         return arg_parser
 
     def parse_args(self):
@@ -196,6 +204,8 @@ class ServerMainLoop:
         self.http_server_config.http_server_instances = args.http_server_instances
         self.http_server_config.http_server_monitor_interval_seconds = args.http_resources_monitor_interval_seconds
         self.http_server_config.http_port = args.http_port
+
+        self.health_port: int = args.health_port
 
         self.server_context.set_temp_storage_max_items(args.max_temp_networks)
 
@@ -285,6 +295,14 @@ class ServerMainLoop:
         for storage_class in StorageClass.ALL_PERMANENT:
             storage: AgentNetworkStorage = network_storage_dict.get(storage_class)
             storage.setup_agent_networks(self.agent_networks.get(storage_class))
+
+        # Start dedicated health check server if configured:
+        if self.health_port > 0:
+            health_server = HealthServer(
+                self.health_port,
+                self.server_context.get_server_status()
+            )
+            health_server.start()
 
         # Start http server:
         self.http_server.start(components_to_start)


### PR DESCRIPTION
## Summary

Under heavy concurrent load (50+ simultaneous LLM requests), the main Tornado event loop becomes saturated and cannot respond to K8s health probes in time. This causes K8s to kill pods mid-response — the root cause of the `TransferEncodingError` failures observed in load testing at 75/100 concurrency.

This adds a `HealthServer` that runs `/livez` and `/readyz` on a **separate thread with its own asyncio event loop**, completely isolated from main request processing. Enabled via `AGENT_HEALTH_PORT` env var (default `0` = disabled, so it's opt-in and backward-compatible).

```python
# neuro_san/service/http/server/health_server.py
class HealthServer:
    def start(self):
        # Spawns daemon thread → new asyncio loop → Tornado IOLoop
        # Serves only /livez, /readyz, / on the dedicated port
```

Integration in `ServerMainLoop.main_loop()`:
```python
if self.health_port > 0:
    HealthServer(self.health_port, server_status).start()
```

Companion deploy PR: cognizant-ai-lab/neuro-san-deploy (sets `AGENT_HEALTH_PORT=9999` and points K8s probes at port 9999).

Link to Devin session: https://app.devin.ai/sessions/2e5a8890c53840ffbd324456d5c95ccb
Requested by: @donn-leaf
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cognizant-ai-lab/neuro-san/pull/1070" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->