### PR TITLE
Keep backtraces out of client output

### DIFF
--- a/neuro_san/internals/run_context/langchain/core/run_context_runnable.py
+++ b/neuro_san/internals/run_context/langchain/core/run_context_runnable.py
@@ -270,7 +270,12 @@ class RunContextRunnable(NeuroSanRunnable):
                 exception = exception_error
                 backtrace = traceback.format_exc()
 
-        output: str = self.parse_chain_result(chain_result, exception, backtrace)
+        if chain_result is None and backtrace is not None:
+            # Keep the full backtrace in the server logs only. Passing it
+            # through as error details would return raw stack traces to clients.
+            self.sensitive_logger.error("%s", backtrace)
+
+        output: str = self.parse_chain_result(chain_result, exception)
         return_message: BaseMessage = AIMessage(output)
 
         # Chat history is updated in write_message
@@ -299,7 +304,7 @@ class RunContextRunnable(NeuroSanRunnable):
             await self.journal.write_message(AgentFrameworkMessage(content=text))
 
     def parse_chain_result(self, chain_result: Union[Dict[str, Any], AgentFinish, AIMessage],
-                           exception: Exception, backtrace: str) -> str:
+                           exception: Exception) -> str:
         """
         Parse the result from the langchain chain.
 
@@ -311,7 +316,6 @@ class RunContextRunnable(NeuroSanRunnable):
                             "messages" - effectively a chat history
                         * An AIMessage whose content is the output to use
         :param exception: Any exception that happened along the way
-        :param backtrace: Any backtrace to the exception that happened along the way
         :return: A string value to return as the result of the run.
         """
 
@@ -325,7 +329,6 @@ class RunContextRunnable(NeuroSanRunnable):
             output = f"Agent stopped due to exception {exception}"
         else:
             # Set some stuff up for later
-            backtrace = None
             ai_message: AIMessage = None
 
             # Handle the AgentFinish case.
@@ -369,5 +372,5 @@ class RunContextRunnable(NeuroSanRunnable):
             output = text_output
 
         # See if we had some kind of error and format accordingly, if asked for.
-        output = self.error_detector.handle_error(output, backtrace)
+        output = self.error_detector.handle_error(output)
         return output

--- a/neuro_san/internals/run_context/langchain/core/run_context_runnable.py
+++ b/neuro_san/internals/run_context/langchain/core/run_context_runnable.py
@@ -18,6 +18,7 @@ from asyncio import TimeoutError as AsyncTimeout
 from typing import Any
 from typing import Dict
 from typing import List
+from typing import Optional
 from typing import Tuple
 from typing import Type
 from typing import Union
@@ -303,8 +304,8 @@ class RunContextRunnable(NeuroSanRunnable):
         if self.sensitive_logger.should_log():
             await self.journal.write_message(AgentFrameworkMessage(content=text))
 
-    def parse_chain_result(self, chain_result: Union[Dict[str, Any], AgentFinish, AIMessage],
-                           exception: Exception) -> str:
+    def parse_chain_result(self, chain_result: Optional[Union[Dict[str, Any], AgentFinish, AIMessage]],
+                           exception: Optional[Exception]) -> str:
         """
         Parse the result from the langchain chain.
 
@@ -315,7 +316,9 @@ class RunContextRunnable(NeuroSanRunnable):
                             "output" - the actual output to use
                             "messages" - effectively a chat history
                         * An AIMessage whose content is the output to use
-        :param exception: Any exception that happened along the way
+                        * None, when every attempt to invoke the chain failed
+        :param exception: Any exception that happened along the way,
+                        or None if the chain invocation succeeded
         :return: A string value to return as the result of the run.
         """
 

--- a/neuro_san/internals/run_context/langchain/core/run_context_runnable.py
+++ b/neuro_san/internals/run_context/langchain/core/run_context_runnable.py
@@ -206,6 +206,10 @@ class RunContextRunnable(NeuroSanRunnable):
         exception: Exception = None
         backtrace: str = None
         while chain_result is None and attempts > 0:
+            # Reset any backtrace from a previous attempt so that whatever is
+            # logged after the loop always corresponds to the exception that
+            # ended it (not every branch below captures a backtrace).
+            backtrace = None
             try:
                 chain_result: Dict[str, Any] = await self.agent_chain.ainvoke(input=inputs, config=runnable_config)
             except RATE_LIMIT_ERROR_TYPES as rate_limit_error:

--- a/tests/neuro_san/internals/run_context/langchain/core/test_run_context_runnable.py
+++ b/tests/neuro_san/internals/run_context/langchain/core/test_run_context_runnable.py
@@ -18,9 +18,11 @@
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 
+import httpx
 import pytest
 
 from langchain_core.messages.ai import AIMessage
+from openai import RateLimitError
 
 from neuro_san.internals.messages.agent_framework_message import AgentFrameworkMessage
 from neuro_san.internals.run_context.langchain.core.run_context_runnable import RunContextRunnable
@@ -137,3 +139,47 @@ class TestRunContextRunnable:
             "Agent stopped due to exception Server error '504 Gateway Time-out'")
         # The backtrace is logged server-side instead.
         assert any("Traceback" in str(call) for call in sensitive_logger.error.call_args_list)
+
+    @pytest.mark.asyncio
+    async def test_invoke_agent_chain_does_not_log_stale_backtrace(self):
+        """
+        A backtrace captured on an earlier attempt must not be logged when a
+        later attempt fails via a branch that captures no backtrace: any logged
+        traceback must correspond to the exception that ended the retry loop.
+        Here attempt 1 fails with a KeyError (captures a backtrace) and
+        attempt 2 fails with a rate-limit error (captures none), so no
+        traceback should be logged at all.
+        """
+        written = []
+        mock_journal = MagicMock()
+        mock_journal.write_message = AsyncMock(side_effect=lambda msg, *_a, **_k: written.append(msg))
+        sensitive_logger = MagicMock()
+        sensitive_logger.should_log = MagicMock(return_value=True)
+
+        request = httpx.Request("POST", "https://api.openai.com/v1/chat/completions")
+        response = httpx.Response(429, request=request)
+        rate_limit_error = RateLimitError("rate limited", response=response, body=None)
+
+        agent_chain = MagicMock()
+        agent_chain.ainvoke = AsyncMock(side_effect=[KeyError("missing field"), rate_limit_error])
+
+        # error_detector.handle_error is a pass-through for this test.
+        error_detector = MagicMock()
+        error_detector.handle_error = MagicMock(side_effect=lambda output: output)
+
+        runnable = RunContextRunnable.model_construct(
+            journal=mock_journal,
+            sensitive_logger=sensitive_logger,
+            agent_chain=agent_chain,
+            error_detector=error_detector,
+            logger=MagicMock(),
+        )
+
+        await runnable.invoke_agent_chain(inputs={}, runnable_config={}, max_attempts=2)
+
+        # The final message reflects the rate-limit failure from the last attempt...
+        final = written[-1]
+        assert isinstance(final, AIMessage)
+        assert "rate limited" in final.content
+        # ...so the stale KeyError traceback from attempt 1 must not be logged.
+        assert not any("Traceback" in str(call) for call in sensitive_logger.error.call_args_list)

--- a/tests/neuro_san/internals/run_context/langchain/core/test_run_context_runnable.py
+++ b/tests/neuro_san/internals/run_context/langchain/core/test_run_context_runnable.py
@@ -75,7 +75,7 @@ class TestRunContextRunnable:
 
         # error_detector.handle_error is a pass-through for this test.
         error_detector = MagicMock()
-        error_detector.handle_error = MagicMock(side_effect=lambda output, _backtrace: output)
+        error_detector.handle_error = MagicMock(side_effect=lambda output: output)
 
         runnable = RunContextRunnable.model_construct(
             journal=mock_journal,
@@ -93,3 +93,47 @@ class TestRunContextRunnable:
             assert isinstance(msg, AgentFrameworkMessage)
             assert msg.content == "Retrying: the model's output could not be parsed (ValueError) - not a parsing error"
         assert isinstance(written[-1], AIMessage)
+
+    @pytest.mark.asyncio
+    async def test_invoke_agent_chain_keeps_backtrace_out_of_client_output(self):
+        """
+        When the agent chain dies with an unhandled exception (e.g. an MCP tool
+        transport error), the client-facing message must carry only the exception
+        message: the full backtrace goes to the server log, not to the
+        ErrorDetector as client-facing details.
+        See https://github.com/cognizant-ai-lab/neuro-san/issues/1097
+        """
+        written = []
+        mock_journal = MagicMock()
+        mock_journal.write_message = AsyncMock(side_effect=lambda msg, *_a, **_k: written.append(msg))
+        sensitive_logger = MagicMock()
+        sensitive_logger.should_log = MagicMock(return_value=True)
+
+        # A RuntimeError exercises the non-retryable broad-exception branch.
+        agent_chain = MagicMock()
+        agent_chain.ainvoke = AsyncMock(side_effect=RuntimeError("Server error '504 Gateway Time-out'"))
+
+        # error_detector.handle_error is a pass-through for this test.
+        error_detector = MagicMock()
+        error_detector.handle_error = MagicMock(side_effect=lambda output: output)
+
+        runnable = RunContextRunnable.model_construct(
+            journal=mock_journal,
+            sensitive_logger=sensitive_logger,
+            agent_chain=agent_chain,
+            error_detector=error_detector,
+            logger=MagicMock(),
+        )
+
+        await runnable.invoke_agent_chain(inputs={}, runnable_config={}, max_attempts=3)
+
+        # Unhandled exceptions are not retried: a single final AIMessage.
+        assert len(written) == 1
+        final = written[-1]
+        assert isinstance(final, AIMessage)
+        assert final.content == "Agent stopped due to exception Server error '504 Gateway Time-out'"
+        # The ErrorDetector must not receive the backtrace as client-facing details.
+        error_detector.handle_error.assert_called_once_with(
+            "Agent stopped due to exception Server error '504 Gateway Time-out'")
+        # The backtrace is logged server-side instead.
+        assert any("Traceback" in str(call) for call in sensitive_logger.error.call_args_list)


### PR DESCRIPTION
When the agent chain fails, the full backtrace was passed through parse_chain_result to ErrorDetector.handle_error as error details, returning raw stack traces to clients (e.g. on MCP transport errors, see #1097). Log the backtrace server-side through the SensitiveLogger instead, which respects the LEAF_LOG_SENSITIVE env var setting, and drop the backtrace parameter from parse_chain_result. Clients now see only the concise "Agent stopped due to exception ..." message.

Fix #1129