### PR TITLE
Surface recoverable-error retries on the journal as AgentFramework messages

### DIFF
--- a/neuro_san/internals/run_context/langchain/core/run_context_runnable.py
+++ b/neuro_san/internals/run_context/langchain/core/run_context_runnable.py
@@ -41,6 +41,7 @@ from leaf_common.config.resolver_util import ResolverUtil
 
 from neuro_san.internals.errors.error_detector import ErrorDetector
 from neuro_san.internals.journals.journal import Journal
+from neuro_san.internals.messages.agent_framework_message import AgentFrameworkMessage
 from neuro_san.internals.messages.origination import Origination
 from neuro_san.internals.run_context.interfaces.tool_caller import ToolCaller
 from neuro_san.internals.run_context.langchain.journaling.journaling_callback_handler import JournalingCallbackHandler
@@ -210,6 +211,7 @@ class RunContextRunnable(NeuroSanRunnable):
                 self.logger.warning("retrying from RateLimit error %s(%s)",
                                     rate_limit_error.__class__.__name__,
                                     str(rate_limit_error))
+                await self.journal_retry_reason(rate_limit_error, "the LLM provider rate-limited the request")
                 attempts = attempts - 1
                 exception = rate_limit_error
             except API_ERROR_TYPES as api_error:
@@ -236,10 +238,12 @@ class RunContextRunnable(NeuroSanRunnable):
                     break
                 # Continue with regular retry logic:
                 self.logger.warning("retrying from %s", api_error.__class__.__name__)
+                await self.journal_retry_reason(api_error, "the LLM API returned an error")
                 attempts = attempts - 1
                 exception = api_error
             except KeyError as key_error:
                 self.logger.warning("retrying from KeyError")
+                await self.journal_retry_reason(key_error, "the response was missing an expected field")
                 attempts = attempts - 1
                 exception = key_error
                 backtrace = traceback.format_exc()
@@ -259,6 +263,7 @@ class RunContextRunnable(NeuroSanRunnable):
                     }
                 else:
                     self.logger.warning("retrying from ValueError")
+                    await self.journal_retry_reason(value_error, "the model's output could not be parsed")
                     attempts = attempts - 1
                     exception = value_error
                     backtrace = traceback.format_exc()
@@ -279,6 +284,21 @@ class RunContextRunnable(NeuroSanRunnable):
 
         # Chat history is updated in write_message
         await self.journal.write_message(return_message)
+
+    async def journal_retry_reason(self, error: Exception, reason: str):
+        """
+        Surface the reason for a recoverable-error retry on the journal so clients
+        see *why* a step is being retried instead of an unexplained stall. The reason
+        is written as an AgentFrameworkMessage: it carries this agent's origin (so it
+        is never mistaken for the final answer) and is excluded from chat history (so
+        it does not bloat the tokens sent back to the LLM). Backtraces stay in the
+        server log only.
+
+        :param error: The recoverable exception triggering the retry.
+        :param reason: A concise, client-facing description of what went wrong.
+        """
+        text: str = f"Retrying: {reason} ({error.__class__.__name__})"
+        await self.journal.write_message(AgentFrameworkMessage(content=text))
 
     def parse_chain_result(self, chain_result: Union[Dict[str, Any], AgentFinish, AIMessage],
                            exception: Exception, backtrace: str) -> str:

--- a/tests/neuro_san/internals/run_context/langchain/core/test_run_context_runnable.py
+++ b/tests/neuro_san/internals/run_context/langchain/core/test_run_context_runnable.py
@@ -1,0 +1,89 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+
+import pytest
+
+from langchain_core.messages.ai import AIMessage
+
+from neuro_san.internals.messages.agent_framework_message import AgentFrameworkMessage
+from neuro_san.internals.run_context.langchain.core.run_context_runnable import RunContextRunnable
+
+
+class TestRunContextRunnable:
+    """Test cases for surfacing recoverable-error retries on the journal."""
+
+    @pytest.mark.asyncio
+    async def test_journal_retry_reason_writes_agent_framework_message(self):
+        """
+        journal_retry_reason should write a single AgentFrameworkMessage carrying the
+        client-facing reason plus the error class name. AgentFrameworkMessage is the
+        right type because it is excluded from chat history (no token bloat) and is
+        written through this agent's journal (so it carries an origin and is never
+        mistaken for the final answer).
+        """
+        written = []
+        mock_journal = MagicMock()
+        mock_journal.write_message = AsyncMock(side_effect=lambda msg, *_a, **_k: written.append(msg))
+
+        runnable = RunContextRunnable.model_construct(journal=mock_journal)
+
+        await runnable.journal_retry_reason(ValueError("bad json"), "the model's output could not be parsed")
+
+        assert len(written) == 1
+        message = written[0]
+        assert isinstance(message, AgentFrameworkMessage)
+        assert message.content == "Retrying: the model's output could not be parsed (ValueError)"
+
+    @pytest.mark.asyncio
+    async def test_invoke_agent_chain_surfaces_retry_reason_before_final_message(self):
+        """
+        When a recoverable error is retried until attempts are exhausted, each retry
+        should emit an AgentFrameworkMessage diagnostic, and the final AIMessage must
+        still come last so the journal stream order is preserved.
+        """
+        written = []
+        mock_journal = MagicMock()
+        mock_journal.write_message = AsyncMock(side_effect=lambda msg, *_a, **_k: written.append(msg))
+
+        # A non-parse ValueError exercises the retry branch on every attempt.
+        agent_chain = MagicMock()
+        agent_chain.ainvoke = AsyncMock(side_effect=ValueError("not a parsing error"))
+
+        # error_detector.handle_error is a pass-through for this test.
+        error_detector = MagicMock()
+        error_detector.handle_error = MagicMock(side_effect=lambda output, _backtrace: output)
+
+        runnable = RunContextRunnable.model_construct(
+            journal=mock_journal,
+            agent_chain=agent_chain,
+            error_detector=error_detector,
+            logger=MagicMock(),
+        )
+
+        await runnable.invoke_agent_chain(inputs={}, runnable_config={}, max_attempts=2)
+
+        # Two retries -> two diagnostics, then the final AIMessage.
+        assert len(written) == 3
+        assert all(isinstance(msg, AgentFrameworkMessage) for msg in written[:2])
+        assert all(
+            msg.content == "Retrying: the model's output could not be parsed (ValueError)"
+            for msg in written[:2]
+        )
+        assert isinstance(written[-1], AIMessage)


### PR DESCRIPTION
## Summary

Fixes #1029. When the agent loop retries after a recoverable error, the reason was written only to the server log — from a client's activity feed this showed up as an unexplained stall.

Each retry branch in `RunContextRunnable.invoke_agent_chain` (`run_context_runnable.py`) now also emits a concise diagnostic on the journal, e.g.:

> Retrying: the model's output could not be parsed (`ValueError`)

Covered branches: rate-limit, API error (regular-retry path only — the API-key short-circuit is unchanged), `KeyError`, and the non-parse `ValueError` path. Backtraces stay in the server log only.

## Design

Per @d1donlydfink's note on the issue, these are written as **`AgentFrameworkMessage`s** rather than `AgentMessage`s:

- `AgentFrameworkMessage` is excluded from chat history (`is_relevant_to_chat_history`), so retried/recovered errors don't bloat the tokens sent back to the LLM or confuse the conversation.
- It's written through the agent's own journal, so it carries that agent's **origin** and is never mistaken for "the answer" (the last origin-less `AgentFramework` message).
- It's the right architectural layer — these messages originate at the neuro-san level, not langchain.

Because `AgentFrameworkMessage`s don't pollute the chat, emission is unconditional (no verbosity flag needed) — this resolves the always-on vs. opt-in question raised in the issue.

## Tests

`tests/.../core/test_run_context_runnable.py`:
- `journal_retry_reason` writes a single `AgentFrameworkMessage` with the expected content.
- A retried `ValueError` emits a diagnostic per attempt, with the final `AIMessage` still last (journal stream order preserved).