### PR TITLE
Add neuro-san event loop tasks tracking.

### DIFF
--- a/neuro_san/deploy/Dockerfile
+++ b/neuro_san/deploy/Dockerfile
@@ -225,6 +225,24 @@ ENV AGENT_HTTP_PORT="8080"
 # best-case probe responsiveness under load.
 ENV AGENT_HEALTH_PROBE_PORT="8081"
 
+# Enable the sys.setprofile-based loop timeline tracer on the Tornado
+# main event loop. When enabled, records a linear timeline of every
+# scheduled unit of work run by the loop -- task steps, done callbacks,
+# call_soon callbacks, timer callbacks -- keyed by task name or callback
+# qualname. Useful for answering "what is occupying the loop right now?"
+# Adds ~5-10% loop overhead. Leave OFF in production unless diagnosing.
+ENV AGENT_LOOP_TIMELINE="false"
+
+# Ring buffer size for the loop timeline tracer. Older events drop off as
+# newer ones arrive. Only consulted when AGENT_LOOP_TIMELINE is enabled.
+ENV AGENT_LOOP_TIMELINE_MAX_EVENTS="100000"
+
+# If non-empty AND AGENT_LOOP_TIMELINE is enabled, the tracer writes its
+# buffered events to this JSONL file on graceful process shutdown. Leave
+# empty to keep the timeline in-memory only (snapshot via a debug endpoint
+# or signal handler at runtime).
+ENV AGENT_LOOP_TIMELINE_DUMP_PATH=""
+
 # Maximm number of requests that can be served at the same time
 # A value of 0 indicates unlimited requests are handled.
 ENV AGENT_MAX_CONCURRENT_REQUESTS="50"

--- a/neuro_san/deploy/Dockerfile
+++ b/neuro_san/deploy/Dockerfile
@@ -225,6 +225,21 @@ ENV AGENT_HTTP_PORT="8080"
 # best-case probe responsiveness under load.
 ENV AGENT_HEALTH_PROBE_PORT="8081"
 
+# Enable asyncio debug mode on the Tornado main event loop in each worker.
+# When set to "true"/"1"/"yes", the server calls loop.set_debug(True), which:
+#   - turns on additional asyncio diagnostics
+#   - logs a WARNING via the "asyncio" logger whenever any callback runs longer
+#     than AGENT_ASYNCIO_SLOW_CALLBACK_DURATION_MS (see below). The warning
+#     includes the source location of the offending callback -- the diagnostic
+#     to use when /livez probe latency spikes under load.
+# Adds ~5-10% loop overhead. Leave off in production unless diagnosing.
+ENV AGENT_ASYNCIO_DEBUG="false"
+
+# Slow-callback threshold in milliseconds. Only consulted when
+# AGENT_ASYNCIO_DEBUG is enabled. Lower values surface smaller hogs but
+# create more log volume. 50-100ms is a good first pass.
+ENV AGENT_ASYNCIO_SLOW_CALLBACK_DURATION_MS="100"
+
 # Enable the sys.setprofile-based loop timeline tracer on the Tornado
 # main event loop. When enabled, records a linear timeline of every
 # scheduled unit of work run by the loop -- task steps, done callbacks,

--- a/neuro_san/service/http/server/http_server.py
+++ b/neuro_san/service/http/server/http_server.py
@@ -259,7 +259,9 @@ class HttpServer(AgentStateListener):
         try:
             threshold_ms: int = int(raw_threshold)
         except ValueError:
-            self.logger.warning({}, "Invalid AGENT_ASYNCIO_SLOW_CALLBACK_DURATION_MS=%r; falling back to 100ms", raw_threshold)
+            self.logger.warning({},
+                                "Invalid AGENT_ASYNCIO_SLOW_CALLBACK_DURATION_MS=%r; falling back to 100ms",
+                                raw_threshold)
             threshold_ms = 100
 
         io_loop = tornado.ioloop.IOLoop.current()

--- a/neuro_san/service/http/server/http_server.py
+++ b/neuro_san/service/http/server/http_server.py
@@ -261,9 +261,11 @@ class HttpServer(AgentStateListener):
         except ValueError:
             threshold_ms = 100
 
-        loop = asyncio.get_event_loop()
+        io_loop = tornado.ioloop.IOLoop.current()
+        loop = getattr(io_loop, "asyncio_loop", asyncio.get_event_loop())
+        threshold_ms = max(threshold_ms, 1)
         loop.set_debug(True)
-        loop.slow_callback_duration = max(threshold_ms, 1) / 1000.0
+        loop.slow_callback_duration = threshold_ms / 1000.0
         self.logger.info(
             {},
             "asyncio debug enabled on Tornado loop; "

--- a/neuro_san/service/http/server/http_server.py
+++ b/neuro_san/service/http/server/http_server.py
@@ -262,7 +262,7 @@ class HttpServer(AgentStateListener):
             threshold_ms = 100
 
         io_loop = tornado.ioloop.IOLoop.current()
-        loop = getattr(io_loop, "asyncio_loop", asyncio.get_event_loop())
+        loop = getattr(io_loop, "asyncio_loop", None) or asyncio.get_event_loop()
         threshold_ms = max(threshold_ms, 1)
         loop.set_debug(True)
         loop.slow_callback_duration = threshold_ms / 1000.0

--- a/neuro_san/service/http/server/http_server.py
+++ b/neuro_san/service/http/server/http_server.py
@@ -313,7 +313,7 @@ class HttpServer(AgentStateListener):
             self.logger.info(
                 {}, "LoopTimelineTracer will dump to %s on shutdown", dump_path)
 
-        # Start LAST so the tracer sees IOLoop.start() and everything after.
+        # Start LAST so the tracer captures all callbacks executed after the loop starts running.
         self._loop_timeline_tracer.start()
 
     def resolve_health_probe_port(self) -> int:

--- a/neuro_san/service/http/server/http_server.py
+++ b/neuro_san/service/http/server/http_server.py
@@ -22,6 +22,7 @@ from typing import Any
 from typing import Dict
 from typing import List
 
+import asyncio
 import json
 import os
 import random
@@ -216,6 +217,12 @@ class HttpServer(AgentStateListener):
                             {}, "Failed to start %s: %s",
                             startable.__class__.__name__, str(exception))
 
+        # Optionally enable asyncio debug mode + slow-callback warnings on the
+        # Tornado IOLoop's underlying asyncio loop. Off by default to avoid the
+        # ~5-10% debug-mode overhead in production. Done after server.start()
+        # forks so each worker enables it in its own loop.
+        self._maybe_enable_asyncio_debug()
+
         # Optionally install the sys.setprofile-based loop timeline tracer.
         # Must be done on the Tornado loop thread, so we install it here --
         # this method runs on that thread and IOLoop.current().start() below
@@ -224,6 +231,45 @@ class HttpServer(AgentStateListener):
 
         tornado.ioloop.IOLoop.current().start()
         self.logger.info({}, "Http server stopped.")
+
+    def _maybe_enable_asyncio_debug(self) -> None:
+        """
+        Enable asyncio debug mode and the slow-callback warning on the
+        current Tornado IOLoop's asyncio loop when requested via env vars.
+
+        Controls:
+          AGENT_ASYNCIO_DEBUG (bool, default false)
+              When truthy, enables loop.set_debug(True). This turns on
+              additional asyncio diagnostics including the slow-callback
+              warning. Adds ~5-10% loop overhead -- leave off in production
+              unless actively diagnosing.
+          AGENT_ASYNCIO_SLOW_CALLBACK_DURATION_MS (int, default 100)
+              Threshold in milliseconds. Any callback running longer than
+              this on the Tornado loop will be logged at WARNING via the
+              "asyncio" logger, with the source location of the offending
+              callback.
+
+        Must be called after server.start() (i.e. after fork) so each
+        worker process configures its own loop.
+        """
+        if not ConfigUtil.get_bool(os.environ, "AGENT_ASYNCIO_DEBUG"):
+            return
+
+        try:
+            threshold_ms: int = int(os.environ.get(
+                "AGENT_ASYNCIO_SLOW_CALLBACK_DURATION_MS", "100"))
+        except ValueError:
+            threshold_ms = 100
+
+        loop = asyncio.get_event_loop()
+        loop.set_debug(True)
+        loop.slow_callback_duration = max(threshold_ms, 1) / 1000.0
+        self.logger.info(
+            {},
+            "asyncio debug enabled on Tornado loop; "
+            "slow_callback_duration=%dms (warns via 'asyncio' logger)",
+            threshold_ms,
+        )
 
     # pylint: disable=attribute-defined-outside-init
     def _maybe_start_loop_timeline_tracer(self) -> None:

--- a/neuro_san/service/http/server/http_server.py
+++ b/neuro_san/service/http/server/http_server.py
@@ -31,6 +31,7 @@ import tornado
 
 from leaf_common.serialization.util.text_file_reader import TextFileReader
 
+from neuro_san.internals.utils.config_util import ConfigUtil
 from neuro_san.internals.interfaces.agent_network_provider import AgentNetworkProvider
 from neuro_san.internals.interfaces.agent_state_listener import AgentStateListener
 from neuro_san.internals.interfaces.agent_storage_source import AgentStorageSource
@@ -57,6 +58,7 @@ from neuro_san.service.interfaces.agent_server import AgentServer
 from neuro_san.service.interfaces.event_loop_logger import EventLoopLogger
 from neuro_san.internals.interfaces.startable import Startable
 from neuro_san.service.mcp.handlers.mcp_root_handler import McpRootHandler
+from neuro_san.service.utils.loop_timeline_tracer import LoopTimelineTracer
 from neuro_san.service.utils.server_context import ServerContext
 from neuro_san.service.utils.server_status import ServerStatus
 
@@ -214,8 +216,57 @@ class HttpServer(AgentStateListener):
                             {}, "Failed to start %s: %s",
                             startable.__class__.__name__, str(exception))
 
+        # Optionally install the sys.setprofile-based loop timeline tracer.
+        # Must be done on the Tornado loop thread, so we install it here --
+        # this method runs on that thread and IOLoop.current().start() below
+        # runs synchronously on the same thread.
+        self._maybe_start_loop_timeline_tracer()
+
         tornado.ioloop.IOLoop.current().start()
         self.logger.info({}, "Http server stopped.")
+
+    # pylint: disable=attribute-defined-outside-init
+    def _maybe_start_loop_timeline_tracer(self) -> None:
+        """
+        Start a LoopTimelineTracer on this thread if AGENT_LOOP_TIMELINE is
+        truthy. The tracer records per-callback timing on the Tornado event
+        loop -- a linear timeline of what ran and when.
+
+        Environment variables:
+          AGENT_LOOP_TIMELINE (bool, default false)
+              Enables the tracer.
+          AGENT_LOOP_TIMELINE_MAX_EVENTS (int, default 100000)
+              Ring buffer size. Older events drop off as new ones arrive.
+          AGENT_LOOP_TIMELINE_DUMP_PATH (str, default empty)
+              If non-empty, register an atexit hook that writes the buffered
+              timeline as JSONL to this path on graceful shutdown. When left
+              empty the timeline stays in-memory only; snapshot it manually
+              from a debug endpoint or signal handler.
+
+        The tracer adds ~5-10% loop overhead; keep off in production unless
+        actively diagnosing.
+        """
+        if not ConfigUtil.get_bool(os.environ, "AGENT_LOOP_TIMELINE"):
+            return
+
+        try:
+            max_events: int = int(os.environ.get(
+                "AGENT_LOOP_TIMELINE_MAX_EVENTS", str(LoopTimelineTracer.DEFAULT_MAX_EVENTS)))
+        except ValueError:
+            max_events = LoopTimelineTracer.DEFAULT_MAX_EVENTS
+        if max_events <= 0:
+            max_events = LoopTimelineTracer.DEFAULT_MAX_EVENTS
+
+        self._loop_timeline_tracer = LoopTimelineTracer(max_events=max_events)
+
+        dump_path: str = os.environ.get("AGENT_LOOP_TIMELINE_DUMP_PATH", "").strip()
+        if dump_path:
+            self._loop_timeline_tracer.register_atexit_dump(dump_path)
+            self.logger.info(
+                {}, "LoopTimelineTracer will dump to %s on shutdown", dump_path)
+
+        # Start LAST so the tracer sees IOLoop.start() and everything after.
+        self._loop_timeline_tracer.start()
 
     def resolve_health_probe_port(self) -> int:
         """

--- a/neuro_san/service/http/server/http_server.py
+++ b/neuro_san/service/http/server/http_server.py
@@ -255,10 +255,11 @@ class HttpServer(AgentStateListener):
         if not ConfigUtil.get_bool(os.environ, "AGENT_ASYNCIO_DEBUG"):
             return
 
+        raw_threshold: str = os.environ.get("AGENT_ASYNCIO_SLOW_CALLBACK_DURATION_MS", "100")
         try:
-            threshold_ms: int = int(os.environ.get(
-                "AGENT_ASYNCIO_SLOW_CALLBACK_DURATION_MS", "100"))
+            threshold_ms: int = int(raw_threshold)
         except ValueError:
+            self.logger.warning({}, "Invalid AGENT_ASYNCIO_SLOW_CALLBACK_DURATION_MS=%r; falling back to 100ms", raw_threshold)
             threshold_ms = 100
 
         io_loop = tornado.ioloop.IOLoop.current()

--- a/neuro_san/service/utils/loop_timeline_tracer.py
+++ b/neuro_san/service/utils/loop_timeline_tracer.py
@@ -79,9 +79,9 @@ class LoopTimelineTracer:
 
     DEFAULT_MAX_EVENTS: int = 100_000
 
-    # sys.setprofile 'event' string values we care about. Assigned to
-    # module-level constants so the profile callback can do fast identity
-    # comparisons (each string literal is interned by Python).
+    # sys.setprofile 'event' string values we care about. Kept as constants so
+    # the profile callback can do fast equality checks against a small, fixed
+    # vocabulary.
     _EVENT_CALL: str = "call"
     _EVENT_RETURN: str = "return"
 

--- a/neuro_san/service/utils/loop_timeline_tracer.py
+++ b/neuro_san/service/utils/loop_timeline_tracer.py
@@ -186,7 +186,7 @@ class LoopTimelineTracer:
         if frame.f_code is not self._handle_run_code:
             return
         # Only interested in call/return events (skip c_call/c_return, exception).
-        if event not in (self._EVENT_CALL, self._EVENT_RETURN):
+        if event != self._EVENT_CALL and event != self._EVENT_RETURN:
             return
         ts_ns: int = time.monotonic_ns()
         if event == self._EVENT_CALL:

--- a/neuro_san/service/utils/loop_timeline_tracer.py
+++ b/neuro_san/service/utils/loop_timeline_tracer.py
@@ -237,7 +237,6 @@ class LoopTimelineTracer:
             self._logger.warning(
                 "LoopTimelineTracer atexit dump failed: %s", exc)
 
-
     def register_atexit_dump(self, path: str) -> None:
         """
         Convenience: wire dump_to_file(path) into atexit so the process

--- a/neuro_san/service/utils/loop_timeline_tracer.py
+++ b/neuro_san/service/utils/loop_timeline_tracer.py
@@ -134,7 +134,9 @@ class LoopTimelineTracer:
             return
         if threading.get_ident() != self._loop_thread_ident:
             return
-        sys.setprofile(None)
+        prev_profile = getattr(self, "_previous_profile", None)
+        sys.setprofile(prev_profile)
+        self._previous_profile = None
         self._loop_thread_ident = None
 
     def snapshot(self) -> List[Tuple[int, str, str, str]]:

--- a/neuro_san/service/utils/loop_timeline_tracer.py
+++ b/neuro_san/service/utils/loop_timeline_tracer.py
@@ -117,6 +117,7 @@ class LoopTimelineTracer:
         if self._loop_thread_ident is not None:
             return
         self._loop_thread_ident = threading.get_ident()
+        self._previous_profile = sys.getprofile()
         sys.setprofile(self._profile)
         self._logger.info(
             "LoopTimelineTracer active on thread %d (buffer=%d events)",

--- a/neuro_san/service/utils/loop_timeline_tracer.py
+++ b/neuro_san/service/utils/loop_timeline_tracer.py
@@ -157,7 +157,13 @@ class LoopTimelineTracer:
                  first. Empty if tracing has not started or no events have
                  been captured.
         """
-        return list(self._events)
+        # Deque iteration may raise if mutated concurrently from another thread.
+        for _ in range(5):
+            try:
+                return list(self._events)
+            except RuntimeError:
+                time.sleep(0)
+        return []
 
     def dump_to_file(self, path: str) -> int:
         """

--- a/neuro_san/service/utils/loop_timeline_tracer.py
+++ b/neuro_san/service/utils/loop_timeline_tracer.py
@@ -122,6 +122,11 @@ class LoopTimelineTracer:
             return
         self._loop_thread_ident = threading.get_ident()
         self._previous_profile = sys.getprofile()
+        if self._previous_profile is not None:
+            self._logger.warning(
+                "LoopTimelineTracer is replacing an existing sys.setprofile hook (%r); it will be restored on stop()",
+                self._previous_profile,
+            )
         sys.setprofile(self._profile)
         self._logger.info(
             "LoopTimelineTracer active on thread %d (buffer=%d events)",

--- a/neuro_san/service/utils/loop_timeline_tracer.py
+++ b/neuro_san/service/utils/loop_timeline_tracer.py
@@ -105,6 +105,7 @@ class LoopTimelineTracer:
         self._handle_run_code: Any = asyncio.events.Handle._run.__code__
         self._logger: logging.Logger = logging.getLogger(self.__class__.__name__)
         self._registered_atexit: bool = False
+        self._previous_profile: Optional[Any] = None
 
     def start(self) -> None:
         """

--- a/neuro_san/service/utils/loop_timeline_tracer.py
+++ b/neuro_san/service/utils/loop_timeline_tracer.py
@@ -1,0 +1,240 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+"""
+See class comment for details.
+"""
+import asyncio
+import atexit
+import json
+import logging
+import os
+import sys
+import threading
+import time
+from collections import deque
+from typing import Any
+from typing import Deque
+from typing import List
+from typing import Optional
+from typing import Tuple
+
+
+class LoopTimelineTracer:
+    """
+    sys.setprofile-based tracer that records a linear timeline of activity
+    on a single asyncio event-loop thread.
+
+    Every scheduled unit of work an asyncio loop runs -- task steps, done
+    callbacks, call_soon callbacks, timer callbacks -- flows through
+    asyncio.events.Handle._run(). By hooking that function's call/return
+    events via sys.setprofile, this tracer captures:
+
+      - When each scheduled unit of work started.
+      - When it returned (i.e. yielded back to the loop, or finished).
+      - What it was: a Task step (with the task's name) or a plain
+        callback (with the callback's qualname).
+
+    Reading a snapshot back gives you a sequence like:
+
+        call   task_step  streaming_chat.post   t=0.000ms
+        return                                  t=0.140ms
+        call   callback   _add_ready_callback   t=0.145ms
+        return                                  t=0.148ms
+        call   task_step  agent_chat_loop       t=0.200ms
+        return                                  t=1.310ms   <- this task hogged 1.1ms
+        ...
+
+    which directly answers "what is occupying my loop?"
+
+    Design notes:
+      * Ring buffer (collections.deque with maxlen) bounds memory. Old events
+        drop off the front as new ones arrive.
+      * The profile callback is deliberately minimal to keep tracing overhead
+        low; expensive introspection (peeking at frame locals) happens only
+        on 'call' events for the specific Handle._run frame.
+      * f_code identity comparison (frame.f_code is _handle_run_code) is
+        O(1) and avoids string matching in the hot path.
+      * sys.setprofile is per-thread. This tracer must be started on the
+        thread whose loop you want to trace (typically the Tornado main
+        loop thread, right before IOLoop.current().start()).
+
+    Cost: ~5-10% loop overhead depending on callback density. Fine for
+    diagnostic runs and manageable for production if you keep the buffer
+    small.
+    """
+
+    DEFAULT_MAX_EVENTS: int = 100_000
+
+    # sys.setprofile 'event' string values we care about. Assigned to
+    # module-level constants so the profile callback can do fast identity
+    # comparisons (each string literal is interned by Python).
+    _EVENT_CALL: str = "call"
+    _EVENT_RETURN: str = "return"
+
+    # Semantic label values we emit for enriched call events. Keep the
+    # vocabulary small so post-processing tools can filter by string.
+    _LABEL_TASK_STEP: str = "task_step"
+    _LABEL_CALLBACK: str = "callback"
+    _LABEL_UNKNOWN: str = "unknown"
+
+    def __init__(self, max_events: int = DEFAULT_MAX_EVENTS):
+        """
+        :param max_events: Maximum number of events retained in the ring
+                buffer. Older events are dropped as newer ones arrive.
+        """
+        self._events: Deque[Tuple[int, str, str, str]] = deque(maxlen=max_events)
+        self._max_events: int = max_events
+        self._loop_thread_ident: Optional[int] = None
+        # Cache the code object of asyncio.events.Handle._run so the profile
+        # callback can filter by frame.f_code identity (O(1)) instead of
+        # matching by function name (string compare on every profile event).
+        self._handle_run_code: Any = asyncio.events.Handle._run.__code__
+        self._logger: logging.Logger = logging.getLogger(self.__class__.__name__)
+
+    def start(self) -> None:
+        """
+        Install the sys.setprofile hook on the CURRENT thread. Must be
+        called from the thread whose event loop you want to trace
+        (e.g. the Tornado worker's main loop thread, right before
+        IOLoop.current().start()).
+
+        Idempotent: repeated calls from the same thread are a no-op.
+        """
+        if self._loop_thread_ident is not None:
+            return
+        self._loop_thread_ident = threading.get_ident()
+        sys.setprofile(self._profile)
+        self._logger.info(
+            "LoopTimelineTracer active on thread %d (buffer=%d events)",
+            self._loop_thread_ident, self._max_events)
+
+    def stop(self) -> None:
+        """
+        Uninstall the sys.setprofile hook. Must be called from the same
+        thread that called start(); a call from a different thread is a
+        no-op (sys.setprofile is per-thread and cannot be reset from
+        outside the thread).
+        """
+        if self._loop_thread_ident is None:
+            return
+        if threading.get_ident() != self._loop_thread_ident:
+            return
+        sys.setprofile(None)
+        self._loop_thread_ident = None
+
+    def snapshot(self) -> List[Tuple[int, str, str, str]]:
+        """
+        Return a list copy of the current ring-buffer contents. Safe to
+        call from any thread.
+
+        :return: A list of (t_ns, phase, label, detail) tuples, oldest
+                 first. Empty if tracing has not started or no events have
+                 been captured.
+        """
+        return list(self._events)
+
+    def dump_to_file(self, path: str) -> int:
+        """
+        Serialize the buffered timeline as JSONL to the given path. Each
+        line is a JSON object with keys: t_ns, phase, label, detail.
+
+        :param path: Filesystem path to write.
+        :return: Number of events written.
+        """
+        events_snapshot: List[Tuple[int, str, str, str]] = self.snapshot()
+        # Write to a tmp file and rename so partial files never appear on
+        # disk even if the writer is interrupted mid-dump.
+        tmp_path: str = f"{path}.{os.getpid()}.tmp"
+        with open(tmp_path, "w", encoding="utf-8") as fh:
+            for event in events_snapshot:
+                fh.write(json.dumps({
+                    "t_ns": event[0],
+                    "phase": event[1],
+                    "label": event[2],
+                    "detail": event[3],
+                }) + "\n")
+        os.replace(tmp_path, path)
+        return len(events_snapshot)
+
+    def _profile(self, frame, event, _arg) -> None:
+        """
+        The actual sys.setprofile callback. Keep this method small and
+        cheap: it runs on every C->Python and Python->C transition on
+        this thread. Expensive work here dominates the measured timing
+        and defeats the point of tracing.
+        """
+        # Fast filter: only interested in the Handle._run frame.
+        if frame.f_code is not self._handle_run_code:
+            return
+        # Only interested in call/return events (skip c_call/c_return, exception).
+        if event not in (self._EVENT_CALL, self._EVENT_RETURN):
+            return
+        ts_ns: int = time.monotonic_ns()
+        if event == self._EVENT_CALL:
+            label, detail = self._describe_handle(frame)
+            self._events.append((ts_ns, self._EVENT_CALL, label, detail))
+        else:
+            # Return events don't need enrichment -- they close the most
+            # recent open 'call'. Post-processing pairs them up.
+            self._events.append((ts_ns, self._EVENT_RETURN, "", ""))
+
+    @classmethod
+    def _describe_handle(cls, frame) -> Tuple[str, str]:
+        """
+        Introspect the Handle._run frame's locals to identify what is
+        about to run. Returns a (label, detail) pair for logging.
+
+        This is the only introspective step in the hot path; it runs only
+        on 'call' events (once per scheduled unit of work).
+        """
+        try:
+            handle = frame.f_locals.get("self")
+            callback = getattr(handle, "_callback", None)
+            if callback is None:
+                return cls._LABEL_UNKNOWN, ""
+            # A Task step is scheduled by asyncio as a bound method of the
+            # Task instance -- callback.__self__ is the Task.
+            self_obj = getattr(callback, "__self__", None)
+            if isinstance(self_obj, asyncio.Task):
+                return cls._LABEL_TASK_STEP, self_obj.get_name()
+            # Otherwise it's a plain callback (call_soon target, done cb, etc.).
+            qualname: str = getattr(callback, "__qualname__", repr(callback))
+            return cls._LABEL_CALLBACK, qualname
+        except Exception:  # pylint: disable=broad-exception-caught
+            # Anything unexpected: don't crash the profile callback.
+            return cls._LABEL_UNKNOWN, ""
+
+    def register_atexit_dump(self, path: str) -> None:
+        """
+        Convenience: wire dump_to_file(path) into atexit so the process
+        writes its final timeline on graceful shutdown. Idempotent per
+        instance -- calling twice registers only once.
+
+        :param path: Destination path for the JSONL dump.
+        """
+
+        def _on_exit():
+            try:
+                count: int = self.dump_to_file(path)
+                self._logger.info(
+                    "LoopTimelineTracer wrote %d events to %s at shutdown",
+                    count, path)
+            except Exception as exc:  # pylint: disable=broad-exception-caught
+                self._logger.warning(
+                    "LoopTimelineTracer atexit dump failed: %s", exc)
+
+        atexit.register(_on_exit)

--- a/neuro_san/service/utils/loop_timeline_tracer.py
+++ b/neuro_san/service/utils/loop_timeline_tracer.py
@@ -231,7 +231,9 @@ class LoopTimelineTracer:
             if isinstance(self_obj, asyncio.Task):
                 return cls._LABEL_TASK_STEP, self_obj.get_name()
             # Otherwise it's a plain callback (call_soon target, done cb, etc.).
-            qualname: str = getattr(callback, "__qualname__", repr(callback))
+            qualname = getattr(callback, "__qualname__", None)
+            if qualname is None:
+                qualname = repr(callback)
             return cls._LABEL_CALLBACK, qualname
         except Exception:  # pylint: disable=broad-exception-caught
             # Anything unexpected: don't crash the profile callback.

--- a/neuro_san/service/utils/loop_timeline_tracer.py
+++ b/neuro_san/service/utils/loop_timeline_tracer.py
@@ -186,6 +186,7 @@ class LoopTimelineTracer:
         if frame.f_code is not self._handle_run_code:
             return
         # Only interested in call/return events (skip c_call/c_return, exception).
+        # pylint: disable=consider-using-in
         if event != self._EVENT_CALL and event != self._EVENT_RETURN:
             return
         ts_ns: int = time.monotonic_ns()

--- a/neuro_san/service/utils/loop_timeline_tracer.py
+++ b/neuro_san/service/utils/loop_timeline_tracer.py
@@ -104,6 +104,7 @@ class LoopTimelineTracer:
         # matching by function name (string compare on every profile event).
         self._handle_run_code: Any = asyncio.events.Handle._run.__code__
         self._logger: logging.Logger = logging.getLogger(self.__class__.__name__)
+        self._registered_atexit: bool = False
 
     def start(self) -> None:
         """
@@ -221,6 +222,22 @@ class LoopTimelineTracer:
             # Anything unexpected: don't crash the profile callback.
             return cls._LABEL_UNKNOWN, ""
 
+    def _on_exit(self, path: str) -> None:
+        """
+        Internal atexit callback to dump the timeline to a file. Catches
+        and logs any exceptions so the process can exit cleanly.
+        :param path: Destination path for the JSONL dump.
+        """
+        try:
+            count: int = self.dump_to_file(path)
+            self._logger.info(
+                "LoopTimelineTracer wrote %d events to %s at shutdown",
+                count, path)
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            self._logger.warning(
+                "LoopTimelineTracer atexit dump failed: %s", exc)
+
+
     def register_atexit_dump(self, path: str) -> None:
         """
         Convenience: wire dump_to_file(path) into atexit so the process
@@ -229,15 +246,8 @@ class LoopTimelineTracer:
 
         :param path: Destination path for the JSONL dump.
         """
+        if self._registered_atexit:
+            return
 
-        def _on_exit():
-            try:
-                count: int = self.dump_to_file(path)
-                self._logger.info(
-                    "LoopTimelineTracer wrote %d events to %s at shutdown",
-                    count, path)
-            except Exception as exc:  # pylint: disable=broad-exception-caught
-                self._logger.warning(
-                    "LoopTimelineTracer atexit dump failed: %s", exc)
-
-        atexit.register(_on_exit)
+        atexit.register(self._on_exit, path)
+        self._registered_atexit = True

--- a/neuro_san/service/utils/loop_timeline_tracer.py
+++ b/neuro_san/service/utils/loop_timeline_tracer.py
@@ -96,6 +96,8 @@ class LoopTimelineTracer:
         :param max_events: Maximum number of events retained in the ring
                 buffer. Older events are dropped as newer ones arrive.
         """
+        if max_events <= 0:
+            raise ValueError("max_events must be a positive integer")
         self._events: Deque[Tuple[int, str, str, str]] = deque(maxlen=max_events)
         self._max_events: int = max_events
         self._loop_thread_ident: Optional[int] = None


### PR DESCRIPTION
 Summary

  Adds two opt-in diagnostics for investigating Tornado main-loop responsiveness under load — a sys.setprofile-based timeline tracer that records a linear timeline of every scheduled unit of work run by the loop, and asyncio's built-in slow-callback warning wired into the
  neuro-san server. Both are gated behind env vars and default off (each adds 5–10% loop overhead).

  Together they answer two related but distinct questions:
  - "What is occupying my Tornado loop, in order?" — the timeline tracer emits per-callback start/end events.
  - "Which specific coroutine or callback is over the threshold?" — asyncio's slow-callback warning logs the source location of anything running longer than a configurable duration.

  LoopTimelineTracer (neuro_san/service/utils/loop_timeline_tracer.py)

  New class. Records a linear timeline of every scheduled unit of work on a single asyncio event-loop thread:

  - Hooks asyncio.events.Handle._run() via sys.setprofile. Every task step, done callback, call_soon callback, and timer callback flows through that function, so its enter/exit gives a complete picture of loop activity.
  - Uses frame.f_code is <cached_Handle._run_code> identity comparison in the hot path — O(1), no string matching.
  - Enriches call events by inspecting the Handle's _callback. Bound methods of asyncio.Task are labeled task_step with the task's name; other callables are labeled callback with the qualname.
  - Bounded ring buffer (collections.deque(maxlen=N)) keeps memory predictable.
  - API: start(), stop(), snapshot(), dump_to_file(path) (atomic JSONL), register_atexit_dump(path).
  - Cost: ~5–10% loop overhead depending on callback density.

  Output format: JSONL, one line per event, each with {t_ns, phase, label, detail}. Post-process by pairing call/return events to compute per-callback durations. Sample script pattern documented in the docstring.

  Slow-callback warning (http_server.py::_maybe_enable_asyncio_debug)

  Wraps asyncio's built-in loop.set_debug(True) + loop.slow_callback_duration behind two env vars:

  - AGENT_ASYNCIO_DEBUG (bool, default false) — master toggle.
  - AGENT_ASYNCIO_SLOW_CALLBACK_DURATION_MS (int, default 100) — threshold in ms.

  When enabled, any callback running longer than the threshold logs a WARNING via the "asyncio" logger with the source location of the offending coroutine or callback.

  Both configurations are installed on the Tornado worker's own loop after server.start(N) fork, so each worker gets its own instance and no selector/kqueue state is inherited from the parent.

  Wiring in http_server.py
  
  Two new methods on HttpServer, both invoked from start() immediately before IOLoop.current().start() — on the loop thread, per worker after fork:

  - _maybe_enable_asyncio_debug() — reads AGENT_ASYNCIO_DEBUG + AGENT_ASYNCIO_SLOW_CALLBACK_DURATION_MS and configures the loop accordingly.
  - _maybe_start_loop_timeline_tracer() — reads AGENT_LOOP_TIMELINE + AGENT_LOOP_TIMELINE_MAX_EVENTS + AGENT_LOOP_TIMELINE_DUMP_PATH, mints the tracer, calls start(), and optionally registers atexit for JSONL dump on shutdown.

  Both methods are no-ops when their env vars aren't set. Startup overhead is nil in that case.

New Dockerfile env vars
  
  - AGENT_ASYNCIO_DEBUG (default "false") — enables asyncio's debug mode plus slow-callback warnings on the Tornado loop.
  - AGENT_ASYNCIO_SLOW_CALLBACK_DURATION_MS (default "100") — threshold in milliseconds above which callbacks are logged via the "asyncio" logger.
  - AGENT_LOOP_TIMELINE (default "false") — enables the sys.setprofile-based timeline tracer.
  - AGENT_LOOP_TIMELINE_MAX_EVENTS (default "100000") — ring-buffer size; older events drop off as newer ones arrive.
  - AGENT_LOOP_TIMELINE_DUMP_PATH (default "") — if set, JSONL dump path used by an atexit hook on graceful shutdown.

  All five env vars are documented inline in the Dockerfile with commentary on their intended use and the ~5–10% overhead each diagnostic adds when enabled.

