### PR TITLE
S3 Reservations: Robust s3 creds handling with new client for each invocation

### DIFF
--- a/neuro_san/service/watcher/temp_networks/aws_async_client_worker.py
+++ b/neuro_san/service/watcher/temp_networks/aws_async_client_worker.py
@@ -115,7 +115,7 @@ class AwsAsyncClientWorker:
         if last_err is not None:
             raise last_err
 
-        raise RuntimeError("S3 credential retries exhausted without capturing an error") from last_err
+        raise RuntimeError(f"{self.aws_service} credential retries exhausted without capturing an error") from last_err
 
     def ensure_async_lock_exists(self):
         """

--- a/neuro_san/service/watcher/temp_networks/aws_async_client_worker.py
+++ b/neuro_san/service/watcher/temp_networks/aws_async_client_worker.py
@@ -109,12 +109,7 @@ class AwsAsyncClientWorker:
                 self.frozen_credentials = None
                 if source is None:
                     source = self.name
-                self.logger.warning(
-                    "%s (%d): S3 credentials seem to have expired. Retrying. "
-                    "If you believe you have non-expiring S3 credentials, be sure they are correct.",
-                    source,
-                    attempt,
-                )
+                self.logger.warning("%s (%d): %s credentials seem to have expired. Retrying. If you believe you have non-expiring %s credentials, be sure they are correct.", source, attempt, self.aws_service, self.aws_service)
 
         # Exhausted retries
         if last_err is not None:

--- a/neuro_san/service/watcher/temp_networks/aws_async_client_worker.py
+++ b/neuro_san/service/watcher/temp_networks/aws_async_client_worker.py
@@ -109,7 +109,9 @@ class AwsAsyncClientWorker:
                 self.frozen_credentials = None
                 if source is None:
                     source = self.name
-                self.logger.warning("%s (%d): %s credentials seem to have expired. Retrying. If you believe you have non-expiring %s credentials, be sure they are correct.", source, attempt, self.aws_service, self.aws_service)
+                self.logger.warning("%s (%d): %s credentials seem to have expired. Retrying. "
+                                    "If you believe you have non-expiring %s credentials, be sure they are correct.",
+                                    source, attempt, self.aws_service, self.aws_service)
 
         # Exhausted retries
         if last_err is not None:

--- a/neuro_san/service/watcher/temp_networks/aws_async_client_worker.py
+++ b/neuro_san/service/watcher/temp_networks/aws_async_client_worker.py
@@ -44,24 +44,28 @@ from neuro_san.service.watcher.temp_networks.s3_retry_util import S3RetryUtil
 
 
 # pylint: disable=too-many-instance-attributes
-class S3AsyncClientWorker:
+class AwsAsyncClientWorker:
     """
-    AWS S3-based class that manages a particular async work_function (from functools.partial)
-    that has async_s3_client as an argument whose credentials are properly handled for
-    short-lived async S3 clients.
+    Class that manages a particular AWS boto async work_function (from functools.partial)
+    that has async_aws_client as an argument whose credentials are properly handled for
+    short-lived async boto clients.
     """
 
-    def __init__(self, name: str):
+    def __init__(self, name: str, aws_service: str = "s3"):
         """
-        Initialize S3 reservations storage.
+        Constructor
 
         :param name: Name for logging as to whose behalf this class is operating.
+        :param aws_service: Name of the AWS service to initialize the boto client
         """
         self.name: str = name
+        self.aws_service: str = aws_service
         self.logger: Logger = getLogger(self.__class__.__name__)
 
+        # Sync lock is only needed to properly create the async lock
+        # at the right time in the right thread.
         self.sync_lock: SyncLock = SyncLock()
-        self.async_s3_client_lock: AsyncLock = None
+        self.async_aws_client_lock: AsyncLock = None
 
         # Boto Machinations
         # We should be able to have a single Session for the lifetime of this object
@@ -123,11 +127,11 @@ class S3AsyncClientWorker:
         Be sure we have an asyncio Lock to get our sessions.
         """
         # Note that none of this is async in and of itself.
-        if self.async_s3_client_lock is None:
+        if self.async_aws_client_lock is None:
             with self.sync_lock:
                 # Be sure everyone has the same lock
-                if self.async_s3_client_lock is None:
-                    self.async_s3_client_lock = AsyncLock()
+                if self.async_aws_client_lock is None:
+                    self.async_aws_client_lock = AsyncLock()
 
     async def do_work_with_new_client(self, work_function: Awaitable, *, attempt: int = 1) -> Any:
         """
@@ -143,9 +147,9 @@ class S3AsyncClientWorker:
         retval: Any = None
 
         # Create an aiobotocore client for async operations.
-        async_s3_client: AioBaseClient = None
+        async_aws_client: AioBaseClient = None
 
-        async_s3_client_creator_context: ClientCreatorContext = None
+        async_aws_client_creator_context: ClientCreatorContext = None
         lock_released: bool = False
         acquired_lock: bool = False
 
@@ -155,14 +159,14 @@ class S3AsyncClientWorker:
         lock_released_time: float = 0.0
         try:
             # Serialize creation of the ClientCreatorContext with the lock to avoid credential-chain races.
-            await self.async_s3_client_lock.acquire()
+            await self.async_aws_client_lock.acquire()
             lock_aquired_time = perf_counter()
             acquired_lock = True
 
             # Get the current notion of frozen credentials.
             frozen_creds: ReadOnlyCredentials = await self.get_frozen_credentials()
-            async_s3_client_creator_context = self.session.create_client(
-                "s3",
+            async_aws_client_creator_context = self.session.create_client(
+                self.aws_service,
                 aws_access_key_id=frozen_creds.access_key,
                 aws_secret_access_key=frozen_creds.secret_key,
                 aws_session_token=frozen_creds.token,
@@ -173,21 +177,21 @@ class S3AsyncClientWorker:
             # but we want to be holding the lock while we create the client to avoid
             # credential-chain races like NoCredentialsError.
 
-            async with async_s3_client_creator_context as async_s3_client:
+            async with async_aws_client_creator_context as async_aws_client:
 
                 # Release the lock while we process, allowing other tasks to work on
-                # getting their own async_s3_client. (Not an async method)
-                self.async_s3_client_lock.release()
+                # getting their own async_aws_client. (Not an async method)
+                self.async_aws_client_lock.release()
                 lock_released_time = perf_counter()
                 lock_released = True
 
-                retval = await work_function(async_s3_client=async_s3_client)
+                retval = await work_function(async_aws_client=async_aws_client)
 
         finally:
             # Always release the lock if we successfully acquired it and have not already done so,
             # in case there was an error getting/entering the context manager.
             if acquired_lock and not lock_released:
-                self.async_s3_client_lock.release()
+                self.async_aws_client_lock.release()
 
         finish_time: float = perf_counter()
         self.logger.info("%s (%d): Lock acquisition in: %fs. Client context creation after: %fs. "
@@ -202,7 +206,7 @@ class S3AsyncClientWorker:
     async def get_frozen_credentials(self) -> ReadOnlyCredentials:
         """
         Get the frozen credentials for the current session.
-        We are assuming that we already have the async_s3_client_lock.
+        We are assuming that we already have the async_aws_client_lock.
         """
 
         # Use a local copy to avoid a race with the ClientError retry block

--- a/neuro_san/service/watcher/temp_networks/aws_async_client_worker.py
+++ b/neuro_san/service/watcher/temp_networks/aws_async_client_worker.py
@@ -40,7 +40,7 @@ from botocore.exceptions import ClientError
 from leaf_common.logging.sensitive_logger import SensitiveLogger
 from leaf_common.parsers.dictionary_extractor import DictionaryExtractor
 
-from neuro_san.service.watcher.temp_networks.s3_retry_util import S3RetryUtil
+from neuro_san.service.watcher.temp_networks.s3_util import S3Util
 
 
 # pylint: disable=too-many-instance-attributes
@@ -244,10 +244,10 @@ class AwsAsyncClientWorker:
             try:
                 return await fn()
             except ClientError as err:
-                if attempt >= max_attempts or not S3RetryUtil.is_retryable_client_error(err):
+                if attempt >= max_attempts or not S3Util.is_retryable_client_error(err):
                     raise
 
-                sleep = S3RetryUtil.exponential_backoff_with_jitter(base_sleep, attempt)
+                sleep = S3Util.exponential_backoff_with_jitter(base_sleep, attempt)
                 sensitive_logger.warning("%s: Retryable async ClientError (%s). attempt=%d", source, err, attempt)
                 await async_sleep(sleep)
                 attempt += 1
@@ -256,7 +256,7 @@ class AwsAsyncClientWorker:
                 if attempt >= max_attempts:
                     raise
 
-                sleep = S3RetryUtil.exponential_backoff_with_jitter(base_sleep, attempt)
+                sleep = S3Util.exponential_backoff_with_jitter(base_sleep, attempt)
                 sensitive_logger.warning("%s: Retryable async BotoCoreError (%s). attempt=%d", source, err, attempt)
                 await async_sleep(sleep)
                 attempt += 1

--- a/neuro_san/service/watcher/temp_networks/aws_sync_client_worker.py
+++ b/neuro_san/service/watcher/temp_networks/aws_sync_client_worker.py
@@ -99,12 +99,7 @@ class AwsSyncClientWorker:
                 self.frozen_credentials = None
                 if source is None:
                     source = self.name
-                self.logger.warning(
-                    "%s (%d): S3 credentials seem to have expired. Retrying. "
-                    "If you believe you have non-expiring S3 credentials, be sure they are correct.",
-                    source,
-                    attempt,
-                )
+                self.logger.warning("%s (%d): %s credentials seem to have expired. Retrying. If you believe you have non-expiring %s credentials, be sure they are correct.", source, attempt, self.aws_service, self.aws_service)
 
         # Exhausted retries
         if last_err is not None:

--- a/neuro_san/service/watcher/temp_networks/aws_sync_client_worker.py
+++ b/neuro_san/service/watcher/temp_networks/aws_sync_client_worker.py
@@ -99,7 +99,9 @@ class AwsSyncClientWorker:
                 self.frozen_credentials = None
                 if source is None:
                     source = self.name
-                self.logger.warning("%s (%d): %s credentials seem to have expired. Retrying. If you believe you have non-expiring %s credentials, be sure they are correct.", source, attempt, self.aws_service, self.aws_service)
+                self.logger.warning("%s (%d): %s credentials seem to have expired. Retrying. "
+                                    "If you believe you have non-expiring %s credentials, be sure they are correct.",
+                                    source, attempt, self.aws_service, self.aws_service)
 
         # Exhausted retries
         if last_err is not None:

--- a/neuro_san/service/watcher/temp_networks/aws_sync_client_worker.py
+++ b/neuro_san/service/watcher/temp_networks/aws_sync_client_worker.py
@@ -1,0 +1,246 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+from typing import Any
+from typing import Callable
+
+from time import sleep as sync_sleep
+from time import perf_counter
+
+from logging import getLogger
+from logging import Logger
+from threading import Lock as SyncLock
+
+from botocore.client import BaseClient
+from botocore.credentials import Credentials
+from botocore.credentials import ReadOnlyCredentials
+from botocore.exceptions import BotoCoreError
+from botocore.exceptions import ClientError
+from botocore.session import get_session
+from botocore.session import Session
+
+from leaf_common.logging.sensitive_logger import SensitiveLogger
+from leaf_common.parsers.dictionary_extractor import DictionaryExtractor
+
+from neuro_san.service.watcher.temp_networks.s3_retry_util import S3RetryUtil
+
+
+# pylint: disable=too-many-instance-attributes
+class AwsSyncClientWorker:
+    """
+    Class that manages a particular AWS boto synchronous work_function (from functools.partial)
+    that has sync_aws_client as an argument whose credentials are properly handled for
+    short-lived synchronous boto clients.
+    """
+
+    def __init__(self, name: str, aws_service: str = "s3"):
+        """
+        Constructor
+
+        :param name: Name for logging as to whose behalf this class is operating.
+        :param aws_service: Name of the AWS service to initialize the boto client
+        """
+        self.name: str = name
+        self.aws_service: str = aws_service
+        self.logger: Logger = getLogger(self.__class__.__name__)
+
+        self.sync_aws_client_lock: SyncLock = SyncLock()
+
+        # Boto Machinations
+        # We should be able to have a single Session for the lifetime of this object
+        self.session: Session = None
+
+        # Cached frozen credentials which can be invalidated should they expire
+        self.frozen_credentials: ReadOnlyCredentials = None
+
+    def retry_with_new_client(self, work_function: Callable, *, source: str = None) -> Any:
+        """
+        Retries the work_function when client credentials can expire.
+        :param work_function: The work function to retry
+        :param *: extra keyword arguments for work_function
+        :param source: A string describing where the deployment was coming from
+        :return: What work_function returns
+        """
+
+        max_attempts: int = 8
+        last_err: Exception = None
+
+        for attempt in range(1, max_attempts + 1):
+            try:
+                retval: Any = self.do_work_with_new_client(work_function, attempt=attempt)
+                return retval
+
+            except ClientError as err:
+                extractor = DictionaryExtractor(err.response)
+                if "ExpiredToken" not in extractor.get("Error.Code", ""):
+                    raise
+
+                last_err = err
+
+                # Background: Certain IAM Instance Roles, ECS Task Roles or AWS SSO/IAM Identity Center
+                #             profiles have token-based credentials that may expire.
+                #             See: https://docs.aws.amazon.com/boto3/latest/guide/configuration.html
+
+                # Reset the cached credentials as they are likely expired and try again.
+                self.frozen_credentials = None
+                if source is None:
+                    source = self.name
+                self.logger.warning(
+                    "%s (%d): S3 credentials seem to have expired. Retrying. "
+                    "If you believe you have non-expiring S3 credentials, be sure they are correct.",
+                    source,
+                    attempt,
+                )
+
+        # Exhausted retries
+        if last_err is not None:
+            raise last_err
+
+        raise RuntimeError("S3 credential retries exhausted without capturing an error") from last_err
+
+    def do_work_with_new_client(self, work_function: Callable, *, attempt: int = 1) -> Any:
+        """
+        This method separates the machinations of obtaining a proper S3 client
+        from add_all_reservations() which does all the actual work.
+
+        :param work_function: The work function to retry
+        :param *: extra keyword arguments for work_function
+        :param attempt: Attempt number
+        :return: What work_function returns
+        """
+
+        retval: Any = None
+
+        # Create an botocore client for sync operations.
+        sync_aws_client: BaseClient = None
+
+        lock_released: bool = False
+        acquired_lock: bool = False
+
+        start_time: float = perf_counter()
+        lock_aquired_time: float = 0.0
+        client_created_time: float = 0.0
+        lock_released_time: float = 0.0
+        try:
+            # Serialize creation of the Client with the lock to avoid credential-chain races.
+            # pylint: disable=consider-using-with
+            self.sync_aws_client_lock.acquire()
+            lock_aquired_time = perf_counter()
+            acquired_lock = True
+
+            # Get the current notion of frozen credentials.
+            frozen_creds: ReadOnlyCredentials = self.get_frozen_credentials()
+            sync_aws_client = self.session.create_client(
+                self.aws_service,
+                aws_access_key_id=frozen_creds.access_key,
+                aws_secret_access_key=frozen_creds.secret_key,
+                aws_session_token=frozen_creds.token,
+            )
+            client_created_time = perf_counter()
+
+            # Normally this is done in a python ContextManager using a with-statement,
+            # but we want to be holding the lock while we create the client to avoid
+            # credential-chain races like NoCredentialsError.
+
+            # Release the lock while we process, allowing other tasks to work on
+            # getting their own sync_aws_client.
+            self.sync_aws_client_lock.release()
+            lock_released_time = perf_counter()
+            lock_released = True
+
+            retval = work_function(sync_aws_client=sync_aws_client)
+
+        finally:
+            # Always release the lock if we successfully acquired it and have not already done so,
+            # in case there was an error getting/entering the context manager.
+            if acquired_lock and not lock_released:
+                self.sync_aws_client_lock.release()
+
+            if sync_aws_client is not None:
+                sync_aws_client.close()
+
+        finish_time: float = perf_counter()
+        self.logger.info("%s (%d): Lock acquisition in: %fs. Client context creation after: %fs. "
+                         "Lock release after: %fs. Finish after: %fs",
+                         self.name, attempt,
+                         lock_aquired_time - start_time,
+                         client_created_time - start_time,
+                         lock_released_time - start_time,
+                         finish_time - start_time)
+        return retval
+
+    def get_frozen_credentials(self) -> ReadOnlyCredentials:
+        """
+        Get the frozen credentials for the current session.
+        We are assuming that we already have the sync_aws_client_lock.
+        """
+
+        # Use a local copy to avoid a race with the ClientError retry block
+        local_frozen: ReadOnlyCredentials = self.frozen_credentials
+
+        # If we already have some credentials, use them
+        if local_frozen is not None:
+            return local_frozen
+
+        # Create the session if needed
+        # We should only need one for the lifetime of the object
+        if self.session is None:
+            self.session = get_session()
+
+        credentials: Credentials = self.session.get_credentials()
+
+        # Avoid a small race condition with the ClientError retry block
+        # by always returning a local copy
+        local_frozen = credentials.get_frozen_credentials()
+        self.frozen_credentials = local_frozen
+
+        return local_frozen
+
+    @staticmethod
+    def do_with_retries(source: str, fn, *, max_attempts: int = 8, base_sleep: float = 0.25):
+        """
+        Generic retry wrapper for boto3 calls.
+        boto3/botocore already retries, but this adds a bit of extra resilience and backoff for batch operations.
+        """
+        logger: Logger = getLogger(__name__)
+        sensitive_logger: SensitiveLogger = SensitiveLogger(logger)
+        sleep: float = 0.0
+        attempt: int = 1
+        while True:
+            try:
+                return fn()
+            except ClientError as err:
+                if attempt >= max_attempts or not S3RetryUtil.is_retryable_client_error(err):
+                    raise
+
+                sleep = S3RetryUtil.exponential_backoff_with_jitter(base_sleep, attempt)
+                sensitive_logger.warning("%s: Retryable sync ClientError (%s). attempt=%d", source, err, attempt)
+                sync_sleep(sleep)
+                attempt += 1
+            except BotoCoreError as err:
+                # Often transient network/serialization issues
+                if attempt >= max_attempts:
+                    raise
+
+                sleep = S3RetryUtil.exponential_backoff_with_jitter(base_sleep, attempt)
+                sensitive_logger.warning("%s: Retryable sync BotoCoreError (%s). attempt=%d", source, err, attempt)
+                sync_sleep(sleep)
+                attempt += 1
+            except Exception as err:  # pylint: disable=broad-except
+                # Catch-all for unexpected exceptions; log and re-raise
+                sensitive_logger.error("%s: Unexpected sync error (%s). attempt=%d", source, err, attempt)
+                raise

--- a/neuro_san/service/watcher/temp_networks/aws_sync_client_worker.py
+++ b/neuro_san/service/watcher/temp_networks/aws_sync_client_worker.py
@@ -36,7 +36,7 @@ from botocore.session import Session
 from leaf_common.logging.sensitive_logger import SensitiveLogger
 from leaf_common.parsers.dictionary_extractor import DictionaryExtractor
 
-from neuro_san.service.watcher.temp_networks.s3_retry_util import S3RetryUtil
+from neuro_san.service.watcher.temp_networks.s3_util import S3Util
 
 
 # pylint: disable=too-many-instance-attributes
@@ -224,10 +224,10 @@ class AwsSyncClientWorker:
             try:
                 return fn()
             except ClientError as err:
-                if attempt >= max_attempts or not S3RetryUtil.is_retryable_client_error(err):
+                if attempt >= max_attempts or not S3Util.is_retryable_client_error(err):
                     raise
 
-                sleep = S3RetryUtil.exponential_backoff_with_jitter(base_sleep, attempt)
+                sleep = S3Util.exponential_backoff_with_jitter(base_sleep, attempt)
                 sensitive_logger.warning("%s: Retryable sync ClientError (%s). attempt=%d", source, err, attempt)
                 sync_sleep(sleep)
                 attempt += 1
@@ -236,7 +236,7 @@ class AwsSyncClientWorker:
                 if attempt >= max_attempts:
                     raise
 
-                sleep = S3RetryUtil.exponential_backoff_with_jitter(base_sleep, attempt)
+                sleep = S3Util.exponential_backoff_with_jitter(base_sleep, attempt)
                 sensitive_logger.warning("%s: Retryable sync BotoCoreError (%s). attempt=%d", source, err, attempt)
                 sync_sleep(sleep)
                 attempt += 1

--- a/neuro_san/service/watcher/temp_networks/aws_sync_client_worker.py
+++ b/neuro_san/service/watcher/temp_networks/aws_sync_client_worker.py
@@ -105,7 +105,7 @@ class AwsSyncClientWorker:
         if last_err is not None:
             raise last_err
 
-        raise RuntimeError("S3 credential retries exhausted without capturing an error") from last_err
+        raise RuntimeError(f"{self.aws_service} credential retries exhausted without capturing an error") from last_err
 
     def do_work_with_new_client(self, work_function: Callable, *, attempt: int = 1) -> Any:
         """

--- a/neuro_san/service/watcher/temp_networks/s3_async_client_worker.py
+++ b/neuro_san/service/watcher/temp_networks/s3_async_client_worker.py
@@ -18,7 +18,9 @@
 from typing import Any
 from typing import Awaitable
 
+from asyncio import CancelledError
 from asyncio import Lock as AsyncLock
+from asyncio import sleep as async_sleep
 from time import perf_counter
 
 from logging import getLogger
@@ -30,11 +32,15 @@ from aiobotocore.session import get_session
 from aiobotocore.session import AioSession
 from aiobotocore.session import ClientCreatorContext
 
+from botocore.exceptions import BotoCoreError
 from botocore.credentials import Credentials
 from botocore.credentials import ReadOnlyCredentials
 from botocore.exceptions import ClientError
 
+from leaf_common.logging.sensitive_logger import SensitiveLogger
 from leaf_common.parsers.dictionary_extractor import DictionaryExtractor
+
+from neuro_san.service.watcher.temp_networks.s3_retry_util import S3RetryUtil
 
 
 # pylint: disable=too-many-instance-attributes
@@ -112,6 +118,17 @@ class S3AsyncClientWorker:
 
         raise RuntimeError("S3 credential retries exhausted without capturing an error") from last_err
 
+    def ensure_async_lock_exists(self):
+        """
+        Be sure we have an asyncio Lock to get our sessions.
+        """
+        # Note that none of this is async in and of itself.
+        if self.async_s3_client_lock is None:
+            with self.sync_lock:
+                # Be sure everyone has the same lock
+                if self.async_s3_client_lock is None:
+                    self.async_s3_client_lock = AsyncLock()
+
     async def do_work_with_new_client(self, work_function: Awaitable, *, attempt: int = 1) -> Any:
         """
         This method separates the machinations of obtaining a proper S3 client
@@ -182,17 +199,6 @@ class S3AsyncClientWorker:
                          finish_time - start_time)
         return retval
 
-    def ensure_async_lock_exists(self):
-        """
-        Be sure we have an asyncio Lock to get our sessions.
-        """
-        # Note that none of this is async in and of itself.
-        if self.async_s3_client_lock is None:
-            with self.sync_lock:
-                # Be sure everyone has the same lock
-                if self.async_s3_client_lock is None:
-                    self.async_s3_client_lock = AsyncLock()
-
     async def get_frozen_credentials(self) -> ReadOnlyCredentials:
         """
         Get the frozen credentials for the current session.
@@ -219,3 +225,41 @@ class S3AsyncClientWorker:
         self.frozen_credentials = local_frozen
 
         return local_frozen
+
+    @staticmethod
+    async def do_with_retries(source: str, fn, *, max_attempts: int = 8, base_sleep: float = 0.25):
+        """
+        Generic retry wrapper for boto3 calls.
+        boto3/botocore already retries, but this adds a bit of extra resilience and backoff for batch operations.
+        """
+        logger: Logger = getLogger(__name__)
+        sensitive_logger: SensitiveLogger = SensitiveLogger(logger)
+        sleep: float = 0.0
+        attempt: int = 1
+        while True:
+            try:
+                return await fn()
+            except ClientError as err:
+                if attempt >= max_attempts or not S3RetryUtil.is_retryable_client_error(err):
+                    raise
+
+                sleep = S3RetryUtil.exponential_backoff_with_jitter(base_sleep, attempt)
+                sensitive_logger.warning("%s: Retryable async ClientError (%s). attempt=%d", source, err, attempt)
+                await async_sleep(sleep)
+                attempt += 1
+            except BotoCoreError as err:
+                # Often transient network/serialization issues
+                if attempt >= max_attempts:
+                    raise
+
+                sleep = S3RetryUtil.exponential_backoff_with_jitter(base_sleep, attempt)
+                sensitive_logger.warning("%s: Retryable async BotoCoreError (%s). attempt=%d", source, err, attempt)
+                await async_sleep(sleep)
+                attempt += 1
+            except CancelledError:
+                logger.info("%s: async Task was cancelled.", source)
+                raise
+            except Exception as err:  # pylint: disable=broad-except
+                # Catch-all for unexpected exceptions; log and re-raise
+                sensitive_logger.error("%s: Unexpected async error (%s). attempt=%d", source, err, attempt)
+                raise

--- a/neuro_san/service/watcher/temp_networks/s3_async_client_worker.py
+++ b/neuro_san/service/watcher/temp_networks/s3_async_client_worker.py
@@ -1,0 +1,221 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+from typing import Any
+from typing import Awaitable
+
+from asyncio import Lock as AsyncLock
+from time import perf_counter
+
+from logging import getLogger
+from logging import Logger
+from threading import Lock as SyncLock
+
+from aiobotocore.client import AioBaseClient
+from aiobotocore.session import get_session
+from aiobotocore.session import AioSession
+from aiobotocore.session import ClientCreatorContext
+
+from botocore.credentials import Credentials
+from botocore.credentials import ReadOnlyCredentials
+from botocore.exceptions import ClientError
+
+from leaf_common.parsers.dictionary_extractor import DictionaryExtractor
+
+
+# pylint: disable=too-many-instance-attributes
+class S3AsyncClientWorker:
+    """
+    AWS S3-based class that manages a particular async work_function (from functools.partial)
+    that has async_s3_client as an argument whose credentials are properly handled for
+    short-lived async S3 clients.
+    """
+
+    def __init__(self, name: str):
+        """
+        Initialize S3 reservations storage.
+
+        :param name: Name for logging as to whose behalf this class is operating.
+        """
+        self.name: str = name
+        self.logger: Logger = getLogger(self.__class__.__name__)
+
+        self.sync_lock: SyncLock = SyncLock()
+        self.async_s3_client_lock: AsyncLock = None
+
+        # Boto Machinations
+        # We should be able to have a single Session for the lifetime of this object
+        self.session: AioSession = None
+
+        # Cached frozen credentials which can be invalidated should they expire
+        self.frozen_credentials: ReadOnlyCredentials = None
+
+    async def retry_with_new_client(self, work_function: Awaitable, *, source: str = None) -> Any:
+        """
+        Retries the async work_function when client credentials can expire.
+        :param work_function: The async work function to retry
+        :param *: extra keyword arguments for work_function
+        :param source: A string describing where the deployment was coming from
+        :return: What work_function returns
+        """
+
+        # Async lock has to be created in the thread that uses it.
+        self.ensure_async_lock_exists()
+
+        max_attempts: int = 8
+        last_err: Exception = None
+
+        for attempt in range(1, max_attempts + 1):
+            try:
+                retval: Any = await self.do_work_with_new_client(work_function, attempt=attempt)
+                return retval
+
+            except ClientError as err:
+                extractor = DictionaryExtractor(err.response)
+                if "ExpiredToken" not in extractor.get("Error.Code", ""):
+                    raise
+
+                last_err = err
+
+                # Background: Certain IAM Instance Roles, ECS Task Roles or AWS SSO/IAM Identity Center
+                #             profiles have token-based credentials that may expire.
+                #             See: https://docs.aws.amazon.com/boto3/latest/guide/configuration.html
+
+                # Reset the cached credentials as they are likely expired and try again.
+                self.frozen_credentials = None
+                if source is None:
+                    source = self.name
+                self.logger.warning(
+                    "%s (%d): S3 credentials seem to have expired. Retrying. "
+                    "If you believe you have non-expiring S3 credentials, be sure they are correct.",
+                    source,
+                    attempt,
+                )
+
+        # Exhausted retries
+        if last_err is not None:
+            raise last_err
+
+        raise RuntimeError("S3 credential retries exhausted without capturing an error") from last_err
+
+    async def do_work_with_new_client(self, work_function: Awaitable, *, attempt: int = 1) -> Any:
+        """
+        This method separates the machinations of obtaining a proper S3 client
+        from add_all_reservations() which does all the actual work.
+
+        :param work_function: The async work function to retry
+        :param *: extra keyword arguments for work_function
+        :param attempt: Attempt number
+        :return: What work_function returns
+        """
+
+        retval: Any = None
+
+        # Create an aiobotocore client for async operations.
+        async_s3_client: AioBaseClient = None
+
+        async_s3_client_creator_context: ClientCreatorContext = None
+        lock_released: bool = False
+        acquired_lock: bool = False
+
+        start_time: float = perf_counter()
+        lock_aquired_time: float = 0.0
+        client_created_time: float = 0.0
+        lock_released_time: float = 0.0
+        try:
+            # Serialize creation of the ClientCreatorContext with the lock to avoid credential-chain races.
+            await self.async_s3_client_lock.acquire()
+            lock_aquired_time = perf_counter()
+            acquired_lock = True
+
+            # Get the current notion of frozen credentials.
+            frozen_creds: ReadOnlyCredentials = await self.get_frozen_credentials()
+            async_s3_client_creator_context = self.session.create_client(
+                "s3",
+                aws_access_key_id=frozen_creds.access_key,
+                aws_secret_access_key=frozen_creds.secret_key,
+                aws_session_token=frozen_creds.token,
+            )
+            client_created_time = perf_counter()
+
+            # Normally this is done in a python ContextManager using a with-statement,
+            # but we want to be holding the lock while we create the client to avoid
+            # credential-chain races like NoCredentialsError.
+
+            async with async_s3_client_creator_context as async_s3_client:
+
+                # Release the lock while we process, allowing other tasks to work on
+                # getting their own async_s3_client. (Not an async method)
+                self.async_s3_client_lock.release()
+                lock_released_time = perf_counter()
+                lock_released = True
+
+                retval = await work_function(async_s3_client=async_s3_client)
+
+        finally:
+            # Always release the lock if we successfully acquired it and have not already done so,
+            # in case there was an error getting/entering the context manager.
+            if acquired_lock and not lock_released:
+                self.async_s3_client_lock.release()
+
+        finish_time: float = perf_counter()
+        self.logger.info("%s (%d): Lock acquisition in: %fs. Client context creation after: %fs. "
+                         "Lock release after: %fs. Finish after: %fs",
+                         self.name, attempt,
+                         lock_aquired_time - start_time,
+                         client_created_time - start_time,
+                         lock_released_time - start_time,
+                         finish_time - start_time)
+        return retval
+
+    def ensure_async_lock_exists(self):
+        """
+        Be sure we have an asyncio Lock to get our sessions.
+        """
+        # Note that none of this is async in and of itself.
+        if self.async_s3_client_lock is None:
+            with self.sync_lock:
+                # Be sure everyone has the same lock
+                if self.async_s3_client_lock is None:
+                    self.async_s3_client_lock = AsyncLock()
+
+    async def get_frozen_credentials(self) -> ReadOnlyCredentials:
+        """
+        Get the frozen credentials for the current session.
+        We are assuming that we already have the async_s3_client_lock.
+        """
+
+        # Use a local copy to avoid a race with the ClientError retry block
+        local_frozen: ReadOnlyCredentials = self.frozen_credentials
+
+        # If we already have some credentials, use them
+        if local_frozen is not None:
+            return local_frozen
+
+        # Create the session if needed
+        # We should only need one for the lifetime of the object
+        if self.session is None:
+            self.session = get_session()
+
+        credentials: Credentials = await self.session.get_credentials()
+
+        # Avoid a small race condition with the ClientError retry block
+        # by always returning a local copy
+        local_frozen = await credentials.get_frozen_credentials()
+        self.frozen_credentials = local_frozen
+
+        return local_frozen

--- a/neuro_san/service/watcher/temp_networks/s3_reservations_expiration.py
+++ b/neuro_san/service/watcher/temp_networks/s3_reservations_expiration.py
@@ -140,6 +140,7 @@ class S3ReservationsExpiration:
                 break
             continuation_token = response.get("NextContinuationToken")
 
+    # pylint: disable=too-many-locals
     def expire_one_reservation(self, obj_key: str, current_time: float,
                                source: str = None, sync_aws_client: BaseClient = None) -> bool:
         """

--- a/neuro_san/service/watcher/temp_networks/s3_reservations_expiration.py
+++ b/neuro_san/service/watcher/temp_networks/s3_reservations_expiration.py
@@ -79,7 +79,7 @@ class S3ReservationsExpiration:
         expire_function = partial(self.expire_any_reservations)
 
         client_worker: AwsSyncClientWorker = self.retriever.get_sync_client_worker()
-client_worker.retry_with_new_client(expire_function, source=self.name)
+        client_worker.retry_with_new_client(expire_function, source=self.name)
 
     def expire_any_reservations(self, sync_aws_client: BaseClient = None):
         """
@@ -157,7 +157,11 @@ client_worker.retry_with_new_client(expire_function, source=self.name)
         expired: bool = False
         try:
             # Retrieve the reservation object from S3
-agent_spec: Dict[str, Any] = self.retriever.retrieve_object_with_retries(obj_key=obj_key, source=source, sync_aws_client=sync_aws_client)
+            agent_spec: Dict[str, Any] = self.retriever.retrieve_object_with_retries(
+                obj_key=obj_key,
+                source=source,
+                sync_aws_client=sync_aws_client
+            )
             if agent_spec is None:
                 agent_spec = empty
 

--- a/neuro_san/service/watcher/temp_networks/s3_reservations_expiration.py
+++ b/neuro_san/service/watcher/temp_networks/s3_reservations_expiration.py
@@ -131,6 +131,8 @@ class S3ReservationsExpiration:
 
             list_objects_function = partial(sync_aws_client.list_objects_v2, **kwargs)
             response = client_worker.do_with_retries(self.name, list_objects_function)
+            if response is None:
+                response = {}
             for obj in response.get("Contents", []):
                 yield obj.get("Key")
             if not response.get("IsTruncated"):
@@ -155,6 +157,8 @@ class S3ReservationsExpiration:
         try:
             # Retrieve the reservation object from S3
             agent_spec: Dict[str, Any] = self.retriever.retrieve_object_with_retries(obj_key)
+            if agent_spec is None:
+                agent_spec = empty
 
             extractor = DictionaryExtractor(agent_spec)
             reservation_data: Dict[str, Any] = extractor.get("metadata.reservation", empty)

--- a/neuro_san/service/watcher/temp_networks/s3_reservations_expiration.py
+++ b/neuro_san/service/watcher/temp_networks/s3_reservations_expiration.py
@@ -31,6 +31,7 @@ from botocore.exceptions import ClientError
 
 from neuro_san.service.watcher.temp_networks.aws_sync_client_worker import AwsSyncClientWorker
 from neuro_san.service.watcher.temp_networks.s3_reservations_retriever import S3ReservationsRetriever
+from neuro_san.service.watcher.temp_networks.s3_util import S3Util
 
 
 class S3ReservationsExpiration:
@@ -41,10 +42,12 @@ class S3ReservationsExpiration:
     S3ReservationsStorage watcher loop.
     """
 
-    def __init__(self, name: str = "S3ReservationsExpiration", bucket_name: str = "", prefix: str = "reservations/"):
+    def __init__(self, name: str = "S3ReservationsExpiration", bucket_name: str = "",
+                 prefix: str = S3Util.DEFAULT_RESERVATIONS_PREFIX):
         """
         Initialize S3 reservations storage.
 
+        :param name: Name of this writer
         :param bucket_name: S3 bucket name (defaults to AGENT_RESERVATIONS_S3_BUCKET env var)
         :param prefix: S3 key prefix for reservation objects
         """

--- a/neuro_san/service/watcher/temp_networks/s3_reservations_expiration.py
+++ b/neuro_san/service/watcher/temp_networks/s3_reservations_expiration.py
@@ -29,6 +29,8 @@ from logging import Logger
 from botocore.client import BaseClient
 from botocore.exceptions import ClientError
 
+from leaf_common.parsers.dictionary_extractor import DictionaryExtractor
+
 from neuro_san.service.watcher.temp_networks.aws_sync_client_worker import AwsSyncClientWorker
 from neuro_san.service.watcher.temp_networks.s3_reservations_retriever import S3ReservationsRetriever
 from neuro_san.service.watcher.temp_networks.s3_util import S3Util
@@ -90,6 +92,8 @@ class S3ReservationsExpiration:
         current_time: float = time()
 
         for reservation_key in self.iter_reservation_keys(sync_aws_client):
+            if not reservation_key:
+                continue
             # Attempt to expire this reservation and increment counter if successful
             if self.expire_one_reservation(reservation_key, current_time, sync_aws_client):
                 expired_count += 1
@@ -128,11 +132,11 @@ class S3ReservationsExpiration:
             list_objects_function = partial(sync_aws_client.list_objects_v2, **kwargs)
             response = client_worker.do_with_retries(self.name, list_objects_function)
             for obj in response.get("Contents", []):
-                yield obj["Key"]
+                yield obj.get("Key")
             if not response.get("IsTruncated"):
                 # This was the last page - exit loop
                 break
-            continuation_token = response["NextContinuationToken"]
+            continuation_token = response.get("NextContinuationToken")
 
     def expire_one_reservation(self, obj_key: str, current_time: float,
                                source: str = None, sync_aws_client: BaseClient = None) -> bool:
@@ -145,17 +149,20 @@ class S3ReservationsExpiration:
         """
         if source is None:
             source = self.name
+
+        empty: Dict[str, Any] = {}
         expired: bool = False
         try:
             # Retrieve the reservation object from S3
             agent_spec: Dict[str, Any] = self.retriever.retrieve_object_with_retries(obj_key)
-            metadata: Dict[str, Any] = agent_spec.get("metadata")
-            reservation_data: Dict[str, Any] = metadata.get("reservation")
+
+            extractor = DictionaryExtractor(agent_spec)
+            reservation_data: Dict[str, Any] = extractor.get("metadata.reservation", empty)
 
             client_worker: AwsSyncClientWorker = self.retriever.get_sync_client_worker()
 
             # Compare current time against reservation's expiration timestamp
-            expiration_time: float = reservation_data.get("expiration_time_in_seconds")
+            expiration_time: float = reservation_data.get("expiration_time_in_seconds", 0)
             if current_time > expiration_time:
                 # Reservation has expired - remove it from S3 storage
                 try:
@@ -163,12 +170,13 @@ class S3ReservationsExpiration:
                                               Bucket=self.retriever.get_bucket_name(),
                                               Key=obj_key)
                     client_worker.do_with_retries(source, delete_function)
-                    reservation_id: str = reservation_data.get("id")
+                    reservation_id: str = reservation_data.get("id", "<unknown>")
                     self.logger.debug("%s: Deleted expired reservation %s from S3", self.name, reservation_id)
                     expired = True
                 except ClientError as delete_error:
+                    extractor = DictionaryExtractor(delete_error.response)
                     # Handle case where another process already deleted the object
-                    if delete_error.response["Error"]["Code"] != "NoSuchKey":
+                    if extractor.get("Error.Code") != "NoSuchKey":
                         # Re-raise other delete errors
                         raise delete_error
 
@@ -179,7 +187,8 @@ class S3ReservationsExpiration:
 
         except ClientError as exception:
             # Handle case where another process already removed the object before we could read it
-            if exception.response["Error"]["Code"] == "NoSuchKey":
+            extractor = DictionaryExtractor(exception.response)
+            if extractor.get("Error.Code") == "NoSuchKey":
                 self.logger.debug("%s: Reservation %s was already removed by another process", self.name, obj_key)
                 expired = True  # Object is gone, which is the desired outcome for expiration
             else:

--- a/neuro_san/service/watcher/temp_networks/s3_reservations_expiration.py
+++ b/neuro_san/service/watcher/temp_networks/s3_reservations_expiration.py
@@ -29,8 +29,8 @@ from logging import Logger
 from botocore.client import BaseClient
 from botocore.exceptions import ClientError
 
+from neuro_san.service.watcher.temp_networks.aws_sync_client_worker import AwsSyncClientWorker
 from neuro_san.service.watcher.temp_networks.s3_reservations_retriever import S3ReservationsRetriever
-from neuro_san.service.watcher.temp_networks.s3_retry_util import S3RetryUtil
 
 
 class S3ReservationsExpiration:
@@ -71,14 +71,24 @@ class S3ReservationsExpiration:
         """
         self.logger.debug("%s: Starting expiration process for S3 reservations", self.name)
 
+        expire_function = partial(self.expire_any_reservations)
+
+        client_worker: AwsSyncClientWorker = self.retriever.get_sync_client_worker()
+        client_worker.do_work_with_new_client(expire_function)
+
+    def expire_any_reservations(self, sync_aws_client: BaseClient = None):
+        """
+        Remove expired reservations from S3 storage.
+        :param sync_aws_client: S3 client
+        """
         # Track how many reservations we expire for reporting
         expired_count: int = 0
         # Get current timestamp once for consistent expiration checking
         current_time: float = time()
 
-        for reservation_key in self.iter_reservation_keys():
+        for reservation_key in self.iter_reservation_keys(sync_aws_client):
             # Attempt to expire this reservation and increment counter if successful
-            if self.expire_one_reservation(reservation_key, current_time):
+            if self.expire_one_reservation(reservation_key, current_time, sync_aws_client):
                 expired_count += 1
 
         if expired_count > 0:
@@ -87,7 +97,7 @@ class S3ReservationsExpiration:
         else:
             self.logger.debug("%s: Expiration complete: removed no expired reservations from S3", self.name)
 
-    def iter_reservation_keys(self) -> Iterable[str]:
+    def iter_reservation_keys(self, sync_aws_client: BaseClient) -> Iterable[str]:
         """
         Lists ALL objects under the current S3 bucket prefix and yields their
         object keys.
@@ -95,11 +105,13 @@ class S3ReservationsExpiration:
         Pages through results by calling list_objects_v2 directly with
         ContinuationToken rather than using a boto3 Paginator. Each
         list_objects_v2 call is a single, eager HTTP request, so wrapping it
-        in S3RetryUtil.do_with_retries gives correct per-page retry semantics for
+        in do_with_retries() gives correct per-page retry semantics for
         transient ClientError/BotoCoreError: each page fetch is retried in
         isolation, and the ContinuationToken from the previous successful
         response is only consulted after that response has actually arrived.
         """
+        client_worker: AwsSyncClientWorker = self.retriever.get_sync_client_worker()
+
         continuation_token = None
         while True:
             kwargs = {
@@ -110,11 +122,8 @@ class S3ReservationsExpiration:
             if continuation_token:
                 kwargs["ContinuationToken"] = continuation_token
 
-            s3_client: BaseClient = self.retriever.get_client()
-            response = S3RetryUtil.do_with_retries(
-                self.name,
-                partial(s3_client.list_objects_v2, **kwargs)
-            )
+            list_objects_function = partial(sync_aws_client.list_objects_v2, **kwargs)
+            response = client_worker.do_with_retries(self.name, list_objects_function)
             for obj in response.get("Contents", []):
                 yield obj["Key"]
             if not response.get("IsTruncated"):
@@ -122,7 +131,8 @@ class S3ReservationsExpiration:
                 break
             continuation_token = response["NextContinuationToken"]
 
-    def expire_one_reservation(self, obj_key: str, current_time: float, source: str = None) -> bool:
+    def expire_one_reservation(self, obj_key: str, current_time: float,
+                               source: str = None, sync_aws_client: BaseClient = None) -> bool:
         """
         Check and expire a single reservation if it's expired.
 
@@ -139,16 +149,17 @@ class S3ReservationsExpiration:
             metadata: Dict[str, Any] = agent_spec.get("metadata")
             reservation_data: Dict[str, Any] = metadata.get("reservation")
 
+            client_worker: AwsSyncClientWorker = self.retriever.get_sync_client_worker()
+
             # Compare current time against reservation's expiration timestamp
             expiration_time: float = reservation_data.get("expiration_time_in_seconds")
             if current_time > expiration_time:
                 # Reservation has expired - remove it from S3 storage
                 try:
-                    s3_client: BaseClient = self.retriever.get_client()
-                    delete_function = partial(s3_client.delete_object,
+                    delete_function = partial(sync_aws_client.delete_object,
                                               Bucket=self.retriever.get_bucket_name(),
                                               Key=obj_key)
-                    S3RetryUtil.do_with_retries(source, delete_function)
+                    client_worker.do_with_retries(source, delete_function)
                     reservation_id: str = reservation_data.get("id")
                     self.logger.debug("%s: Deleted expired reservation %s from S3", self.name, reservation_id)
                     expired = True

--- a/neuro_san/service/watcher/temp_networks/s3_reservations_expiration.py
+++ b/neuro_san/service/watcher/temp_networks/s3_reservations_expiration.py
@@ -95,7 +95,7 @@ class S3ReservationsExpiration:
             if not reservation_key:
                 continue
             # Attempt to expire this reservation and increment counter if successful
-            if self.expire_one_reservation(reservation_key, current_time, sync_aws_client):
+            if self.expire_one_reservation(reservation_key, current_time, sync_aws_client=sync_aws_client):
                 expired_count += 1
 
         if expired_count > 0:

--- a/neuro_san/service/watcher/temp_networks/s3_reservations_expiration.py
+++ b/neuro_san/service/watcher/temp_networks/s3_reservations_expiration.py
@@ -79,7 +79,7 @@ class S3ReservationsExpiration:
         expire_function = partial(self.expire_any_reservations)
 
         client_worker: AwsSyncClientWorker = self.retriever.get_sync_client_worker()
-        client_worker.do_work_with_new_client(expire_function)
+client_worker.retry_with_new_client(expire_function, source=self.name)
 
     def expire_any_reservations(self, sync_aws_client: BaseClient = None):
         """

--- a/neuro_san/service/watcher/temp_networks/s3_reservations_expiration.py
+++ b/neuro_san/service/watcher/temp_networks/s3_reservations_expiration.py
@@ -157,7 +157,7 @@ class S3ReservationsExpiration:
         expired: bool = False
         try:
             # Retrieve the reservation object from S3
-            agent_spec: Dict[str, Any] = self.retriever.retrieve_object_with_retries(obj_key)
+agent_spec: Dict[str, Any] = self.retriever.retrieve_object_with_retries(obj_key=obj_key, source=source, sync_aws_client=sync_aws_client)
             if agent_spec is None:
                 agent_spec = empty
 

--- a/neuro_san/service/watcher/temp_networks/s3_reservations_reader.py
+++ b/neuro_san/service/watcher/temp_networks/s3_reservations_reader.py
@@ -33,7 +33,7 @@ from neuro_san.internals.graph.registry.agent_network import AgentNetwork
 from neuro_san.internals.reservations.reservation_dictionary_converter import ReservationDictionaryConverter
 from neuro_san.service.watcher.temp_networks.aws_sync_client_worker import AwsSyncClientWorker
 from neuro_san.service.watcher.temp_networks.s3_reservations_retriever import S3ReservationsRetriever
-from neuro_san.service.watcher.temp_networks.s3_retry_util import S3RetryUtil
+from neuro_san.service.watcher.temp_networks.s3_util import S3Util
 
 
 class S3ReservationsReader:
@@ -44,7 +44,8 @@ class S3ReservationsReader:
     ExpiringAgentNetworkStorage.get_agent_network_provider() as part of a request query.
     """
 
-    def __init__(self, name: str = "S3ReservationsReader", bucket_name: str = "", prefix: str = "reservations/"):
+    def __init__(self, name: str = "S3ReservationsReader", bucket_name: str = "",
+                 prefix: str = S3Util.DEFAULT_RESERVATIONS_PREFIX):
         """
         Initialize the S3 reservations reader.
 
@@ -77,7 +78,7 @@ class S3ReservationsReader:
         agent_network: AgentNetwork = None
 
         # Construct the S3 object key for this reservation ID
-        s3_obj_key: str = S3RetryUtil.get_obj_key_for_reservation(self.retriever.get_prefix(), reservation_id)
+        s3_obj_key: str = S3Util.get_obj_key_for_reservation(self.retriever.get_prefix(), reservation_id)
 
         client_worker: AwsSyncClientWorker = self.retriever.get_sync_client_worker()
         get_function = partial(self.retriever.retrieve_object_with_retries, obj_key=s3_obj_key, source=self.name)

--- a/neuro_san/service/watcher/temp_networks/s3_reservations_reader.py
+++ b/neuro_san/service/watcher/temp_networks/s3_reservations_reader.py
@@ -19,15 +19,19 @@ from typing import Any
 from typing import Dict
 from typing import Tuple
 
+from functools import partial
 from json.decoder import JSONDecodeError
 from logging import getLogger
 from logging import Logger
 
 from botocore.exceptions import ClientError
 
+from leaf_common.parsers.dictionary_extractor import DictionaryExtractor
+
 from neuro_san.interfaces.reservation import Reservation
 from neuro_san.internals.graph.registry.agent_network import AgentNetwork
 from neuro_san.internals.reservations.reservation_dictionary_converter import ReservationDictionaryConverter
+from neuro_san.service.watcher.temp_networks.aws_sync_client_worker import AwsSyncClientWorker
 from neuro_san.service.watcher.temp_networks.s3_reservations_retriever import S3ReservationsRetriever
 from neuro_san.service.watcher.temp_networks.s3_retry_util import S3RetryUtil
 
@@ -71,16 +75,32 @@ class S3ReservationsReader:
         """
         reservation: Reservation = None
         agent_network: AgentNetwork = None
+
         # Construct the S3 object key for this reservation ID
         s3_obj_key: str = S3RetryUtil.get_obj_key_for_reservation(self.retriever.get_prefix(), reservation_id)
+
+        client_worker: AwsSyncClientWorker = self.retriever.get_sync_client_worker()
+        get_function = partial(self.retriever.retrieve_object_with_retries, obj_key=s3_obj_key, source=self.name)
+
         try:
+            # Use empty in case we have malformed data
+            empty: Dict[str, Any] = {}
+
             # Retrieve the reservation object from S3
-            agent_spec: Dict[str, Any] = self.retriever.retrieve_object_with_retries(s3_obj_key)
-            metadata: Dict[str, Any] = agent_spec.get("metadata")
+            agent_spec: Dict[str, Any] = client_worker.retry_with_new_client(get_function)
+            if agent_spec is None:
+                agent_spec = empty
 
             # Reconstruct the Reservation object from stored dictionary
-            reservation_dict: Dict[str, Any] = metadata.get("reservation")
+            extractor = DictionaryExtractor(agent_spec)
+            reservation_dict: Dict[str, Any] = extractor.get("metadata.reservation", empty)
+
             reservation = self.converter.from_dict(reservation_dict)
+            if not reservation:
+                self.logger.error("%s: Failed to get contents of reservation %s",
+                                  self.name, reservation.get_reservation_id())
+                return reservation, agent_network
+
             # Reconstruct the AgentNetwork object using the agent spec dictionary
             # and reservation ID - which is our agent name in this design
             agent_network: AgentNetwork = AgentNetwork(agent_spec, reservation.get_reservation_id())

--- a/neuro_san/service/watcher/temp_networks/s3_reservations_reader.py
+++ b/neuro_san/service/watcher/temp_networks/s3_reservations_reader.py
@@ -98,9 +98,8 @@ class S3ReservationsReader:
 
             reservation = self.converter.from_dict(reservation_dict)
             if not reservation:
-                self.logger.error("%s: Failed to get contents of reservation %s",
-                                  self.name, reservation.get_reservation_id())
-                return reservation, agent_network
+                self.logger.error("%s: Failed to parse reservation payload for %s", self.name, reservation_id)
+                return None, None
 
             # Reconstruct the AgentNetwork object using the agent spec dictionary
             # and reservation ID - which is our agent name in this design

--- a/neuro_san/service/watcher/temp_networks/s3_reservations_retriever.py
+++ b/neuro_san/service/watcher/temp_networks/s3_reservations_retriever.py
@@ -129,8 +129,9 @@ self.s3_sync_client_worker.retry_with_new_client(initialize_function, source=sel
         """
         if obj_key is None:
             raise ValueError(f"{self.name}: S3 object key must be provided")
+        if sync_aws_client is None:
+            raise ValueError(f"{self.name}: S3 client must be provided")
         get_function = partial(sync_aws_client.get_object, Bucket=self.bucket_name, Key=obj_key)
-        if source is None:
             source = self.name
         obj_response: Dict[str, Any] = self.s3_sync_client_worker.do_with_retries(source, get_function)
         # Parse JSON content from S3 object body

--- a/neuro_san/service/watcher/temp_networks/s3_reservations_retriever.py
+++ b/neuro_san/service/watcher/temp_networks/s3_reservations_retriever.py
@@ -25,12 +25,11 @@ from json import loads
 from logging import getLogger
 from logging import Logger
 
-from boto3 import client as boto3_client
 from botocore.client import BaseClient
 from botocore.exceptions import ClientError
 from botocore.exceptions import NoCredentialsError
 
-from neuro_san.service.watcher.temp_networks.s3_retry_util import S3RetryUtil
+from neuro_san.service.watcher.temp_networks.aws_sync_client_worker import AwsSyncClientWorker
 
 
 class S3ReservationsRetriever:
@@ -64,7 +63,7 @@ class S3ReservationsRetriever:
 
         # Set up S3 key prefix and initialize sync target
         self.prefix: str = prefix
-        self.client: BaseClient = None
+        self.s3_sync_client_worker = AwsSyncClientWorker(self.name, "s3")
 
     def get_prefix(self) -> str:
         """
@@ -78,25 +77,28 @@ class S3ReservationsRetriever:
         """
         return self.bucket_name
 
-    def get_client(self) -> BaseClient:
+    def get_sync_client_worker(self) -> AwsSyncClientWorker:
         """
-        :return: The synchronous S3 client.
+        :return: The S3 client worker.
         """
-        return self.client
+        return self.s3_sync_client_worker
 
     def start(self):
         """
         Initialize the S3 client and validate connection to the bucket.
+        """
+        initialize_function = partial(self.initialize)
+        self.s3_sync_client_worker.do_work_with_new_client(initialize_function)
 
-        This method can be called to re-initialize the connection if needed.
+    def initialize(self, sync_aws_client: BaseClient = None):
+        """
+        Initialize the S3 client and validate connection to the bucket
+        using default AWS credential chain
         """
         try:
-            # Initialize S3 client using default AWS credential chain
-            # DEF - these are long-lived. What if credentials expire?
-            self.client = boto3_client("s3")
 
             # Validate bucket exists and we have access by performing a head operation
-            self.client.head_bucket(Bucket=self.bucket_name)
+            sync_aws_client.head_bucket(Bucket=self.bucket_name)
             self.logger.info("%s: Successfully connected to S3 bucket: %s", self.name, self.bucket_name)
 
         except NoCredentialsError as exception:
@@ -113,7 +115,9 @@ class S3ReservationsRetriever:
             raise ValueError(f"{self.name}: Error accessing S3 bucket '{self.bucket_name}': {exception}") \
                 from exception
 
-    def retrieve_object_with_retries(self, obj_key: str, source: str = None) -> Dict[str, Any]:
+    def retrieve_object_with_retries(self, obj_key: str = None,
+                                     source: str = None,
+                                     sync_aws_client: BaseClient = None) -> Dict[str, Any]:
         """
         Helper method to retrieve an S3 object with retries.
         :param obj_key: S3 object key to retrieve
@@ -121,10 +125,12 @@ class S3ReservationsRetriever:
         :raises: ClientError if the object cannot be retrieved after retries
                  JSONDecodeError if the content cannot be parsed as JSON
         """
-        get_function = partial(self.client.get_object, Bucket=self.bucket_name, Key=obj_key)
+        if obj_key is None:
+            raise ValueError(f"{self.name}: S3 object key must be provided")
+        get_function = partial(sync_aws_client.get_object, Bucket=self.bucket_name, Key=obj_key)
         if source is None:
             source = self.name
-        obj_response: Dict[str, Any] = S3RetryUtil.do_with_retries(source, get_function)
+        obj_response: Dict[str, Any] = self.s3_sync_client_worker.do_with_retries(source, get_function)
         # Parse JSON content from S3 object body
         json_content: str = obj_response["Body"].read().decode("utf-8")
         return loads(json_content)

--- a/neuro_san/service/watcher/temp_networks/s3_reservations_retriever.py
+++ b/neuro_san/service/watcher/temp_networks/s3_reservations_retriever.py
@@ -90,7 +90,7 @@ class S3ReservationsRetriever:
         Initialize the S3 client and validate connection to the bucket.
         """
         initialize_function = partial(self.initialize)
-self.s3_sync_client_worker.retry_with_new_client(initialize_function, source=self.name)
+        self.s3_sync_client_worker.retry_with_new_client(initialize_function, source=self.name)
 
     def initialize(self, sync_aws_client: BaseClient = None):
         """
@@ -131,8 +131,11 @@ self.s3_sync_client_worker.retry_with_new_client(initialize_function, source=sel
             raise ValueError(f"{self.name}: S3 object key must be provided")
         if sync_aws_client is None:
             raise ValueError(f"{self.name}: S3 client must be provided")
-        get_function = partial(sync_aws_client.get_object, Bucket=self.bucket_name, Key=obj_key)
+
+        if source is None:
             source = self.name
+
+        get_function = partial(sync_aws_client.get_object, Bucket=self.bucket_name, Key=obj_key)
         obj_response: Dict[str, Any] = self.s3_sync_client_worker.do_with_retries(source, get_function)
         # Parse JSON content from S3 object body
         json_content: str = obj_response["Body"].read().decode("utf-8")

--- a/neuro_san/service/watcher/temp_networks/s3_reservations_retriever.py
+++ b/neuro_san/service/watcher/temp_networks/s3_reservations_retriever.py
@@ -30,6 +30,7 @@ from botocore.exceptions import ClientError
 from botocore.exceptions import NoCredentialsError
 
 from neuro_san.service.watcher.temp_networks.aws_sync_client_worker import AwsSyncClientWorker
+from neuro_san.service.watcher.temp_networks.s3_util import S3Util
 
 
 class S3ReservationsRetriever:
@@ -42,7 +43,8 @@ class S3ReservationsRetriever:
     This guy is used by the S3ReservationsReader and S3ReservationsExpiration.
     """
 
-    def __init__(self, name: str = "S3ReservationsRetriever", bucket_name: str = "", prefix: str = "reservations/"):
+    def __init__(self, name: str = "S3ReservationsRetriever", bucket_name: str = "",
+                 prefix: str = S3Util.DEFAULT_RESERVATIONS_PREFIX):
         """
         Initialize the S3 reservations retriever.
 

--- a/neuro_san/service/watcher/temp_networks/s3_reservations_retriever.py
+++ b/neuro_san/service/watcher/temp_networks/s3_reservations_retriever.py
@@ -90,7 +90,7 @@ class S3ReservationsRetriever:
         Initialize the S3 client and validate connection to the bucket.
         """
         initialize_function = partial(self.initialize)
-        self.s3_sync_client_worker.do_work_with_new_client(initialize_function)
+self.s3_sync_client_worker.retry_with_new_client(initialize_function, source=self.name)
 
     def initialize(self, sync_aws_client: BaseClient = None):
         """

--- a/neuro_san/service/watcher/temp_networks/s3_reservations_storage.py
+++ b/neuro_san/service/watcher/temp_networks/s3_reservations_storage.py
@@ -30,6 +30,7 @@ from neuro_san.internals.network_providers.abstract_reservations_storage import 
 from neuro_san.service.watcher.temp_networks.s3_reservations_expiration import S3ReservationsExpiration
 from neuro_san.service.watcher.temp_networks.s3_reservations_reader import S3ReservationsReader
 from neuro_san.service.watcher.temp_networks.s3_reservations_writer import S3ReservationsWriter
+from neuro_san.service.watcher.temp_networks.s3_util import S3Util
 
 
 class S3ReservationsStorage(AbstractReservationsStorage):
@@ -40,7 +41,7 @@ class S3ReservationsStorage(AbstractReservationsStorage):
     stored in its associated agent spec as metadata.
     """
 
-    def __init__(self, bucket_name: str = "", prefix: str = "reservations/",
+    def __init__(self, bucket_name: str = "", prefix: str = S3Util.DEFAULT_RESERVATIONS_PREFIX,
                  check_expirations_interval_seconds: float = 0.0):
         """
         Initialize S3 reservations storage.

--- a/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
+++ b/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
@@ -16,32 +16,22 @@
 # END COPYRIGHT
 
 from typing import Any
+from typing import Awaitable
 from typing import Dict
 
-from asyncio import Lock as AsyncLock
 from os import getenv
-from time import perf_counter
 from time import time
 from functools import partial
 
 from json import dumps
 from logging import getLogger
 from logging import Logger
-from threading import Lock as SyncLock
 
 from aiobotocore.client import AioBaseClient
-from aiobotocore.session import get_session
-from aiobotocore.session import AioSession
-from aiobotocore.session import ClientCreatorContext
-
-from botocore.credentials import Credentials
-from botocore.credentials import ReadOnlyCredentials
-from botocore.exceptions import ClientError
-
-from leaf_common.parsers.dictionary_extractor import DictionaryExtractor
 
 from neuro_san.interfaces.reservation import Reservation
 from neuro_san.internals.reservations.reservation_dictionary_converter import ReservationDictionaryConverter
+from neuro_san.service.watcher.temp_networks.s3_async_client_worker import S3AsyncClientWorker
 from neuro_san.service.watcher.temp_networks.s3_retry_util import S3RetryUtil
 
 
@@ -82,18 +72,9 @@ class S3ReservationsWriter:
 
         # Set up S3 key prefix and initialize sync target
         self.prefix: str = prefix
-
-        self.sync_lock: SyncLock = SyncLock()
-        self.async_s3_client_lock: AsyncLock = None
-
         self.converter = ReservationDictionaryConverter()
 
-        # Boto Machinations
-        # We should be able to have a single Session for the lifetime of this object
-        self.session: AioSession = None
-
-        # Cached frozen credentials which can be invalidated should they expire
-        self.frozen_credentials: ReadOnlyCredentials = None
+        self.s3_async_client_worker = S3AsyncClientWorker(self.name)
 
     async def add_reservations(self, reservations_dict: Dict[Reservation, Any],
                                source: str = None):
@@ -140,169 +121,18 @@ class S3ReservationsWriter:
         if source is None:
             source = self.name
 
-        # Async lock has to be created in the thread that uses it.
-        self.ensure_async_lock_exists()
+        work_function: Awaitable = partial(self.add_all_reservations, reservations_dict, source)
+        await self.s3_async_client_worker.retry_with_new_client(work_function)
 
-        await self.add_reservations_with_new_client_credential_retries(reservations_dict, source)
-
-    async def add_reservations_with_new_client_credential_retries(self,
-                                                                  reservations_dict: Dict[Reservation, Any],
-                                                                  source: str):
-        """
-        Retries adding the reservations when client credentials can expire.
-
-        :param reservations_dict: A mapping of Reservation -> some deployable agent spec
-        :param source: A string describing where the deployment was coming from
-        """
-
-        max_attempts: int = 8
-        last_err: Exception = None
-
-        for attempt in range(1, max_attempts + 1):
-            try:
-                await self.add_reservations_with_new_client(reservations_dict, source, attempt)
-                return
-
-            except ClientError as err:
-                extractor = DictionaryExtractor(err.response)
-                if "ExpiredToken" not in extractor.get("Error.Code", ""):
-                    raise
-
-                last_err = err
-
-                # Background: Certain IAM Instance Roles, ECS Task Roles or AWS SSO/IAM Identity Center
-                #             profiles have token-based credentials that may expire.
-                #             See: https://docs.aws.amazon.com/boto3/latest/guide/configuration.html
-
-                # Reset the cached credentials as they are likely expired and try again.
-                self.frozen_credentials = None
-                self.logger.warning(
-                    "%s (%d): S3 credentials seem to have expired. Retrying. "
-                    "If you believe you have non-expiring S3 credentials, be sure they are correct.",
-                    source,
-                    attempt,
-                )
-
-        # Exhausted retries
-        if last_err is not None:
-            raise last_err
-        raise RuntimeError("S3 credential retries exhausted without capturing an error") from last_err
-
-    async def add_reservations_with_new_client(self,
-                                               reservations_dict: Dict[Reservation, Any],
-                                               source: str,
-                                               attempt: int = 1):
-        """
-        This method separates the machinations of obtaining a proper S3 client
-        from add_all_reservations() which does all the actual work.
-
-        :param reservations_dict: A mapping of Reservation -> some deployable agent spec
-        :param source: A string describing where the deployment was coming from
-        :param attempt: Attempt number
-        """
-
-        # Create an aiobotocore client for async operations.
-        async_s3_client: AioBaseClient = None
-
-        async_s3_client_creator_context: ClientCreatorContext = None
-        lock_released: bool = False
-        acquired_lock: bool = False
-
-        start_time: float = perf_counter()
-        lock_aquired_time: float = 0.0
-        client_created_time: float = 0.0
-        lock_released_time: float = 0.0
-        try:
-            # Serialize creation of the ClientCreatorContext with the lock to avoid credential-chain races.
-            await self.async_s3_client_lock.acquire()
-            lock_aquired_time = perf_counter()
-            acquired_lock = True
-
-            # Get the current notion of frozen credentials.
-            frozen_creds: ReadOnlyCredentials = await self.get_frozen_credentials()
-            async_s3_client_creator_context = self.session.create_client(
-                "s3",
-                aws_access_key_id=frozen_creds.access_key,
-                aws_secret_access_key=frozen_creds.secret_key,
-                aws_session_token=frozen_creds.token,
-            )
-            client_created_time = perf_counter()
-
-            # Normally this is done in a python ContextManager using a with-statement,
-            # but we want to be holding the lock while we create the client to avoid
-            # credential-chain races like NoCredentialsError.
-
-            async with async_s3_client_creator_context as async_s3_client:
-
-                # Release the lock while we process, allowing other tasks to work on
-                # getting their own async_s3_client. (Not an async method)
-                self.async_s3_client_lock.release()
-                lock_released_time = perf_counter()
-                lock_released = True
-
-                await self.add_all_reservations(async_s3_client, reservations_dict, source)
-
-        finally:
-            # Always release the lock if we successfully acquired it and have not already done so,
-            # in case there was an error getting/entering the context manager.
-            if acquired_lock and not lock_released:
-                self.async_s3_client_lock.release()
-
-        finish_time: float = perf_counter()
-        self.logger.info("%s (%d): Lock acquisition in: %fs. Client context creation after: %fs. "
-                         "Lock release after: %fs. Finish after: %fs",
-                         self.name, attempt,
-                         lock_aquired_time - start_time,
-                         client_created_time - start_time,
-                         lock_released_time - start_time,
-                         finish_time - start_time)
-
-    def ensure_async_lock_exists(self):
-        """
-        Be sure we have an asyncio Lock to get our sessions.
-        """
-        # Note that none of this is async in and of itself.
-        if self.async_s3_client_lock is None:
-            with self.sync_lock:
-                # Be sure everyone has the same lock
-                if self.async_s3_client_lock is None:
-                    self.async_s3_client_lock = AsyncLock()
-
-    async def get_frozen_credentials(self) -> ReadOnlyCredentials:
-        """
-        Get the frozen credentials for the current session.
-        We are assuming that we already have the async_s3_client_lock.
-        """
-
-        # Use a local copy to avoid a race with the ClientError retry block
-        local_frozen: ReadOnlyCredentials = self.frozen_credentials
-
-        # If we already have some credentials, use them
-        if local_frozen is not None:
-            return local_frozen
-
-        # Create the session if needed
-        # We should only need one for the lifetime of the object
-        if self.session is None:
-            self.session = get_session()
-
-        credentials: Credentials = await self.session.get_credentials()
-
-        # Avoid a small race condition with the ClientError retry block
-        # by always returning a local copy
-        local_frozen = await credentials.get_frozen_credentials()
-        self.frozen_credentials = local_frozen
-
-        return local_frozen
-
-    async def add_all_reservations(self, async_s3_client: AioBaseClient,
+    async def add_all_reservations(self,
                                    reservations_dict: Dict[Reservation, Dict[str, Any]],
-                                   source: str):
+                                   source: str,
+                                   async_s3_client: AioBaseClient = None):
         """
         Add all reservations to S3 storage.
-        :param async_s3_client: An aiobotocore S3 client to use for the put_object call
         :param reservations_dict: A mapping of Reservation -> some deployable agent spec
         :param source: A string describing where the deployment was coming from
+        :param async_s3_client: An aiobotocore S3 client to use for the put_object call
         """
         # Process each reservation/agent spec pair individually
         reservation: Reservation = None
@@ -339,11 +169,11 @@ class S3ReservationsWriter:
         # Store as JSON object in S3 with proper content type
         json_body: str = dumps(agent_spec, indent=4)  # Pretty-printed JSON
 
-        put_function = partial(async_s3_client.put_object,
-                               Bucket=self.bucket_name,
-                               Key=key,
-                               Body=json_body,
-                               ContentType="application/json")
+        put_function: Awaitable = partial(async_s3_client.put_object,
+                                          Bucket=self.bucket_name,
+                                          Key=key,
+                                          Body=json_body,
+                                          ContentType="application/json")
 
         await S3RetryUtil.async_do_with_retries(source, put_function)
 

--- a/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
+++ b/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
@@ -175,6 +175,6 @@ class S3ReservationsWriter:
                                           Body=json_body,
                                           ContentType="application/json")
 
-        await S3RetryUtil.async_do_with_retries(source, put_function)
+        await self.s3_async_client_worker.do_with_retries(source, put_function)
 
         self.logger.debug("%s: Successfully stored reservation %s in S3", self.name, reservation_id)

--- a/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
+++ b/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
@@ -31,7 +31,7 @@ from aiobotocore.client import AioBaseClient
 
 from neuro_san.interfaces.reservation import Reservation
 from neuro_san.internals.reservations.reservation_dictionary_converter import ReservationDictionaryConverter
-from neuro_san.service.watcher.temp_networks.s3_async_client_worker import S3AsyncClientWorker
+from neuro_san.service.watcher.temp_networks.aws_async_client_worker import AwsAsyncClientWorker
 from neuro_san.service.watcher.temp_networks.s3_retry_util import S3RetryUtil
 
 
@@ -74,7 +74,7 @@ class S3ReservationsWriter:
         self.prefix: str = prefix
         self.converter = ReservationDictionaryConverter()
 
-        self.s3_async_client_worker = S3AsyncClientWorker(self.name)
+        self.s3_async_client_worker = AwsAsyncClientWorker(self.name, "s3")
 
     async def add_reservations(self, reservations_dict: Dict[Reservation, Any],
                                source: str = None):
@@ -127,26 +127,26 @@ class S3ReservationsWriter:
     async def add_all_reservations(self,
                                    reservations_dict: Dict[Reservation, Dict[str, Any]],
                                    source: str,
-                                   async_s3_client: AioBaseClient = None):
+                                   async_aws_client: AioBaseClient = None):
         """
         Add all reservations to S3 storage.
         :param reservations_dict: A mapping of Reservation -> some deployable agent spec
         :param source: A string describing where the deployment was coming from
-        :param async_s3_client: An aiobotocore S3 client to use for the put_object call
+        :param async_aws_client: An aiobotocore S3 client to use for the put_object call
         """
         # Process each reservation/agent spec pair individually
         reservation: Reservation = None
         agent_spec: Dict[str, Any] = None
         for reservation, agent_spec in reservations_dict.items():
-            await self.add_one_reservation(async_s3_client, reservation, agent_spec, source)
+            await self.add_one_reservation(async_aws_client, reservation, agent_spec, source)
 
-    async def add_one_reservation(self, async_s3_client: AioBaseClient,
+    async def add_one_reservation(self, async_aws_client: AioBaseClient,
                                   reservation: Reservation,
                                   agent_spec: Dict[str, Any],
                                   source: str):
         """
         Add a single reservation to S3 storage.
-        :param async_s3_client: An aiobotocore S3 client to use for the put_object call
+        :param async_aws_client: An aiobotocore S3 client to use for the put_object call
         :param reservation: The reservation to add
         :param agent_spec: The agent spec to add
         :param source: A string describing where the deployment was coming from
@@ -169,7 +169,7 @@ class S3ReservationsWriter:
         # Store as JSON object in S3 with proper content type
         json_body: str = dumps(agent_spec, indent=4)  # Pretty-printed JSON
 
-        put_function: Awaitable = partial(async_s3_client.put_object,
+        put_function: Awaitable = partial(async_aws_client.put_object,
                                           Bucket=self.bucket_name,
                                           Key=key,
                                           Body=json_body,

--- a/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
+++ b/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
@@ -32,7 +32,7 @@ from aiobotocore.client import AioBaseClient
 from neuro_san.interfaces.reservation import Reservation
 from neuro_san.internals.reservations.reservation_dictionary_converter import ReservationDictionaryConverter
 from neuro_san.service.watcher.temp_networks.aws_async_client_worker import AwsAsyncClientWorker
-from neuro_san.service.watcher.temp_networks.s3_retry_util import S3RetryUtil
+from neuro_san.service.watcher.temp_networks.s3_util import S3Util
 
 
 # pylint: disable=too-many-instance-attributes
@@ -51,10 +51,12 @@ class S3ReservationsWriter:
     also managed by S3ReservationsStorage.
     """
 
-    def __init__(self, name: str = "S3ReservationsWriter", bucket_name: str = "", prefix: str = "reservations/"):
+    def __init__(self, name: str = "S3ReservationsWriter", bucket_name: str = "",
+                 prefix: str = S3Util.DEFAULT_RESERVATIONS_PREFIX):
         """
         Initialize S3 reservations storage.
 
+        :param name: Name of this writer
         :param bucket_name: S3 bucket name (defaults to AGENT_RESERVATIONS_S3_BUCKET env var)
         :param prefix: S3 key prefix for reservation objects
         """
@@ -164,7 +166,7 @@ class S3ReservationsWriter:
 
         # Generate S3 key using prefix and reservation ID for easy lookup
         reservation_id: str = reservation.get_reservation_id()
-        key: str = S3RetryUtil.get_obj_key_for_reservation(self.prefix, reservation_id)
+        key: str = S3Util.get_obj_key_for_reservation(self.prefix, reservation_id)
 
         # Store as JSON object in S3 with proper content type
         json_body: str = dumps(agent_spec, indent=4)  # Pretty-printed JSON

--- a/neuro_san/service/watcher/temp_networks/s3_retry_util.py
+++ b/neuro_san/service/watcher/temp_networks/s3_retry_util.py
@@ -16,15 +16,8 @@
 # END COPYRIGHT
 
 from random import random
-from time import sleep as sync_sleep
 
-from logging import getLogger
-from logging import Logger
-
-from botocore.exceptions import BotoCoreError
 from botocore.exceptions import ClientError
-
-from leaf_common.logging.sensitive_logger import SensitiveLogger
 
 
 class S3RetryUtil:
@@ -65,39 +58,6 @@ class S3RetryUtil:
         if isinstance(status, int) and 500 <= status < 600:
             return True
         return False
-
-    @staticmethod
-    def do_with_retries(source: str, fn, *, max_attempts: int = 8, base_sleep: float = 0.25):
-        """
-        Generic retry wrapper for boto3 calls.
-        boto3/botocore already retries, but this adds a bit of extra resilience and backoff for batch operations.
-        """
-        logger: Logger = getLogger(__name__)
-        sensitive_logger: SensitiveLogger = SensitiveLogger(logger)
-        sleep: float = 0.0
-        attempt: int = 1
-        while True:
-            try:
-                return fn()
-            except ClientError as err:
-                if attempt >= max_attempts or not S3RetryUtil.is_retryable_client_error(err):
-                    raise
-                sleep = S3RetryUtil.exponential_backoff_with_jitter(base_sleep, attempt)
-                sensitive_logger.warning("%s: Retryable sync ClientError (%s). attempt=%d", source, err, attempt)
-                sync_sleep(sleep)
-                attempt += 1
-            except BotoCoreError as err:
-                # Often transient network/serialization issues
-                if attempt >= max_attempts:
-                    raise
-                sleep = S3RetryUtil.exponential_backoff_with_jitter(base_sleep, attempt)
-                sensitive_logger.warning("%s: Retryable sync BotoCoreError (%s). attempt=%d", source, err, attempt)
-                sync_sleep(sleep)
-                attempt += 1
-            except Exception as err:  # pylint: disable=broad-except
-                # Catch-all for unexpected exceptions; log and re-raise
-                sensitive_logger.error("%s: Unexpected sync error (%s). attempt=%d", source, err, attempt)
-                raise
 
     @staticmethod
     def exponential_backoff_with_jitter(base_sleep: float, attempt: int) -> float:

--- a/neuro_san/service/watcher/temp_networks/s3_retry_util.py
+++ b/neuro_san/service/watcher/temp_networks/s3_retry_util.py
@@ -15,8 +15,6 @@
 #
 # END COPYRIGHT
 
-from asyncio import sleep as async_sleep
-from asyncio import CancelledError
 from random import random
 from time import sleep as sync_sleep
 
@@ -99,45 +97,6 @@ class S3RetryUtil:
             except Exception as err:  # pylint: disable=broad-except
                 # Catch-all for unexpected exceptions; log and re-raise
                 sensitive_logger.error("%s: Unexpected sync error (%s). attempt=%d", source, err, attempt)
-                raise
-
-    @staticmethod
-    async def async_do_with_retries(source: str, fn, *, max_attempts: int = 8, base_sleep: float = 0.25):
-        """
-        Generic retry wrapper for boto3 calls.
-        boto3/botocore already retries, but this adds a bit of extra resilience and backoff for batch operations.
-        """
-        logger: Logger = getLogger(__name__)
-        sensitive_logger: SensitiveLogger = SensitiveLogger(logger)
-        sleep: float = 0.0
-        attempt: int = 1
-
-        while True:
-            try:
-                return await fn()
-            except ClientError as err:
-                if attempt >= max_attempts or not S3RetryUtil.is_retryable_client_error(err):
-                    raise
-
-                sleep = S3RetryUtil.exponential_backoff_with_jitter(base_sleep, attempt)
-                sensitive_logger.warning("%s: Retryable async ClientError (%s). attempt=%d", source, err, attempt)
-                await async_sleep(sleep)
-                attempt += 1
-            except BotoCoreError as err:
-                # Often transient network/serialization issues
-                if attempt >= max_attempts:
-                    raise
-
-                sleep = S3RetryUtil.exponential_backoff_with_jitter(base_sleep, attempt)
-                sensitive_logger.warning("%s: Retryable async BotoCoreError (%s). attempt=%d", source, err, attempt)
-                await async_sleep(sleep)
-                attempt += 1
-            except CancelledError:
-                logger.info("%s: async Task was cancelled.", source)
-                raise
-            except Exception as err:  # pylint: disable=broad-except
-                # Catch-all for unexpected exceptions; log and re-raise
-                sensitive_logger.error("%s: Unexpected async error (%s). attempt=%d", source, err, attempt)
                 raise
 
     @staticmethod

--- a/neuro_san/service/watcher/temp_networks/s3_util.py
+++ b/neuro_san/service/watcher/temp_networks/s3_util.py
@@ -19,11 +19,15 @@ from random import random
 
 from botocore.exceptions import ClientError
 
+from leaf_common.parsers.dictionary_extractor import DictionaryExtractor
 
-class S3RetryUtil:
+
+class S3Util:
     """
-    Utilities for retrying AWS S3 operations.
+    Utilities for AWS S3 operations.
     """
+
+    DEFAULT_RESERVATIONS_PREFIX: str = "reservations/"
 
     @staticmethod
     def is_retryable_client_error(err: ClientError) -> bool:
@@ -32,14 +36,9 @@ class S3RetryUtil:
         :param err: The ClientError exception to evaluate
         :return: True if the error is likely transient and worth retrying, False otherwise
         """
-        client_error = err.response.get("Error")
-        if not client_error:
-            client_error = {}
-        code = client_error.get("Code", "")
-        error_response = err.response.get("ResponseMetadata")
-        if not error_response:
-            error_response = {}
-        status = error_response.get("HTTPStatusCode", 0)
+        extractor = DictionaryExtractor(err.response)
+        code = extractor.get("Error.Code", "")
+        status = extractor.get("ResponseMetadata.HTTPStatusCode", 0)
 
         # Common codes for transient situations
         retryable_codes = {

--- a/tests/neuro_san/service/watcher/temp_networks/fake_s3_client.py
+++ b/tests/neuro_san/service/watcher/temp_networks/fake_s3_client.py
@@ -79,3 +79,9 @@ class FakeS3Client:
                 "GetObject",
             )
         return {"Body": io.BytesIO(self.objects[Key])}
+
+    def close(self):
+        """
+        Close the in-memory bucket.
+        """
+        self.objects = {}

--- a/tests/neuro_san/service/watcher/temp_networks/fake_s3_client.py
+++ b/tests/neuro_san/service/watcher/temp_networks/fake_s3_client.py
@@ -84,4 +84,4 @@ class FakeS3Client:
         """
         Close the in-memory bucket.
         """
-        self.objects = {}
+        # Do nothing

--- a/tests/neuro_san/service/watcher/temp_networks/s3_reservations_storage_test_base.py
+++ b/tests/neuro_san/service/watcher/temp_networks/s3_reservations_storage_test_base.py
@@ -78,7 +78,7 @@ class S3ReservationsStorageTestBase(IsolatedAsyncioTestCase):
         # Patch boto3_client at the import boundary in s3_reservations_storage
         # so storage.start() receives our fake instead of a real boto3 client.
         boto3_patcher = patch(
-            "neuro_san.service.watcher.temp_networks.s3_reservations_retriever.boto3_client",
+            "neuro_san.service.watcher.temp_networks.aws_sync_client_worker.Session.create_client",
             return_value=self.fake_s3,
         )
         boto3_patcher.start()
@@ -91,7 +91,7 @@ class S3ReservationsStorageTestBase(IsolatedAsyncioTestCase):
         # Patch aiobotocore_client at the import boundary in s3_reservations_storage
         # so storage.start() receives our fake instead of a real aiobotocore client.
         aiobotocore_patcher = patch(
-            "neuro_san.service.watcher.temp_networks.s3_reservations_writer.AioSession.create_client",
+            "neuro_san.service.watcher.temp_networks.aws_async_client_worker.AioSession.create_client",
             return_value=self.fake_async_s3,
         )
         aiobotocore_patcher.start()

--- a/tests/neuro_san/service/watcher/temp_networks/s3_reservations_storage_test_base.py
+++ b/tests/neuro_san/service/watcher/temp_networks/s3_reservations_storage_test_base.py
@@ -31,6 +31,7 @@ from unittest import IsolatedAsyncioTestCase
 from unittest.mock import patch
 
 from aiobotocore.credentials import AioCredentials
+from botocore.credentials import Credentials
 
 from neuro_san.internals.reservations.agent_reservation import AgentReservation
 from neuro_san.service.watcher.temp_networks.s3_reservations_storage import S3ReservationsStorage
@@ -86,6 +87,19 @@ class S3ReservationsStorageTestBase(IsolatedAsyncioTestCase):
         # regardless of pass/fail.
         self.addCleanup(boto3_patcher.stop)
 
+        # Patch Session.get_credentials at the import boundary in s3_reservations_writer
+        # so storage.start() receives deterministic fake credentials.
+        def _fake_get_credentials(*_args, **_kwargs):
+            return Credentials("bogus", "bogus")
+
+        credentials_patcher = patch(
+            "neuro_san.service.watcher.temp_networks.aws_sync_client_worker.Session.get_credentials",
+            new=_fake_get_credentials,
+        )
+        credentials_patcher.start()
+        # Restores the real AioSession symbol after the test completes, regardless of pass/fail.
+        self.addCleanup(credentials_patcher.stop)
+
         self.fake_async_s3: FakeAsyncS3Client = FakeAsyncS3Client(self.fake_s3)
 
         # Patch aiobotocore_client at the import boundary in s3_reservations_storage
@@ -101,12 +115,12 @@ class S3ReservationsStorageTestBase(IsolatedAsyncioTestCase):
 
         # Patch AioSession.get_credentials at the import boundary in s3_reservations_writer
         # so storage.start() receives deterministic fake credentials.
-        async def _fake_get_credentials(*_args, **_kwargs):
+        async def _async_fake_get_credentials(*_args, **_kwargs):
             return AioCredentials("bogus", "bogus")
 
         credentials_patcher = patch(
             "neuro_san.service.watcher.temp_networks.aws_async_client_worker.AioSession.get_credentials",
-            new=_fake_get_credentials,
+            new=_async_fake_get_credentials,
         )
         credentials_patcher.start()
         # Restores the real AioSession symbol after the test completes, regardless of pass/fail.

--- a/tests/neuro_san/service/watcher/temp_networks/s3_reservations_storage_test_base.py
+++ b/tests/neuro_san/service/watcher/temp_networks/s3_reservations_storage_test_base.py
@@ -105,7 +105,7 @@ class S3ReservationsStorageTestBase(IsolatedAsyncioTestCase):
             return AioCredentials("bogus", "bogus")
 
         credentials_patcher = patch(
-            "neuro_san.service.watcher.temp_networks.s3_reservations_writer.AioSession.get_credentials",
+            "neuro_san.service.watcher.temp_networks.aws_async_client_worker.AioSession.get_credentials",
             new=_fake_get_credentials,
         )
         credentials_patcher.start()

--- a/tests/neuro_san/service/watcher/temp_networks/test_batch_partial_failure.py
+++ b/tests/neuro_san/service/watcher/temp_networks/test_batch_partial_failure.py
@@ -102,7 +102,7 @@ class TestBatchPartialFailure(S3ReservationsStorageTestBase):
         # so no sleep should fire, but we patch it so a regression that
         # adds AccessDenied to retryable_codes does not hang the test.
         with patch(
-            "neuro_san.service.watcher.temp_networks.s3_retry_util.async_sleep"
+            "neuro_san.service.watcher.temp_networks.aws_async_client_worker.async_sleep"
         ):
 
             with self.assertRaises(ClientError) as ctx:

--- a/tests/neuro_san/service/watcher/temp_networks/test_no_retry_on_access_denied.py
+++ b/tests/neuro_san/service/watcher/temp_networks/test_no_retry_on_access_denied.py
@@ -76,7 +76,7 @@ class TestNoRetryOnAccessDenied(S3ReservationsStorageTestBase):
         # Skip backoff sleep defensively. If a regression makes
         # AccessDenied retryable, we don't want the test to hang.
         with patch(
-            "neuro_san.service.watcher.temp_networks.s3_retry_util.async_sleep"
+            "neuro_san.service.watcher.temp_networks.aws_async_client_worker.async_sleep"
         ):
             with self.assertRaises(ClientError) as ctx:
                 await self.storage.add_reservations({reservation: agent_spec})

--- a/tests/neuro_san/service/watcher/temp_networks/test_object_key_format.py
+++ b/tests/neuro_san/service/watcher/temp_networks/test_object_key_format.py
@@ -20,7 +20,7 @@ specific S3 object key. This module pins that key format as a contract.
 """
 import pytest
 
-from neuro_san.service.watcher.temp_networks.s3_retry_util import S3RetryUtil
+from neuro_san.service.watcher.temp_networks.s3_util import S3Util
 
 from tests.neuro_san.service.watcher.temp_networks.s3_reservations_storage_test_base \
     import S3ReservationsStorageTestBase
@@ -79,7 +79,7 @@ class TestObjectKeyFormat(S3ReservationsStorageTestBase):
         # (e.g., the writer is refactored but the helper is not).
         self.assertEqual(
             expected_key,
-            S3RetryUtil.get_obj_key_for_reservation(self.storage.writer.prefix, reservation_id),
+            S3Util.get_obj_key_for_reservation(self.storage.writer.prefix, reservation_id),
             "get_obj_key_for_reservation does not produce the same key "
             "the storage wrote to; read and write would disagree.",
         )

--- a/tests/neuro_san/service/watcher/temp_networks/test_retry_on_listing_pagination.py
+++ b/tests/neuro_san/service/watcher/temp_networks/test_retry_on_listing_pagination.py
@@ -90,7 +90,7 @@ class TestRetryOnListingPagination(S3ReservationsStorageTestBase):
         # Patches the module-local time.sleep symbol that _do_with_retries
         # uses.
         with patch(
-            "neuro_san.service.watcher.temp_networks.s3_retry_util.sync_sleep"
+            "neuro_san.service.watcher.temp_networks.aws_sync_client_worker.sync_sleep"
         ):
             keys = list(self.storage.expiration.iter_reservation_keys(self.fake_s3))
 

--- a/tests/neuro_san/service/watcher/temp_networks/test_retry_on_listing_pagination.py
+++ b/tests/neuro_san/service/watcher/temp_networks/test_retry_on_listing_pagination.py
@@ -92,7 +92,7 @@ class TestRetryOnListingPagination(S3ReservationsStorageTestBase):
         with patch(
             "neuro_san.service.watcher.temp_networks.s3_retry_util.sync_sleep"
         ):
-            keys = list(self.storage.expiration.iter_reservation_keys())
+            keys = list(self.storage.expiration.iter_reservation_keys(self.fake_s3))
 
         # Every configured key is yielded exactly once, in page order.
         # Under the original (paginator-based) implementation a mid-listing

--- a/tests/neuro_san/service/watcher/temp_networks/test_retry_on_throttling.py
+++ b/tests/neuro_san/service/watcher/temp_networks/test_retry_on_throttling.py
@@ -80,7 +80,7 @@ class TestRetryOnThrottling(S3ReservationsStorageTestBase):
         # fast. Patches the module-local asyncio.sleep symbol that
         # _do_with_retries uses.
         with patch(
-            "neuro_san.service.watcher.temp_networks.s3_retry_util.async_sleep"
+            "neuro_san.service.watcher.temp_networks.aws_async_client_worker.async_sleep"
         ):
             await self.storage.add_reservations({reservation: agent_spec})
 


### PR DESCRIPTION
Factor our sync and asynchronous versions of a Aws[A]syncClientWorker, which handles the correct locking
and retries for getting AWS credentials from a single Session object.  These guys acknowledge that the credentials can change (as we now know some configurations are token based).

Refactor the Retriever, Writer and Expiration to all use the appropriate ClientWorker for their stuff.
Now, each time they are invoked via their main entry point, they get a new version of a client with correct credentials.
This will actually fix a latent undiscovered problem we had with the previous Reader code where each request would use the same client, meaning everyone would have to wait for each other.

Some other refactoring:
* S3RetryUtil -> S3Util
* Actual do_with_retry() methods move to their respective AwsClientWorker
* Have a single constant for the "reservations/" prefix
* Use DictionaryExtractors to better manage getting malformed data when doing deep dictionary dives. This should fix what @vince-leaf saw in the Expiration with "NoneType has no 'get()' attribute" messages

Tested santas workshop