### PR TITLE
Break out streaming_chat() message filtering loop to its own asynchronous task

### DIFF
--- a/neuro_san/internals/chat/data_driven_chat_session.py
+++ b/neuro_san/internals/chat/data_driven_chat_session.py
@@ -22,7 +22,6 @@ from typing import Tuple
 from typing import Type
 from typing import Union
 
-from copy import copy
 from copy import deepcopy
 from os import environ
 import traceback
@@ -37,7 +36,6 @@ from leaf_common.config.resolver_util import ResolverUtil
 
 from neuro_san.internals.chat.async_collating_queue import AsyncCollatingQueue
 from neuro_san.internals.chat.chat_history_message_processor import ChatHistoryMessageProcessor
-from neuro_san.internals.filters.message_filter import MessageFilter
 from neuro_san.internals.graph.registry.agent_network import AgentNetwork
 from neuro_san.internals.graph.registry.agent_tool_registry import AgentToolRegistry
 from neuro_san.internals.interfaces.context_type_tracing_context_factory import ContextTypeTracingContextFactory
@@ -50,7 +48,6 @@ from neuro_san.internals.journals.intercepting_journal import InterceptingJourna
 from neuro_san.internals.journals.journal import Journal
 from neuro_san.internals.messages.agent_framework_message import AgentFrameworkMessage
 from neuro_san.internals.messages.base_message_dictionary_converter import BaseMessageDictionaryConverter
-from neuro_san.internals.messages.chat_message_type import ChatMessageType
 from neuro_san.internals.messages.sly_data_redactor import SlyDataRedactor
 from neuro_san.internals.run_context.factory.run_context_factory import RunContextFactory
 from neuro_san.internals.run_context.factory.master_tracing_context_factory import MasterTracingContextFactory
@@ -422,52 +419,6 @@ class DataDrivenChatSession(RunTarget, LingeringResource):
         # Eventually this might be a CompositeMessageProcessor
         message_processor = StructureMessageProcessor(structure_formats)
         return message_processor
-
-    async def filter_queue(self, invocation_context: InvocationContext,
-                           template_response_dict: Dict[str, Any],
-                           message_filter: MessageFilter,
-                           message_processor: MessageProcessor):
-
-        input_queue: AsyncCollatingQueue = invocation_context.get_queue()
-        output_queue: AsyncCollatingQueue = invocation_context.get_filtered_queue()
-
-        response_dict: Dict[str, Any] = None
-        async for message in input_queue:
-            response_dict = await self.process_queue_message(message, template_response_dict,
-                                                             message_filter, message_processor)
-            if response_dict is not None:
-                await output_queue.put(response_dict, synchronous=True)
-
-        await output_queue.put_final_item(synchronous=True)
-
-    async def process_queue_message(self, message: Dict[str, Any],
-                                    template_response_dict: Dict[str, Any],
-                                    message_filter: MessageFilter,
-                                    message_processor: MessageProcessor) -> Dict[str, Any]:
-        """
-        Process the message and return an appropriate response dictionary
-        This is called by the server main loop in streaming_chat() to filter
-        what needs to be sent to the client.
-        We'd rather this be done on the DataDrivenChatSession side of the queue.
-
-        :param message: A dictionary form of chat.ChatMessage
-        :param template_response_dict: A dictionary form of chat.ChatResponse
-        :param message_filter: An instance of MessageFilter
-        :param message_processor: An instance of MessageProcessor
-        :return: A dictionary form of chat.ChatResponse
-        """
-        if not message_filter.allow(message):
-            return None
-
-        # We expect the message to be a dictionary form of chat.ChatMessage
-        if message_processor is not None:
-            message_type: ChatMessageType = message.get("type")
-            # Can modify message
-            await message_processor.async_process_message(message, message_type)
-
-        response_dict: Dict[str, Any] = copy(template_response_dict)
-        response_dict["response"] = message
-        return response_dict
 
     async def close_of_work(self, parent_resource: LingeringResource = None):
         """

--- a/neuro_san/internals/chat/data_driven_chat_session.py
+++ b/neuro_san/internals/chat/data_driven_chat_session.py
@@ -22,6 +22,7 @@ from typing import Tuple
 from typing import Type
 from typing import Union
 
+from copy import copy
 from copy import deepcopy
 from os import environ
 import traceback
@@ -36,6 +37,7 @@ from leaf_common.config.resolver_util import ResolverUtil
 
 from neuro_san.internals.chat.async_collating_queue import AsyncCollatingQueue
 from neuro_san.internals.chat.chat_history_message_processor import ChatHistoryMessageProcessor
+from neuro_san.internals.filters.message_filter import MessageFilter
 from neuro_san.internals.graph.registry.agent_network import AgentNetwork
 from neuro_san.internals.graph.registry.agent_tool_registry import AgentToolRegistry
 from neuro_san.internals.interfaces.context_type_tracing_context_factory import ContextTypeTracingContextFactory
@@ -48,6 +50,7 @@ from neuro_san.internals.journals.intercepting_journal import InterceptingJourna
 from neuro_san.internals.journals.journal import Journal
 from neuro_san.internals.messages.agent_framework_message import AgentFrameworkMessage
 from neuro_san.internals.messages.base_message_dictionary_converter import BaseMessageDictionaryConverter
+from neuro_san.internals.messages.chat_message_type import ChatMessageType
 from neuro_san.internals.messages.sly_data_redactor import SlyDataRedactor
 from neuro_san.internals.run_context.factory.run_context_factory import RunContextFactory
 from neuro_san.internals.run_context.factory.master_tracing_context_factory import MasterTracingContextFactory
@@ -419,6 +422,35 @@ class DataDrivenChatSession(RunTarget, LingeringResource):
         # Eventually this might be a CompositeMessageProcessor
         message_processor = StructureMessageProcessor(structure_formats)
         return message_processor
+
+    async def process_queue_message(self, message: Dict[str, Any],
+                                    template_response_dict: Dict[str, Any],
+                                    message_filter: MessageFilter,
+                                    message_processor: MessageProcessor) -> Dict[str, Any]:
+        """
+        Process the message and return an appropriate response dictionary
+        This is called by the server main loop in streaming_chat() to filter
+        what needs to be sent to the client.
+        We'd rather this be done on the DataDrivenChatSession side of the queue.
+
+        :param message: A dictionary form of chat.ChatMessage
+        :param template_response_dict: A dictionary form of chat.ChatResponse
+        :param message_filter: An instance of MessageFilter
+        :param message_processor: An instance of MessageProcessor
+        :return: A dictionary form of chat.ChatResponse
+        """
+        if not message_filter.allow(message):
+            return None
+
+        # We expect the message to be a dictionary form of chat.ChatMessage
+        if message_processor is not None:
+            message_type: ChatMessageType = message.get("type")
+            # Can modify message
+            await message_processor.async_process_message(message, message_type)
+
+        response_dict: Dict[str, Any] = copy(template_response_dict)
+        response_dict["response"] = message
+        return response_dict
 
     async def close_of_work(self, parent_resource: LingeringResource = None):
         """

--- a/neuro_san/internals/chat/data_driven_chat_session.py
+++ b/neuro_san/internals/chat/data_driven_chat_session.py
@@ -423,6 +423,23 @@ class DataDrivenChatSession(RunTarget, LingeringResource):
         message_processor = StructureMessageProcessor(structure_formats)
         return message_processor
 
+    async def filter_queue(self, invocation_context: InvocationContext,
+                           template_response_dict: Dict[str, Any],
+                           message_filter: MessageFilter,
+                           message_processor: MessageProcessor):
+
+        input_queue: AsyncCollatingQueue = invocation_context.get_queue()
+        output_queue: AsyncCollatingQueue = invocation_context.get_filtered_queue()
+
+        response_dict: Dict[str, Any] = None
+        async for message in input_queue:
+            response_dict = await self.process_queue_message(message, template_response_dict,
+                                                             message_filter, message_processor)
+            if response_dict is not None:
+                await output_queue.put(response_dict, synchronous=True)
+
+        await output_queue.put_final_item(synchronous=True)
+
     async def process_queue_message(self, message: Dict[str, Any],
                                     template_response_dict: Dict[str, Any],
                                     message_filter: MessageFilter,

--- a/neuro_san/internals/chat/data_driven_chat_session.py
+++ b/neuro_san/internals/chat/data_driven_chat_session.py
@@ -54,7 +54,6 @@ from neuro_san.internals.run_context.factory.master_tracing_context_factory impo
 from neuro_san.internals.run_context.interfaces.run_context import RunContext
 from neuro_san.message_processing.message_processor import MessageProcessor
 from neuro_san.message_processing.answer_message_processor import AnswerMessageProcessor
-from neuro_san.message_processing.structure_message_processor import StructureMessageProcessor
 
 # Lazily import specific errors from llm providers
 PATIENCE_ERRORS: Tuple[Type[Any], ...] = ResolverUtil.create_type_tuple([
@@ -398,27 +397,6 @@ class DataDrivenChatSession(RunTarget, LingeringResource):
         }
 
         return chat_context
-
-    def create_outgoing_message_processor(self) -> MessageProcessor:
-        """
-        :return: A MessageProcessor that filters messages outgoing to the client.
-                How this works is based on settings on the front man.
-                Can be None.
-        """
-        message_processor: MessageProcessor = None
-
-        front_man_name: str = self.registry.find_front_man()
-        front_man_spec: Dict[str, Any] = self.registry.get_agent_tool_spec(front_man_name)
-
-        # Get the formats we should parse from the final answer from the config for the network.
-        # As of 6/24/25, this is an unadvertised experimental feature.
-        structure_formats: Union[str, List[str]] = front_man_spec.get("structure_formats")
-        if structure_formats is None:
-            return message_processor
-
-        # Eventually this might be a CompositeMessageProcessor
-        message_processor = StructureMessageProcessor(structure_formats)
-        return message_processor
 
     async def close_of_work(self, parent_resource: LingeringResource = None):
         """

--- a/neuro_san/internals/chat/queue_filter.py
+++ b/neuro_san/internals/chat/queue_filter.py
@@ -89,14 +89,17 @@ class QueueFilter:
         via the output queue.
         We'd rather this work be done off the main server thread.
         """
-        response_dict: Dict[str, Any] = None
-        async for message in self.input_queue:
-            response_dict = await self.process_queue_message(message)
-            if response_dict is not None:
-                await self.output_queue.put(response_dict, synchronous=True)
-
-        await self.output_queue.put_final_item(synchronous=True)
-
+        try:
+            async for message in self.input_queue:
+                response_dict = await self.process_queue_message(message)
+                if response_dict is not None:
+                    await self.output_queue.put(response_dict, synchronous=True)
+        finally:
+            # Always signal completion so consumers don't hang if processing fails mid-stream.
+            try:
+                await self.output_queue.put_final_item(synchronous=True)
+            except Exception:
+                pass
     async def process_queue_message(self, message: Dict[str, Any]) -> Dict[str, Any]:
         """
         Process the single message and return an appropriate response dictionary

--- a/neuro_san/internals/chat/queue_filter.py
+++ b/neuro_san/internals/chat/queue_filter.py
@@ -17,14 +17,19 @@
 
 from typing import Any
 from typing import Dict
+from typing import List
+from typing import Union
 
 from copy import copy
 
 from neuro_san.internals.chat.async_collating_queue import AsyncCollatingQueue
 from neuro_san.internals.filters.message_filter import MessageFilter
+from neuro_san.internals.filters.message_filter_factory import MessageFilterFactory
+from neuro_san.internals.graph.registry.agent_network import AgentNetwork
 from neuro_san.internals.interfaces.invocation_context import InvocationContext
 from neuro_san.internals.messages.chat_message_type import ChatMessageType
 from neuro_san.message_processing.message_processor import MessageProcessor
+from neuro_san.message_processing.structure_message_processor import StructureMessageProcessor
 
 
 class QueueFilter:
@@ -33,19 +38,43 @@ class QueueFilter:
 
     def __init__(self, invocation_context: InvocationContext,
                  template_response_dict: Dict[str, Any],
-                 message_filter: MessageFilter,
-                 message_processor: MessageProcessor):
+                 chat_filter: Dict[str, Any],
+                 agent_network: AgentNetwork):
         """
         Constructor
 
-        :param input_queue: The queue we will be iterating over.
-        :param output_queue: The queue we will be iterating over.
+        :param invocation_context: An instance of InvocationContext
+        :param template_response_dict: A dictionary form of chat.ChatResponse
+        :param chat_filter: A dictionary form of chat.ChatFilter
+        :param agent_network: An instance of AgentNetwork
         """
         self.input_queue: AsyncCollatingQueue = invocation_context.get_queue()
         self.output_queue: AsyncCollatingQueue = invocation_context.get_filtered_queue()
         self.template_response_dict: Dict[str, Any] = template_response_dict
-        self.message_filter: MessageFilter = message_filter
-        self.message_processor: MessageProcessor = message_processor
+
+        self.message_filter: MessageFilter = MessageFilterFactory.create_message_filter(chat_filter)
+        self.message_processor: MessageProcessor = self.create_outgoing_message_processor(agent_network)
+
+    def create_outgoing_message_processor(self, agent_network: AgentNetwork) -> MessageProcessor:
+        """
+        :return: A MessageProcessor that filters messages outgoing to the client.
+                How this works is based on settings on the front man.
+                Can be None.
+        """
+        message_processor: MessageProcessor = None
+
+        front_man_name: str = agent_network.find_front_man()
+        front_man_spec: Dict[str, Any] = agent_network.get_agent_tool_spec(front_man_name)
+
+        # Get the formats we should parse from the final answer from the config for the network.
+        # As of 6/24/25, this is an unadvertised experimental feature.
+        structure_formats: Union[str, List[str]] = front_man_spec.get("structure_formats")
+        if structure_formats is None:
+            return message_processor
+
+        # Eventually this might be a CompositeMessageProcessor
+        message_processor = StructureMessageProcessor(structure_formats)
+        return message_processor
 
     async def filter_queue(self):
 

--- a/neuro_san/internals/chat/queue_filter.py
+++ b/neuro_san/internals/chat/queue_filter.py
@@ -62,6 +62,7 @@ class QueueFilter:
 
     def create_outgoing_message_processor(self, agent_network: AgentNetwork) -> MessageProcessor:
         """
+        :param agent_network: An instance of AgentNetwork
         :return: A MessageProcessor that filters messages outgoing to the client.
                 How this works is based on settings on the front man.
                 Can be None.
@@ -86,8 +87,8 @@ class QueueFilter:
         Main task entry point for DirectAgentSession.
         Filter the messages coming off the input queue so that they can be sent to the client
         via the output queue.
+        We'd rather this work be done off the main server thread.
         """
-
         response_dict: Dict[str, Any] = None
         async for message in self.input_queue:
             response_dict = await self.process_queue_message(message)
@@ -98,15 +99,9 @@ class QueueFilter:
 
     async def process_queue_message(self, message: Dict[str, Any]) -> Dict[str, Any]:
         """
-        Process the message and return an appropriate response dictionary
-        This is called by the server main loop in streaming_chat() to filter
-        what needs to be sent to the client.
-        We'd rather this be done on the DataDrivenChatSession side of the queue.
+        Process the single message and return an appropriate response dictionary
 
         :param message: A dictionary form of chat.ChatMessage
-        :param template_response_dict: A dictionary form of chat.ChatResponse
-        :param message_filter: An instance of MessageFilter
-        :param message_processor: An instance of MessageProcessor
         :return: A dictionary form of chat.ChatResponse
         """
         if not self.message_filter.allow(message):

--- a/neuro_san/internals/chat/queue_filter.py
+++ b/neuro_san/internals/chat/queue_filter.py
@@ -34,6 +34,11 @@ from neuro_san.message_processing.structure_message_processor import StructureMe
 
 class QueueFilter:
     """
+    Filters messages from the input queue (the one from the MessageJournal)
+    to be sure they are suitable to be sent to the client on the output queue.
+
+    The main entrypoint to this class is filter_queue().
+    We want the work done in filter_queue() to be done off the main server thread.
     """
 
     def __init__(self, invocation_context: InvocationContext,
@@ -77,6 +82,11 @@ class QueueFilter:
         return message_processor
 
     async def filter_queue(self):
+        """
+        Main task entry point for DirectAgentSession.
+        Filter the messages coming off the input queue so that they can be sent to the client
+        via the output queue.
+        """
 
         response_dict: Dict[str, Any] = None
         async for message in self.input_queue:

--- a/neuro_san/internals/chat/queue_filter.py
+++ b/neuro_san/internals/chat/queue_filter.py
@@ -1,0 +1,84 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+from typing import Any
+from typing import Dict
+
+from copy import copy
+
+from neuro_san.internals.chat.async_collating_queue import AsyncCollatingQueue
+from neuro_san.internals.filters.message_filter import MessageFilter
+from neuro_san.internals.interfaces.invocation_context import InvocationContext
+from neuro_san.internals.messages.chat_message_type import ChatMessageType
+from neuro_san.message_processing.message_processor import MessageProcessor
+
+
+class QueueFilter:
+    """
+    """
+
+    def __init__(self, invocation_context: InvocationContext,
+                 template_response_dict: Dict[str, Any],
+                 message_filter: MessageFilter,
+                 message_processor: MessageProcessor):
+        """
+        Constructor
+
+        :param input_queue: The queue we will be iterating over.
+        :param output_queue: The queue we will be iterating over.
+        """
+        self.input_queue: AsyncCollatingQueue = invocation_context.get_queue()
+        self.output_queue: AsyncCollatingQueue = invocation_context.get_filtered_queue()
+        self.template_response_dict: Dict[str, Any] = template_response_dict
+        self.message_filter: MessageFilter = message_filter
+        self.message_processor: MessageProcessor = message_processor
+
+    async def filter_queue(self):
+
+        response_dict: Dict[str, Any] = None
+        async for message in self.input_queue:
+            response_dict = await self.process_queue_message(message)
+            if response_dict is not None:
+                await self.output_queue.put(response_dict, synchronous=True)
+
+        await self.output_queue.put_final_item(synchronous=True)
+
+    async def process_queue_message(self, message: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Process the message and return an appropriate response dictionary
+        This is called by the server main loop in streaming_chat() to filter
+        what needs to be sent to the client.
+        We'd rather this be done on the DataDrivenChatSession side of the queue.
+
+        :param message: A dictionary form of chat.ChatMessage
+        :param template_response_dict: A dictionary form of chat.ChatResponse
+        :param message_filter: An instance of MessageFilter
+        :param message_processor: An instance of MessageProcessor
+        :return: A dictionary form of chat.ChatResponse
+        """
+        if not self.message_filter.allow(message):
+            return None
+
+        # We expect the message to be a dictionary form of chat.ChatMessage
+        if self.message_processor is not None:
+            message_type: ChatMessageType = message.get("type")
+            # Can modify message
+            await self.message_processor.async_process_message(message, message_type)
+
+        response_dict: Dict[str, Any] = copy(self.template_response_dict)
+        response_dict["response"] = message
+        return response_dict

--- a/neuro_san/internals/chat/queue_filter.py
+++ b/neuro_san/internals/chat/queue_filter.py
@@ -98,8 +98,10 @@ class QueueFilter:
             # Always signal completion so consumers don't hang if processing fails mid-stream.
             try:
                 await self.output_queue.put_final_item(synchronous=True)
+            # pylint: disable=broad-except
             except Exception:
                 pass
+
     async def process_queue_message(self, message: Dict[str, Any]) -> Dict[str, Any]:
         """
         Process the single message and return an appropriate response dictionary

--- a/neuro_san/internals/interfaces/invocation_context.py
+++ b/neuro_san/internals/interfaces/invocation_context.py
@@ -85,6 +85,13 @@ class InvocationContext(LingeringResource):
     def get_queue(self) -> AsyncCollatingQueue:
         """
         :return: The AsyncCollatingQueue instance via which messages are streamed to the
+                QueueFilter mechanics
+        """
+        raise NotImplementedError
+
+    def get_filtered_queue(self) -> AsyncCollatingQueue:
+        """
+        :return: The AsyncCollatingQueue instance via which messages are streamed to the
                 AgentSession mechanics
         """
         raise NotImplementedError

--- a/neuro_san/session/async_direct_agent_session.py
+++ b/neuro_san/session/async_direct_agent_session.py
@@ -191,18 +191,21 @@ class AsyncDirectAgentSession(AsyncAgentSession):
         # Late-stage conversions for any and all messages
         message_processor: MessageProcessor = chat_session.create_outgoing_message_processor()
 
+        task: Task = asyncio_executor.submit(self.request_id, chat_session.filter_queue,
+                                             self.invocation_context, template_response_dict,
+                                             message_filter, message_processor)
+        # Ignore the future. Live in the now.
+        _ = task
+
         # The generator below will asynchronously block waiting for
         # chat.ChatMessage dictionaries to come back asynchronously from the submit()
         # above until there are no more from the input.
-        queue_generator = self.invocation_context.get_queue()
+        queue_generator = self.invocation_context.get_filtered_queue()
         try:
+            message: Dict[str, Any] = None
             async for message in queue_generator:
-                response_dict: Dict[str, Any] = await chat_session.process_queue_message(message,
-                                                                                         template_response_dict,
-                                                                                         message_filter,
-                                                                                         message_processor)
-                if response_dict is not None:
-                    yield response_dict
+                if message is not None:
+                    yield message
         finally:
             # Logic of what is done here:
             # 1. We tell underlying chat_session to delete its resources since we are done with this request;

--- a/neuro_san/session/async_direct_agent_session.py
+++ b/neuro_san/session/async_direct_agent_session.py
@@ -186,7 +186,6 @@ class AsyncDirectAgentSession(AsyncAgentSession):
 
         # Task for late-stage conversions for any and all messages
         queue_filter = QueueFilter(self.invocation_context, template_response_dict, chat_filter, self.agent_network)
-
         task: Task = asyncio_executor.submit(self.request_id, queue_filter.filter_queue)
         # Ignore the future. Live in the now.
         _ = task

--- a/neuro_san/session/async_direct_agent_session.py
+++ b/neuro_san/session/async_direct_agent_session.py
@@ -206,19 +206,41 @@ class AsyncDirectAgentSession(AsyncAgentSession):
             #    interrupted by caller-side "aclose" method.
             # 3. And we suppress all exceptions while deleting resources to keep things quieter.
             async for message in queue_generator:
-                response_dict: Dict[str, Any] = copy(template_response_dict)
-                if message_filter.allow(message):
-                    # We expect the message to be a dictionary form of chat.ChatMessage
-                    if message_processor is not None:
-                        message_type: ChatMessageType = message.get("type")
-                        # Can modify message
-                        await message_processor.async_process_message(message, message_type)
-                    response_dict["response"] = message
+                response_dict: Dict[str, Any] = await self._process_queue_message(message,
+                                                                                  template_response_dict,
+                                                                                  message_filter,
+                                                                                  message_processor)
+                if response_dict is not None:
                     yield response_dict
         finally:
             # Release resources without exceptions
             with suppress(Exception):
                 self.invocation_context.finish_request()
+
+    async def _process_queue_message(self, message: Dict[str, Any],
+                                     template_response_dict: Dict[str, Any],
+                                     message_filter: MessageFilter,
+                                     message_processor: MessageProcessor) -> Dict[str, Any]:
+        """
+        Process the message and return an appropriate response dictionary
+        :param message: A dictionary form of chat.ChatMessage
+        :param template_response_dict: A dictionary form of chat.ChatResponse
+        :param message_filter: An instance of MessageFilter
+        :param message_processor: An instance of MessageProcessor
+        :return: A dictionary form of chat.ChatResponse
+        """
+        if not message_filter.allow(message):
+            return None
+
+        # We expect the message to be a dictionary form of chat.ChatMessage
+        if message_processor is not None:
+            message_type: ChatMessageType = message.get("type")
+            # Can modify message
+            await message_processor.async_process_message(message, message_type)
+
+        response_dict: Dict[str, Any] = copy(template_response_dict)
+        response_dict["response"] = message
+        return response_dict
 
     def reset(self):
         """

--- a/neuro_san/session/async_direct_agent_session.py
+++ b/neuro_san/session/async_direct_agent_session.py
@@ -30,6 +30,7 @@ from leaf_common.parsers.dictionary_extractor import DictionaryExtractor
 from neuro_san.interfaces.async_agent_session import AsyncAgentSession
 from neuro_san.internals.chat.connectivity_reporter import ConnectivityReporter
 from neuro_san.internals.chat.data_driven_chat_session import DataDrivenChatSession
+from neuro_san.internals.chat.queue_filter import QueueFilter
 from neuro_san.internals.filters.message_filter import MessageFilter
 from neuro_san.internals.filters.message_filter_factory import MessageFilterFactory
 from neuro_san.internals.graph.registry.agent_network import AgentNetwork
@@ -190,10 +191,9 @@ class AsyncDirectAgentSession(AsyncAgentSession):
 
         # Late-stage conversions for any and all messages
         message_processor: MessageProcessor = chat_session.create_outgoing_message_processor()
+        queue_filter = QueueFilter(self.invocation_context, template_response_dict, message_filter, message_processor)
 
-        task: Task = asyncio_executor.submit(self.request_id, chat_session.filter_queue,
-                                             self.invocation_context, template_response_dict,
-                                             message_filter, message_processor)
+        task: Task = asyncio_executor.submit(self.request_id, queue_filter.filter_queue)
         # Ignore the future. Live in the now.
         _ = task
 

--- a/neuro_san/session/async_direct_agent_session.py
+++ b/neuro_san/session/async_direct_agent_session.py
@@ -31,10 +31,7 @@ from neuro_san.interfaces.async_agent_session import AsyncAgentSession
 from neuro_san.internals.chat.connectivity_reporter import ConnectivityReporter
 from neuro_san.internals.chat.data_driven_chat_session import DataDrivenChatSession
 from neuro_san.internals.chat.queue_filter import QueueFilter
-from neuro_san.internals.filters.message_filter import MessageFilter
-from neuro_san.internals.filters.message_filter_factory import MessageFilterFactory
 from neuro_san.internals.graph.registry.agent_network import AgentNetwork
-from neuro_san.message_processing.message_processor import MessageProcessor
 from neuro_san.session.session_invocation_context import SessionInvocationContext
 
 
@@ -174,8 +171,6 @@ class AsyncDirectAgentSession(AsyncAgentSession):
 
         # Create a message filter so as to minimize network traffic per what the user wants
         chat_filter: Dict[str, Any] = request_dict.get("chat_filter")
-        message_filter: MessageFilter = MessageFilterFactory.create_message_filter(chat_filter)
-
         chat_context: Dict[str, Any] = request_dict.get("chat_context")
         sly_data: Dict[str, Any] = request_dict.get("sly_data")
 
@@ -189,9 +184,8 @@ class AsyncDirectAgentSession(AsyncAgentSession):
         # Ignore the future. Live in the now.
         _ = task
 
-        # Late-stage conversions for any and all messages
-        message_processor: MessageProcessor = chat_session.create_outgoing_message_processor()
-        queue_filter = QueueFilter(self.invocation_context, template_response_dict, message_filter, message_processor)
+        # Task for late-stage conversions for any and all messages
+        queue_filter = QueueFilter(self.invocation_context, template_response_dict, chat_filter, self.agent_network)
 
         task: Task = asyncio_executor.submit(self.request_id, queue_filter.filter_queue)
         # Ignore the future. Live in the now.

--- a/neuro_san/session/async_direct_agent_session.py
+++ b/neuro_san/session/async_direct_agent_session.py
@@ -22,7 +22,6 @@ from typing import List
 
 from asyncio import Task
 from contextlib import suppress
-from copy import copy
 import logging
 
 from leaf_common.asyncio.asyncio_executor import AsyncioExecutor
@@ -34,7 +33,6 @@ from neuro_san.internals.chat.data_driven_chat_session import DataDrivenChatSess
 from neuro_san.internals.filters.message_filter import MessageFilter
 from neuro_san.internals.filters.message_filter_factory import MessageFilterFactory
 from neuro_san.internals.graph.registry.agent_network import AgentNetwork
-from neuro_san.internals.messages.chat_message_type import ChatMessageType
 from neuro_san.message_processing.message_processor import MessageProcessor
 from neuro_san.session.session_invocation_context import SessionInvocationContext
 
@@ -198,6 +196,14 @@ class AsyncDirectAgentSession(AsyncAgentSession):
         # above until there are no more from the input.
         queue_generator = self.invocation_context.get_queue()
         try:
+            async for message in queue_generator:
+                response_dict: Dict[str, Any] = await chat_session.process_queue_message(message,
+                                                                                         template_response_dict,
+                                                                                         message_filter,
+                                                                                         message_processor)
+                if response_dict is not None:
+                    yield response_dict
+        finally:
             # Logic of what is done here:
             # 1. We tell underlying chat_session to delete its resources since we are done with this request;
             # 2. We do this in "finally" block so this releasing of resources happens in any case,
@@ -205,42 +211,8 @@ class AsyncDirectAgentSession(AsyncAgentSession):
             #    (which is implicitly constructed by these code lines and returned by this method)
             #    interrupted by caller-side "aclose" method.
             # 3. And we suppress all exceptions while deleting resources to keep things quieter.
-            async for message in queue_generator:
-                response_dict: Dict[str, Any] = await self._process_queue_message(message,
-                                                                                  template_response_dict,
-                                                                                  message_filter,
-                                                                                  message_processor)
-                if response_dict is not None:
-                    yield response_dict
-        finally:
-            # Release resources without exceptions
             with suppress(Exception):
                 self.invocation_context.finish_request()
-
-    async def _process_queue_message(self, message: Dict[str, Any],
-                                     template_response_dict: Dict[str, Any],
-                                     message_filter: MessageFilter,
-                                     message_processor: MessageProcessor) -> Dict[str, Any]:
-        """
-        Process the message and return an appropriate response dictionary
-        :param message: A dictionary form of chat.ChatMessage
-        :param template_response_dict: A dictionary form of chat.ChatResponse
-        :param message_filter: An instance of MessageFilter
-        :param message_processor: An instance of MessageProcessor
-        :return: A dictionary form of chat.ChatResponse
-        """
-        if not message_filter.allow(message):
-            return None
-
-        # We expect the message to be a dictionary form of chat.ChatMessage
-        if message_processor is not None:
-            message_type: ChatMessageType = message.get("type")
-            # Can modify message
-            await message_processor.async_process_message(message, message_type)
-
-        response_dict: Dict[str, Any] = copy(template_response_dict)
-        response_dict["response"] = message
-        return response_dict
 
     def reset(self):
         """

--- a/neuro_san/session/direct_agent_session.py
+++ b/neuro_san/session/direct_agent_session.py
@@ -22,7 +22,6 @@ from typing import List
 
 from asyncio import Task
 from contextlib import suppress
-from copy import copy
 
 from leaf_common.asyncio.async_to_sync_generator import AsyncToSyncGenerator
 from leaf_common.asyncio.asyncio_executor import AsyncioExecutor
@@ -32,11 +31,8 @@ from leaf_common.time.timeout import Timeout
 from neuro_san.interfaces.agent_session import AgentSession
 from neuro_san.internals.chat.connectivity_reporter import ConnectivityReporter
 from neuro_san.internals.chat.data_driven_chat_session import DataDrivenChatSession
-from neuro_san.internals.filters.message_filter import MessageFilter
-from neuro_san.internals.filters.message_filter_factory import MessageFilterFactory
+from neuro_san.internals.chat.queue_filter import QueueFilter
 from neuro_san.internals.graph.registry.agent_network import AgentNetwork
-from neuro_san.internals.messages.chat_message_type import ChatMessageType
-from neuro_san.message_processing.message_processor import MessageProcessor
 from neuro_san.session.session_invocation_context import SessionInvocationContext
 
 
@@ -165,8 +161,6 @@ class DirectAgentSession(AgentSession):
 
         # Create a message filter so as to minimize network traffic per what the user wants
         chat_filter: Dict[str, Any] = request_dict.get("chat_filter")
-        message_filter: MessageFilter = MessageFilterFactory.create_message_filter(chat_filter)
-
         chat_context: Dict[str, Any] = request_dict.get("chat_context")
         sly_data: Dict[str, Any] = request_dict.get("sly_data")
 
@@ -180,8 +174,11 @@ class DirectAgentSession(AgentSession):
         # Ignore the future. Live in the now.
         _ = task
 
-        # Late-stage conversions for any and all messages
-        message_processor: MessageProcessor = chat_session.create_outgoing_message_processor()
+        # Task for late-stage conversions for any and all messages
+        queue_filter = QueueFilter(self.invocation_context, template_response_dict, chat_filter, self.agent_network)
+        task: Task = asyncio_executor.submit(self.request_id, queue_filter.filter_queue)
+        # Ignore the future. Live in the now.
+        _ = task
 
         # The synchronously_iterate() method below will synchronously block waiting for
         # chat.ChatMessage dictionaries to come back asynchronously from the submit()
@@ -200,16 +197,10 @@ class DirectAgentSession(AgentSession):
             #    (which is implicitly constructed by these code lines and returned by this method)
             #    interrupted by caller-side "close" method.
             # 3. And we suppress all exceptions while deleting resources to keep things quieter.
+            message: Dict[str, Any] = None
             for message in generator.synchronously_iterate(self.invocation_context.get_queue()):
-                response_dict: Dict[str, Any] = copy(template_response_dict)
-                if message_filter.allow(message):
-                    # We expect the message to be a dictionary form of chat.ChatMessage
-                    if message_processor is not None:
-                        message_type: ChatMessageType = message.get("type")
-                        # Can modify message
-                        message_processor.process_message(message, message_type)
-                    response_dict["response"] = message
-                    yield response_dict
+                if message is not None:
+                    yield message
         finally:
             # Release resources without exceptions
             with suppress(Exception):

--- a/neuro_san/session/direct_agent_session.py
+++ b/neuro_san/session/direct_agent_session.py
@@ -198,7 +198,7 @@ class DirectAgentSession(AgentSession):
             #    interrupted by caller-side "close" method.
             # 3. And we suppress all exceptions while deleting resources to keep things quieter.
             message: Dict[str, Any] = None
-            for message in generator.synchronously_iterate(self.invocation_context.get_queue()):
+            for message in generator.synchronously_iterate(self.invocation_context.get_filtered_queue()):
                 if message is not None:
                     yield message
         finally:

--- a/neuro_san/session/session_invocation_context.py
+++ b/neuro_san/session/session_invocation_context.py
@@ -110,6 +110,7 @@ class SessionInvocationContext(InvocationContext):
         # Anything that has to do with the queue will need a new instance in
         # safe_shallow_copy() below to keep AsyncDirectAgentSessions happy.
         self.queue: AsyncCollatingQueue = AsyncCollatingQueue()
+        self.filtered_queue: AsyncCollatingQueue = AsyncCollatingQueue()
         self.journal: Journal = MessageJournal(self.queue)
         self.resources: List[LingeringResource] = []
         self.work_done_event: Event = Event()
@@ -170,6 +171,13 @@ class SessionInvocationContext(InvocationContext):
         """
         return self.queue
 
+    def get_filtered_queue(self) -> AsyncCollatingQueue:
+        """
+        :return: The AsyncCollatingQueue instance via which messages are streamed to the
+                AgentSession mechanics
+        """
+        return self.filtered_queue
+
     def get_metadata(self) -> Dict[str, str]:
         """
         :return: The metadata to pass along with any request
@@ -192,6 +200,10 @@ class SessionInvocationContext(InvocationContext):
         if self.queue is not None:
             self.queue.close()
             self.queue = None
+
+        if self.filtered_queue is not None:
+            self.filtered_queue.close()
+            self.filtered_queue = None
 
         for resource in self.resources:
             await resource.close_of_request()
@@ -270,6 +282,12 @@ class SessionInvocationContext(InvocationContext):
             self.queue = AsyncCollatingQueue()
             self.journal: Journal = MessageJournal(self.queue)
 
+        if self.filtered_queue is not None:
+            self.filtered_queue.reset()
+        else:
+            # When creating a new queue, we need to make sure that the journal knows about it
+            self.filtered_queue = AsyncCollatingQueue()
+
         # Be sure we have an executor
         if self.asyncio_executor is None:
             self.asyncio_executor = self.async_executors_pool.get_executor()
@@ -303,6 +321,7 @@ class SessionInvocationContext(InvocationContext):
 
         # We need a different queue in order to call external agents with direct sessions.
         invocation_context.queue: AsyncCollatingQueue = AsyncCollatingQueue()
+        invocation_context.filtered_queue: AsyncCollatingQueue = AsyncCollatingQueue()
 
         # Now that the queue has changed, we need a new Journal as well
         # to be sure that the messages are sent to the correct queue.

--- a/neuro_san/session/session_invocation_context.py
+++ b/neuro_san/session/session_invocation_context.py
@@ -285,7 +285,7 @@ class SessionInvocationContext(InvocationContext):
         if self.filtered_queue is not None:
             self.filtered_queue.reset()
         else:
-            # When creating a new queue, we need to make sure that the journal knows about it
+            # filtered_queue is independent of the MessageJournal; just create a new instance.
             self.filtered_queue = AsyncCollatingQueue()
 
         # Be sure we have an executor


### PR DESCRIPTION
* Move the work that was happening inside the async-for loop of AsyncDirectAgentSession.streaming_chat()
into a new class QueueFilter. 
* This guy has an entry point method called filter_queue() which is scheduled as a separate task that takes what was coming off the main MessageJournal queue and filters the results so that streaming_chat() can now do as little as possible in its async-for loop. 
* The results themselves appear on yet another "filtered_queue" that shows up on InvocationContext. 
* The difference here is that streaming_chat() can take the results from that filtered_queue as gospel to send back to the client.

Tested santa's workshop on an http server. All is good.

With this change it will be good to see if @vince-leaf 's  low-number requests curve gets any flatter w/rt time.
It's also possible that the health-check problem could get better with a lot less to do on the server main loop.