### PR TITLE
Fetch full history in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,6 +21,8 @@ jobs:
       # v6.0.2
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 0
 
       - name: Setup Python environment
         # 1.0.7


### PR DESCRIPTION
## Summary
There are multiple ways to Release in github (target main or target branch, create tag our use existing tag). Today we hit a flow where the new tag was not in the checkout. The fix is to make checkout more robust by fetching full history then we'll be sure to get the tags no matter how the Release was created. 

We'll need to fix this vulnerability in some other consuming repos, I'll hunt them down.

The publish job was failing with a 400 from PyPI because the package version contained a local identifier (`0.1.dev1+g0795801`). `setuptools-scm` couldn't find the release tag in a shallow clone (the default `fetch-depth: 1`), so it fell back to a dev version with `+gSHA` — which PyPI rejects per PEP 440.

Adds `fetch-depth: 0` to the checkout step so `setuptools-scm` sees the full tag history and resolves the correct release version.

Link to Devin session: https://app.devin.ai/sessions/b4bf1e6fe6ca43f481601fea4fb35e60
Requested by: @donn-leaf
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cognizant-ai-lab/neuro-san/pull/1079" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->