### PR TITLE
NS-1086 Do not use http/s when calling local /external agent networks

### DIFF
--- a/neuro_san/internals/chat/data_driven_chat_session.py
+++ b/neuro_san/internals/chat/data_driven_chat_session.py
@@ -33,7 +33,6 @@ from langchain_core.messages.base import BaseMessage
 
 from leaf_common.config.resolver_util import ResolverUtil
 
-from neuro_san.interfaces.reservationist import Reservationist
 from neuro_san.internals.chat.async_collating_queue import AsyncCollatingQueue
 from neuro_san.internals.chat.chat_history_message_processor import ChatHistoryMessageProcessor
 from neuro_san.internals.graph.registry.agent_network import AgentNetwork

--- a/neuro_san/internals/chat/data_driven_chat_session.py
+++ b/neuro_san/internals/chat/data_driven_chat_session.py
@@ -422,12 +422,6 @@ class DataDrivenChatSession(RunTarget, LingeringResource):
 
         :param parent_resource: The parent resource, if any
         """
-        # Now that we are done, tell the Reservationist that we used for this request
-        # that there will be no more Reservations to corral.
-        reservationist: Reservationist = self.invocation_context.get_reservationist()
-        if reservationist is not None and isinstance(reservationist, LingeringResource):
-            await reservationist.close_of_work()
-
         # Close any objects on sly data that can be closed.
         await self.close_sly_data()
 

--- a/neuro_san/service/generic/agent_service.py
+++ b/neuro_san/service/generic/agent_service.py
@@ -110,6 +110,7 @@ class AgentService:
 
         self.request_timeout_seconds: float = agent_network.get_request_timeout_seconds()
         self.event_work_queue: AsyncCollatingQueue = server_context.get_event_work_queue()
+        self.network_storage_dict: Dict[str, Any] = server_context.get_network_storage_dict()
 
         # Load once
         self.llm_factory.load()
@@ -261,7 +262,7 @@ class AgentService:
             self.queues.sync_q.put(reservationist.get_queue())
 
         # Prepare
-        factory = ExternalAgentSessionFactory(use_direct=False)
+        factory = ExternalAgentSessionFactory(use_direct=False, network_storage_dict=self.network_storage_dict)
         invocation_context = SessionInvocationContext(
             self.agent_name,
             factory,

--- a/neuro_san/service/generic/agent_service.py
+++ b/neuro_san/service/generic/agent_service.py
@@ -262,7 +262,7 @@ class AgentService:
             self.queues.sync_q.put(reservationist.get_queue())
 
         # Prepare
-        factory = ExternalAgentSessionFactory(use_direct=False, network_storage_dict=self.network_storage_dict)
+        factory = ExternalAgentSessionFactory(use_direct=True, network_storage_dict=self.network_storage_dict)
         invocation_context = SessionInvocationContext(
             self.agent_name,
             factory,

--- a/neuro_san/service/generic/async_agent_service.py
+++ b/neuro_san/service/generic/async_agent_service.py
@@ -98,6 +98,7 @@ class AsyncAgentService:
 
         self.async_executor_pool: AsyncioExecutorPool = server_context.get_executor_pool()
         self.event_work_queue: AsyncCollatingQueue = server_context.get_event_work_queue()
+        self.network_storage_dict: Dict[str, Any] = server_context.get_network_storage_dict()
 
         self.reload_factories()
 
@@ -266,7 +267,7 @@ class AsyncAgentService:
             self.queues.sync_q.put(reservationist.get_queue())
 
         # Prepare
-        factory = ExternalAgentSessionFactory(use_direct=False)
+        factory = ExternalAgentSessionFactory(use_direct=False, network_storage_dict=self.network_storage_dict)
         invocation_context = SessionInvocationContext(
             self.agent_name,
             factory,

--- a/neuro_san/service/generic/async_agent_service.py
+++ b/neuro_san/service/generic/async_agent_service.py
@@ -267,7 +267,7 @@ class AsyncAgentService:
             self.queues.sync_q.put(reservationist.get_queue())
 
         # Prepare
-        factory = ExternalAgentSessionFactory(use_direct=False, network_storage_dict=self.network_storage_dict)
+        factory = ExternalAgentSessionFactory(use_direct=True, network_storage_dict=self.network_storage_dict)
         invocation_context = SessionInvocationContext(
             self.agent_name,
             factory,

--- a/neuro_san/service/interfaces/server_context_lite.py
+++ b/neuro_san/service/interfaces/server_context_lite.py
@@ -15,11 +15,14 @@
 #
 # END COPYRIGHT
 
+from typing import Dict
+
 from janus import Queue
 
 from leaf_common.asyncio.asyncio_executor_pool import AsyncioExecutorPool
 
 from neuro_san.internals.chat.async_collating_queue import AsyncCollatingQueue
+from neuro_san.internals.network_providers.agent_network_storage import AgentNetworkStorage
 
 
 class ServerContextLite:
@@ -48,5 +51,11 @@ class ServerContextLite:
     def get_event_work_queue(self) -> AsyncCollatingQueue:
         """
         :return: The event work queue
+        """
+        raise NotImplementedError
+
+    def get_network_storage_dict(self) -> Dict[str, AgentNetworkStorage]:
+        """
+        :return: The Network Storage dictionary
         """
         raise NotImplementedError

--- a/neuro_san/session/external_agent_session_factory.py
+++ b/neuro_san/session/external_agent_session_factory.py
@@ -80,11 +80,16 @@ class ExternalAgentSessionFactory(AsyncAgentSessionFactory):
         because in the general case this might involve querying external storage, which is potentially slow.
         """
         networks_order: List[str] = []
+        if network_storage_dict is None:
+            return networks_order
+
         for storage_name in network_storage_dict.keys():
             if storage_name != StorageClass.TEMP:
                 networks_order.append(storage_name)
+
         if StorageClass.TEMP in network_storage_dict:
             networks_order.append(StorageClass.TEMP)
+
         return networks_order
 
     def create_session_from_location_dict(self, agent_location: Dict[str, str],
@@ -129,9 +134,10 @@ class ExternalAgentSessionFactory(AsyncAgentSessionFactory):
                 if agent_network_provider.get_agent_network() is not None:
                     break
 
-            agent_network: AgentNetwork = agent_network_provider.get_agent_network()
-            safe_invocation_context: InvocationContext = invocation_context.safe_shallow_copy(invocation)
-            session = AsyncDirectAgentSession(agent_network, safe_invocation_context, metadata=metadata)
+            if agent_network_provider is not None:
+                agent_network: AgentNetwork = agent_network_provider.get_agent_network()
+                safe_invocation_context: InvocationContext = invocation_context.safe_shallow_copy(invocation)
+                session = AsyncDirectAgentSession(agent_network, safe_invocation_context, metadata=metadata)
 
         if session is None:
             # When creating a session for external agents, specifically use None for the

--- a/neuro_san/session/external_agent_session_factory.py
+++ b/neuro_san/session/external_agent_session_factory.py
@@ -128,9 +128,13 @@ class ExternalAgentSessionFactory(AsyncAgentSessionFactory):
 
             agent_network_provider: AgentNetworkProvider = None
             for network_storage_name in self.get_networks_order(self.network_storage_dict):
+
                 network_storage = self.network_storage_dict.get(network_storage_name)
                 # Be sure we have something
                 agent_network_provider = network_storage.get_agent_network_provider(agent_name)
+                if agent_network_provider is None:
+                    continue
+
                 if agent_network_provider.get_agent_network() is not None:
                     break
 

--- a/neuro_san/session/external_agent_session_factory.py
+++ b/neuro_san/session/external_agent_session_factory.py
@@ -121,7 +121,7 @@ class ExternalAgentSessionFactory(AsyncAgentSessionFactory):
             metadata = invocation_context.get_metadata()
 
         session: AsyncAgentSession = None
-        if self.use_direct and (host is None or len(host) == 0 or host == "localhost"):
+        if self.is_use_direct() and (host is None or len(host) == 0 or host == "localhost"):
 
             # Optimization: We want to create a different kind of session to minimize socket usage
             # and potentially relieve the direct user of the burden of having to start a server

--- a/neuro_san/session/external_agent_session_factory.py
+++ b/neuro_san/session/external_agent_session_factory.py
@@ -136,8 +136,9 @@ class ExternalAgentSessionFactory(AsyncAgentSessionFactory):
 
             if agent_network_provider is not None:
                 agent_network: AgentNetwork = agent_network_provider.get_agent_network()
-                safe_invocation_context: InvocationContext = invocation_context.safe_shallow_copy(invocation)
-                session = AsyncDirectAgentSession(agent_network, safe_invocation_context, metadata=metadata)
+                if agent_network is not None:
+                    safe_invocation_context: InvocationContext = invocation_context.safe_shallow_copy(invocation)
+                    session = AsyncDirectAgentSession(agent_network, safe_invocation_context, metadata=metadata)
 
         if session is None:
             # When creating a session for external agents, specifically use None for the

--- a/neuro_san/session/session_invocation_context.py
+++ b/neuro_san/session/session_invocation_context.py
@@ -210,6 +210,13 @@ class SessionInvocationContext(InvocationContext):
         for resource in self.resources:
             await resource.close_of_work()
 
+        # Now that we are done, tell the Reservationist that we used for this request
+        # that there will be no more Reservations to corral.
+        if not self.is_cloned and \
+                self.reservationist is not None and \
+                isinstance(self.reservationist, LingeringResource):
+            await self.reservationist.close_of_work()
+
     def get_request_reporting(self) -> Dict[str, Any]:
         """
         :return: The request reporting dictionary


### PR DESCRIPTION
Using an AsyncDirectAgentSession when calling local external agents will save us a lot of threads and maybe a lot of memory, thus having great potential to increase capacity of a single server.

It might seem the easy thing to do to "just" pass use_direct=True into ExternalSessionFactory, but 
there are 2 main stumbling blocks to this:
1. Adding network_storage_dict to ExternalSessionFactory constructor.  This gets you pretty far.
2. Just when Reservationist is being closed (shutting down its queue) is tricky

So we fix all that, and now use_direct=True is the default for "/external" agent references on the server.
This should be OK because if people really do want to go back out for an http connection, they can use an http(s)://<servername> specification for their external agents.

Initial memray flamegaphs show only 13MB per AND request, this is down from around 30MB per AND request before.  This is a good sign.