### PR TITLE
Cache / Retry frozen s3 credentials for S3ReservationsWriter

### DIFF
--- a/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
+++ b/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
@@ -266,7 +266,7 @@ class S3ReservationsWriter:
             self.session: AioSession = get_session()
 
         credentials: Credentials = await self.session.get_credentials()
-        self.frozen_credentials = credentials.get_frozen_credentials()
+        self.frozen_credentials = await credentials.get_frozen_credentials()
 
         return self.frozen_credentials
 

--- a/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
+++ b/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
@@ -93,6 +93,7 @@ class S3ReservationsWriter:
         self.session: AioSession = None
 
         # Cached frozen credentials which can be invalidated should they expire
+        self.frozen_credentials: ReadOnlyCredentials = None
 
     async def add_reservations(self, reservations_dict: Dict[Reservation, Any],
                                source: str = None):

--- a/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
+++ b/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
@@ -274,9 +274,12 @@ class S3ReservationsWriter:
         We are assuming that we already have the async_s3_client_lock.
         """
 
+        # Use a local copy to avoid a race with the ClientError retry block
+        local_frozen: ReadOnlyCredentials = self.frozen_credentials
+
         # If we already have some credentials, use them
-        if self.frozen_credentials is not None:
-            return self.frozen_credentials
+        if local_frozen is not None:
+            return local_frozen
 
         # Create the session if needed
         # We should only need one for the lifetime of the object
@@ -287,7 +290,7 @@ class S3ReservationsWriter:
 
         # Avoid a small race condition with the ClientError retry block
         # by always returning a local copy
-        local_frozen: ReadOnlyCredentials = await credentials.get_frozen_credentials()
+        local_frozen = await credentials.get_frozen_credentials()
         self.frozen_credentials = local_frozen
 
         return local_frozen

--- a/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
+++ b/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
@@ -36,7 +36,9 @@ from aiobotocore.session import ClientCreatorContext
 
 from botocore.credentials import Credentials
 from botocore.credentials import ReadOnlyCredentials
-from botocore.exceptions import NoCredentialsError
+from botocore.exceptions import ClientError
+
+from leaf_common.parser.dictionary_extractor import DictionaryExtractor
 
 from neuro_san.interfaces.reservation import Reservation
 from neuro_san.internals.reservations.reservation_dictionary_converter import ReservationDictionaryConverter
@@ -161,7 +163,10 @@ class S3ReservationsWriter:
                 await self.add_reservations_with_new_client(reservations_dict, source, attempts)
                 success = True
 
-            except NoCredentialsError:
+            except ClientError as err:
+                extractor = DictionaryExtractor(err.response)
+                if "ExpiredToken" not in extractor.get("Error.Code", ""):
+                    raise
 
                 # Background: Certain IAM Instance Roles, ECS Task Roles or AWS SSO/IAM Identity Center
                 #             profiles have token-based credentials that may expire.

--- a/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
+++ b/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
@@ -266,7 +266,7 @@ class S3ReservationsWriter:
         # Create the session if needed
         # We should only need one for the lifetime of the object
         if self.session is None:
-            self.session: AioSession = get_session()
+            self.session = get_session()
 
         credentials: Credentials = await self.session.get_credentials()
         self.frozen_credentials = await credentials.get_frozen_credentials()

--- a/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
+++ b/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
@@ -145,6 +145,7 @@ class S3ReservationsWriter:
                                                                   source: str):
         """
         Retries adding the reservations when client credentials can expire.
+
         :param reservations_dict: A mapping of Reservation -> some deployable agent spec
         :param source: A string describing where the deployment was coming from
         """
@@ -156,10 +157,18 @@ class S3ReservationsWriter:
             try:
                 await self.add_reservations_with_new_client(reservations_dict, source, attempts)
                 success = True
+
             except NoCredentialsError:
+
+                # Background: Certain IAM Instance Roles, ECS Task Roles or AWS SSO/IAM Identity Center
+                #             profiles have token-based credentials that may expire.
+                #             See: https://docs.aws.amazon.com/boto3/latest/guide/configuration.html
+
                 # Reset the cached credentials as they are likely expired and try again.
                 self.frozen_credentials = None
-                self.logger.warning("%s (%d): S3 credentials seem to have expired. Retrying.", source, attempts)
+                self.logger.warning("%s (%d): S3 credentials seem to have expired. Retrying."
+                                    "If you believe you have non-expiring S3 credentials, be sure they are correct.",
+                                    source, attempts)
 
     async def add_reservations_with_new_client(self,
                                                reservations_dict: Dict[Reservation, Any],

--- a/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
+++ b/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
@@ -250,7 +250,7 @@ class S3ReservationsWriter:
                 self.async_s3_client_lock.release()
 
         finish_time: float = perf_counter()
-        self.logger.info("%s (%d): Lock acquisition in: %fs. Client creation after: %fs. "
+        self.logger.info("%s (%d): Lock acquisition in: %fs. Client context creation after: %fs. "
                          "Lock release after: %fs. Finish after: %fs",
                          self.name, attempt,
                          lock_aquired_time - start_time,

--- a/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
+++ b/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
@@ -178,7 +178,7 @@ class S3ReservationsWriter:
                                                source: str,
                                                attempt: int = 1):
         """
-        This method separates the machinactions of obtaining a proper S3 client
+        This method separates the machinations of obtaining a proper S3 client
         from add_all_reservations() which does all the actual work.
 
         :param reservations_dict: A mapping of Reservation -> some deployable agent spec

--- a/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
+++ b/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
@@ -138,7 +138,7 @@ class S3ReservationsWriter:
         if source is None:
             source = self.name
 
-        # Aync lock has to be created in the thread that uses it.
+        # Async lock has to be created in the thread that uses it.
         self.ensure_async_lock_exists()
 
         await self.add_reservations_with_new_client_credential_retries(reservations_dict, source)

--- a/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
+++ b/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
@@ -124,7 +124,7 @@ class S3ReservationsWriter:
             return
 
         # Aync lock has to be created in the thread that uses it.
-        self.ensure_asnync_lock_exists()
+        self.ensure_async_lock_exists()
 
         # Create an aiobotocore client for async operations.
         async_s3_client: AioBaseClient = None
@@ -179,7 +179,7 @@ class S3ReservationsWriter:
                          lock_released_time - start_time,
                          finish_time - start_time)
 
-    def ensure_asnync_lock_exists(self):
+    def ensure_async_lock_exists(self):
         """
         Be sure we have an asyncio Lock to get our sessions.
         """

--- a/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
+++ b/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
@@ -155,18 +155,19 @@ class S3ReservationsWriter:
         """
 
         max_attempts: int = 8
-        attempts: int = 0
-        success: bool = False
-        while not success and attempts < max_attempts:
-            attempts += 1
+        last_err = None
+
+        for attempt in range(1, max_attempts + 1):
             try:
-                await self.add_reservations_with_new_client(reservations_dict, source, attempts)
-                success = True
+                await self.add_reservations_with_new_client(reservations_dict, source, attempt)
+                return
 
             except ClientError as err:
                 extractor = DictionaryExtractor(err.response)
                 if "ExpiredToken" not in extractor.get("Error.Code", ""):
                     raise
+
+                last_err = err
 
                 # Background: Certain IAM Instance Roles, ECS Task Roles or AWS SSO/IAM Identity Center
                 #             profiles have token-based credentials that may expire.
@@ -174,9 +175,17 @@ class S3ReservationsWriter:
 
                 # Reset the cached credentials as they are likely expired and try again.
                 self.frozen_credentials = None
-                self.logger.warning("%s (%d): S3 credentials seem to have expired. Retrying."
-                                    "If you believe you have non-expiring S3 credentials, be sure they are correct.",
-                                    source, attempts)
+                self.logger.warning(
+                    "%s (%d): S3 credentials seem to have expired. Retrying. "
+                    "If you believe you have non-expiring S3 credentials, be sure they are correct.",
+                    source,
+                    attempt,
+                )
+
+        # Exhausted retries
+        if last_err is not None:
+            raise last_err
+        raise RuntimeError("S3 credential retries exhausted without capturing an error")
 
     async def add_reservations_with_new_client(self,
                                                reservations_dict: Dict[Reservation, Any],

--- a/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
+++ b/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
@@ -123,6 +123,7 @@ class S3ReservationsWriter:
         if len(reservations_dict) == 0:
             return
 
+        # Aync lock has to be created in the thread that uses it.
         self.ensure_asnync_lock_exists()
 
         # Create an aiobotocore client for async operations.

--- a/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
+++ b/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
@@ -284,9 +284,13 @@ class S3ReservationsWriter:
             self.session = get_session()
 
         credentials: Credentials = await self.session.get_credentials()
-        self.frozen_credentials = await credentials.get_frozen_credentials()
 
-        return self.frozen_credentials
+        # Avoid a small race condition with the ClientError retry block
+        # by always returning a local copy
+        local_frozen: ReadOnlyCredentials = await credentials.get_frozen_credentials()
+        self.frozen_credentials = local_frozen
+
+        return local_frozen
 
     async def add_all_reservations(self, async_s3_client: AioBaseClient,
                                    reservations_dict: Dict[Reservation, Dict[str, Any]],

--- a/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
+++ b/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
@@ -38,7 +38,7 @@ from botocore.credentials import Credentials
 from botocore.credentials import ReadOnlyCredentials
 from botocore.exceptions import ClientError
 
-from leaf_common.parser.dictionary_extractor import DictionaryExtractor
+from leaf_common.parsers.dictionary_extractor import DictionaryExtractor
 
 from neuro_san.interfaces.reservation import Reservation
 from neuro_san.internals.reservations.reservation_dictionary_converter import ReservationDictionaryConverter

--- a/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
+++ b/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
@@ -215,7 +215,8 @@ class S3ReservationsWriter:
                 "s3",
                 aws_access_key_id=frozen_creds.access_key,
                 aws_secret_access_key=frozen_creds.secret_key,
-                aws_session_token=frozen_creds.token
+                aws_session_token=frozen_creds.token,
+                aws_account_id=frozen_creds.account_id
             )
             client_created_time = perf_counter()
 

--- a/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
+++ b/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
@@ -266,7 +266,7 @@ class S3ReservationsWriter:
             self.session: AioSession = get_session()
 
         credentials: Credentials = self.session.get_credentials()
-        self.frozen_credentials = credentials.get_frozen_credentials()
+        self.frozen_credentials = await credentials.get_frozen_credentials()
 
         return self.frozen_credentials
 

--- a/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
+++ b/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
@@ -141,7 +141,7 @@ class S3ReservationsWriter:
         # Aync lock has to be created in the thread that uses it.
         self.ensure_async_lock_exists()
 
-        await self.add_reservations_with_new_client_retries(reservations_dict, source)
+        await self.add_reservations_with_new_client_credential_retries(reservations_dict, source)
 
     async def add_reservations_with_new_client_credential_retries(self,
                                                                   reservations_dict: Dict[Reservation, Any],

--- a/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
+++ b/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
@@ -256,7 +256,7 @@ class S3ReservationsWriter:
     async def get_frozen_credentials(self) -> ReadOnlyCredentials:
         """
         Get the frozen credentials for the current session.
-        We are asssuming that we already have the async_s3_client_lock.
+        We are assuming that we already have the async_s3_client_lock.
         """
 
         # If we already have some credentials, use them

--- a/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
+++ b/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
@@ -141,7 +141,7 @@ class S3ReservationsWriter:
         # Aync lock has to be created in the thread that uses it.
         self.ensure_async_lock_exists()
 
-        await self.add_reservations_with_new_client(reservations_dict, source)
+        await self.add_reservations_with_new_client_retries(reservations_dict, source)
 
     async def add_reservations_with_new_client_credential_retries(self,
                                                                   reservations_dict: Dict[Reservation, Any],

--- a/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
+++ b/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
@@ -85,6 +85,7 @@ class S3ReservationsWriter:
                                source: str = None):
         """
         Add reservations to S3 storage.
+        Main entry point.
 
         On-disk JSON schema written per reservation
         (key = "<prefix><reservation_id>.json"):

--- a/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
+++ b/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
@@ -155,7 +155,7 @@ class S3ReservationsWriter:
         """
 
         max_attempts: int = 8
-        last_err = None
+        last_err: Exception = None
 
         for attempt in range(1, max_attempts + 1):
             try:
@@ -185,7 +185,7 @@ class S3ReservationsWriter:
         # Exhausted retries
         if last_err is not None:
             raise last_err
-        raise RuntimeError("S3 credential retries exhausted without capturing an error")
+        raise RuntimeError("S3 credential retries exhausted without capturing an error") from last_err
 
     async def add_reservations_with_new_client(self,
                                                reservations_dict: Dict[Reservation, Any],

--- a/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
+++ b/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
@@ -36,6 +36,7 @@ from aiobotocore.session import ClientCreatorContext
 
 from botocore.credentials import Credentials
 from botocore.credentials import ReadOnlyCredentials
+from botocore.exceptions import NoCredentialsError
 
 from neuro_san.interfaces.reservation import Reservation
 from neuro_san.internals.reservations.reservation_dictionary_converter import ReservationDictionaryConverter
@@ -139,10 +140,38 @@ class S3ReservationsWriter:
 
         await self.add_reservations_with_new_client(reservations_dict, source)
 
-    async def add_reservations_with_new_client(self, reservations_dict: Dict[Reservation, Any], source: str):
+    async def add_reservations_with_new_client_credential_retries(self,
+                                                                  reservations_dict: Dict[Reservation, Any],
+                                                                  source: str):
+        """
+        Retries adding the reservations when client credentials can expire.
+        :param reservations_dict: A mapping of Reservation -> some deployable agent spec
+        :param source: A string describing where the deployment was coming from
+        """
+
+        attempts: int = 0
+        success: bool = False
+        while not success:
+            attempts += 1
+            try:
+                await self.add_reservations_with_new_client(reservations_dict, source, attempts)
+                success = True
+            except NoCredentialsError:
+                # Reset the cached credentials as they are likely expired and try again.
+                self.frozen_credentials = None
+                self.logger.warning("%s (%d): S3 credentials seem to have expired. Retrying.", source, attempts)
+
+    async def add_reservations_with_new_client(self,
+                                               reservations_dict: Dict[Reservation, Any],
+                                               source: str,
+                                               attempt: int = 1):
         """
         This method separates the machinactions of obtaining a proper S3 client
         from add_all_reservations() which does all the actual work.
+
+        :param reservations_dict: A mapping of Reservation -> some deployable agent spec
+        :param source: A string describing where the deployment was coming from
+        :param attempt: Attempt number
         """
 
         # Create an aiobotocore client for async operations.
@@ -193,10 +222,9 @@ class S3ReservationsWriter:
                 self.async_s3_client_lock.release()
 
         finish_time: float = perf_counter()
-
-        self.logger.info("%s: Lock acquisition in: %fs. Client creation after: %fs. "
+        self.logger.info("%s (%d): Lock acquisition in: %fs. Client creation after: %fs. "
                          "Lock release after: %fs. Finish after: %fs",
-                         self.name,
+                         self.name, attempt,
                          lock_aquired_time - start_time,
                          client_created_time - start_time,
                          lock_released_time - start_time,
@@ -224,6 +252,7 @@ class S3ReservationsWriter:
             return self.frozen_credentials
 
         # Create the session if needed
+        # We should only need one for the lifetime of the object
         if self.session is None:
             self.session: AioSession = get_session()
 

--- a/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
+++ b/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
@@ -225,7 +225,6 @@ class S3ReservationsWriter:
                 aws_access_key_id=frozen_creds.access_key,
                 aws_secret_access_key=frozen_creds.secret_key,
                 aws_session_token=frozen_creds.token,
-                aws_account_id=frozen_creds.account_id
             )
             client_created_time = perf_counter()
 

--- a/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
+++ b/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
@@ -34,6 +34,9 @@ from aiobotocore.session import get_session
 from aiobotocore.session import AioSession
 from aiobotocore.session import ClientCreatorContext
 
+from botocore.credentials import Credentials
+from botocore.credentials import ReadOnlyCredentials
+
 from neuro_san.interfaces.reservation import Reservation
 from neuro_san.internals.reservations.reservation_dictionary_converter import ReservationDictionaryConverter
 from neuro_san.service.watcher.temp_networks.s3_retry_util import S3RetryUtil
@@ -80,6 +83,10 @@ class S3ReservationsWriter:
         self.async_s3_client_lock: AsyncLock = None
 
         self.converter = ReservationDictionaryConverter()
+
+        # Boto Machinations
+        self.session: AioSession = None
+        self.frozen_creds: ReadOnlyCredentials = None
 
     async def add_reservations(self, reservations_dict: Dict[Reservation, Any],
                                source: str = None):
@@ -146,7 +153,7 @@ class S3ReservationsWriter:
 
         start_time: float = perf_counter()
         lock_aquired_time: float = 0.0
-        session_created_time: float = 0.0
+        client_created_time: float = 0.0
         lock_released_time: float = 0.0
         try:
             # Serialize creation of the ClientCreatorContext with the lock to avoid credential-chain races.
@@ -157,9 +164,14 @@ class S3ReservationsWriter:
             # Note: We can probably do better than doing this block every single time.
             #       Many articles hint at frozen-credentials caching, but that will require
             #       an extra layer of retry complexity at this level.
-            session: AioSession = get_session()
-            async_s3_client_creator_context = session.create_client("s3")
-            session_created_time = perf_counter()
+            frozen_creds: ReadOnlyCredentials = await self.get_frozen_credentials()
+            async_s3_client_creator_context = self.session.create_client(
+                "s3",
+                aws_access_key_id=frozen_creds.access_key,
+                aws_secret_access_key=frozen_creds.secret_key,
+                aws_session_token=frozen_creds.token
+            )
+            client_created_time = perf_counter()
 
             # Normally this is done in a python ContextManager using a with-statement,
             # but we want to be holding the lock while we create the client to avoid
@@ -183,10 +195,11 @@ class S3ReservationsWriter:
 
         finish_time: float = perf_counter()
 
-        self.logger.info("Lock acquisition in: %fs. Session creation after: %fs. "
+        self.logger.info("%s: Lock acquisition in: %fs. Client creation after: %fs. "
                          "Lock release after: %fs. Finish after: %fs",
+                         self.name,
                          lock_aquired_time - start_time,
-                         session_created_time - start_time,
+                         client_created_time - start_time,
                          lock_released_time - start_time,
                          finish_time - start_time)
 
@@ -200,6 +213,25 @@ class S3ReservationsWriter:
                 # Be sure everyone has the same lock
                 if self.async_s3_client_lock is None:
                     self.async_s3_client_lock = AsyncLock()
+
+    async def get_frozen_credentials(self) -> ReadOnlyCredentials:
+        """
+        Get the frozen credentials for the current session.
+        We are asssuming that we already have the async_s3_client_lock.
+        """
+
+        # If we already have some credentials, use them
+        if self.frozen_credentials is not None:
+            return self.frozen_credentials
+
+        # Create the session if needed
+        if self.session is None:
+            self.session: AioSession = get_session()
+
+        credentials: Credentials = self.session.get_credentials()
+        self.frozen_credentials = credentials.get_frozen_credentials()
+
+        return self.frozen_credentials
 
     async def add_all_reservations(self, async_s3_client: AioBaseClient,
                                    reservations_dict: Dict[Reservation, Dict[str, Any]],

--- a/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
+++ b/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
@@ -123,8 +123,19 @@ class S3ReservationsWriter:
         if len(reservations_dict) == 0:
             return
 
+        if source is None:
+            source = self.name
+
         # Aync lock has to be created in the thread that uses it.
         self.ensure_async_lock_exists()
+
+        await self.add_reservations_with_new_client(reservations_dict, source)
+
+    async def add_reservations_with_new_client(self, reservations_dict: Dict[Reservation, Any], source: str):
+        """
+        This method separates the machinactions of obtaining a proper S3 client
+        from add_all_reservations() which does all the actual work.
+        """
 
         # Create an aiobotocore client for async operations.
         async_s3_client: AioBaseClient = None
@@ -183,6 +194,7 @@ class S3ReservationsWriter:
         """
         Be sure we have an asyncio Lock to get our sessions.
         """
+        # Note that none of this is async in and of itself.
         if self.async_s3_client_lock is None:
             with self.sync_lock:
                 # Be sure everyone has the same lock
@@ -191,7 +203,7 @@ class S3ReservationsWriter:
 
     async def add_all_reservations(self, async_s3_client: AioBaseClient,
                                    reservations_dict: Dict[Reservation, Dict[str, Any]],
-                                   source: str = None):
+                                   source: str):
         """
         Add all reservations to S3 storage.
         :param async_s3_client: An aiobotocore S3 client to use for the put_object call
@@ -207,7 +219,7 @@ class S3ReservationsWriter:
     async def add_one_reservation(self, async_s3_client: AioBaseClient,
                                   reservation: Reservation,
                                   agent_spec: Dict[str, Any],
-                                  source: str = None):
+                                  source: str):
         """
         Add a single reservation to S3 storage.
         :param async_s3_client: An aiobotocore S3 client to use for the put_object call
@@ -239,8 +251,6 @@ class S3ReservationsWriter:
                                Body=json_body,
                                ContentType="application/json")
 
-        if source is None:
-            source = self.name
         await S3RetryUtil.async_do_with_retries(source, put_function)
 
         self.logger.debug("%s: Successfully stored reservation %s in S3", self.name, reservation_id)

--- a/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
+++ b/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
@@ -87,7 +87,10 @@ class S3ReservationsWriter:
         self.converter = ReservationDictionaryConverter()
 
         # Boto Machinations
+        # We should be able to have a single Session for the lifetime of this object
         self.session: AioSession = None
+
+        # Cached frozed credentials which can be invalidated should they expire
         self.frozen_credentials: ReadOnlyCredentials = None
 
     async def add_reservations(self, reservations_dict: Dict[Reservation, Any],

--- a/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
+++ b/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
@@ -265,8 +265,8 @@ class S3ReservationsWriter:
         if self.session is None:
             self.session: AioSession = get_session()
 
-        credentials: Credentials = self.session.get_credentials()
-        self.frozen_credentials = await credentials.get_frozen_credentials()
+        credentials: Credentials = await self.session.get_credentials()
+        self.frozen_credentials = credentials.get_frozen_credentials()
 
         return self.frozen_credentials
 

--- a/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
+++ b/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
@@ -42,6 +42,7 @@ from neuro_san.internals.reservations.reservation_dictionary_converter import Re
 from neuro_san.service.watcher.temp_networks.s3_retry_util import S3RetryUtil
 
 
+# pylint: disable=too-many-instance-attributes
 class S3ReservationsWriter:
     """
     AWS S3-based class that writes reservations out to persistent store
@@ -86,7 +87,7 @@ class S3ReservationsWriter:
 
         # Boto Machinations
         self.session: AioSession = None
-        self.frozen_creds: ReadOnlyCredentials = None
+        self.frozen_credentials: ReadOnlyCredentials = None
 
     async def add_reservations(self, reservations_dict: Dict[Reservation, Any],
                                source: str = None):
@@ -161,9 +162,7 @@ class S3ReservationsWriter:
             lock_aquired_time = perf_counter()
             acquired_lock = True
 
-            # Note: We can probably do better than doing this block every single time.
-            #       Many articles hint at frozen-credentials caching, but that will require
-            #       an extra layer of retry complexity at this level.
+            # Get the current notion of frozen credentials.
             frozen_creds: ReadOnlyCredentials = await self.get_frozen_credentials()
             async_s3_client_creator_context = self.session.create_client(
                 "s3",

--- a/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
+++ b/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
@@ -155,9 +155,10 @@ class S3ReservationsWriter:
         :param source: A string describing where the deployment was coming from
         """
 
+        max_attempts: int = 8
         attempts: int = 0
         success: bool = False
-        while not success:
+        while not success and attempts < max_attempts:
             attempts += 1
             try:
                 await self.add_reservations_with_new_client(reservations_dict, source, attempts)

--- a/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
+++ b/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
@@ -92,8 +92,7 @@ class S3ReservationsWriter:
         # We should be able to have a single Session for the lifetime of this object
         self.session: AioSession = None
 
-        # Cached frozed credentials which can be invalidated should they expire
-        self.frozen_credentials: ReadOnlyCredentials = None
+        # Cached frozen credentials which can be invalidated should they expire
 
     async def add_reservations(self, reservations_dict: Dict[Reservation, Any],
                                source: str = None):

--- a/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
+++ b/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
@@ -122,12 +122,7 @@ class S3ReservationsWriter:
         if len(reservations_dict) == 0:
             return
 
-        # Be sure we have an asyncio Lock to get our sessions.
-        if self.async_s3_client_lock is None:
-            with self.sync_lock:
-                # Be sure everyone has the same lock
-                if self.async_s3_client_lock is None:
-                    self.async_s3_client_lock = AsyncLock()
+        self.ensure_asnync_lock_exists()
 
         # Create an aiobotocore client for async operations.
         async_s3_client: AioBaseClient = None
@@ -165,11 +160,7 @@ class S3ReservationsWriter:
                 lock_released_time = perf_counter()
                 lock_released = True
 
-                # Process each reservation/agent spec pair individually
-                reservation: Reservation = None
-                agent_spec: Dict[str, Any] = None
-                for reservation, agent_spec in reservations_dict.items():
-                    await self.add_one_reservation(async_s3_client, reservation, agent_spec, source)
+                await self.add_all_reservations(async_s3_client, reservations_dict, source)
 
         finally:
             # Always release the lock if we successfully acquired it and have not already done so,
@@ -185,6 +176,31 @@ class S3ReservationsWriter:
                          session_created_time - start_time,
                          lock_released_time - start_time,
                          finish_time - start_time)
+
+    def ensure_asnync_lock_exists(self):
+        """
+        Be sure we have an asyncio Lock to get our sessions.
+        """
+        if self.async_s3_client_lock is None:
+            with self.sync_lock:
+                # Be sure everyone has the same lock
+                if self.async_s3_client_lock is None:
+                    self.async_s3_client_lock = AsyncLock()
+
+    async def add_all_reservations(self, async_s3_client: AioBaseClient,
+                                   reservations_dict: Dict[Reservation, Dict[str, Any]],
+                                   source: str = None):
+        """
+        Add all reservations to S3 storage.
+        :param async_s3_client: An aiobotocore S3 client to use for the put_object call
+        :param reservations_dict: A mapping of Reservation -> some deployable agent spec
+        :param source: A string describing where the deployment was coming from
+        """
+        # Process each reservation/agent spec pair individually
+        reservation: Reservation = None
+        agent_spec: Dict[str, Any] = None
+        for reservation, agent_spec in reservations_dict.items():
+            await self.add_one_reservation(async_s3_client, reservation, agent_spec, source)
 
     async def add_one_reservation(self, async_s3_client: AioBaseClient,
                                   reservation: Reservation,

--- a/tests/neuro_san/service/watcher/temp_networks/s3_reservations_storage_test_base.py
+++ b/tests/neuro_san/service/watcher/temp_networks/s3_reservations_storage_test_base.py
@@ -99,11 +99,14 @@ class S3ReservationsStorageTestBase(IsolatedAsyncioTestCase):
         # regardless of pass/fail.
         self.addCleanup(aiobotocore_patcher.stop)
 
-        # Patch AioSession at the import boundary in s3_reservations_storage
-        # so storage.start() receives our fake credentials.
+        # Patch AioSession.get_credentials at the import boundary in s3_reservations_writer
+        # so storage.start() receives deterministic fake credentials.
+        async def _fake_get_credentials(*_args, **_kwargs):
+            return AioCredentials("bogus", "bogus")
+
         credentials_patcher = patch(
             "neuro_san.service.watcher.temp_networks.s3_reservations_writer.AioSession.get_credentials",
-            return_value=AioCredentials("bogus", "bogus")
+            new=_fake_get_credentials,
         )
         credentials_patcher.start()
         # Restores the real AioSession symbol after the test completes, regardless of pass/fail.

--- a/tests/neuro_san/service/watcher/temp_networks/s3_reservations_storage_test_base.py
+++ b/tests/neuro_san/service/watcher/temp_networks/s3_reservations_storage_test_base.py
@@ -30,6 +30,8 @@ from typing import Dict
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import patch
 
+from aiobotocore.credentials import AioCredentials
+
 from neuro_san.internals.reservations.agent_reservation import AgentReservation
 from neuro_san.service.watcher.temp_networks.s3_reservations_storage import S3ReservationsStorage
 from tests.neuro_san.service.watcher.temp_networks.fake_s3_client import FakeS3Client
@@ -96,6 +98,16 @@ class S3ReservationsStorageTestBase(IsolatedAsyncioTestCase):
         # Restores the real aiobotocore symbol after the test completes,
         # regardless of pass/fail.
         self.addCleanup(aiobotocore_patcher.stop)
+
+        # Patch AioSession at the import boundary in s3_reservations_storage
+        # so storage.start() receives our fake credentials.
+        credentials_patcher = patch(
+            "neuro_san.service.watcher.temp_networks.s3_reservations_writer.AioSession.get_credentials",
+            return_value=AioCredentials("bogus", "bogus")
+        )
+        credentials_patcher.start()
+        # Restores the real AioSession symbol after the test completes, regardless of pass/fail.
+        self.addCleanup(credentials_patcher.stop)
 
         self.storage: S3ReservationsStorage = S3ReservationsStorage(
             bucket_name="test-bucket",


### PR DESCRIPTION
I learned that:
* We only need 1 Boto session for the lifetime of long-running stuff
* The session will cache authorization credentials
* It is possible for these cached credentials to expire depending on the AWS authorization setup

So in this PR we:
* Lazily get our own "frozen credentials" snapshot to re-use when creating a client.
* Cache these credentials for use with creating new clients.
  (Apparently creating a Client is a relatively lightweight operation. Creating a new Session is the heavyweight aspect)
* Invalidate the cached frozen credentials and retry when we detect these credentials have expired.

If this approach is successful in boosting performance we should replicate this across Reader and Expiration.

Tested locally on santa's workshop

This has potential to take upwards of 30s off some requests in the load testing.