### PR TITLE
LangChainRunContext: Clear more in close_of_work() / Reorg of constructor.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ Neuro SAN also offers:
     * an Assessor app which classifies the modes of failure for your agents, given a data-driven test case
 * MCP protocol API - Every Neuro SAN server can be an MCP Server.
 * per-user authorization for Agent Networks - optional implementations include: OpenFGA
-* Secure Bring-Your-Own-Key (BYOK) support for client-provided API keys so your deployments do not have to shoulder everyone else's token costs.
+* Secure Bring-Your-Own-Key (BYOK) support for client-provided API keys so your deployments do not have to
+  shoulder everyone else's token costs.
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Neuro SAN also offers:
     * an Assessor app which classifies the modes of failure for your agents, given a data-driven test case
 * MCP protocol API - Every Neuro SAN server can be an MCP Server.
 * per-user authorization for Agent Networks - optional implementations include: OpenFGA
+* Secure Bring-Your-Own-Key (BYOK) support for client-provided API keys so your deployments do not have to shoulder everyone else's token costs.
 
 ## Quick Start
 

--- a/neuro_san/internals/run_context/langchain/core/langchain_run_context.py
+++ b/neuro_san/internals/run_context/langchain/core/langchain_run_context.py
@@ -119,6 +119,7 @@ class LangChainRunContext(RunContext):
         self.tracing_context: TracingContext = tracing_context
 
         self.capsule: ActivationCapsule = None
+
         if self.tool_caller is not None:
             agent_spec: Dict[str, Any] = self.tool_caller.get_agent_tool_spec()
             # DEF: This is perhaps too brave a usage/cast, but it is indeed an AgentToolFactory
@@ -500,14 +501,27 @@ class LangChainRunContext(RunContext):
         if self.capsule:
             await self.capsule.close_of_work()
 
-        self.tools = []
+        # In order of appearance from the constructor
+
         self.chat_history = []
-        self.agent_chain = None
-        self.recent_human_message = None
-        self.llm_resources = None
-        self.capsule = None
+        # middleware_config comes from the agent spec
         self.journal = None
         self.interceptor = None
+        self.llm_resources = None
+        self.agent_chain = None
+        # llm_config comes from the agent spec
+        self.run_id_base = None
+        self.tools = []
+        self.error_detector = None
+        self.recent_human_message = None
+        # tool_caller comes from the caller 
+        # invocation_context comes from the caller 
+        self.chat_context = None
+        self.origin = []
+        self.resources_created = False
+        self.tracing_context = None
+        # Don't need to clear logger
+        self.capsule = None
 
     def get_agent_tool_spec(self) -> Dict[str, Any]:
         """

--- a/neuro_san/internals/run_context/langchain/core/langchain_run_context.py
+++ b/neuro_san/internals/run_context/langchain/core/langchain_run_context.py
@@ -174,44 +174,6 @@ class LangChainRunContext(RunContext):
         origination: Origination = self.invocation_context.get_origination()
         self.origin = origination.add_spec_name_to_origin(parent_origin, agent_name)
 
-    def update_from_chat_context(self, chat_context: Dict[str, Any]):
-        """
-        :param chat_context: A ChatContext dictionary that contains all the state necessary
-                to carry on a previous conversation, possibly from a different server.
-        """
-        self.chat_context = chat_context
-
-        if self.chat_context is None:
-            return
-
-        # See if our origin appears in the chat histories.
-        # If so, get ours from there.
-        empty: List[Any] = []
-        chat_histories: List[Dict[str, Any]] = self.chat_context.get("chat_histories", empty)
-        our_origin_str: str = Origination.get_full_name_from_origin(self.origin)
-        for one_chat_history in chat_histories:
-
-            # See if the origin matches our own
-            test_origin: List[Dict[str, Any]] = one_chat_history.get("origin", empty)
-            test_origin_str: str = Origination.get_full_name_from_origin(test_origin)
-            if test_origin_str != our_origin_str:
-                continue
-
-            one_messages: List[Dict[str, Any]] = one_chat_history.get("messages", empty)
-            if not one_messages:
-                # Empty list - Nothing to convert. Use default empty list.
-                break
-
-            converter = BaseMessageDictionaryConverter()
-            self.chat_history = []
-            for chat_message in one_messages:
-                base_message: BaseMessage = converter.from_dict(chat_message)
-                if base_message is not None:
-                    self.chat_history.append(base_message)
-
-            # Nothing left to search for
-            break
-
     async def create_resources(self, agent_name: str,
                                instructions: str,
                                assignments: str,
@@ -628,6 +590,44 @@ class LangChainRunContext(RunContext):
             for message in old_interceptor.get_messages():
                 self.interceptor.write_unwrapped_message(message, self.origin)
         self.journal = OriginatingJournal(self.interceptor, self.origin, self.chat_history)
+
+    def update_from_chat_context(self, chat_context: Dict[str, Any]):
+        """
+        :param chat_context: A ChatContext dictionary that contains all the state necessary
+                to carry on a previous conversation, possibly from a different server.
+        """
+        self.chat_context = chat_context
+
+        if self.chat_context is None:
+            return
+
+        # See if our origin appears in the chat histories.
+        # If so, get ours from there.
+        empty: List[Any] = []
+        chat_histories: List[Dict[str, Any]] = self.chat_context.get("chat_histories", empty)
+        our_origin_str: str = Origination.get_full_name_from_origin(self.origin)
+        for one_chat_history in chat_histories:
+
+            # See if the origin matches our own
+            test_origin: List[Dict[str, Any]] = one_chat_history.get("origin", empty)
+            test_origin_str: str = Origination.get_full_name_from_origin(test_origin)
+            if test_origin_str != our_origin_str:
+                continue
+
+            one_messages: List[Dict[str, Any]] = one_chat_history.get("messages", empty)
+            if not one_messages:
+                # Empty list - Nothing to convert. Use default empty list.
+                break
+
+            converter = BaseMessageDictionaryConverter()
+            self.chat_history = []
+            for chat_message in one_messages:
+                base_message: BaseMessage = converter.from_dict(chat_message)
+                if base_message is not None:
+                    self.chat_history.append(base_message)
+
+            # Nothing left to search for
+            break
 
     def get_journal(self) -> Journal:
         """

--- a/neuro_san/internals/run_context/langchain/core/langchain_run_context.py
+++ b/neuro_san/internals/run_context/langchain/core/langchain_run_context.py
@@ -174,6 +174,44 @@ class LangChainRunContext(RunContext):
         origination: Origination = self.invocation_context.get_origination()
         self.origin = origination.add_spec_name_to_origin(parent_origin, agent_name)
 
+    def update_from_chat_context(self, chat_context: Dict[str, Any]):
+        """
+        :param chat_context: A ChatContext dictionary that contains all the state necessary
+                to carry on a previous conversation, possibly from a different server.
+        """
+        self.chat_context = chat_context
+
+        if self.chat_context is None:
+            return
+
+        # See if our origin appears in the chat histories.
+        # If so, get ours from there.
+        empty: List[Any] = []
+        chat_histories: List[Dict[str, Any]] = self.chat_context.get("chat_histories", empty)
+        our_origin_str: str = Origination.get_full_name_from_origin(self.origin)
+        for one_chat_history in chat_histories:
+
+            # See if the origin matches our own
+            test_origin: List[Dict[str, Any]] = one_chat_history.get("origin", empty)
+            test_origin_str: str = Origination.get_full_name_from_origin(test_origin)
+            if test_origin_str != our_origin_str:
+                continue
+
+            one_messages: List[Dict[str, Any]] = one_chat_history.get("messages", empty)
+            if not one_messages:
+                # Empty list - Nothing to convert. Use default empty list.
+                break
+
+            converter = BaseMessageDictionaryConverter()
+            self.chat_history = []
+            for chat_message in one_messages:
+                base_message: BaseMessage = converter.from_dict(chat_message)
+                if base_message is not None:
+                    self.chat_history.append(base_message)
+
+            # Nothing left to search for
+            break
+
     async def create_resources(self, agent_name: str,
                                instructions: str,
                                assignments: str,
@@ -590,44 +628,6 @@ class LangChainRunContext(RunContext):
             for message in old_interceptor.get_messages():
                 self.interceptor.write_unwrapped_message(message, self.origin)
         self.journal = OriginatingJournal(self.interceptor, self.origin, self.chat_history)
-
-    def update_from_chat_context(self, chat_context: Dict[str, Any]):
-        """
-        :param chat_context: A ChatContext dictionary that contains all the state necessary
-                to carry on a previous conversation, possibly from a different server.
-        """
-        self.chat_context = chat_context
-
-        if self.chat_context is None:
-            return
-
-        # See if our origin appears in the chat histories.
-        # If so, get ours from there.
-        empty: List[Any] = []
-        chat_histories: List[Dict[str, Any]] = self.chat_context.get("chat_histories", empty)
-        our_origin_str: str = Origination.get_full_name_from_origin(self.origin)
-        for one_chat_history in chat_histories:
-
-            # See if the origin matches our own
-            test_origin: List[Dict[str, Any]] = one_chat_history.get("origin", empty)
-            test_origin_str: str = Origination.get_full_name_from_origin(test_origin)
-            if test_origin_str != our_origin_str:
-                continue
-
-            one_messages: List[Dict[str, Any]] = one_chat_history.get("messages", empty)
-            if not one_messages:
-                # Empty list - Nothing to convert. Use default empty list.
-                break
-
-            converter = BaseMessageDictionaryConverter()
-            self.chat_history = []
-            for chat_message in one_messages:
-                base_message: BaseMessage = converter.from_dict(chat_message)
-                if base_message is not None:
-                    self.chat_history.append(base_message)
-
-            # Nothing left to search for
-            break
 
     def get_journal(self) -> Journal:
         """

--- a/neuro_san/internals/run_context/langchain/core/langchain_run_context.py
+++ b/neuro_san/internals/run_context/langchain/core/langchain_run_context.py
@@ -110,7 +110,7 @@ class LangChainRunContext(RunContext):
         self.invocation_context: InvocationContext = invocation_context
         self.chat_context: Dict[str, Any] = chat_context
         self.origin: List[Dict[str, Any]] = []
-        # Have we already created resources for this RunContext:
+        # Have we already created resources for this RunContext?
         self.resources_created: bool = False
         # Default logger
         self.logger: Logger = getLogger(self.__class__.__name__)
@@ -120,6 +120,26 @@ class LangChainRunContext(RunContext):
 
         self.capsule: ActivationCapsule = None
 
+        # If you add more members here, be sure to clear them out in close_of_work() below.
+
+        # Now that we have initialized all the members, some procedural initialization
+        self.create_capsule()
+        self.update_from_parent_run_context(parent_run_context)
+        self.update_from_chat_context(self.chat_context)
+
+        # Set up so local logging gives origin info.
+        if self.origin is not None and len(self.origin) > 0:
+            full_name: str = Origination.get_full_name_from_origin(self.origin)
+            self.logger = getLogger(full_name)
+
+        if self.invocation_context is not None:
+            # Sets up self.journal
+            self.update_invocation_context(self.invocation_context)
+
+    def create_capsule(self):
+        """
+        Create the ActivationCapsule
+        """
         if self.tool_caller is not None:
             agent_spec: Dict[str, Any] = self.tool_caller.get_agent_tool_spec()
             # DEF: This is perhaps too brave a usage/cast, but it is indeed an AgentToolFactory
@@ -132,33 +152,23 @@ class LangChainRunContext(RunContext):
             # to look for tools specified in the middleware.
             self.capsule = ActivationCapsule(self)
 
-        parent_origin: List[Dict[str, Any]] = []
-        if parent_run_context is not None:
+    def update_from_parent_run_context(self, parent_run_context: RunContext):
+        if parent_run_context is None:
+            return
 
-            # Get other stuff from parent if not specified
-            if self.invocation_context is None:
-                self.invocation_context = parent_run_context.get_invocation_context()
-            if self.chat_context is None:
-                self.chat_context = parent_run_context.get_chat_context()
+        # Get other stuff from parent if not specified
+        if self.invocation_context is None:
+            self.invocation_context = parent_run_context.get_invocation_context()
+        if self.chat_context is None:
+            self.chat_context = parent_run_context.get_chat_context()
 
-            self.tracing_context = parent_run_context.get_tracing_context().clone()
-            parent_origin = parent_run_context.get_origin()
+        self.tracing_context = parent_run_context.get_tracing_context().clone()
+        parent_origin: List[Dict[str, Any]] = parent_run_context.get_origin()
 
-            # Initialize the origin.
-            agent_name: str = tool_caller.get_name()
-            origination: Origination = self.invocation_context.get_origination()
-            self.origin = origination.add_spec_name_to_origin(parent_origin, agent_name)
-
-        self.update_from_chat_context(self.chat_context)
-
-        # Set up so local logging gives origin info.
-        if self.origin is not None and len(self.origin) > 0:
-            full_name: str = Origination.get_full_name_from_origin(self.origin)
-            self.logger = getLogger(full_name)
-
-        if self.invocation_context is not None:
-            # Sets up self.journal
-            self.update_invocation_context(self.invocation_context)
+        # Initialize the origin.
+        agent_name: str = self.tool_caller.get_name()
+        origination: Origination = self.invocation_context.get_origination()
+        self.origin = origination.add_spec_name_to_origin(parent_origin, agent_name)
 
     async def create_resources(self, agent_name: str,
                                instructions: str,
@@ -514,8 +524,8 @@ class LangChainRunContext(RunContext):
         self.tools = []
         self.error_detector = None
         self.recent_human_message = None
-        # tool_caller comes from the caller 
-        # invocation_context comes from the caller 
+        # tool_caller comes from the caller
+        # invocation_context comes from the caller
         self.chat_context = None
         self.origin = []
         self.resources_created = False

--- a/neuro_san/internals/run_context/langchain/core/langchain_run_context.py
+++ b/neuro_san/internals/run_context/langchain/core/langchain_run_context.py
@@ -153,6 +153,10 @@ class LangChainRunContext(RunContext):
             self.capsule = ActivationCapsule(self)
 
     def update_from_parent_run_context(self, parent_run_context: RunContext):
+        """
+        Update from parent run context
+        :param parent_run_context: The parent RunContext
+        """
         if parent_run_context is None:
             return
 

--- a/neuro_san/internals/run_context/langchain/core/langchain_run_context.py
+++ b/neuro_san/internals/run_context/langchain/core/langchain_run_context.py
@@ -518,17 +518,17 @@ class LangChainRunContext(RunContext):
         # In order of appearance from the constructor
 
         self.chat_history = []
-        # middleware_config comes from the agent spec
+        self.middleware_config = None
         self.journal = None
         self.interceptor = None
         self.llm_resources = None
         self.agent_chain = None
-        # llm_config comes from the agent spec
+        self.llm_config = None
         self.run_id_base = None
         self.tools = []
         self.error_detector = None
         self.recent_human_message = None
-        # tool_caller comes from the caller
+        self.tool_caller = None
         # invocation_context comes from the caller
         self.chat_context = None
         self.origin = []


### PR DESCRIPTION
* Reorganize the LangChainRunContext constructor so there are 2 clear sections:
    * member declaration/initialization
    * procedural initialization
* Make methods out of 2 blocks in the constructor to make the procedural initialization read more sanely
* Now that the member initialization is clearer, be sure we clear out the member variables we can in close_of_work() to avoid hanging onto any memory we don't need to when we know we are done.

Also: Tout BYOK in README