### PR TITLE
Add memory stats to ADDED and REPLACED messages

### DIFF
--- a/neuro_san/internals/chat/data_driven_chat_session.py
+++ b/neuro_san/internals/chat/data_driven_chat_session.py
@@ -22,7 +22,8 @@ from typing import Tuple
 from typing import Type
 from typing import Union
 
-import copy
+from copy import deepcopy
+from os import environ
 import traceback
 
 from logging import getLogger
@@ -74,9 +75,14 @@ class DataDrivenChatSession(RunTarget, LingeringResource):
 
         :param agent_network: The AgentNetwork to use.
         """
+        agent_network_copy: AgentNetwork = agent_network
+
         # We make a copy of the AgentNetwork at this level to allow for interactions
         # within this scope to modify the network topology.
-        agent_network_copy: AgentNetwork = copy.deepcopy(agent_network)
+        protect_original_copy: bool = environ.get("AGENT_PROTECT_ORIGINAL_COPY", "true").lower() == "true"
+        if protect_original_copy:
+            agent_network_copy = deepcopy(agent_network)
+
         self.registry: AgentToolRegistry = AgentToolRegistry(agent_network_copy)
 
         self.front_man: FrontMan = None
@@ -122,7 +128,7 @@ class DataDrivenChatSession(RunTarget, LingeringResource):
         if self.sly_data.get("request_metadata") is None:
             # Make a deep copy so the server's idea of the original metadata doesn't get modified
             # should any CodedTool somehow get the idea to modify it.
-            self.sly_data["request_metadata"] = copy.deepcopy(invocation_context.get_metadata())
+            self.sly_data["request_metadata"] = deepcopy(invocation_context.get_metadata())
 
         run_context: RunContext = RunContextFactory.create_run_context(None, None,
                                                                        invocation_context=invocation_context,

--- a/neuro_san/internals/graph/registry/agent_network.py
+++ b/neuro_san/internals/graph/registry/agent_network.py
@@ -18,6 +18,8 @@ from typing import Any
 from typing import Dict
 from typing import List
 
+from objsize import get_deep_size
+
 from leaf_common.parsers.dictionary_extractor import DictionaryExtractor
 
 from neuro_san.internals.run_context.interfaces.agent_network_inspector import \
@@ -51,6 +53,8 @@ class AgentNetwork(AgentNetworkInspector):
         if agent_specs is not None:
             for agent_spec in agent_specs:
                 self.register(agent_spec)
+
+        self.size_in_bytes: int = get_deep_size(self, "bytes")
 
     def get_config(self) -> Dict[str, Any]:
         """
@@ -179,3 +183,9 @@ However, the front man must not be:
         if timeout is None:
             return 0.0
         return float(timeout)
+
+    def get_size_in_bytes(self) -> int:
+        """
+        :return: The size in bytes of this AgentNetwork
+        """
+        return self.size_in_bytes

--- a/neuro_san/internals/graph/registry/agent_tool_registry.py
+++ b/neuro_san/internals/graph/registry/agent_tool_registry.py
@@ -117,3 +117,9 @@ class AgentToolRegistry(AgentNetworkInspector, AgentToolFactory):
         :return: The absolute path of agent llm info file for llm extension.
         """
         return self.agent_network.get_agent_llm_info_file()
+
+    def get_size_in_bytes(self) -> int:
+        """
+        :return: The size in bytes of this AgentNetwork
+        """
+        return self.agent_network.get_size_in_bytes()

--- a/neuro_san/internals/network_providers/agent_network_storage.py
+++ b/neuro_san/internals/network_providers/agent_network_storage.py
@@ -66,15 +66,19 @@ class AgentNetworkStorage(AgentStorageSource):
             is_new = self.agents_table.get(agent_name) is None
             self.agents_table[agent_name] = agent_network
 
+        agent_size_in_bytes: int = agent_network.get_size_in_bytes()
+
         # Notify listeners about this state change:
         # do it outside of internal lock
         for listener in self.listeners:
             if is_new:
                 listener.agent_added(agent_name, self)
-                self.logger.info("ADDED network for agent %s : %d", agent_name, id(agent_network))
+                self.logger.info("ADDED network for agent %s (%d bytes): %d",
+                                 agent_name, agent_size_in_bytes, id(agent_network))
             else:
                 listener.agent_modified(agent_name, self)
-                self.logger.info("REPLACED network for agent %s : %d", agent_name, id(agent_network))
+                self.logger.info("REPLACED network for agent %s (%d bytes): %d",
+                                 agent_name, agent_size_in_bytes, id(agent_network))
 
     def setup_agent_networks(self, agent_networks: Dict[str, AgentNetwork]):
         """

--- a/neuro_san/internals/network_providers/expiring_agent_network_storage.py
+++ b/neuro_san/internals/network_providers/expiring_agent_network_storage.py
@@ -286,6 +286,7 @@ class ExpiringAgentNetworkStorage(AbstractReservationsStorage, AgentNetworkStora
 
                 # Our agent network no longer exists.
                 return None
+
             # Reservation is still valid, so we can return the AgentNetworkProvider for this agent.
             agent_network: AgentNetwork = self.agents_table.get(agent_name, None)
             if agent_network is not None:
@@ -293,11 +294,13 @@ class ExpiringAgentNetworkStorage(AbstractReservationsStorage, AgentNetworkStora
                     self.access_times[agent_name] = time.time()
                 return FixedAgentNetworkProvider(agent_network)
             return None
+
         # We don't have a reservation for this agent,
         # so check the source storage if we have one:
         if self.base_storage is not None:
             reservation, agent_network = self.base_storage.get_one_reservation(agent_name)
             if reservation is not None and not self.is_expired(reservation):
+                agent_size_in_bytes: int = agent_network.get_size_in_bytes()
                 # We have a valid reservation for this agent in the source storage,
                 # so return the AgentNetworkProvider for this agent.
                 # Also cache this reservation and agent network locally:
@@ -306,8 +309,7 @@ class ExpiringAgentNetworkStorage(AbstractReservationsStorage, AgentNetworkStora
                     self.reservations_table[agent_name] = reservation
                     self.agents_table[agent_name] = agent_network
                     self.access_times[agent_name] = now
-
-                agent_size_in_bytes: int = agent_network.get_size_in_bytes()
+                    self.sizes[agent_name] = agent_size_in_bytes
 
                 # Notify listeners about this state change:
                 # do it outside of internal lock

--- a/neuro_san/internals/network_providers/expiring_agent_network_storage.py
+++ b/neuro_san/internals/network_providers/expiring_agent_network_storage.py
@@ -54,6 +54,7 @@ class ExpiringAgentNetworkStorage(AbstractReservationsStorage, AgentNetworkStora
         self.reservations_table: Dict[str, Reservation] = {}
         # Table maps agent name to the latest time it was accessed:
         self.access_times: Dict[str, float] = {}
+        self.sizes: Dict[str, int] = {}
 
         # Maximum number of items to keep in storage. 0 or negative means unlimited.
         self.max_items: int = 0
@@ -158,23 +159,24 @@ class ExpiringAgentNetworkStorage(AbstractReservationsStorage, AgentNetworkStora
                 self.agents_table[agent_name] = agent_network
                 self.reservations_table[agent_name] = reservation
                 self.access_times[agent_name] = now
+                self.sizes[agent_name] = agent_network.get_size_in_bytes()
 
                 if is_new:
                     added.append(agent_name)
                 else:
                     replaced.append(agent_name)
 
-        agent_size_in_bytes: int = agent_network.get_size_in_bytes()
-
         # Notify listeners about this state change:
         # do it outside of internal lock
         for listener in self.listeners:
             for agent_name in added:
                 listener.agent_added(agent_name, self)
+                agent_size_in_bytes: int = self.sizes.get(agent_name, 0)
                 self.logger.info("%s: ADDED network for agent %s (%d bytes) from %s",
                                  self._name, agent_name, agent_size_in_bytes, source)
             for agent_name in replaced:
                 listener.agent_modified(agent_name, self)
+                agent_size_in_bytes: int = self.sizes.get(agent_name, 0)
                 self.logger.info("%s: REPLACED network for agent %s (%d bytes) from %s",
                                  self._name, agent_name, agent_size_in_bytes, source)
 
@@ -233,6 +235,7 @@ class ExpiringAgentNetworkStorage(AbstractReservationsStorage, AgentNetworkStora
         self.reservations_table.pop(agent_name, None)
         self.agents_table.pop(agent_name, None)
         self.access_times.pop(agent_name, None)
+        self.sizes.pop(agent_name, None)
 
     def evict_lru_agent_networks(self):
         """

--- a/neuro_san/internals/network_providers/expiring_agent_network_storage.py
+++ b/neuro_san/internals/network_providers/expiring_agent_network_storage.py
@@ -164,15 +164,19 @@ class ExpiringAgentNetworkStorage(AbstractReservationsStorage, AgentNetworkStora
                 else:
                     replaced.append(agent_name)
 
+        agent_size_in_bytes: int = agent_network.get_size_in_bytes()
+
         # Notify listeners about this state change:
         # do it outside of internal lock
         for listener in self.listeners:
             for agent_name in added:
                 listener.agent_added(agent_name, self)
-                self.logger.info("%s: ADDED network for agent %s from %s", self._name, agent_name, source)
+                self.logger.info("%s: ADDED network for agent %s (%d bytes) from %s",
+                                 self._name, agent_name, agent_size_in_bytes, source)
             for agent_name in replaced:
                 listener.agent_modified(agent_name, self)
-                self.logger.info("%s: REPLACED network for agent %s from %s", self._name, agent_name, source)
+                self.logger.info("%s: REPLACED network for agent %s (%d bytes) from %s",
+                                 self._name, agent_name, agent_size_in_bytes, source)
 
         # Evict least recently used items if we exceeded the limit
         self.evict_lru_agent_networks()
@@ -299,11 +303,15 @@ class ExpiringAgentNetworkStorage(AbstractReservationsStorage, AgentNetworkStora
                     self.reservations_table[agent_name] = reservation
                     self.agents_table[agent_name] = agent_network
                     self.access_times[agent_name] = now
+
+                agent_size_in_bytes: int = agent_network.get_size_in_bytes()
+
                 # Notify listeners about this state change:
                 # do it outside of internal lock
                 for listener in self.listeners:
                     listener.agent_added(agent_name, self)
-                    self.logger.info("ADDED network for agent %s from %s", agent_name, "base storage")
+                    self.logger.info("ADDED network for agent %s (%d bytes) from %s",
+                                     agent_name, agent_size_in_bytes, "base storage")
 
                 # Evict least recently used items if we exceeded the limit
                 self.evict_lru_agent_networks()

--- a/neuro_san/internals/run_context/interfaces/agent_network_inspector.py
+++ b/neuro_san/internals/run_context/interfaces/agent_network_inspector.py
@@ -52,3 +52,9 @@ class AgentNetworkInspector:
                  an exception will be raised.
         """
         raise NotImplementedError
+
+    def get_size_in_bytes(self) -> int:
+        """
+        :return: The size in bytes of this AgentNetwork
+        """
+        raise NotImplementedError

--- a/requirements.txt
+++ b/requirements.txt
@@ -77,6 +77,9 @@ json-repair>=0.47.3,<1.0
 # For cron-string parsing
 croniter>=6.2.2
 
+# Memory size estimation
+objsize>=0.8.0
+
 # MCP tools
 # These two pins are coupled: langchain-mcp-adapters depends on the mcp package,
 # so changes in either can affect us. Keep the rationales in sync.


### PR DESCRIPTION
* Add memory stats to ADDED and REPLACED messages in network_provider areas
* Add an env switch to experiment with turning off copying of networks for each request.
   AGENT_PROTECT_ORIGINAL_COPY is the env var and it has a default value of "true".

FWIW: A typical santa's workshop from AND is about 100kB per the new stats.