### PR TITLE
Bump build-common to 1.0.8

### DIFF
--- a/.github/workflows/checkmarx.yml
+++ b/.github/workflows/checkmarx.yml
@@ -25,8 +25,8 @@ jobs:
 
       - name: Run Checkmarx One scan
         id: scan
-        # build-common 1.0.7
-        uses: cognizant-ai-lab/build-common/actions/checkmarx-one@3ead7f681f92044709ffc3a533f41c3f48230cfd
+        # build-common 1.0.8
+        uses: cognizant-ai-lab/build-common/actions/checkmarx-one@30321843331e00848309b34e08b839e1f6490ba2
         with:
           base-uri: ${{ vars.CX_BASE_URI }}
           cx-tenant: ${{ vars.CX_TENANT }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,8 +12,8 @@ jobs:
   test:
     # don't run this job in sync'd clones
     if: github.repository == 'cognizant-ai-lab/neuro-san'
-    # 1.0.7
-    uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@3ead7f681f92044709ffc3a533f41c3f48230cfd
+    # 1.0.8
+    uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@30321843331e00848309b34e08b839e1f6490ba2
     with:
       python-version: '3.12'
       lint-command-override: 'true'  # no lint in this workflow

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,8 +23,8 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Setup Python environment
-        # 1.0.7
-        uses: cognizant-ai-lab/build-common/actions/setup-python-env@3ead7f681f92044709ffc3a533f41c3f48230cfd
+        # 1.0.8
+        uses: cognizant-ai-lab/build-common/actions/setup-python-env@30321843331e00848309b34e08b839e1f6490ba2
         with:
           python-version: '3.10'
           requirements-file: ''
@@ -40,8 +40,8 @@ jobs:
 
       - name: Notify Slack
         if: ${{ !cancelled() }}
-        # 1.0.7
-        uses: cognizant-ai-lab/build-common/actions/slack-notify@3ead7f681f92044709ffc3a533f41c3f48230cfd
+        # 1.0.8
+        uses: cognizant-ai-lab/build-common/actions/slack-notify@30321843331e00848309b34e08b839e1f6490ba2
         with:
           status: ${{ job.status }}
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -96,8 +96,8 @@ jobs:
 
       - name: Notify Slack
         if: ${{ !cancelled() }}
-        # 1.0.7
-        uses: cognizant-ai-lab/build-common/actions/slack-notify@3ead7f681f92044709ffc3a533f41c3f48230cfd
+        # 1.0.8
+        uses: cognizant-ai-lab/build-common/actions/slack-notify@30321843331e00848309b34e08b839e1f6490ba2
         with:
           status: ${{ job.status }}
           details: ${{ steps.smoke.outputs.summary }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,8 +16,8 @@ jobs:
     if: >
       (github.event_name == 'push' && github.ref != 'refs/heads/main') ||
       (github.event_name == 'pull_request' && github.base_ref == 'main')
-    # 1.0.7
-    uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@3ead7f681f92044709ffc3a533f41c3f48230cfd
+    # 1.0.8
+    uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@30321843331e00848309b34e08b839e1f6490ba2
     with:
       python-version: '3.12'
       lint-toolchain: 'legacy'  # flake8 only (black/isort are opt-in)


### PR DESCRIPTION
## Summary

Bumps all `cognizant-ai-lab/build-common` references from 1.0.7 (`3ead7f6`) to 1.0.8 (`3032184`). Updates SHA pins and version comments in `tests.yml`, `integration.yml`, `publish.yml`, `smoke.yml`, and `checkmarx.yml`.

Link to Devin session: https://app.devin.ai/sessions/aad527cb16b14184a12c5ff5c362cccf
Requested by: @donn-leaf
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cognizant-ai-lab/neuro-san/pull/1075" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->