### PR TITLE
NS-1029 Surface retry-able tool errors as AgentFramework messages.

### DIFF
--- a/neuro_san/deploy/Dockerfile
+++ b/neuro_san/deploy/Dockerfile
@@ -212,6 +212,7 @@ ENV AGENT_FORWARDED_REQUEST_METADATA="request_id user_id"
 ENV AGENT_HTTP_PORT="8080"
 
 # Maximm number of requests that can be served at the same time
+# A value of 0 indicates unlimited requests are handled.
 ENV AGENT_MAX_CONCURRENT_REQUESTS="50"
 
 # Number of requests served before the server shuts down in an orderly fashion.

--- a/neuro_san/internals/run_context/langchain/core/langchain_run_context.py
+++ b/neuro_san/internals/run_context/langchain/core/langchain_run_context.py
@@ -174,6 +174,44 @@ class LangChainRunContext(RunContext):
         origination: Origination = self.invocation_context.get_origination()
         self.origin = origination.add_spec_name_to_origin(parent_origin, agent_name)
 
+    def update_from_chat_context(self, chat_context: Dict[str, Any]):
+        """
+        :param chat_context: A ChatContext dictionary that contains all the state necessary
+                to carry on a previous conversation, possibly from a different server.
+        """
+        self.chat_context = chat_context
+
+        if self.chat_context is None:
+            return
+
+        # See if our origin appears in the chat histories.
+        # If so, get ours from there.
+        empty: List[Any] = []
+        chat_histories: List[Dict[str, Any]] = self.chat_context.get("chat_histories", empty)
+        our_origin_str: str = Origination.get_full_name_from_origin(self.origin)
+        for one_chat_history in chat_histories:
+
+            # See if the origin matches our own
+            test_origin: List[Dict[str, Any]] = one_chat_history.get("origin", empty)
+            test_origin_str: str = Origination.get_full_name_from_origin(test_origin)
+            if test_origin_str != our_origin_str:
+                continue
+
+            one_messages: List[Dict[str, Any]] = one_chat_history.get("messages", empty)
+            if not one_messages:
+                # Empty list - Nothing to convert. Use default empty list.
+                break
+
+            converter = BaseMessageDictionaryConverter()
+            self.chat_history = []
+            for chat_message in one_messages:
+                base_message: BaseMessage = converter.from_dict(chat_message)
+                if base_message is not None:
+                    self.chat_history.append(base_message)
+
+            # Nothing left to search for
+            break
+
     async def create_resources(self, agent_name: str,
                                instructions: str,
                                assignments: str,
@@ -590,44 +628,6 @@ class LangChainRunContext(RunContext):
             for message in old_interceptor.get_messages():
                 self.interceptor.write_unwrapped_message(message, self.origin)
         self.journal = OriginatingJournal(self.interceptor, self.origin, self.chat_history)
-
-    def update_from_chat_context(self, chat_context: Dict[str, Any]):
-        """
-        :param chat_context: A ChatContext dictionary that contains all the state necessary
-                to carry on a previous conversation, possibly from a different server.
-        """
-        self.chat_context = chat_context
-
-        if self.chat_context is None:
-            return
-
-        # See if our origin appears in the chat histories.
-        # If so, get ours from there.
-        empty: List[Any] = []
-        chat_histories: List[Dict[str, Any]] = self.chat_context.get("chat_histories", empty)
-        our_origin_str: str = Origination.get_full_name_from_origin(self.origin)
-        for one_chat_history in chat_histories:
-
-            # See if the origin matches our own
-            test_origin: List[Dict[str, Any]] = one_chat_history.get("origin", empty)
-            test_origin_str: str = Origination.get_full_name_from_origin(test_origin)
-            if test_origin_str != our_origin_str:
-                continue
-
-            one_messages: List[Dict[str, Any]] = one_chat_history.get("messages", empty)
-            if not one_messages:
-                # Empty list - Nothing to convert. Use default empty list.
-                break
-
-            converter = BaseMessageDictionaryConverter()
-            self.chat_history = []
-            for chat_message in one_messages:
-                base_message: BaseMessage = converter.from_dict(chat_message)
-                if base_message is not None:
-                    self.chat_history.append(base_message)
-
-            # Nothing left to search for
-            break
 
     def get_journal(self) -> Journal:
         """

--- a/neuro_san/internals/run_context/langchain/core/run_context_runnable.py
+++ b/neuro_san/internals/run_context/langchain/core/run_context_runnable.py
@@ -265,9 +265,9 @@ class RunContextRunnable(NeuroSanRunnable):
                     message = f"Retrying from ValueError: {value_error}"
                     sensitive_logger.warning(message)
 
-                    if sensitive_logger._should_log():
-                        # Also write the error message to the journal under the same env var setting
-                        # as the SensitiveLogger.
+                    if sensitive_logger.should_log():
+                        # Also write the error message to the journal under the same
+                        # LEAF_LOG_SENSITIVE env var setting as the SensitiveLogger uses.
                         error_message = AgentFrameworkMessage(content=message)
                         await self.journal.write_message(error_message)
 

--- a/neuro_san/internals/run_context/langchain/core/run_context_runnable.py
+++ b/neuro_san/internals/run_context/langchain/core/run_context_runnable.py
@@ -208,9 +208,6 @@ class RunContextRunnable(NeuroSanRunnable):
             try:
                 chain_result: Dict[str, Any] = await self.agent_chain.ainvoke(input=inputs, config=runnable_config)
             except RATE_LIMIT_ERROR_TYPES as rate_limit_error:
-                self.logger.warning("retrying from RateLimit error %s(%s)",
-                                    rate_limit_error.__class__.__name__,
-                                    str(rate_limit_error))
                 await self.journal_retry_reason(rate_limit_error, "the LLM provider rate-limited the request")
                 attempts = attempts - 1
                 exception = rate_limit_error
@@ -237,12 +234,10 @@ class RunContextRunnable(NeuroSanRunnable):
                                       ApiKeyErrorCheck.get_safe_log_message(api_error))
                     break
                 # Continue with regular retry logic:
-                self.logger.warning("retrying from %s", api_error.__class__.__name__)
                 await self.journal_retry_reason(api_error, "the LLM API returned an error")
                 attempts = attempts - 1
                 exception = api_error
             except KeyError as key_error:
-                self.logger.warning("retrying from KeyError")
                 await self.journal_retry_reason(key_error, "the response was missing an expected field")
                 attempts = attempts - 1
                 exception = key_error
@@ -262,14 +257,7 @@ class RunContextRunnable(NeuroSanRunnable):
                         "output": response.removeprefix(find_string).removesuffix("`")
                     }
                 else:
-                    # Log the ValueError, respecting server log sensitivity settings
-                    message = f"Retrying from ValueError: {value_error}"
-                    self.sensitive_logger.warning(message)
-
-                    if self.sensitive_logger.should_log():
-                        # Also write the error message to the journal under the same
-                        # LEAF_LOG_SENSITIVE env var setting as the SensitiveLogger uses.
-                        await self.journal_retry_reason(value_error, "the model's output could not be parsed")
+                    await self.journal_retry_reason(value_error, "the model's output could not be parsed")
                     attempts = attempts - 1
                     exception = value_error
                     backtrace = traceback.format_exc()
@@ -300,8 +288,15 @@ class RunContextRunnable(NeuroSanRunnable):
         :param error: The recoverable exception triggering the retry.
         :param reason: A concise, client-facing description of what went wrong.
         """
-        text: str = f"Retrying: {reason} ({error.__class__.__name__})"
-        await self.journal.write_message(AgentFrameworkMessage(content=text))
+        text: str = f"Retrying: {reason} ({error.__class__.__name__}) - {error}"
+
+        # Log the Exception as a warning, respecting server log sensitivity settings
+        self.sensitive_logger.warning(text)
+
+        # Also write the error message to the journal under the same
+        # LEAF_LOG_SENSITIVE env var setting as the SensitiveLogger uses.
+        if self.sensitive_logger.should_log():
+            await self.journal.write_message(AgentFrameworkMessage(content=text))
 
     def parse_chain_result(self, chain_result: Union[Dict[str, Any], AgentFinish, AIMessage],
                            exception: Exception, backtrace: str) -> str:

--- a/neuro_san/internals/run_context/langchain/core/run_context_runnable.py
+++ b/neuro_san/internals/run_context/langchain/core/run_context_runnable.py
@@ -265,9 +265,11 @@ class RunContextRunnable(NeuroSanRunnable):
                     message = f"Retrying from ValueError: {value_error}"
                     sensitive_logger.warning(message)
 
-                    # Write the error message to the journal
-                    error_message = AgentFrameworkMessage(content=message)
-                    await self.journal.write_message(error_message)
+                    if sensitive_logger._should_log():
+                        # Also write the error message to the journal under the same env var setting
+                        # as the SensitiveLogger.
+                        error_message = AgentFrameworkMessage(content=message)
+                        await self.journal.write_message(error_message)
 
                     attempts = attempts - 1
                     exception = value_error

--- a/neuro_san/internals/run_context/langchain/core/run_context_runnable.py
+++ b/neuro_san/internals/run_context/langchain/core/run_context_runnable.py
@@ -38,7 +38,6 @@ from langchain_core.runnables.utils import Input
 from langchain_core.runnables.utils import Output
 
 from leaf_common.config.resolver_util import ResolverUtil
-from leaf_common.logging.sensitive_logger import SensitiveLogger
 
 from neuro_san.internals.errors.error_detector import ErrorDetector
 from neuro_san.internals.journals.journal import Journal
@@ -264,11 +263,10 @@ class RunContextRunnable(NeuroSanRunnable):
                     }
                 else:
                     # Log the ValueError, respecting server log sensitivity settings
-                    sensitive_logger = SensitiveLogger(self.logger)
                     message = f"Retrying from ValueError: {value_error}"
-                    sensitive_logger.warning(message)
+                    self.sensitive_logger.warning(message)
 
-                    if sensitive_logger.should_log():
+                    if self.sensitive_logger.should_log():
                         # Also write the error message to the journal under the same
                         # LEAF_LOG_SENSITIVE env var setting as the SensitiveLogger uses.
                         await self.journal_retry_reason(value_error, "the model's output could not be parsed")
@@ -278,8 +276,7 @@ class RunContextRunnable(NeuroSanRunnable):
             # pylint: disable=broad-exception-caught
             except Exception as exception_error:
                 # This catches any errors from running middlewares and also error form exceeding the recursion_limit.
-                sensitive_logger = SensitiveLogger(self.logger)
-                sensitive_logger.error("Got exception in  %s. Error: %s", self.__class__.__name__, exception_error)
+                self.sensitive_logger.error("Got exception in  %s. Error: %s", self.__class__.__name__, exception_error)
                 # These are likely real issues and non-retryable.
                 attempts = 0
                 exception = exception_error

--- a/neuro_san/internals/run_context/langchain/core/run_context_runnable.py
+++ b/neuro_san/internals/run_context/langchain/core/run_context_runnable.py
@@ -38,9 +38,11 @@ from langchain_core.runnables.utils import Input
 from langchain_core.runnables.utils import Output
 
 from leaf_common.config.resolver_util import ResolverUtil
+from leaf_common.logging.sensitive_logger import SensitiveLogger
 
 from neuro_san.internals.errors.error_detector import ErrorDetector
 from neuro_san.internals.journals.journal import Journal
+from neuro_san.internals.messages.agent_framework_message import AgentFrameworkMessage
 from neuro_san.internals.messages.origination import Origination
 from neuro_san.internals.run_context.interfaces.tool_caller import ToolCaller
 from neuro_san.internals.run_context.langchain.journaling.journaling_callback_handler import JournalingCallbackHandler
@@ -258,17 +260,23 @@ class RunContextRunnable(NeuroSanRunnable):
                         "output": response.removeprefix(find_string).removesuffix("`")
                     }
                 else:
-                    self.logger.warning("retrying from ValueError")
+                    # Log the ValueError, respecting server log sensitivity settings
+                    sensitive_logger = SensitiveLogger(self.logger)
+                    message = f"Retrying from ValueError: {value_error}"
+                    sensitive_logger.warning(message)
+
+                    # Write the error message to the journal
+                    error_message = AgentFrameworkMessage(content=message)
+                    await self.journal.write_message(error_message)
+
                     attempts = attempts - 1
                     exception = value_error
                     backtrace = traceback.format_exc()
             # pylint: disable=broad-exception-caught
             except Exception as exception_error:
                 # This catches any errors from running middlewares and also error form exceeding the recursion_limit.
-                self.logger.error("Got exception in  %s. Error: %s",
-                                  self.__class__.__name__,
-                                  exception_error,
-                                  )
+                sensitive_logger = SensitiveLogger(self.logger)
+                sensitive_logger.error("Got exception in  %s. Error: %s", self.__class__.__name__, exception_error)
                 # These are likely real issues and non-retryable.
                 attempts = 0
                 exception = exception_error

--- a/neuro_san/internals/run_context/langchain/tracing/neuro_san_runnable.py
+++ b/neuro_san/internals/run_context/langchain/tracing/neuro_san_runnable.py
@@ -36,6 +36,8 @@ from langchain_core.runnables.passthrough import RunnablePassthrough
 from langchain_core.runnables.utils import Input
 from langchain_core.runnables.utils import Output
 
+from leaf_common.logging.sensitive_logger import SensitiveLogger
+
 from neuro_san.internals.interfaces.invocation_context import InvocationContext
 from neuro_san.internals.interfaces.run_target import RunTarget
 from neuro_san.internals.interfaces.tracing_context import TracingContext
@@ -63,6 +65,7 @@ class NeuroSanRunnable(RunnablePassthrough, RunTarget):
 
     # Default logger
     logger: Optional[Logger] = None
+    senstive_logger: Optional[SensitiveLogger] = None
 
     run_target: Optional[RunTarget] = None
 
@@ -86,6 +89,7 @@ class NeuroSanRunnable(RunnablePassthrough, RunTarget):
         super().__init__(afunc=run_target.run_it, **kwargs)
 
         self.logger: Logger = getLogger(self.__class__.__name__)
+        self.sensitive_logger: SensitiveLogger = SensitiveLogger(self.logger)
 
     # pylint: disable=redefined-builtin
     @override

--- a/neuro_san/internals/run_context/langchain/tracing/neuro_san_runnable.py
+++ b/neuro_san/internals/run_context/langchain/tracing/neuro_san_runnable.py
@@ -65,7 +65,7 @@ class NeuroSanRunnable(RunnablePassthrough, RunTarget):
 
     # Default logger
     logger: Optional[Logger] = None
-    senstive_logger: Optional[SensitiveLogger] = None
+    sensitive_logger: Optional[SensitiveLogger] = None
 
     run_target: Optional[RunTarget] = None
 

--- a/tests/neuro_san/internals/run_context/langchain/core/test_run_context_runnable.py
+++ b/tests/neuro_san/internals/run_context/langchain/core/test_run_context_runnable.py
@@ -41,15 +41,20 @@ class TestRunContextRunnable:
         written = []
         mock_journal = MagicMock()
         mock_journal.write_message = AsyncMock(side_effect=lambda msg, *_a, **_k: written.append(msg))
+        sensitive_logger = MagicMock()
+        sensitive_logger.should_log = MagicMock(return_value=True)
 
-        runnable = RunContextRunnable.model_construct(journal=mock_journal)
+        runnable = RunContextRunnable.model_construct(
+            journal=mock_journal,
+            sensitive_logger=sensitive_logger
+        )
 
         await runnable.journal_retry_reason(ValueError("bad json"), "the model's output could not be parsed")
 
         assert len(written) == 1
         message = written[0]
         assert isinstance(message, AgentFrameworkMessage)
-        assert message.content == "Retrying: the model's output could not be parsed (ValueError)"
+        assert message.content == "Retrying: the model's output could not be parsed (ValueError) - bad json"
 
     @pytest.mark.asyncio
     async def test_invoke_agent_chain_surfaces_retry_reason_before_final_message(self):
@@ -61,6 +66,8 @@ class TestRunContextRunnable:
         written = []
         mock_journal = MagicMock()
         mock_journal.write_message = AsyncMock(side_effect=lambda msg, *_a, **_k: written.append(msg))
+        sensitive_logger = MagicMock()
+        sensitive_logger.should_log = MagicMock(return_value=True)
 
         # A non-parse ValueError exercises the retry branch on every attempt.
         agent_chain = MagicMock()
@@ -72,6 +79,7 @@ class TestRunContextRunnable:
 
         runnable = RunContextRunnable.model_construct(
             journal=mock_journal,
+            sensitive_logger=sensitive_logger,
             agent_chain=agent_chain,
             error_detector=error_detector,
             logger=MagicMock(),
@@ -81,9 +89,7 @@ class TestRunContextRunnable:
 
         # Two retries -> two diagnostics, then the final AIMessage.
         assert len(written) == 3
-        assert all(isinstance(msg, AgentFrameworkMessage) for msg in written[:2])
-        assert all(
-            msg.content == "Retrying: the model's output could not be parsed (ValueError)"
-            for msg in written[:2]
-        )
+        for msg in written[:2]:
+            assert isinstance(msg, AgentFrameworkMessage)
+            assert msg.content == "Retrying: the model's output could not be parsed (ValueError) - not a parsing error"
         assert isinstance(written[-1], AIMessage)


### PR DESCRIPTION
Addresses #1029  using @thilo11 's original PR as a basis (https://github.com/cognizant-ai-lab/neuro-san/pull/1089)

The additions to the policy here are:
* We always use a SensitiveLogger to log the retry exception as a warning via the SensitiveLogger.  This guy checks the value of LEAF_LOG_SENSITIVE (which is on by default for developer convenience) before doing any logging so as to funnel SAST check concerns to a single API.
* We also always check the SensitiveLogger before sending out the journal message.  The idea here is that this is yet another place where we are sending potentially sensitive info/implementation details out of the server, this time to a client.

Worth noting that:
* We recommend that in production LEAF_LOG_SENSITIVE be turned off from its default of true (see Dockerfile comments here: https://github.com/cognizant-ai-lab/neuro-san/blob/main/neuro_san/deploy/Dockerfile#L349), but default is on for developer convenience
* Production clients shouldn't really care about the errors going on inside the server that are retried. These are implementation details.

A few other nits in here:
* An added comment in the Dockerfile with an info nugget about AGENT_MAX_CONCURRENT_REQUESTS server setting
* Move a block of code up in LangChainRunContext for better readability.