### PR TITLE
Add visibility into Reservation deployment failures by logging

### DIFF
--- a/neuro_san/service/watcher/temp_networks/temp_network_storage_updater.py
+++ b/neuro_san/service/watcher/temp_networks/temp_network_storage_updater.py
@@ -16,6 +16,7 @@
 # END COPYRIGHT
 from typing import Any
 from typing import Dict
+from typing import List
 
 from os import environ
 
@@ -206,9 +207,19 @@ class TempNetworkStorageUpdater(Startable):
         max_lifetime_in_seconds: float = queued_item.get("max_lifetime_in_seconds")
 
         # Do the deployment
-        await self.reservationist.deploy_together(deployment_dict, source, max_lifetime_in_seconds)
+        try:
+            await self.reservationist.deploy_together(deployment_dict, source, max_lifetime_in_seconds)
+
+        # pylint: disable=broad-except
+        except Exception as exception:
+            # We are failing to process a queued item, so we should log it.
+            reservations: List[AgentReservation] = list(deployment_dict.keys())
+            reservation_ids: List[str] = [reservation.get_reservation_id() for reservation in reservations]
+            self.logger.error("Exception %s while processing queued item for the following reservations: %s",
+                              str(exception), str(reservation_ids))
 
         # Maybe notify the deployer.
+        # Note if there is a failure, the deployer will not be notified (yet).
         event: Event = queued_item.get("event")
         if event is not None:
             event_loop: AbstractEventLoop = queued_item.get("event_loop")

--- a/neuro_san/service/watcher/temp_networks/temp_network_storage_updater.py
+++ b/neuro_san/service/watcher/temp_networks/temp_network_storage_updater.py
@@ -226,7 +226,7 @@ class TempNetworkStorageUpdater(Startable):
             sensitive_logger.exception("Exception while processing queued item for reservations: %s", reservation_ids)
 
         # Maybe notify the deployer.
-        # Note if there is a failure, the deployer will not be notified (yet).
+        # Note: even if deployment fails, we still notify (set the event) to avoid callers waiting indefinitely.
         event: Event = queued_item.get("event")
         if event is not None:
             event_loop: AbstractEventLoop = queued_item.get("event_loop")

--- a/neuro_san/service/watcher/temp_networks/temp_network_storage_updater.py
+++ b/neuro_san/service/watcher/temp_networks/temp_network_storage_updater.py
@@ -211,12 +211,9 @@ class TempNetworkStorageUpdater(Startable):
             await self.reservationist.deploy_together(deployment_dict, source, max_lifetime_in_seconds)
 
         # pylint: disable=broad-except
-        except Exception as exception:
-            # We are failing to process a queued item, so we should log it.
-            reservations: List[AgentReservation] = list(deployment_dict.keys())
-            reservation_ids: List[str] = [reservation.get_reservation_id() for reservation in reservations]
-            self.logger.error("Exception %s while processing queued item for the following reservations: %s",
-                              str(exception), str(reservation_ids))
+        except Exception:  # pylint: disable=broad-except
+            reservation_ids: List[str] = [r.get_reservation_id() for r in (deployment_dict or {}).keys()]
+            self.logger.exception("Exception while processing queued item for reservations: %s", reservation_ids)
 
         # Maybe notify the deployer.
         # Note if there is a failure, the deployer will not be notified (yet).

--- a/neuro_san/service/watcher/temp_networks/temp_network_storage_updater.py
+++ b/neuro_san/service/watcher/temp_networks/temp_network_storage_updater.py
@@ -32,8 +32,9 @@ import queue as queue_mod
 from janus import Queue
 from janus import SyncQueueShutDown
 
-from leaf_common.config.resolver_util import ResolverUtil
 from leaf_common.asyncio.asyncio_executor import AsyncioExecutor
+from leaf_common.config.resolver_util import ResolverUtil
+from leaf_common.logging.sensitive_logger import SensitiveLogger
 
 from neuro_san.internals.chat.async_collating_queue import AsyncCollatingQueue
 from neuro_san.internals.interfaces.reservations_storage import ReservationsStorage
@@ -210,10 +211,15 @@ class TempNetworkStorageUpdater(Startable):
         try:
             await self.reservationist.deploy_together(deployment_dict, source, max_lifetime_in_seconds)
 
-        # pylint: disable=broad-except
         except Exception:  # pylint: disable=broad-except
-            reservation_ids: List[str] = [r.get_reservation_id() for r in (deployment_dict or {}).keys()]
-            self.logger.exception("Exception while processing queued item for reservations: %s", reservation_ids)
+
+            # Gather info about who will be effected by this failure
+            reservation_ids: List[str] = []
+            for reservation in deployment_dict.keys():
+                reservation_ids.append(reservation.get_reservation_id())
+
+            sensitive_logger = SensitiveLogger(self.logger)
+            sensitive_logger.exception("Exception while processing queued item for reservations: %s", reservation_ids)
 
         # Maybe notify the deployer.
         # Note if there is a failure, the deployer will not be notified (yet).

--- a/neuro_san/service/watcher/temp_networks/temp_network_storage_updater.py
+++ b/neuro_san/service/watcher/temp_networks/temp_network_storage_updater.py
@@ -213,6 +213,10 @@ class TempNetworkStorageUpdater(Startable):
 
         except Exception:  # pylint: disable=broad-except
 
+            if deployment_dict is None:
+                self.logger.warning("Deployment dictionary was None")
+                deployment_dict = {}
+
             # Gather info about who will be effected by this failure
             reservation_ids: List[str] = []
             for reservation in deployment_dict.keys():


### PR DESCRIPTION
Catching exceptions at this level will also no longer block the request, however that does not yet mean lack of success is communicated to the request. We want to see what kind of errors we are getting first.