### PR TITLE
NS-709 Change AGENT_MANIFEST_FILE multi-file separator to os.pathsep (':' on linux, ';' on Windows) instead of space (' ')

### DIFF
--- a/neuro_san/deploy/Dockerfile
+++ b/neuro_san/deploy/Dockerfile
@@ -156,9 +156,9 @@ ENV NVIDIA_API_KEY=""
 
 # Where to find the tool registry manifest file which lists all the agent hocon
 # files to serve up from this server instance.  To specify multiple manifest files,
-# simply use a space-separated list of manifest files.  Manifest dictionaries will
-# effectively be merged, where content coming from manifests later in the list
-# have precedence.
+# simply use a delimited list of manifest files approriate to the OS (':' on linux, ';' on Windows).
+# Manifest dictionaries will then effectively be merged, where content coming from manifests later
+# in the list have precedence.
 ENV AGENT_MANIFEST_FILE="${APP_SOURCE}/registries/manifest.hocon"
 
 # An llm_info hocon file with user-provided llm descriptions that are to be used

--- a/neuro_san/deploy/Dockerfile
+++ b/neuro_san/deploy/Dockerfile
@@ -156,9 +156,9 @@ ENV NVIDIA_API_KEY=""
 
 # Where to find the tool registry manifest file which lists all the agent hocon
 # files to serve up from this server instance.  To specify multiple manifest files,
-# simply use a delimited list of manifest files approriate to the OS (':' on linux, ';' on Windows).
-# Manifest dictionaries will then effectively be merged, where content coming from manifests later
-# in the list have precedence.
+# simply use a delimited list of manifest files approriate to the OS
+# (delimiter is ':' on linux, ';' on Windows).  Manifest dictionaries will then effectively
+# be merged, where content coming from manifests later in the list have precedence.
 ENV AGENT_MANIFEST_FILE="${APP_SOURCE}/registries/manifest.hocon"
 
 # An llm_info hocon file with user-provided llm descriptions that are to be used

--- a/neuro_san/internals/graph/persistence/registry_manifest_restorer.py
+++ b/neuro_san/internals/graph/persistence/registry_manifest_restorer.py
@@ -78,10 +78,10 @@ class RegistryManifestRestorer(Restorer):
                 manifest_file = REGISTRIES_DIR.get_file_in_basis("manifest.hocon")
 
             # Add what was found above
-            use_files: List[str] = manifest_file.split(" ")
+            use_files: List[str] = manifest_file.split(os.pathsep)
             self.manifest_files.extend(use_files)
         elif isinstance(manifest_files, str):
-            use_files: List[str] = manifest_files.split(" ")
+            use_files: List[str] = manifest_files.split(os.pathsep)
             self.manifest_files.extend(use_files)
         else:
             self.manifest_files = manifest_files


### PR DESCRIPTION
This was previously a space (" ") which would cause consternation on Windows machines which tend to like spaces in path names (unlike linux).