### PR TITLE
NS-1022 Adjust GC timeout threshold for neuro-san AsyncioExecutorPool.

### DIFF
--- a/neuro_san/service/utils/server_context.py
+++ b/neuro_san/service/utils/server_context.py
@@ -45,7 +45,7 @@ class ServerContext(ServerContextLite):
         Constructor.
         """
         self.server_status: ServerStatus = None
-        self.executor_pool = AsyncioExecutorPool(reuse_mode=True)
+        self.executor_pool = AsyncioExecutorPool(reuse_mode=True, idle_timeout_seconds=60)
         self.queues: Queue[AsyncCollatingQueue] = Queue()
         self.mcp_server_context: McpServerContext = McpServerContext()
         self.server_port: int = AgentSessionConstants.DEFAULT_HTTP_PORT

--- a/neuro_san/service/utils/server_context.py
+++ b/neuro_san/service/utils/server_context.py
@@ -45,7 +45,7 @@ class ServerContext(ServerContextLite):
         Constructor.
         """
         self.server_status: ServerStatus = None
-        self.executor_pool = AsyncioExecutorPool(reuse_mode=True, idle_timeout_seconds=60)
+        self.executor_pool = AsyncioExecutorPool(reuse_mode=True, idle_timeout_seconds=30)
         self.queues: Queue[AsyncCollatingQueue] = Queue()
         self.mcp_server_context: McpServerContext = McpServerContext()
         self.server_port: int = AgentSessionConstants.DEFAULT_HTTP_PORT


### PR DESCRIPTION
Default GC timeout threshold for AsyncioExecutorPool proved to be too long (180 sec).
Adjust it to 30 sec and make it explicit in neuro-san code, so we know what's happening.
Note that in CLI client for direct connection we leave it at default - for single client session it will work OK.
 