### PR TITLE
Switch default sense of Dockerfile hardening for better security-by-default

### DIFF
--- a/neuro_san/deploy/Dockerfile
+++ b/neuro_san/deploy/Dockerfile
@@ -327,15 +327,15 @@ ENV AGENT_MCP_ONLY="false"
 #
 
 # When set to "true", this parameter requires https for internal agent session communication.
-# The default is "false", to allow developers to work locally without acquiring certificates.
-# Strongly consider turning this on for production deployments.
-ENV AGENT_SESSION_REQUIRE_HTTPS="false"
+# The default is "true". Developers should set this to false to work locally without acquiring certificates.
+# Strongly consider keeping this on for production deployments.
+ENV AGENT_SESSION_REQUIRE_HTTPS="true"
 
 # When set to "false", this parameter will squelch the logging of sensitive information
 # as flagged by static analysis (SAST) tools.
-# The default is "true", to allow developers to work locally with reasonable failure information.
-# Strongly consider turning this off for production deployments.
-ENV LEAF_LOG_SENSITIVE="true"
+# The default is "false". Developers should set this to true to work locally with reasonable failure information.
+# Strongly consider keeping this off for production deployments.
+ENV LEAF_LOG_SENSITIVE="false"
 
 #
 # Authorization

--- a/neuro_san/deploy/run.sh
+++ b/neuro_san/deploy/run.sh
@@ -65,8 +65,8 @@ function run() {
         --network=$network \
         -e OPENAI_API_KEY \
         -e ANTHROPIC_API_KEY \
-        -e AGENT_SESSION_REQUIRE_HTTPS="false" \
-        -e LEAF_LOG_SENSITIVE="true" \
+        -e AGENT_SESSION_REQUIRE_HTTPS='false' \
+        -e LEAF_LOG_SENSITIVE='true' \
         -p $SERVICE_HTTP_PORT:$SERVICE_HTTP_PORT \
             neuro-san/neuro-san:$CONTAINER_VERSION"
 

--- a/neuro_san/deploy/run.sh
+++ b/neuro_san/deploy/run.sh
@@ -65,8 +65,8 @@ function run() {
         --network=$network \
         -e OPENAI_API_KEY \
         -e ANTHROPIC_API_KEY \
-        -e AGENT_SESSION_REQUIRE_HTTPS='false' \
-        -e LEAF_LOG_SENSITIVE='true' \
+        -e AGENT_SESSION_REQUIRE_HTTPS=false \
+        -e LEAF_LOG_SENSITIVE=true \
         -p $SERVICE_HTTP_PORT:$SERVICE_HTTP_PORT \
             neuro-san/neuro-san:$CONTAINER_VERSION"
 

--- a/neuro_san/deploy/run.sh
+++ b/neuro_san/deploy/run.sh
@@ -65,6 +65,8 @@ function run() {
         --network=$network \
         -e OPENAI_API_KEY \
         -e ANTHROPIC_API_KEY \
+        -e AGENT_SESSION_REQUIRE_HTTPS="false" \
+        -e LEAF_LOG_SENSITIVE="true" \
         -p $SERVICE_HTTP_PORT:$SERVICE_HTTP_PORT \
             neuro-san/neuro-san:$CONTAINER_VERSION"
 


### PR DESCRIPTION
There are 2 env vars whose default sense in the Dockerfile has been switched to better adhere to security-by-default:
ENV AGENT_SESSION_REQUIRE_HTTPS=true
ENV LEAF_LOG_SENSITIVE=false

The run.sh script now has these turned to false and true respectively for developer sanity.