### PR TITLE
NS-1126 Don't send internal error details back to client.

### DIFF
--- a/neuro_san/service/mcp/handlers/mcp_root_handler.py
+++ b/neuro_san/service/mcp/handlers/mcp_root_handler.py
@@ -184,7 +184,7 @@ class McpRootHandler(BaseRequestHandler):
                 if validation_errors:
                     extra_error: str = "; ".join(validation_errors)
                     error_msg: Dict[str, Any] = \
-                        McpErrorsUtil.get_protocol_error(request_id, McpError.InvalidRequest, extra_error)
+                        McpErrorsUtil.get_protocol_error(request_id, McpError.InvalidRequest)
                     self.set_status(HTTPStatus.BAD_REQUEST)
                     self.write(error_msg)
                     self.logger.error(self.get_metadata(), f"Error: Invalid tool call request: {extra_error}")


### PR DESCRIPTION
This PR addresses CodeQL alert:
given some internal details about MCP tool call validation errors,
we log them to service log, but don't send back to client over HTTP wire.
