### PR TITLE
NS-1103 Fix start logic for multi-instance service.

### DIFF
--- a/neuro_san/service/utils/server_context.py
+++ b/neuro_san/service/utils/server_context.py
@@ -17,6 +17,9 @@
 
 from typing import Any
 from typing import Dict
+from typing import Optional
+
+from threading import Lock
 
 from janus import Queue
 
@@ -45,7 +48,16 @@ class ServerContext(ServerContextLite):
         Constructor.
         """
         self.server_status: ServerStatus = None
-        self.executor_pool = AsyncioExecutorPool(reuse_mode=True, idle_timeout_seconds=30)
+        # NB: do NOT construct the AsyncioExecutorPool here. When Tornado is
+        # configured for multiple worker processes (AGENT_HTTP_SERVER_INSTANCES
+        # > 1), the server forks *after* this instance is created but before
+        # any request-path code runs. AsyncioExecutorPool starts a daemon GC
+        # thread in its constructor, and threads do not survive fork -- the
+        # child ends up with a _gc_thread reference to a thread that no longer
+        # exists, and stale executors are never reaped in the workers.
+        # Lazy-construct in get_executor_pool() so each worker builds its own.
+        self.executor_pool: Optional[AsyncioExecutorPool] = None
+        self._executor_pool_lock: Lock = Lock()
         self.queues: Queue[AsyncCollatingQueue] = Queue()
         self.mcp_server_context: McpServerContext = McpServerContext()
         self.server_port: int = AgentSessionConstants.DEFAULT_HTTP_PORT
@@ -72,8 +84,16 @@ class ServerContext(ServerContextLite):
 
     def get_executor_pool(self) -> AsyncioExecutorPool:
         """
-        :return: The AsyncioExecutorPool
+        :return: The AsyncioExecutorPool for the current worker process.
+                 Constructed on first access so that each post-fork worker
+                 gets its own pool (with its own live GC thread), rather
+                 than inheriting a dead reference from the parent.
         """
+        if self.executor_pool is None:
+            with self._executor_pool_lock:
+                if self.executor_pool is None:
+                    self.executor_pool = AsyncioExecutorPool(reuse_mode=True,
+                                                             idle_timeout_seconds=30)
         return self.executor_pool
 
     def set_server_status(self, server_status: ServerStatus):

--- a/neuro_san/service/watcher/event_initiator/periodic_event_initiator.py
+++ b/neuro_san/service/watcher/event_initiator/periodic_event_initiator.py
@@ -63,7 +63,7 @@ class PeriodicEventInitiator(WatcherThread):
         # "I/O operation on closed kqueue object" the moment a child tries to
         # run it. Construct the executor in run() below so each worker gets
         # its own fresh loop after fork.
-        self.executor: AsyncioExecutor = None
+        self.executor: AsyncioExecutor | None = None
         # Probably need to set up logging in this guy
 
     def run(self):

--- a/neuro_san/service/watcher/event_initiator/periodic_event_initiator.py
+++ b/neuro_san/service/watcher/event_initiator/periodic_event_initiator.py
@@ -55,13 +55,24 @@ class PeriodicEventInitiator(WatcherThread):
         """
         super().__init__(server_context)
         self.verbose: bool = False
-        self.executor = AsyncioExecutor()
+        # NB: do NOT construct the AsyncioExecutor here. When Tornado is
+        # configured for multiple worker processes (AGENT_HTTP_SERVER_INSTANCES
+        # > 1), the server forks *after* this instance is created but before
+        # run() is invoked. asyncio event loops -- and their kqueue/epoll
+        # selectors -- do not survive fork; a pre-fork loop yields
+        # "I/O operation on closed kqueue object" the moment a child tries to
+        # run it. Construct the executor in run() below so each worker gets
+        # its own fresh loop after fork.
+        self.executor: AsyncioExecutor = None
         # Probably need to set up logging in this guy
 
     def run(self):
         """
         Main loop
         """
+        # Construct the executor here, after fork(), so this worker's loop
+        # is fresh and its selector fds are valid. See __init__ note.
+        self.executor = AsyncioExecutor()
         # Start the executor so our async event initiators have someplace to run
         self.executor.start()
 

--- a/neuro_san/service/watcher/temp_networks/temp_network_storage_updater.py
+++ b/neuro_san/service/watcher/temp_networks/temp_network_storage_updater.py
@@ -81,14 +81,6 @@ class TempNetworkStorageUpdater(Startable):
                 self.temp_storage.set_base_storage(external_storage)
             self.reservationist = AbstractAgentReservationist({self.temp_storage})
 
-            # We use an AsyncioExecutor and its event loop to process the collection of tasks
-            # this TempNetworkStorageUpdater instance is responsible for:
-            # 1. Checking for new queues to process coming in self.incoming "main" queue
-            # 2. Processing the individual queues that come in,
-            #    which involves processing the items that come in on those queues
-            #    and deploying reservations to the temp storage, which is done by self.reservationist.
-            self.executor = AsyncioExecutor()
-
             self.incoming: Queue[AsyncCollatingQueue] = queues
         else:
             # We don't have a temp storage, so we won't be doing any processing,
@@ -105,6 +97,15 @@ class TempNetworkStorageUpdater(Startable):
             return
 
         self.logger.info("Starting TempNetworkStorageUpdater")
+
+        # We use an AsyncioExecutor and its event loop to process the collection of tasks
+        # this TempNetworkStorageUpdater instance is responsible for:
+        # 1. Checking for new queues to process coming in self.incoming "main" queue
+        # 2. Processing the individual queues that come in,
+        #    which involves processing the items that come in on those queues
+        #    and deploying reservations to the temp storage, which is done by self.reservationist.
+        self.executor = AsyncioExecutor()
+
         # Start any Startables
         if isinstance(self.temp_storage, Startable):
             self.temp_storage.start()


### PR DESCRIPTION
This PR fixes problems with starting neuro-san service when scaling to several instances is requested.
Several Python objects - like threads and event loops - do not survive process fork,
and so must be created post-forking.
