### PR TITLE
Remove token cost fallback tables and put deprecated warning for langchain tool from langchain-community

### DIFF
--- a/docs/agent_hocon_reference.md
+++ b/docs/agent_hocon_reference.md
@@ -173,6 +173,11 @@ The `llm_info_file` key allows you to specify a custom HOCON file that extends t
 by agents in a neuro-san network. This is especially useful if you're using models or providers that are not included in
 the default configuration (e.g., newly released models or organization-specific endpoints).
 
+This file is also the only source of model prices for token-cost reporting: set
+[price_per_1k_input_tokens](./llm_info_hocon_reference.md#price_per_1k_input_tokens) and
+[price_per_1k_output_tokens](./llm_info_hocon_reference.md#price_per_1k_output_tokens) for your models,
+otherwise their reported cost defaults to 0 and a warning is logged.
+
 For more information on selecting and customizing models, see the [model_name](#model_name) and [class](#class) section below.
 
 ### toolbox_info_file

--- a/docs/llm_info_hocon_reference.md
+++ b/docs/llm_info_hocon_reference.md
@@ -171,7 +171,9 @@ the price fields in the default file for the relevant URL). Providers change pri
 periodically, so this number should be treated as a snapshot at the time the entry was
 authored.
 
-This key is optional. If present, neuro-san will use it for token-cost estimation in the token callback handler.
+This key is optional, but the prices in the LLM info file are the only source used for token-cost
+estimation in the token callback handler. If no price information is found for a model, the
+reported cost defaults to 0 and a warning is logged.
 If a model has tiered or context-dependent pricing, the value here should be the standard published rate.
 
 #### `price_per_1k_output_tokens`
@@ -182,8 +184,9 @@ from the model. Output tokens are the tokens the model produces in its response.
 For most providers, output tokens are billed at a higher rate than input tokens.
 
 This key is optional and follows the same caveats as
-[`price_per_1k_input_tokens`](#price_per_1k_input_tokens). If present, neuro-san will use it
-for token-cost estimation in the token callback handler.
+[`price_per_1k_input_tokens`](#price_per_1k_input_tokens): prices in the LLM info file are the
+only source used for token-cost estimation, and a model without price information reports a
+cost of 0 with a logged warning.
 
 #### `model_launch_date`
 

--- a/docs/toolbox_info_hocon_reference.md
+++ b/docs/toolbox_info_hocon_reference.md
@@ -63,6 +63,13 @@ The value for each key is a dictionary describing the tool's properties. The sch
 
 These tools extend from the Langchain's `BaseTool` class.
 
+> [!WARNING]
+> The [langchain-community](https://github.com/langchain-ai/langchain-community/issues/674) package has been sunset
+> and its repository archived. The default request tools in `toolbox_info.hocon`, which are built on
+> `langchain_community` classes (as in the examples below), will be removed in a future release.
+> Prefer tools from maintained, dedicated integration packages — see the
+> [LangChain tool integrations](https://docs.langchain.com/oss/python/integrations/tools) for what is available.
+
 #### `class`
 
 Fully qualified class name of the tool. It must exist in the server's `PYTHONPATH`.

--- a/neuro_san/internals/run_context/langchain/token_counting/llm_token_callback_handler.py
+++ b/neuro_san/internals/run_context/langchain/token_counting/llm_token_callback_handler.py
@@ -20,15 +20,9 @@ import logging
 from time import time
 from typing import Any
 from typing import Dict
-from typing import List
-from typing import Literal
 from typing import Optional
 from typing_extensions import override
 
-from langchain_community.callbacks.bedrock_anthropic_callback import MODEL_COST_PER_1K_INPUT_TOKENS
-from langchain_community.callbacks.bedrock_anthropic_callback import MODEL_COST_PER_1K_OUTPUT_TOKENS
-from langchain_community.callbacks.openai_info import get_openai_token_cost_for_model
-from langchain_community.callbacks.openai_info import TokenType
 from langchain_core.callbacks import AsyncCallbackHandler
 from langchain_core.messages import AIMessage
 from langchain_core.messages import BaseMessage
@@ -54,11 +48,10 @@ class LlmTokenCallbackHandler(AsyncCallbackHandler):
     """
     Callback handler that tracks token usage via "AIMessage.usage_metadata".
 
-    This class is a modification of LangChain’s "UsageMetadataCallbackHandler" and "OpenAICallbackHandler":
-    - https://python.langchain.com/api_reference/_modules/langchain_core/callbacks/usage.html
-    #get_usage_metadata_callback
-    - https://python.langchain.com/api_reference/_modules/langchain_community/callbacks/openai_info.html
-    #OpenAICallbackHandler
+    This class is a modification of LangChain’s:
+    - "UsageMetadataCallbackHandler" in langchain_core.callbacks.usage
+    - "OpenAICallbackHandler" in langchain_community.callbacks.openai_info, from the sunset
+      langchain-community package (repository archived at https://github.com/langchain-ai/langchain-community)
 
     It collects token usage from the "usage_metadata" field of "AIMessage" each time an LLM or chat model
     finishes execution.
@@ -71,11 +64,9 @@ class LlmTokenCallbackHandler(AsyncCallbackHandler):
     regardless of provider.
 
     Note:
-    Token cost is calculated using prices from the LLM info file when available.
-    For OpenAI, Azure OpenAI, Anthropic, and Bedrock Anthropic, there are  fallbacks to lookup tables in:
-        - langchain_community.callbacks.openai_info.py
-        - langchain_community.callbacks.bedrock_anthropic_callback.py
-    If no price information is found, the cost defaults to 0.
+    Token cost is calculated using prices from the LLM info file
+    ("price_per_1k_input_tokens" / "price_per_1k_output_tokens") when available.
+    If no price information is found, the cost defaults to 0 and a warning is logged.
     """
 
     # Token stats
@@ -210,30 +201,19 @@ class LlmTokenCallbackHandler(AsyncCallbackHandler):
 
     def calculate_token_costs(self, model_name: str, completion_tokens: int, prompt_tokens: int) -> float:
         """
-        Calculate token costs with fallback methods for different providers.
+        Calculate token costs from prices in the LLM info file.
         :param model_name: Model to calculate the cost
         :param completion_tokens: Number of output tokens
         :param prompt_tokens: Number of input tokens
         :return: Total cost
         """
-
-        # Try to get costs from llm_infos first
-        completion_token_cost: float = \
+        completion_token_cost: Optional[float] = \
             self._get_cost_from_info(model_name, completion_tokens, "price_per_1k_output_tokens")
-        prompt_token_cost: float = self._get_cost_from_info(model_name, prompt_tokens, "price_per_1k_input_tokens")
+        prompt_token_cost: Optional[float] = \
+            self._get_cost_from_info(model_name, prompt_tokens, "price_per_1k_input_tokens")
 
-        # Fallback to provider-specific methods for anthropic and openai based models
-        # Since there are lookup tables for these models in langchain-community
-        if self.provider_class in ["azure-openai", "openai"]:
-            completion_token_cost = completion_token_cost or \
-                self._get_openai_cost(model_name, completion_tokens, token_type=TokenType.COMPLETION)
-            prompt_token_cost = prompt_token_cost or \
-                self._get_openai_cost(model_name, prompt_tokens, token_type=TokenType.PROMPT)
-
-        elif self.provider_class in ["anthropic", "bedrock"]:
-            completion_token_cost = completion_token_cost or \
-                self._get_anthropic_cost(model_name, completion_tokens, "completion")
-            prompt_token_cost = prompt_token_cost or self._get_anthropic_cost(model_name, prompt_tokens, "prompt")
+        if completion_token_cost is None and prompt_token_cost is None:
+            logging.warning("No price info found for model %s in llm info. Token cost defaults to 0.", model_name)
 
         # Return total cost
         return (completion_token_cost or 0.0) + (prompt_token_cost or 0.0)
@@ -251,32 +231,6 @@ class LlmTokenCallbackHandler(AsyncCallbackHandler):
 
         price = self.llm_infos.get(model_name).get(price_key)
         return (num_tokens / 1000) * price if price is not None else None
-
-    def _get_openai_cost(self, model_name: str, num_tokens: int, token_type: TokenType) -> Optional[float]:
-        """
-        Get OpenAI cost with error handling.
-        :param model_name: Anthorpic model to calculate the cost
-        :param num_tokens: Amount of tokens
-        :param token_type: Type of token, either "prompt" (input) or "completion" (output)
-        :return: Token cost
-        """
-        try:
-            return get_openai_token_cost_for_model(model_name=model_name, num_tokens=num_tokens, token_type=token_type)
-        except ValueError:
-            return None
-
-    def _get_anthropic_cost(self, model_name: str, num_tokens: int, token_type: str) -> Optional[float]:
-        """
-        Get Anthropic/Bedrock cost with error handling.
-        :param model_name: Anthorpic model to calculate the cost
-        :param num_tokens: Amount of tokens
-        :param token_type: Type of token, either "prompt" (input) or "completion" (output)
-        :return: Token cost
-        """
-        try:
-            return self._get_anthropic_bedrock_token_cost(model_name, num_tokens, token_type)
-        except ValueError:
-            return None
 
     def _init_model_entry(self, model_name: str):
         """
@@ -326,61 +280,3 @@ class LlmTokenCallbackHandler(AsyncCallbackHandler):
         else:
             has_content = bool(content)
         return not has_content and not getattr(message, "tool_calls", None)
-
-    def _get_anthropic_bedrock_token_cost(
-            self,
-            model_name: str,
-            num_tokens: int,
-            token_type: Literal["completion", "prompt"] = "prompt"
-    ) -> float:
-        """
-        Calculate token cost for Anthropic/Bedrock models from the lookup table with unified logic.
-        :param model_name: Anthorpic model to calculate the cost
-        :param num_tokens: Amount of tokens
-        :param token_type: Type of token, either "prompt" (input) or "completion" (output)
-        :return: Token cost
-        """
-
-        # Normalize model name for lookup
-        normalized_model: str = self._normalize_model_name(model_name)
-
-        # Find matching model in cost tables
-        # matching_models = [model for model in MODEL_COST_PER_1K_INPUT_TOKENS if normalized_model in model]
-        matching_models: List[str] = []
-        for model in MODEL_COST_PER_1K_INPUT_TOKENS:
-            if normalized_model in model:
-                matching_models.append(model)
-
-        if not matching_models:
-            error_msg = f"Unknown model: {model_name}. Known models: {', '.join(MODEL_COST_PER_1K_INPUT_TOKENS.keys())}"
-            logging.warning(error_msg)
-            raise ValueError(error_msg)
-
-        if len(matching_models) > 1:
-            error_msg = f"Ambiguous model name '{model_name}'. Matches: {', '.join(matching_models)}"
-            logging.warning(error_msg)
-            raise ValueError(error_msg)
-
-        # Calculate cost
-        full_model_id: str = matching_models[0]
-        if token_type == "prompt":
-            cost_table: Dict[str, float] = MODEL_COST_PER_1K_INPUT_TOKENS
-        else:
-            cost_table = MODEL_COST_PER_1K_OUTPUT_TOKENS
-
-        return (num_tokens / 1000) * cost_table[full_model_id]
-
-    def _normalize_model_name(self, model_name: str) -> str:
-        """
-        Normalize model name for consistent lookup across Bedrock and Anthropic formats.
-        :param model_name: Full name or id of Anthropic LLM
-        :return: Name for checking in the lookup table
-        """
-        if "anthropic" in model_name:
-            # For Bedrock: extract base model from cross-region inference profile
-            # e.g., 'us.anthropic.claude-3-sonnet' -> 'anthropic.claude-3-sonnet'
-            parts = model_name.split(".")
-            if len(parts) >= 2:
-                return ".".join(parts[-2:])
-
-        return model_name

--- a/neuro_san/internals/run_context/langchain/toolbox/toolbox_factory.py
+++ b/neuro_san/internals/run_context/langchain/toolbox/toolbox_factory.py
@@ -163,6 +163,9 @@ class ToolboxFactory(ContextTypeToolboxFactory):
             return tool_info
 
         tool_class_name: str = tool_info.get("class")
+        if not isinstance(tool_class_name, str) or not tool_class_name:
+            raise ValueError(f"Value for '{tool_name}.class' must be a non-empty string.")
+
         if tool_class_name.startswith("langchain_community."):
             logging.warning(
                 "Tool '%s' uses a class from langchain-community, which has been sunset "

--- a/neuro_san/internals/run_context/langchain/toolbox/toolbox_factory.py
+++ b/neuro_san/internals/run_context/langchain/toolbox/toolbox_factory.py
@@ -24,10 +24,11 @@ from typing import Optional
 from typing import Type
 from typing import Union
 
+import logging
 import os
 
 from langchain_core.tools.base import BaseTool
-from langchain_community.agent_toolkits.base import BaseToolkit
+from langchain_core.tools.base import BaseToolkit
 from pydantic import BaseModel
 
 from leaf_common.config.dictionary_overlay import DictionaryOverlay
@@ -152,8 +153,8 @@ class ToolboxFactory(ContextTypeToolboxFactory):
                 "Missing required key: 'class'.\n"
                 "Each tool must include a 'class' key:\n"
                 "- For Langchain base tools: use the full class path "
-                "(e.g., 'langchain_community.tools.bing_search.BingSearchResults')\n"
-                "- For shared CodedTools: use 'module.Class' format (e.g., 'websearch.WebSearch')"
+                "(e.g., 'some_package.some_module.SomeTool')\n"
+                "- For shared CodedTools: use 'module.Class' format (e.g., 'some_module.SomeCodedTool')"
             )
 
         # If "description" in the tool info, then it is a shared coded tool.
@@ -161,8 +162,18 @@ class ToolboxFactory(ContextTypeToolboxFactory):
         if "description" in tool_info:
             return tool_info
 
+        tool_class_name: str = tool_info.get("class")
+        if tool_class_name.startswith("langchain_community."):
+            logging.warning(
+                "Tool '%s' uses a class from langchain-community, which has been sunset "
+                "(https://github.com/langchain-ai/langchain-community/issues/674). "
+                "Tools based on langchain-community will be removed from the default toolbox "
+                "in a future release.",
+                tool_name
+            )
+
         # Instantiate the main tool or toolkit class
-        tool_class: Type[Any] = self._resolve_class(tool_info.get("class"))
+        tool_class: Type[Any] = self._resolve_class(tool_class_name)
         # Recursively resolve arguments (including wrapper dependencies)
         resolved_args: Dict[str, Any] = self._resolve_args(tool_info.get("args", empty))
         # Merge with user arguments where user_args get the priority

--- a/neuro_san/internals/run_context/langchain/toolbox/toolbox_info.hocon
+++ b/neuro_san/internals/run_context/langchain/toolbox/toolbox_info.hocon
@@ -23,7 +23,7 @@
     # Overview:
     # - This file defines configurations for langchain's tools and toolkits as well as shared coded tools.
     # - More details about LangChain tools and toolkits can be found at:
-    #   https://python.langchain.com/docs/integrations/tools/
+    #   https://docs.langchain.com/oss/python/integrations/tools
     # - See https://github.com/cognizant-ai-lab/neuro-san/blob/main/docs/agent_hocon_reference.md for more informations on coded tools.
     #
     # Customization via Agent HOCON File:
@@ -37,7 +37,16 @@
     # - The specified class must be available in the server's PYTHONPATH.
     # - Additional dependencies (outside of langchain_community) must be installed separately.
 
-    # NOTE on Request tools and toolkit: 
+    # DEPRECATION WARNING:
+    # The langchain-community package has been sunset and its repository archived
+    # (https://github.com/langchain-ai/langchain-community/issues/674).
+    # The request tools and toolkit below are built on langchain_community classes and will be
+    # removed from this default toolbox in a future release.
+    # Tools from maintained, dedicated integration packages can be configured here instead;
+    # browse the available integrations at:
+    #   https://docs.langchain.com/oss/python/integrations/tools
+
+    # NOTE on Request tools and toolkit:
     # There are inherent risks in giving models discretion to execute real-world actions.
     # Users must "opt-in" to these risks by setting allow_dangerous_request=True to use these tools.
 

--- a/tests/neuro_san/internals/run_context/langchain/token_counting/test_llm_token_callback_handler.py
+++ b/tests/neuro_san/internals/run_context/langchain/token_counting/test_llm_token_callback_handler.py
@@ -16,10 +16,8 @@
 # END COPYRIGHT
 
 from time import time
-from unittest.mock import patch
 from typing import Dict
 
-from langchain_community.callbacks.openai_info import TokenType
 from langchain_core.messages import AIMessage
 from langchain_core.outputs import ChatGeneration
 from langchain_core.outputs import LLMResult
@@ -72,68 +70,13 @@ class TestLlmTokenCallbackHandler:
         }
         handler.provider_class = "custom"
 
-        with patch.object(handler, '_get_openai_cost', return_value=None), \
-             patch.object(handler, '_get_anthropic_cost', return_value=None):
+        cost = handler.calculate_token_costs("partial-model", 1000, 1000)
 
-            cost = handler.calculate_token_costs("partial-model", 1000, 1000)
+        # Expected: (1000/1000 * 0.002) + 0.0 = 0.002
+        assert cost == 0.002
 
-            # Expected: (1000/1000 * 0.002) + 0.0 = 0.002
-            assert cost == 0.002
-
-    def test_calculate_token_costs_openai_fallback(self, handler_with_empty_infos):
-        """Test fallback to OpenAI cost calculation."""
-        handler = handler_with_empty_infos
-        handler.provider_class = "openai"
-
-        with patch.object(handler, '_get_openai_cost', side_effect=[0.025, 0.015]) as mock_openai_cost:
-            cost = handler.calculate_token_costs("gpt-3.5-turbo", 1000, 2000)
-
-            # Should call OpenAI cost calculation twice
-            assert mock_openai_cost.call_count == 2
-            mock_openai_cost.assert_any_call("gpt-3.5-turbo", 1000, token_type=TokenType.COMPLETION)
-            mock_openai_cost.assert_any_call("gpt-3.5-turbo", 2000, token_type=TokenType.PROMPT)
-
-            # Expected: 0.025 + 0.015 = 0.04
-            assert cost == 0.04
-
-    def test_calculate_token_costs_azure_openai_fallback(self, handler_with_empty_infos):
-        """Test fallback to Azure OpenAI cost calculation."""
-        handler = handler_with_empty_infos
-        handler.provider_class = "azure-openai"
-
-        with patch.object(handler, '_get_openai_cost', side_effect=[0.020, 0.010]) as mock_openai_cost:
-            cost = handler.calculate_token_costs("gpt-4", 500, 1500)
-
-            assert mock_openai_cost.call_count == 2
-            assert cost == 0.03
-
-    def test_calculate_token_costs_anthropic_fallback(self, handler_with_empty_infos):
-        """Test fallback to Anthropic cost calculation."""
-        handler = handler_with_empty_infos
-        handler.provider_class = "anthropic"
-
-        with patch.object(handler, '_get_anthropic_cost', side_effect=[0.030, 0.006]) as mock_anthropic_cost:
-            cost = handler.calculate_token_costs("claude-3-opus", 1000, 2000)
-
-            assert mock_anthropic_cost.call_count == 2
-            mock_anthropic_cost.assert_any_call("claude-3-opus", 1000, "completion")
-            mock_anthropic_cost.assert_any_call("claude-3-opus", 2000, "prompt")
-
-            assert cost == 0.036
-
-    def test_calculate_token_costs_bedrock_fallback(self, handler_with_empty_infos):
-        """Test fallback to Bedrock cost calculation."""
-        handler = handler_with_empty_infos
-        handler.provider_class = "bedrock"
-
-        with patch.object(handler, '_get_anthropic_cost', side_effect=[0.045, 0.009]) as mock_anthropic_cost:
-            cost = handler.calculate_token_costs("anthropic.claude-3-sonnet", 1500, 3000)
-
-            assert mock_anthropic_cost.call_count == 2
-            assert cost == 0.054
-
-    def test_calculate_token_costs_no_fallback_available(self, handler_with_empty_infos):
-        """Test when no cost information is available anywhere."""
+    def test_calculate_token_costs_no_info_available(self, handler_with_empty_infos):
+        """Test when no cost information is available."""
         handler = handler_with_empty_infos
         handler.provider_class = "custom-provider"
 
@@ -141,33 +84,6 @@ class TestLlmTokenCallbackHandler:
 
         # Should return 0.0 when no cost information is available
         assert cost == 0.0
-
-    def test_calculate_token_costs_fallback_returns_none(self, handler_with_empty_infos):
-        """Test when fallback methods return None."""
-        handler = handler_with_empty_infos
-        handler.provider_class = "openai"
-
-        with patch.object(handler, '_get_openai_cost', return_value=None):
-            cost = handler.calculate_token_costs("unknown-openai-model", 1000, 2000)
-
-            assert cost == 0.0
-
-    def test_calculate_token_costs_mixed_sources(self, handler_with_empty_infos):
-        """Test when costs come from different sources (llm_infos and fallback)."""
-        handler = handler_with_empty_infos
-        handler.llm_infos = {
-            "mixed-model": {
-                "price_per_1k_input_tokens": 0.005
-                # Missing output token pricing
-            }
-        }
-        handler.provider_class = "openai"
-
-        with patch.object(handler, '_get_openai_cost', side_effect=[0.020, None]):
-            cost = handler.calculate_token_costs("mixed-model", 1000, 2000)
-
-            # Expected: (1000/1000 * 0.020) + (2000/1000 * 0.005) = 0.020 + 0.010 = 0.030
-            assert cost == 0.030
 
     def test_calculate_token_costs_zero_tokens(self, handler_with_model_infos):
         """Test with zero tokens."""
@@ -177,21 +93,6 @@ class TestLlmTokenCallbackHandler:
         cost = handler.calculate_token_costs("gpt-4", 0, 0)
 
         assert cost == 0.0
-
-    def test_calculate_token_costs_llm_infos_priority(self, handler_with_model_infos):
-        """Test that llm_infos takes priority over fallback methods."""
-        handler = handler_with_model_infos
-        handler.provider_class = "openai"
-
-        # Mock the fallback to return different values
-        with patch.object(handler, '_get_openai_cost', side_effect=[999.0, 999.0]) as mock_openai_cost:
-            cost = handler.calculate_token_costs("gpt-4", 1000, 1000)
-
-            # Should not call the fallback since llm_infos has the info
-            mock_openai_cost.assert_not_called()
-
-            # Should use llm_infos values: (1000/1000 * 0.03) + (1000/1000 * 0.01) = 0.04
-            assert cost == 0.04
 
     @pytest.mark.parametrize("completion_tokens,prompt_tokens,expected_cost", [
         (100, 200, 0.005),      # Small numbers

--- a/tests/neuro_san/internals/run_context/langchain/token_counting/test_llm_token_callback_handler.py
+++ b/tests/neuro_san/internals/run_context/langchain/token_counting/test_llm_token_callback_handler.py
@@ -15,6 +15,8 @@
 #
 # END COPYRIGHT
 
+import logging
+
 from time import time
 from typing import Dict
 
@@ -75,15 +77,22 @@ class TestLlmTokenCallbackHandler:
         # Expected: (1000/1000 * 0.002) + 0.0 = 0.002
         assert cost == 0.002
 
-    def test_calculate_token_costs_no_info_available(self, handler_with_empty_infos):
+    def test_calculate_token_costs_no_info_available(self, handler_with_empty_infos, caplog):
         """Test when no cost information is available."""
         handler = handler_with_empty_infos
         handler.provider_class = "custom-provider"
 
-        cost = handler.calculate_token_costs("unknown-model", 1000, 2000)
+        with caplog.at_level(logging.WARNING):
+            cost = handler.calculate_token_costs("unknown-model", 1000, 2000)
 
         # Should return 0.0 when no cost information is available
         assert cost == 0.0
+
+        # Should log a warning that no price info was found for the model
+        assert any(
+            record.levelno == logging.WARNING and "No price info found for model unknown-model" in record.getMessage()
+            for record in caplog.records
+        )
 
     def test_calculate_token_costs_zero_tokens(self, handler_with_model_infos):
         """Test with zero tokens."""

--- a/tests/neuro_san/internals/run_context/langchain/toolbox/test_toolbox_factory.py
+++ b/tests/neuro_san/internals/run_context/langchain/toolbox/test_toolbox_factory.py
@@ -19,8 +19,8 @@ from unittest.mock import patch, MagicMock
 
 import pytest
 
-from langchain_community.agent_toolkits.base import BaseToolkit
 from langchain_core.tools.base import BaseTool
+from langchain_core.tools.base import BaseToolkit
 
 from neuro_san.internals.run_context.langchain.toolbox.toolbox_factory import ToolboxFactory
 

--- a/tests/neuro_san/internals/run_context/langchain/toolbox/test_toolbox_factory.py
+++ b/tests/neuro_san/internals/run_context/langchain/toolbox/test_toolbox_factory.py
@@ -78,6 +78,18 @@ class TestToolboxFactory:
             # Ensure the returned tool is an instance of the mocked class
             assert tool is mock_instance
 
+    @pytest.mark.parametrize("bad_class", [None, 123, ""])
+    def test_create_toolbox_with_invalid_class_value(self, factory, bad_class):
+        """Test that a non-string or empty 'class' value raises a clear ValueError."""
+        factory.toolbox_infos = {
+            "bad_tool": {
+                "class": bad_class
+            }
+        }
+
+        with pytest.raises(ValueError, match="must be a non-empty string"):
+            factory.create_tool_from_toolbox("bad_tool", {})
+
     def test_create_toolbox_with_toolkit_constructor(self, factory):
         """Test the toolkit instantiates with constructor."""
         factory.toolbox_infos = {


### PR DESCRIPTION
langchain-community has been sunset and its repository archived (https://github.com/langchain-ai/langchain-community/issues/674), with no successor packages for the pieces neuro-san relied on.

- LlmTokenCallbackHandler: remove the langchain_community token cost-table fallbacks (frozen upstream and already missing newer models). Prices in the LLM info hocon ("price_per_1k_input_tokens" / "price_per_1k_output_tokens") are now the only source; when a model has no price info the cost defaults to 0 and a warning is logged.
- ToolboxFactory: import BaseToolkit from langchain_core.tools.base instead of the langchain_community re-export; make the missing-'class' error message examples package-agnostic.
- Toolbox: keep the requests tools for now, but log a runtime deprecation warning when a tool resolves a langchain_community class, and note in toolbox_info.hocon and docs/toolbox_info_hocon_reference.md that these tools will be removed in a future release, linking the maintained integrations index (https://docs.langchain.com/oss/python/integrations/tools).
- Update unit tests accordingly.

The langchain-community requirement stays until the requests tools are removed or replaced.

Fix #1135 