### PR TITLE
NS-1080 Remove leading/trailing whitespace from sly_data llm_config values

### DIFF
--- a/neuro_san/internals/run_context/langchain/llms/default_llm_factory.py
+++ b/neuro_san/internals/run_context/langchain/llms/default_llm_factory.py
@@ -326,6 +326,10 @@ class DefaultLlmFactory(ContextTypeLlmFactory, LangChainLlmFactory):
                 # If we have a value in the sly_data.llm_config dictionary, use it,
                 new_value: Any = use_api_keys.get(key)
                 if new_value is not None:
+                    if isinstance(new_value, str):
+                        # Remove leading and trailing whitespace because often these values
+                        # are going into http headers which don't like the extra whitespace.
+                        new_value = new_value.strip()
                     config[key] = new_value
                 else:
                     # Add to the list of complaints about what is missing.


### PR DESCRIPTION
BYOK sly_data values often make it into HTTP headers and HTTP headers do not like the extra whitespace.
Strip()-ing makes BYOK values a bit more fault-tolerant from the user's perspective.

We already have decent funneling of "your key is invalid" to non-divulging error messages sent back to the user.
This header thing evaded that until now.

Luckily, the error that @dsargent saw on the client side never actually made it into the logs, by design.

Fixes #1080 