### PR TITLE
Restore S3ReservationsStorage tests previously worked around

### DIFF
--- a/tests/neuro_san/service/watcher/temp_networks/fake_async_s3_client.py
+++ b/tests/neuro_san/service/watcher/temp_networks/fake_async_s3_client.py
@@ -53,8 +53,9 @@ class FakeAsyncS3Client:
     async def __aexit__(self, exception_type, exception_value, traceback):
         """
         Async Context Manager protocol exit method.
+        :return: True to suppress exception. False to propagate exception.
         """
-        return self
+        return False
 
     # pylint: disable=invalid-name
     async def head_bucket(self, Bucket: str):

--- a/tests/neuro_san/service/watcher/temp_networks/test_batch_partial_failure.py
+++ b/tests/neuro_san/service/watcher/temp_networks/test_batch_partial_failure.py
@@ -67,7 +67,7 @@ class TestBatchPartialFailure(S3ReservationsStorageTestBase):
         # iterations 1 and 2 fall through to the real in-memory store.
         # Status 403 lands the error on the non-retryable branch of
         # _is_retryable_client_error so we know the failure is final.
-        real_put = self.fake_async_s3.put_object
+        real_put = self.fake_s3.put_object
         # Defensively restore put_object on the fake at end-of-test. The
         # base class hands each test a fresh FakeS3Client in setUp, so
         # this is a no-op today; the cleanup is here to document intent
@@ -84,19 +84,19 @@ class TestBatchPartialFailure(S3ReservationsStorageTestBase):
         )
 
         # pylint: disable=invalid-name
-        async def fail_on_third(Bucket, Key, Body, ContentType):
+        def fail_on_third(Bucket, Key, Body, ContentType):
             call_log["count"] += 1
             if call_log["count"] == 3:
                 raise template_error
 
-            return await real_put(
+            return real_put(
                 Bucket=Bucket,
                 Key=Key,
                 Body=Body,
                 ContentType=ContentType,
             )
 
-        self.fake_async_s3.put_object = fail_on_third
+        self.fake_s3.put_object = fail_on_third
 
         # Skip backoff sleep defensively. AccessDenied is non-retryable
         # so no sleep should fire, but we patch it so a regression that
@@ -104,28 +104,18 @@ class TestBatchPartialFailure(S3ReservationsStorageTestBase):
         with patch(
             "neuro_san.service.watcher.temp_networks.s3_reservations_storage.asyncio.sleep"
         ):
-            one_exception: ClientError = None
-            try:
+
+            with self.assertRaises(ClientError) as ctx:
                 await self.storage.add_reservations(
                     {res_a: spec_a, res_b: spec_b, res_c: spec_c}
                 )
-            except ClientError as ctx:
-                one_exception = ctx
-
-        # Not clear why this exception is not getting thrown. Pass for now.
-        one_exception = template_error
-
-        self.assertIsNotNone(
-            one_exception,
-            "Expected add_reservations to raise an AccessDenied error, but it did not.",
-        )
 
         # The original AccessDenied error code propagates. Catches a
         # bug where the storage swallows the error or wraps it in a
         # different exception type.
         self.assertEqual(
             "AccessDenied",
-            one_exception.response["Error"]["Code"],
+            ctx.exception.response["Error"]["Code"],
             "AccessDenied error code was not preserved on propagation.",
         )
 

--- a/tests/neuro_san/service/watcher/temp_networks/test_no_retry_on_access_denied.py
+++ b/tests/neuro_san/service/watcher/temp_networks/test_no_retry_on_access_denied.py
@@ -67,7 +67,7 @@ class TestNoRetryOnAccessDenied(S3ReservationsStorageTestBase):
         )
 
         # pylint: disable=invalid-name,unused-argument
-        async def denied_put(Bucket, Key, Body, ContentType):
+        def denied_put(Bucket, Key, Body, ContentType):
             call_log["count"] += 1
             raise template_error
 
@@ -78,25 +78,15 @@ class TestNoRetryOnAccessDenied(S3ReservationsStorageTestBase):
         with patch(
             "neuro_san.service.watcher.temp_networks.s3_reservations_storage.asyncio.sleep"
         ):
-            one_error = None
-            try:
+            with self.assertRaises(ClientError) as ctx:
                 await self.storage.add_reservations({reservation: agent_spec})
-            except ClientError as ctx:
-                one_error = ctx
-
-        # Not sure why the exception does not fire. Passing for now.
-        one_error = template_error
-        self.assertIsNotNone(
-            one_error,
-            "Expected exactly one error from add_reservations; got none.",
-        )
 
         # The original error code is preserved on the way up. Catches
         # bugs where the storage swallows or wraps the error in a
         # different exception type, hiding the real cause from callers.
         self.assertEqual(
             "AccessDenied",
-            template_error.response["Error"]["Code"],
+            ctx.exception.response["Error"]["Code"],
             "AccessDenied error code was not preserved on propagation; "
             "the original cause is being hidden from callers.",
         )


### PR DESCRIPTION
Restore S3ReservationsStorage tests to work how they did before by correctly propagating exceptions in the Mock object's context manager.

The good news is that this was only a problem with the tests and the pathological behavior exhibited in recent load testing is its own beast.