### PR TITLE
Neuro-san probes running on a separate thread/event loop.

### DIFF
--- a/neuro_san/deploy/Dockerfile
+++ b/neuro_san/deploy/Dockerfile
@@ -211,6 +211,20 @@ ENV AGENT_FORWARDED_REQUEST_METADATA="request_id user_id"
 # for it on your docker run command line.
 ENV AGENT_HTTP_PORT="8080"
 
+# Dedicated port for the isolated health-probe server. Serves /, /healthz,
+# /readyz, /livez on its own asyncio event loop in a dedicated thread, so
+# probes stay fast even when the main Tornado loop is saturated by request
+# work. Uses SO_REUSEPORT so every worker process binds the same port and
+# the kernel distributes accepted connections across them.
+#
+# Set to 0 to disable the isolated probe server (in that case probes must
+# hit AGENT_HTTP_PORT, which continues to register the same handlers for
+# backward compatibility).
+#
+# Point your Kubernetes livenessProbe.httpGet.port at this port for
+# best-case probe responsiveness under load.
+ENV AGENT_HEALTH_PROBE_PORT="8081"
+
 # Maximm number of requests that can be served at the same time
 # A value of 0 indicates unlimited requests are handled.
 ENV AGENT_MAX_CONCURRENT_REQUESTS="50"

--- a/neuro_san/service/http/config/http_server_config.py
+++ b/neuro_san/service/http/config/http_server_config.py
@@ -17,12 +17,17 @@
 """
 See class comment for details
 """
+# Env var: dedicated port for the isolated health-probe server. 0 disables it,
+# in which case k8s/LB probes must hit the main server port's handlers (which
+# remain registered for backward compatibility).
+ENV_HEALTH_PROBE_PORT: str = "AGENT_HEALTH_PROBE_PORT"
 
 DEFAULT_HTTP_CONNECTIONS_BACKLOG: int = 128
 DEFAULT_HTTP_IDLE_CONNECTIONS_TIMEOUT_SECONDS: int = 3600
 DEFAULT_HTTP_SERVER_INSTANCES: int = 1
 DEFAULT_HTTP_SERVER_MONITOR_INTERVAL_SECONDS: int = 0
 DEFAULT_KEEP_ALIVE_INTERVAL_SECONDS: int = 0
+DEFAULT_HEALTH_PROBE_PORT: int = 8081
 
 
 class HttpServerConfig:
@@ -35,5 +40,6 @@ class HttpServerConfig:
         self.http_idle_connection_timeout_seconds: int = DEFAULT_HTTP_IDLE_CONNECTIONS_TIMEOUT_SECONDS
         self.http_server_instances: int = DEFAULT_HTTP_SERVER_INSTANCES
         self.http_port: int = 80
+        self.http_probe_port: int = DEFAULT_HEALTH_PROBE_PORT
         self.http_server_monitor_interval_seconds: int = DEFAULT_HTTP_SERVER_MONITOR_INTERVAL_SECONDS
         self.stream_keep_alive_with_progress_interval_seconds: int = DEFAULT_KEEP_ALIVE_INTERVAL_SECONDS

--- a/neuro_san/service/http/handlers/health_check_handler.py
+++ b/neuro_san/service/http/handlers/health_check_handler.py
@@ -25,10 +25,6 @@ import http
 import os
 
 from http import HTTPStatus
-from threading import Lock
-
-from importlib.metadata import version as library_version
-from importlib.metadata import PackageNotFoundError
 
 from tornado.web import RequestHandler
 from neuro_san.service.http.logging.http_logger import HttpLogger
@@ -40,18 +36,14 @@ class HealthCheckHandler(RequestHandler):
     Handler class for API endpoint health check.
     """
 
-    # Current service versions are cached in a class variable to avoid repeated lookups.
-    # Note that we cannot do it in the handler initialization
-    # because the handler is created new for each request
-    service_versions: Dict[str, Any] | None = None
-    versions_lock: Lock = Lock()
-
     # pylint: disable=attribute-defined-outside-init
+    # pylint: disable=too-many-positional-arguments,too-many-arguments
     def initialize(self,
                    forwarded_request_metadata: List[str],
                    server_status: ServerStatus,
                    op: str,
-                   logging_config: Dict[str, Any]):
+                   logging_config: Dict[str, Any],
+                   versions: Dict[str, Any]):
         """
         This method is called by Tornado framework to allow
         injecting service-specific data into local handler context.
@@ -62,6 +54,10 @@ class HealthCheckHandler(RequestHandler):
                    "ready" for /readyz query
                    "live" for /livez query
         :param logging_config: logging configuration dictionary
+        :param versions: pre-computed library version dict returned in the
+                   "versions" field of a successful health response. Supplied
+                   from ServerStatus.get_versions() so per-request handlers
+                   do not have to re-resolve importlib metadata on every probe.
         """
         self.logger = HttpLogger(forwarded_request_metadata, logging_config)
         if op == "ready":
@@ -69,6 +65,7 @@ class HealthCheckHandler(RequestHandler):
         else:
             self.status = server_status.is_server_live()
         self.server_name = server_status.get_server_name()
+        self.versions = versions
 
         if os.environ.get("AGENT_ALLOW_CORS_HEADERS") is not None:
             self.set_header("Access-Control-Allow-Origin", "*")
@@ -82,14 +79,10 @@ class HealthCheckHandler(RequestHandler):
 
         try:
             if self.status:
-                if HealthCheckHandler.service_versions is None:
-                    with HealthCheckHandler.versions_lock:
-                        if HealthCheckHandler.service_versions is None:
-                            HealthCheckHandler.service_versions = HealthCheckHandler.determine_versions()
                 result_dict: Dict[str, Any] = {
                     "service": self.server_name,
                     "status": "ok",
-                    "versions": HealthCheckHandler.service_versions
+                    "versions": self.versions,
                 }
                 self.set_header("Content-Type", "application/json")
                 self.write(result_dict)
@@ -124,54 +117,3 @@ class HealthCheckHandler(RequestHandler):
         # No body needed. Just return a 204 No Content
         self.set_status(http.HTTPStatus.NO_CONTENT)
         self.finish()
-
-    @classmethod
-    def determine_versions(cls) -> Dict[str, Any]:
-        """
-        Allow for a list of libraries to report versioning.
-        We have a static list that we always support, but also look at the
-        AGENT_VERSION_LIBS env var (if set) to potentially report more.
-        :return: A dictionary whose keys are libraries and whose values are the
-                 versions installed for those libraries.
-        """
-        versions: Dict[str, Any] = {}
-
-        # Start with a static list of libs we always support
-        versioned_libs: List[str] = ["neuro-san"]
-
-        # Try to incorporate libs from the env var.
-        env_var_libs: str = os.environ.get("AGENT_VERSION_LIBS")
-        if env_var_libs is not None:
-            for env_var_lib in env_var_libs.split(" "):
-                if env_var_lib is None:
-                    # Skip anything with nothing in it
-                    continue
-
-                env_var_lib = env_var_lib.strip()
-                if len(env_var_lib) == 0:
-                    # Skip anything with nothing in it
-                    continue
-
-                if ":" not in env_var_lib:
-                    # Look for the library in the versioning loop below
-                    versioned_libs.append(env_var_lib)
-                    continue
-
-                # We have a version coming in from the env var
-                version: str = env_var_lib.split(":")[1]
-                env_var_lib = env_var_lib.split(":")[0]
-                versions[env_var_lib] = version
-
-        for lib in versioned_libs:
-            # Did we already find a version from the env var?
-            version: str = versions.get(lib)
-            if version is None:
-                try:
-                    # Try getting the pip-installed version from the system
-                    version = str(library_version(lib))
-                except PackageNotFoundError:
-                    # Don't know what to do, so report a shrug.
-                    version = "unknown"
-                versions[lib] = version
-
-        return versions

--- a/neuro_san/service/http/handlers/health_check_handler.py
+++ b/neuro_san/service/http/handlers/health_check_handler.py
@@ -43,7 +43,7 @@ class HealthCheckHandler(RequestHandler):
     # Current service versions are cached in a class variable to avoid repeated lookups.
     # Note that we cannot do it in the handler initialization
     # because the handler is created new for each request
-    service_versions: Dict[str, Any] = None
+    service_versions: Dict[str, Any] | None = None
     versions_lock: Lock = Lock()
 
     # pylint: disable=attribute-defined-outside-init

--- a/neuro_san/service/http/handlers/health_check_handler.py
+++ b/neuro_san/service/http/handlers/health_check_handler.py
@@ -25,6 +25,7 @@ import http
 import os
 
 from http import HTTPStatus
+from threading import Lock
 
 from importlib.metadata import version as library_version
 from importlib.metadata import PackageNotFoundError
@@ -38,6 +39,12 @@ class HealthCheckHandler(RequestHandler):
     """
     Handler class for API endpoint health check.
     """
+
+    # Current service versions are cached in a class variable to avoid repeated lookups.
+    # Note that we cannot do it in the handler initialization
+    # because the handler is created new for each request
+    service_versions: Dict[str, Any] = None
+    versions_lock: Lock = Lock()
 
     # pylint: disable=attribute-defined-outside-init
     def initialize(self,
@@ -75,11 +82,14 @@ class HealthCheckHandler(RequestHandler):
 
         try:
             if self.status:
-                versions: Dict[str, Any] = self.determine_versions()
+                if HealthCheckHandler.service_versions is None:
+                    with HealthCheckHandler.versions_lock:
+                        if HealthCheckHandler.service_versions is None:
+                            HealthCheckHandler.service_versions = HealthCheckHandler.determine_versions()
                 result_dict: Dict[str, Any] = {
                     "service": self.server_name,
                     "status": "ok",
-                    "versions": versions
+                    "versions": HealthCheckHandler.service_versions
                 }
                 self.set_header("Content-Type", "application/json")
                 self.write(result_dict)
@@ -115,7 +125,8 @@ class HealthCheckHandler(RequestHandler):
         self.set_status(http.HTTPStatus.NO_CONTENT)
         self.finish()
 
-    def determine_versions(self) -> Dict[str, Any]:
+    @classmethod
+    def determine_versions(cls) -> Dict[str, Any]:
         """
         Allow for a list of libraries to report versioning.
         We have a static list that we always support, but also look at the

--- a/neuro_san/service/http/server/health_probe_server.py
+++ b/neuro_san/service/http/server/health_probe_server.py
@@ -119,7 +119,6 @@ class HealthProbeServer(Startable):
             daemon=True,
         )
         self._thread.start()
-        self.logger.info("HealthProbeServer started on port %d", self.port)
 
     def stop(self):
         """
@@ -168,6 +167,8 @@ class HealthProbeServer(Startable):
         server.start(1)
 
         self._ioloop = tornado.ioloop.IOLoop.current()
+        # Now we have really started the probe server. The thread will run until process exit.
+        self.logger.info("HealthProbeServer started on port %d", self.port)
         try:
             self._ioloop.start()
         finally:

--- a/neuro_san/service/http/server/health_probe_server.py
+++ b/neuro_san/service/http/server/health_probe_server.py
@@ -155,8 +155,8 @@ class HealthProbeServer(Startable):
         server: tornado.httpserver.HTTPServer = tornado.httpserver.HTTPServer(app)
         try:
             server.bind(self.port, reuse_port=True)
-        except OSError as exc:
-            self.logger.error("HealthProbeServer failed to bind port %d: %s",
+        except (OSError, ValueError, NotImplementedError) as exc:
+            self.logger.error("HealthProbeServer failed to bind port %d (reuse_port=True): %s",
                               self.port, exc)
             asyncio.set_event_loop(None)
             with contextlib.suppress(Exception):

--- a/neuro_san/service/http/server/health_probe_server.py
+++ b/neuro_san/service/http/server/health_probe_server.py
@@ -176,6 +176,9 @@ class HealthProbeServer(Startable):
             # here -- shutdown is best-effort.
             with contextlib.suppress(OSError):
                 server.stop()
+            asyncio.set_event_loop(None)
+            with contextlib.suppress(Exception):
+                loop.close()
 
     def make_probe_app(self) -> tornado.web.Application:
         """

--- a/neuro_san/service/http/server/health_probe_server.py
+++ b/neuro_san/service/http/server/health_probe_server.py
@@ -188,17 +188,22 @@ class HealthProbeServer(Startable):
         responses look identical to the main port's.
         """
         server_status = self.server_context.get_server_status()
+        # get_versions() is cached on ServerStatus; the same dict lands in
+        # every probe response so we do not re-run importlib.metadata per hit.
+        versions: Dict[str, Any] = server_status.get_versions()
         live_data: Dict[str, Any] = {
             "forwarded_request_metadata": self.forwarded_request_metadata,
             "server_status": server_status,
             "op": "live",
             "logging_config": self.logging_config,
+            "versions": versions,
         }
         ready_data: Dict[str, Any] = {
             "forwarded_request_metadata": self.forwarded_request_metadata,
             "server_status": server_status,
             "op": "ready",
             "logging_config": self.logging_config,
+            "versions": versions,
         }
         handlers: List[Any] = [
             ("/", HealthCheckHandler, ready_data),

--- a/neuro_san/service/http/server/health_probe_server.py
+++ b/neuro_san/service/http/server/health_probe_server.py
@@ -159,6 +159,9 @@ class HealthProbeServer(Startable):
         except OSError as exc:
             self.logger.error("HealthProbeServer failed to bind port %d: %s",
                               self.port, exc)
+            asyncio.set_event_loop(None)
+            with contextlib.suppress(Exception):
+                loop.close()
             return
         # start(1) attaches to the current IOLoop without forking (the
         # fork parameter only kicks in for N > 1).

--- a/neuro_san/service/http/server/health_probe_server.py
+++ b/neuro_san/service/http/server/health_probe_server.py
@@ -71,6 +71,7 @@ class HealthProbeServer(Startable):
     registered for backward compatibility.
     """
 
+    # pylint: disable=too-many-instance-attributes
     def __init__(self,
                  port: int,
                  server_context: ServerContext,

--- a/neuro_san/service/http/server/health_probe_server.py
+++ b/neuro_san/service/http/server/health_probe_server.py
@@ -1,0 +1,201 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+"""
+See class comment for details.
+"""
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
+
+import asyncio
+import contextlib
+import logging
+import threading
+
+import tornado.httpserver
+import tornado.ioloop
+import tornado.web
+
+from leaf_common.asyncio.event_loop_factory import EventLoopFactory
+
+from neuro_san.internals.interfaces.startable import Startable
+from neuro_san.service.http.handlers.health_check_handler import HealthCheckHandler
+from neuro_san.service.utils.server_context import ServerContext
+
+
+class HealthProbeServer(Startable):
+    """
+    Runs the /, /healthz, /readyz, /livez health-probe endpoints on a
+    dedicated port, in a dedicated OS thread with its own asyncio event
+    loop. This isolates probe responsiveness from the main Tornado loop
+    that serves streaming_chat and other request traffic -- so probes
+    keep returning quickly even when the main loop is saturated by
+    request work.
+
+    The probe server binds its port with SO_REUSEPORT, so every worker
+    process can bind the same port and the kernel distributes accepted
+    connections across them. This matches the model used for the main
+    server's port (server.bind() + server.start(N)).
+
+    Lifecycle:
+      - The instance is created before Tornado's server.start(N) fork.
+      - Its start() (invoked as a Startable inside each worker, after
+        fork) launches a background thread that:
+          * creates a fresh asyncio event loop for itself,
+          * builds a minimal Tornado Application with only the health
+            handlers,
+          * binds the probe port with reuse_port=True,
+          * runs its IOLoop until process exit.
+      - Because it's post-fork and daemon-threaded, no selector/kqueue
+        state is inherited from the parent and process exit tears it
+        down cleanly.
+
+    Disabling: pass port=0 (or set AGENT_HEALTH_PROBE_PORT=0) to skip
+    starting the separate server. In that case k8s / load-balancer
+    probes must still hit the main port's handlers, which remain
+    registered for backward compatibility.
+    """
+
+    def __init__(self,
+                 port: int,
+                 server_context: ServerContext,
+                 forwarded_request_metadata: List[str],
+                 logging_config: Dict[str, Any]):
+        """
+        :param port: TCP port to bind. 0 disables the probe server.
+        :param server_context: The ServerContext supplying ServerStatus
+                    (readiness / liveness state) to the handler.
+        :param forwarded_request_metadata: Same list the main server
+                    passes to HealthCheckHandler.initialize() so the
+                    handler behaves identically on both ports.
+        :param logging_config: Logging configuration dict, forwarded to
+                    the handler's initialize().
+        """
+        self.port: int = port
+        self.server_context: ServerContext = server_context
+        self.forwarded_request_metadata: List[str] = forwarded_request_metadata
+        self.logging_config: Dict[str, Any] = logging_config
+
+        self.logger: logging.Logger = logging.getLogger(self.__class__.__name__)
+        self._thread: Optional[threading.Thread] = None
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+        self._ioloop: Optional[tornado.ioloop.IOLoop] = None
+
+    def start(self):
+        """
+        Launch the probe server's background thread. Called inside each
+        Tornado worker (as a Startable) after server.start(N) fork so
+        each worker gets its own fresh loop and its own SO_REUSEPORT
+        socket on the same probe port.
+
+        No-op if port <= 0 (disabled).
+        """
+        if self.port <= 0:
+            self.logger.info("HealthProbeServer disabled (port=%d)", self.port)
+            return
+        if self._thread is not None:
+            self.logger.debug("HealthProbeServer already started; skipping")
+            return
+
+        self._thread = threading.Thread(
+            target=self._run,
+            name=f"HealthProbeServer-{self.port}",
+            daemon=True,
+        )
+        self._thread.start()
+        self.logger.info("HealthProbeServer started on port %d", self.port)
+
+    def stop(self):
+        """
+        Best-effort shutdown of the probe IOLoop. Safe to call multiple
+        times. If the loop hasn't been started yet, this is a no-op.
+        The daemon thread will die at process exit either way.
+        """
+        if self._ioloop is None:
+            return
+        # add_callback is thread-safe; asks the probe loop to stop itself.
+        self._ioloop.add_callback(self._ioloop.stop)
+
+    def _run(self) -> None:
+        """
+        Thread entry point. Owns the probe's asyncio loop for its full
+        lifetime. Never returns under normal operation.
+        """
+        # Every thread that hosts an asyncio loop needs the loop assigned
+        # to it explicitly (otherwise Tornado's IOLoop.current() would
+        # fail to find one). EventLoopFactory produces the correct type
+        # for the platform (SelectorEventLoop on Windows).
+        loop: asyncio.AbstractEventLoop = EventLoopFactory.new_event_loop()
+        asyncio.set_event_loop(loop)
+        self._loop = loop
+
+        # Build the minimal app -- ONLY the health endpoints. Deliberately
+        # excludes /profiler, /resources_utilization, /_debug/tasks, and
+        # every /api/v1/* handler so this loop can't be starved by request work.
+        app: tornado.web.Application = self.make_probe_app()
+
+        # Bind the probe port with SO_REUSEPORT. Each worker's thread runs
+        # this same code, so all workers share the port; the kernel
+        # dispatches accepted connections across them.
+        server: tornado.httpserver.HTTPServer = tornado.httpserver.HTTPServer(app)
+        try:
+            server.bind(self.port, reuse_port=True)
+        except OSError as exc:
+            self.logger.error("HealthProbeServer failed to bind port %d: %s",
+                              self.port, exc)
+            return
+        # start(1) attaches to the current IOLoop without forking (the
+        # fork parameter only kicks in for N > 1).
+        server.start(1)
+
+        self._ioloop = tornado.ioloop.IOLoop.current()
+        try:
+            self._ioloop.start()
+        finally:
+            # If start() returns (via stop()), tear the socket down. Any OSError
+            # during teardown (e.g. the socket is already closed) is harmless
+            # here -- shutdown is best-effort.
+            with contextlib.suppress(OSError):
+                server.stop()
+
+    def make_probe_app(self) -> tornado.web.Application:
+        """
+        Construct the Tornado Application. Same handler class as the main
+        server uses on its port, initialized the same way, so probe
+        responses look identical to the main port's.
+        """
+        server_status = self.server_context.get_server_status()
+        live_data: Dict[str, Any] = {
+            "forwarded_request_metadata": self.forwarded_request_metadata,
+            "server_status": server_status,
+            "op": "live",
+            "logging_config": self.logging_config,
+        }
+        ready_data: Dict[str, Any] = {
+            "forwarded_request_metadata": self.forwarded_request_metadata,
+            "server_status": server_status,
+            "op": "ready",
+            "logging_config": self.logging_config,
+        }
+        handlers: List[Any] = [
+            ("/", HealthCheckHandler, ready_data),
+            ("/healthz", HealthCheckHandler, ready_data),
+            ("/readyz", HealthCheckHandler, ready_data),
+            ("/livez", HealthCheckHandler, live_data),
+        ]
+        return tornado.web.Application(handlers)

--- a/neuro_san/service/http/server/http_server.py
+++ b/neuro_san/service/http/server/http_server.py
@@ -226,6 +226,8 @@ class HttpServer(AgentStateListener):
         try:
             value: int = int(raw)
         except ValueError:
+            self.logger.warning({}, "Invalid %s=%r; falling back to default probe port %d",
+                                ENV_HEALTH_PROBE_PORT, raw, self.server_config.http_probe_port)
             return self.server_config.http_probe_port
         return max(value, 0)
 

--- a/neuro_san/service/http/server/http_server.py
+++ b/neuro_san/service/http/server/http_server.py
@@ -23,10 +23,17 @@ from typing import Dict
 from typing import List
 
 import json
+import os
 import random
 import threading
 
 import tornado
+
+# Env var: dedicated port for the isolated health-probe server. 0 disables it,
+# in which case k8s/LB probes must hit the main server port's handlers (which
+# remain registered for backward compatibility).
+_ENV_HEALTH_PROBE_PORT: str = "AGENT_HEALTH_PROBE_PORT"
+_DEFAULT_HEALTH_PROBE_PORT: int = 8081
 
 from leaf_common.serialization.util.text_file_reader import TextFileReader
 
@@ -36,6 +43,7 @@ from neuro_san.internals.interfaces.agent_storage_source import AgentStorageSour
 from neuro_san.internals.network_providers.agent_network_storage import AgentNetworkStorage
 from neuro_san.service.generic.agent_server_logging import AgentServerLogging
 from neuro_san.service.generic.async_agent_service_provider import AsyncAgentServiceProvider
+from neuro_san.service.http.config.http_server_config import ENV_HEALTH_PROBE_PORT
 from neuro_san.service.http.config.http_server_config import HttpServerConfig
 from neuro_san.service.http.handlers.concierge_handler import ConciergeHandler
 from neuro_san.service.http.handlers.connectivity_handler import ConnectivityHandler
@@ -47,6 +55,7 @@ from neuro_san.service.http.handlers.profiler_control_handler import ProfilerCon
 from neuro_san.service.http.handlers.snapshot_handler import SnapshotHandler
 from neuro_san.service.http.logging.http_logger import HttpLogger
 from neuro_san.service.http.server.agent_authorization_policy import AgentAuthorizationPolicy
+from neuro_san.service.http.server.health_probe_server import HealthProbeServer
 from neuro_san.service.http.server.http_server_app import HttpServerApp
 from neuro_san.service.http.server.resources_usage_logger import ResourcesUsageLogger
 from neuro_san.service.interfaces.agent_authorizer import AgentAuthorizer
@@ -156,6 +165,20 @@ class HttpServer(AgentStateListener):
                     self.server_config.http_server_monitor_interval_seconds, self.http_port, self.logger)
             startables.append(resources_logger)
 
+        # Add the isolated health-probe server. It binds a dedicated port
+        # (default 8081, configurable via AGENT_HEALTH_PROBE_PORT; 0 disables)
+        # and serves /, /healthz, /readyz, /livez on its own asyncio loop in
+        # a dedicated thread -- so probes stay fast even when the main
+        # Tornado loop is saturated by request work.
+        probe_port: int = self.resolve_health_probe_port()
+        if probe_port > 0:
+            startables.append(HealthProbeServer(
+                port=probe_port,
+                server_context=self.server_context,
+                forwarded_request_metadata=self.forwarded_request_metadata,
+                logging_config=self.logging_config,
+            ))
+
         # Bind the socket with a custom backlog
         server.bind(self.http_port, backlog=self.server_config.http_connections_backlog)
 
@@ -193,6 +216,24 @@ class HttpServer(AgentStateListener):
 
         tornado.ioloop.IOLoop.current().start()
         self.logger.info({}, "Http server stopped.")
+
+    def resolve_health_probe_port(self) -> int:
+        """
+        Resolve the port for the isolated HealthProbeServer.
+
+        Reads the AGENT_HEALTH_PROBE_PORT env var. Non-numeric values fall
+        back to the default (8081), and a value of 0 (or negative) disables
+        the separate probe server, in which case k8s / LB probes should hit
+        the main port's registered health handlers.
+
+        :return: A non-negative int. 0 disables the probe server.
+        """
+        raw: str = os.environ.get(ENV_HEALTH_PROBE_PORT, str(self.server_config.http_probe_port))
+        try:
+            value: int = int(raw)
+        except ValueError:
+            return self.server_config.http_probe_port
+        return max(value, 0)
 
     def make_app(self, requests_limit: int, concurrent_requests_limit: int, logger: EventLoopLogger):
         """

--- a/neuro_san/service/http/server/http_server.py
+++ b/neuro_san/service/http/server/http_server.py
@@ -165,6 +165,12 @@ class HttpServer(AgentStateListener):
         # a dedicated thread -- so probes stay fast even when the main
         # Tornado loop is saturated by request work.
         probe_port: int = self.resolve_health_probe_port()
+        if probe_port == self.http_port:
+            self.logger.warning({},
+                                "Health probe port %d is the same as main HTTP port; "
+                                "dedicated probe server is not started, "
+                                "but /healthz, /readyz, /livez remain registered on the main port", probe_port)
+            probe_port = -1
         if probe_port > 0:
             startables.append(HealthProbeServer(
                 port=probe_port,
@@ -239,17 +245,24 @@ class HttpServer(AgentStateListener):
         enable_http_handlers: bool = self.server_context.get_server_status().http_service.is_requested()
 
         request_initialize_data: Dict[str, Any] = self.build_request_data()
+        # Resolve library versions once here; the same dict is passed to every
+        # health handler on both the main port and the isolated probe server so
+        # per-request probes never re-run importlib.metadata lookups.
+        server_status = self.server_context.get_server_status()
+        versions: Dict[str, Any] = server_status.get_versions()
         live_request_initialize_data: Dict[str, Any] = {
             "forwarded_request_metadata": self.forwarded_request_metadata,
-            "server_status": self.server_context.get_server_status(),
+            "server_status": server_status,
             "op": "live",
-            "logging_config": self.logging_config
+            "logging_config": self.logging_config,
+            "versions": versions,
         }
         ready_request_initialize_data: Dict[str, Any] = {
             "forwarded_request_metadata": self.forwarded_request_metadata,
-            "server_status": self.server_context.get_server_status(),
+            "server_status": server_status,
             "op": "ready",
-            "logging_config": self.logging_config
+            "logging_config": self.logging_config,
+            "versions": versions,
         }
         handlers = []
         # Health check handlers are enabled always

--- a/neuro_san/service/http/server/http_server.py
+++ b/neuro_san/service/http/server/http_server.py
@@ -29,12 +29,6 @@ import threading
 
 import tornado
 
-# Env var: dedicated port for the isolated health-probe server. 0 disables it,
-# in which case k8s/LB probes must hit the main server port's handlers (which
-# remain registered for backward compatibility).
-_ENV_HEALTH_PROBE_PORT: str = "AGENT_HEALTH_PROBE_PORT"
-_DEFAULT_HEALTH_PROBE_PORT: int = 8081
-
 from leaf_common.serialization.util.text_file_reader import TextFileReader
 
 from neuro_san.internals.interfaces.agent_network_provider import AgentNetworkProvider

--- a/neuro_san/service/utils/server_status.py
+++ b/neuro_san/service/utils/server_status.py
@@ -15,6 +15,16 @@
 #
 # END COPYRIGHT
 
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
+
+import os
+
+from importlib.metadata import version as library_version
+from importlib.metadata import PackageNotFoundError
+
 from neuro_san.service.utils.service_status import ServiceStatus
 
 
@@ -32,6 +42,13 @@ class ServerStatus:
         self.http_service: ServiceStatus = ServiceStatus("http")
         self.updater: ServiceStatus = ServiceStatus("updater")
         self.mcp_service: ServiceStatus = ServiceStatus("mcp")
+
+        # Library versions are process-invariant: they depend on what pip
+        # installed (or on AGENT_VERSION_LIBS which is read once at startup)
+        # and do not change over the server's lifetime. Compute them once
+        # here so health-check requests do not re-run importlib.metadata
+        # lookups on every probe.
+        self._versions: Optional[Dict[str, Any]] = None
 
     def is_server_live(self) -> bool:
         """
@@ -54,3 +71,72 @@ class ServerStatus:
         Return server name
         """
         return self.server_name
+
+    def get_versions(self) -> Dict[str, Any]:
+        """
+        Return a mapping of library name -> installed version, suitable for
+        inclusion in health-check responses. Computed on first access and
+        cached, since library versions do not change over a process's
+        lifetime.
+
+        Always includes the neuro-san version. The AGENT_VERSION_LIBS env
+        var can add more entries: it is parsed as a space-delimited list
+        where each entry is either a library name (in which case the
+        version is looked up via importlib.metadata) or "name:version"
+        (in which case the version is taken verbatim from the env var --
+        useful for libraries that are not pip-installed, such as a checked-
+        out neuro-san source tree whose "version" should be a repo tag).
+
+        :return: A dict of {library_name: version_string}. Libraries whose
+                 versions cannot be resolved are reported as "unknown".
+        """
+        if self._versions is None:
+            self._versions = self._resolve_versions()
+        return self._versions
+
+    @staticmethod
+    def _resolve_versions() -> Dict[str, Any]:
+        """
+        One-shot version resolver: reads AGENT_VERSION_LIBS, resolves any
+        listed libraries via importlib.metadata, and returns the combined
+        mapping. See get_versions() for the semantics of the env var.
+        """
+        versions: Dict[str, Any] = {}
+
+        # Static baseline -- always report neuro-san.
+        versioned_libs: List[str] = ["neuro-san"]
+
+        # AGENT_VERSION_LIBS can add libraries and/or pre-declared versions.
+        env_var_libs: str = os.environ.get("AGENT_VERSION_LIBS")
+        if env_var_libs is not None:
+            for env_var_lib in env_var_libs.split(" "):
+                if env_var_lib is None:
+                    continue
+
+                env_var_lib = env_var_lib.strip()
+                if len(env_var_lib) == 0:
+                    continue
+
+                if ":" not in env_var_lib:
+                    # No explicit version; queue for lookup.
+                    versioned_libs.append(env_var_lib)
+                    continue
+
+                # Explicit version handed to us via env var; take it as-is.
+                # This is useful when running from a source tree where the
+                # library isn't pip-installed.
+                lib_version: str = env_var_lib.split(":")[1]
+                env_var_lib = env_var_lib.split(":")[0]
+                versions[env_var_lib] = lib_version
+
+        for lib in versioned_libs:
+            if versions.get(lib) is not None:
+                # Already set from the env var (would happen if the same
+                # library name appears both bare and with a colon).
+                continue
+            try:
+                versions[lib] = str(library_version(lib))
+            except PackageNotFoundError:
+                versions[lib] = "unknown"
+
+        return versions


### PR DESCRIPTION
Problem

  Under load, neuro-san's Tornado main event loop can become saturated by request work (streaming chat, LLM I/O, etc.). Because /, /healthz, /readyz, and /livez were handled on that same loop, probe responses stalled along with everything else — leading to Kubernetes killing pods that were slow rather than dead ("death by health check").

  Solution

  Runs the health-probe endpoints on a separate port, in a dedicated OS thread with its own asyncio event loop. The main Tornado loop can be arbitrarily busy and probes still return quickly.

  New module — neuro_san/service/http/server/health_probe_server.py:
  - HealthProbeServer(Startable) — launches a daemon thread that creates its own asyncio loop and runs a minimal Tornado Application with only the four health routes.
  - Reuses the existing HealthCheckHandler verbatim, so probe response bodies are byte-for-byte identical to the main port.
  - Binds with SO_REUSEPORT so every Tornado worker binds the same probe port; the kernel dispatches accepted connections across workers — same model Tornado uses for the main port.
  - Instantiated pre-fork but start() runs post-fork (as a Startable), so each worker mints its own fresh loop — no kqueue/epoll fd inherited from parent.
  - Clean shutdown via contextlib.suppress(OSError) on socket teardown; daemon thread dies at process exit if stop() isn't called.
  
  http_server.py wiring:
  - New static _resolve_health_probe_port() reads AGENT_HEALTH_PROBE_PORT (default 8081, 0 disables).
  - Appends the HealthProbeServer to the startables list just before server.bind(), so it starts per-worker after server.start(N) fork.
  - Backward compatibility: main-port handlers for /, /healthz, /readyz, /livez remain registered — existing k8s configs pointing at the main port keep working.
  
  Dockerfile — new ENV AGENT_HEALTH_PROBE_PORT="8081" with commentary on the mechanism and how to disable.

  Recommended k8s probe wiring

  livenessProbe:
    httpGet:
      path: /livez
      port: 8081                # isolated loop → probes survive main-loop saturation
    failureThreshold: 3
    periodSeconds: 15
    timeoutSeconds: 3
  readinessProbe:
    httpGet:
      path: /readyz
      port: 8080                # main port → readiness fails when loop is saturated
                                        # (LB drops the pod, no restart)
    failureThreshold: 1
    periodSeconds: 5
    timeoutSeconds: 3

  Split gives the correct semantic for each concern: liveness reflects "process alive" from the isolated loop (survives transient main-loop stalls); readiness reflects "can I serve requests" from the main loop (correctly withdraws saturated pods from LB without restarting them).

  Trade-off worth flagging

  A /livez 200 on port 8081 no longer means "the main loop is healthy" — only "the process is alive." That's the right semantic for liveness (which triggers restart), but the failure mode "main loop wedged, probes still fine, requests still failing" is now hidden from the liveness probe by design. The readiness probe on the main port catches that case.

  Verification

  Smoke test against the isolated probe server showed all four routes responding on the dedicated loop with sub-10ms latency and correct status-code behavior (200 when ready, 503 when readiness signals not set).

