### PR TITLE
Fix S3 expiration: malformed-object policy and ExpiredToken recovery

### DIFF
--- a/neuro_san/service/watcher/temp_networks/aws_async_client_worker.py
+++ b/neuro_san/service/watcher/temp_networks/aws_async_client_worker.py
@@ -36,9 +36,9 @@ from botocore.exceptions import BotoCoreError
 from botocore.credentials import Credentials
 from botocore.credentials import ReadOnlyCredentials
 from botocore.exceptions import ClientError
+from botocore.exceptions import NoCredentialsError
 
 from leaf_common.logging.sensitive_logger import SensitiveLogger
-from leaf_common.parsers.dictionary_extractor import DictionaryExtractor
 
 from neuro_san.service.watcher.temp_networks.s3_util import S3Util
 
@@ -95,8 +95,13 @@ class AwsAsyncClientWorker:
                 return retval
 
             except ClientError as err:
-                extractor = DictionaryExtractor(err.response)
-                if "ExpiredToken" not in extractor.get("Error.Code", ""):
+                # S3Util.is_expired_token_error() is used instead of raw
+                # DictionaryExtractor access: the extractor returns a stored
+                # None in preference to its default, and
+                # '"ExpiredToken" not in None' would raise TypeError inside
+                # this handler, masking the original ClientError
+                # (see S3Util.get_error_code for details).
+                if not S3Util.is_expired_token_error(err):
                     raise
 
                 last_err = err
@@ -219,6 +224,17 @@ class AwsAsyncClientWorker:
             self.session = get_session()
 
         credentials: Credentials = await self.session.get_credentials()
+        if credentials is None:
+            # aiobotocore's credential resolver (like botocore's) returns None -
+            # it does not raise - when nothing in the chain (env vars, config
+            # files, IMDS/ECS, SSO) yields credentials. Without this check the
+            # call below fails with an opaque "AttributeError: 'NoneType' object
+            # has no attribute 'get_frozen_credentials'". Raise the
+            # botocore-idiomatic error instead; a client using the default
+            # credential chain surfaces this same misconfiguration as a
+            # NoCredentialsError from the S3 call itself, so callers/operators
+            # already know what it means.
+            raise NoCredentialsError()
 
         # Avoid a small race condition with the ClientError retry block
         # by always returning a local copy

--- a/neuro_san/service/watcher/temp_networks/aws_async_client_worker.py
+++ b/neuro_san/service/watcher/temp_networks/aws_async_client_worker.py
@@ -16,7 +16,7 @@
 # END COPYRIGHT
 
 from typing import Any
-from typing import Awaitable
+from typing import Callable
 
 from asyncio import CancelledError
 from asyncio import Lock as AsyncLock
@@ -74,7 +74,7 @@ class AwsAsyncClientWorker:
         # Cached frozen credentials which can be invalidated should they expire
         self.frozen_credentials: ReadOnlyCredentials = None
 
-    async def retry_with_new_client(self, work_function: Awaitable, *, source: str = None) -> Any:
+    async def retry_with_new_client(self, work_function: Callable, *, source: str = None) -> Any:
         """
         Retries the async work_function when client credentials can expire.
         :param work_function: The async work function to retry
@@ -135,7 +135,7 @@ class AwsAsyncClientWorker:
                 if self.async_aws_client_lock is None:
                     self.async_aws_client_lock = AsyncLock()
 
-    async def do_work_with_new_client(self, work_function: Awaitable, *, attempt: int = 1) -> Any:
+    async def do_work_with_new_client(self, work_function: Callable, *, attempt: int = 1) -> Any:
         """
         This method separates the machinations of obtaining a proper S3 client
         from add_all_reservations() which does all the actual work.

--- a/neuro_san/service/watcher/temp_networks/aws_sync_client_worker.py
+++ b/neuro_san/service/watcher/temp_networks/aws_sync_client_worker.py
@@ -30,11 +30,11 @@ from botocore.credentials import Credentials
 from botocore.credentials import ReadOnlyCredentials
 from botocore.exceptions import BotoCoreError
 from botocore.exceptions import ClientError
+from botocore.exceptions import NoCredentialsError
 from botocore.session import get_session
 from botocore.session import Session
 
 from leaf_common.logging.sensitive_logger import SensitiveLogger
-from leaf_common.parsers.dictionary_extractor import DictionaryExtractor
 
 from neuro_san.service.watcher.temp_networks.s3_util import S3Util
 
@@ -85,8 +85,13 @@ class AwsSyncClientWorker:
                 return retval
 
             except ClientError as err:
-                extractor = DictionaryExtractor(err.response)
-                if "ExpiredToken" not in extractor.get("Error.Code", ""):
+                # S3Util.is_expired_token_error() is used instead of raw
+                # DictionaryExtractor access: the extractor returns a stored
+                # None in preference to its default, and
+                # '"ExpiredToken" not in None' would raise TypeError inside
+                # this handler, masking the original ClientError
+                # (see S3Util.get_error_code for details).
+                if not S3Util.is_expired_token_error(err):
                     raise
 
                 last_err = err
@@ -199,6 +204,16 @@ class AwsSyncClientWorker:
             self.session = get_session()
 
         credentials: Credentials = self.session.get_credentials()
+        if credentials is None:
+            # botocore's credential resolver returns None - it does not raise -
+            # when nothing in the chain (env vars, config files, IMDS/ECS, SSO)
+            # yields credentials. Without this check the call below fails with
+            # an opaque "AttributeError: 'NoneType' object has no attribute
+            # 'get_frozen_credentials'". Raise the botocore-idiomatic error
+            # instead; a client using the default credential chain surfaces
+            # this same misconfiguration as a NoCredentialsError from the S3
+            # call itself, so callers/operators already know what it means.
+            raise NoCredentialsError()
 
         # Avoid a small race condition with the ClientError retry block
         # by always returning a local copy

--- a/neuro_san/service/watcher/temp_networks/s3_reservations_expiration.py
+++ b/neuro_san/service/watcher/temp_networks/s3_reservations_expiration.py
@@ -29,8 +29,6 @@ from logging import Logger
 from botocore.client import BaseClient
 from botocore.exceptions import ClientError
 
-from leaf_common.parsers.dictionary_extractor import DictionaryExtractor
-
 from neuro_san.service.watcher.temp_networks.aws_sync_client_worker import AwsSyncClientWorker
 from neuro_san.service.watcher.temp_networks.s3_reservations_retriever import S3ReservationsRetriever
 from neuro_san.service.watcher.temp_networks.s3_util import S3Util
@@ -139,6 +137,17 @@ class S3ReservationsExpiration:
                 # This was the last page - exit loop
                 break
             continuation_token = response.get("NextContinuationToken")
+            if not continuation_token:
+                # S3's ListObjectsV2 contract pairs IsTruncated=True with a
+                # NextContinuationToken, so real S3 never lands here. But if a
+                # non-compliant S3-compatible endpoint (or a test fake) omits
+                # the token, looping again without it would re-request the
+                # first page forever - an infinite loop that also burns S3 API
+                # calls for every re-listed key. Keep the failure loud
+                # rather than looping silently.
+                raise RuntimeError(
+                    f"{self.name}: list_objects_v2 returned IsTruncated=True without a "
+                    "NextContinuationToken; aborting listing to avoid an infinite pagination loop")
 
     # pylint: disable=too-many-locals
     def expire_one_reservation(self, obj_key: str, current_time: float,
@@ -153,7 +162,6 @@ class S3ReservationsExpiration:
         if source is None:
             source = self.name
 
-        empty: Dict[str, Any] = {}
         expired: bool = False
         try:
             # Retrieve the reservation object from S3
@@ -162,16 +170,40 @@ class S3ReservationsExpiration:
                 source=source,
                 sync_aws_client=sync_aws_client
             )
-            if agent_spec is None:
-                agent_spec = empty
 
-            extractor = DictionaryExtractor(agent_spec)
-            reservation_data: Dict[str, Any] = extractor.get("metadata.reservation", empty)
+            reservation_data: Dict[str, Any] = S3Util.extract_reservation_data(agent_spec)
+            if reservation_data is None:
+                # Policy for objects under the prefix that do not parse as
+                # reservations: leave them alone and warn. Three behaviors are
+                # possible here, and each has been tried or considered:
+                #   1. Raise: one malformed object makes every sweep crash at
+                #      the same key ("'NoneType' object has no attribute
+                #      'get'"), so nothing sorted after it ever expires.
+                #   2. Treat as expired and delete (e.g. by defaulting
+                #      expiration_time to 0, where current_time > 0 is
+                #      always true): silently destroys any
+                #      object whose shape we merely fail to understand - e.g.
+                #      one written by a newer/older writer version - with only
+                #      a debug-level log naming reservation '<unknown>'.
+                #   3. Skip and warn (current): safe for both the data and the
+                #      sweep. The cost is that true garbage lingers and warns
+                #      on every sweep. That is deliberate: a human should
+                #      decide to delete data, not a parse failure.
+                self.logger.warning(
+                    "%s: Object %s under the reservations prefix does not parse as a "
+                    "reservation (missing/null metadata.reservation or non-numeric "
+                    "expiration_time_in_seconds). Leaving it in place. "
+                    "If this is expected garbage, remove it manually; if it recurs for "
+                    "objects the writer produced, check for schema drift.",
+                    self.name, obj_key)
+                return False
 
             client_worker: AwsSyncClientWorker = self.retriever.get_sync_client_worker()
 
-            # Compare current time against reservation's expiration timestamp
-            expiration_time: float = reservation_data.get("expiration_time_in_seconds", 0)
+            # Compare current time against reservation's expiration timestamp.
+            # extract_reservation_data() guarantees this key exists and is numeric,
+            # so no default is needed and the comparison below cannot TypeError.
+            expiration_time: float = reservation_data.get("expiration_time_in_seconds")
             if current_time > expiration_time:
                 # Reservation has expired - remove it from S3 storage
                 try:
@@ -183,9 +215,11 @@ class S3ReservationsExpiration:
                     self.logger.debug("%s: Deleted expired reservation %s from S3", self.name, reservation_id)
                     expired = True
                 except ClientError as delete_error:
-                    extractor = DictionaryExtractor(delete_error.response)
-                    # Handle case where another process already deleted the object
-                    if extractor.get("Error.Code") != "NoSuchKey":
+                    # Handle case where another process already deleted the object.
+                    # get_error_code() is used instead of raw response access because
+                    # it always returns a str, even when the parsed error body stores
+                    # Code as null (see S3Util.get_error_code for details).
+                    if S3Util.get_error_code(delete_error) != "NoSuchKey":
                         # Re-raise other delete errors
                         raise delete_error
 
@@ -195,11 +229,26 @@ class S3ReservationsExpiration:
             # Reservation is still active - no action needed
 
         except ClientError as exception:
+            error_code: str = S3Util.get_error_code(exception)
             # Handle case where another process already removed the object before we could read it
-            extractor = DictionaryExtractor(exception.response)
-            if extractor.get("Error.Code") == "NoSuchKey":
+            if error_code == "NoSuchKey":
                 self.logger.debug("%s: Reservation %s was already removed by another process", self.name, obj_key)
                 expired = True  # Object is gone, which is the desired outcome for expiration
+            elif "ExpiredToken" in error_code:
+                # Credential expiry must NOT be swallowed here. The client this sweep
+                # uses was created from frozen credentials (see AwsSyncClientWorker),
+                # which never auto-refresh, and the only code that can refresh them is
+                # retry_with_new_client() wrapping expire_any_reservations() at the top
+                # of the sweep - and it can only react to ClientErrors that actually
+                # reach it. If ExpiredToken were merely logged like the codes below,
+                # every remaining key in the sweep would make one doomed S3 call,
+                # nothing would be expired, and the sweep would still report success;
+                # credentials would only refresh when a later sweep's list_objects_v2
+                # call happened to fail outside this handler. Re-raising lets the
+                # wrapper reset the cached credentials and re-run the sweep with a
+                # working client. Restarting the sweep is safe because deletes are
+                # idempotent: NoSuchKey on the re-run is treated as success above.
+                raise
             else:
                 # Log other S3 errors but don't raise - allows expiration to continue
                 self.logger.error("%s: S3 error processing reservation object %s: %s",

--- a/neuro_san/service/watcher/temp_networks/s3_reservations_expiration.py
+++ b/neuro_san/service/watcher/temp_networks/s3_reservations_expiration.py
@@ -16,6 +16,7 @@
 # END COPYRIGHT
 
 from typing import Any
+from typing import Callable
 from typing import Dict
 from typing import Iterable
 from typing import Optional
@@ -30,6 +31,7 @@ from logging import Logger
 from botocore.client import BaseClient
 from botocore.exceptions import ClientError
 
+from neuro_san.interfaces.reservationist import Reservationist
 from neuro_san.service.watcher.temp_networks.aws_sync_client_worker import AwsSyncClientWorker
 from neuro_san.service.watcher.temp_networks.s3_reservations_retriever import S3ReservationsRetriever
 from neuro_san.service.watcher.temp_networks.s3_util import S3Util
@@ -42,6 +44,15 @@ class S3ReservationsExpiration:
     The main entry point to this guy is expire_reservations() which gets called as part of
     S3ReservationsStorage watcher loop.
     """
+
+    # Grace period before an object under the prefix that does not parse as a
+    # reservation is deleted (see handle_malformed_object). Every reservation
+    # has a bounded lifetime (clamped against a server max, which defaults to
+    # Reservationist.DEFAULT_LIFETIME), so an object that has existed for
+    # twice that cannot be a live reservation under ANY schema version.
+    # Deployments that raise the server max lifetime beyond the default
+    # should raise this accordingly.
+    MALFORMED_OBJECT_GRACE_SECONDS: float = 2 * Reservationist.DEFAULT_LIFETIME
 
     def __init__(self, name: str = "S3ReservationsExpiration", bucket_name: str = "",
                  prefix: str = S3Util.DEFAULT_RESERVATIONS_PREFIX):
@@ -75,7 +86,7 @@ class S3ReservationsExpiration:
         """
         self.logger.debug("%s: Starting expiration process for S3 reservations", self.name)
 
-        expire_function = partial(self.expire_any_reservations)
+        expire_function: Callable = partial(self.expire_any_reservations)
 
         client_worker: AwsSyncClientWorker = self.retriever.get_sync_client_worker()
         client_worker.retry_with_new_client(expire_function, source=self.name)
@@ -128,7 +139,7 @@ class S3ReservationsExpiration:
             if continuation_token:
                 kwargs["ContinuationToken"] = continuation_token
 
-            list_objects_function = partial(sync_aws_client.list_objects_v2, **kwargs)
+            list_objects_function: Callable = partial(sync_aws_client.list_objects_v2, **kwargs)
             response = client_worker.do_with_retries(self.name, list_objects_function)
             if response is None:
                 response = {}
@@ -176,43 +187,30 @@ class S3ReservationsExpiration:
 
             reservation_data: Optional[Dict[str, Any]] = S3Util.extract_reservation_data(agent_spec)
             if reservation_data is None:
-                # Policy for objects under the prefix that do not parse as
-                # reservations: leave them alone and warn. Three behaviors are
-                # possible here, and each has been tried or considered:
-                #   1. Raise: one malformed object makes every sweep crash at
-                #      the same key ("'NoneType' object has no attribute
-                #      'get'"), so nothing sorted after it ever expires.
-                #   2. Treat as expired and delete (e.g. by defaulting
-                #      expiration_time to 0, where current_time > 0 is
-                #      always true): silently destroys any
-                #      object whose shape we merely fail to understand - e.g.
-                #      one written by a newer/older writer version - with only
-                #      a debug-level log naming reservation '<unknown>'.
-                #   3. Skip and warn (current): safe for both the data and the
-                #      sweep. The cost is that true garbage lingers and warns
-                #      on every sweep. That is deliberate: a human should
-                #      decide to delete data, not a parse failure.
-                self.logger.warning(
-                    "%s: Object %s under the reservations prefix does not parse as a "
-                    "reservation (missing/null metadata.reservation or non-numeric "
-                    "expiration_time_in_seconds). Leaving it in place. "
-                    "If this is expected garbage, remove it manually; if it recurs for "
-                    "objects the writer produced, check for schema drift.",
-                    self.name, obj_key)
-                return False
+                # Not shaped like a reservation. Note that a stored
+                # expiration_time_in_seconds of None/null lands HERE too:
+                # extract_reservation_data() returns None for the whole
+                # payload when that field is missing, null, or non-numeric.
+                return self.handle_malformed_object(obj_key, current_time,
+                                                    sync_aws_client=sync_aws_client)
 
             client_worker: AwsSyncClientWorker = self.retriever.get_sync_client_worker()
 
             # Compare current time against reservation's expiration timestamp.
-            # extract_reservation_data() guarantees this key exists and is numeric,
-            # so no default is needed and the comparison below cannot TypeError.
+            # What if expiration_time_in_seconds is None (a stored JSON null)
+            # or missing? It cannot be, by this line: null, missing, bool and
+            # non-numeric values all fail extract_reservation_data()'s
+            # isinstance check, which returns None for the WHOLE payload, and
+            # that case exits above via handle_malformed_object(). Here the
+            # value is guaranteed to be an int or float, so no default is
+            # needed and this comparison cannot raise TypeError.
             expiration_time: float = reservation_data.get("expiration_time_in_seconds")
             if current_time > expiration_time:
                 # Reservation has expired - remove it from S3 storage
                 try:
-                    delete_function = partial(sync_aws_client.delete_object,
-                                              Bucket=self.retriever.get_bucket_name(),
-                                              Key=obj_key)
+                    delete_function: Callable = partial(sync_aws_client.delete_object,
+                                                        Bucket=self.retriever.get_bucket_name(),
+                                                        Key=obj_key)
                     client_worker.do_with_retries(source, delete_function)
                     reservation_id: str = reservation_data.get("id", "<unknown>")
                     self.logger.debug("%s: Deleted expired reservation %s from S3", self.name, reservation_id)
@@ -263,3 +261,74 @@ class S3ReservationsExpiration:
                               self.name, obj_key, str(exception))
 
         return expired
+
+    def handle_malformed_object(self, obj_key: str, current_time: float,
+                                sync_aws_client: BaseClient = None) -> bool:
+        """
+        Policy for objects under the reservations prefix that do not parse as
+        reservations (see S3Util.extract_reservation_data). Four behaviors are
+        possible here, and each has been tried or considered:
+          1. Raise: one malformed object makes every sweep crash at the same
+             key ("'NoneType' object has no attribute 'get'"), so nothing
+             sorted after it ever expires.
+          2. Treat as expired and delete immediately: silently destroys any
+             object whose shape we merely fail to understand - including a
+             live reservation written by a newer schema version during a
+             rolling deploy.
+          3. Skip and warn forever: safe for the data, but unparseable
+             detritus builds up and gets re-read and re-logged on every pass.
+          4. Age-gated delete (current): skip and WARN while the object is
+             younger than MALFORMED_OBJECT_GRACE_SECONDS, then delete it with
+             a WARNING. Every reservation has a bounded lifetime, so once an
+             object has existed longer than any reservation could live, no
+             schema version can still consider it live - deleting it is safe,
+             detritus is bounded, and the warnings during the grace period
+             give humans a window to notice and diagnose schema drift.
+
+        :param obj_key: S3 object key of the unparseable object
+        :param current_time: Current timestamp to compare against
+        :param sync_aws_client: S3 client
+        :return: True if the object was deleted (counted as expired),
+                 False if it was left in place for now
+        """
+        client_worker: AwsSyncClientWorker = self.retriever.get_sync_client_worker()
+
+        # The object's age comes from S3's LastModified via head_object. This
+        # extra call happens only on this (rare) malformed path, never during
+        # a normal sweep. Any ClientError it raises (e.g. "404" because
+        # another process already deleted the object, or ExpiredToken) is
+        # handled by expire_one_reservation()'s handler, just like errors
+        # from the get/delete calls.
+        head_function: Callable = partial(sync_aws_client.head_object,
+                                          Bucket=self.retriever.get_bucket_name(),
+                                          Key=obj_key)
+        head_response: Dict[str, Any] = client_worker.do_with_retries(self.name, head_function)
+
+        last_modified: Any = head_response.get("LastModified")
+        if last_modified is None:
+            # No age available: err on the side of keeping data this pass.
+            age_in_seconds: float = 0.0
+        else:
+            age_in_seconds = current_time - last_modified.timestamp()
+
+        if age_in_seconds <= self.MALFORMED_OBJECT_GRACE_SECONDS:
+            self.logger.warning(
+                "%s: Object %s under the reservations prefix does not parse as a "
+                "reservation (missing/null metadata.reservation or non-numeric "
+                "expiration_time_in_seconds). Leaving it in place for now; if it is "
+                "still unparseable %d seconds after its last modification, it will be "
+                "deleted. If this recurs for objects the writer produced, check for "
+                "schema drift.",
+                self.name, obj_key, int(self.MALFORMED_OBJECT_GRACE_SECONDS))
+            return False
+
+        delete_function: Callable = partial(sync_aws_client.delete_object,
+                                            Bucket=self.retriever.get_bucket_name(),
+                                            Key=obj_key)
+        client_worker.do_with_retries(self.name, delete_function)
+        self.logger.warning(
+            "%s: Deleted unparseable object %s: last modified %s, older than the "
+            "%d-second grace period. No reservation lives that long, so no schema "
+            "version could still consider it live.",
+            self.name, obj_key, last_modified, int(self.MALFORMED_OBJECT_GRACE_SECONDS))
+        return True

--- a/neuro_san/service/watcher/temp_networks/s3_reservations_expiration.py
+++ b/neuro_san/service/watcher/temp_networks/s3_reservations_expiration.py
@@ -231,8 +231,12 @@ class S3ReservationsExpiration:
 
         except ClientError as exception:
             error_code: str = S3Util.get_error_code(exception)
-            # Handle case where another process already removed the object before we could read it
-            if error_code == "NoSuchKey":
+            # Handle case where another process already removed the object
+            # before we could read it. Two codes mean "gone": GET errors carry
+            # NoSuchKey in the response body, while HEAD errors (from the
+            # malformed-path head_object age check) have no body for botocore
+            # to parse, so a missing key surfaces as the bare HTTP status "404".
+            if error_code in ("NoSuchKey", "404"):
                 self.logger.debug("%s: Reservation %s was already removed by another process", self.name, obj_key)
                 expired = True  # Object is gone, which is the desired outcome for expiration
             elif S3Util.is_expired_token_error(exception):

--- a/neuro_san/service/watcher/temp_networks/s3_reservations_expiration.py
+++ b/neuro_san/service/watcher/temp_networks/s3_reservations_expiration.py
@@ -18,6 +18,7 @@
 from typing import Any
 from typing import Dict
 from typing import Iterable
+from typing import Optional
 
 from time import time
 from functools import partial
@@ -164,14 +165,16 @@ class S3ReservationsExpiration:
 
         expired: bool = False
         try:
-            # Retrieve the reservation object from S3
-            agent_spec: Dict[str, Any] = self.retriever.retrieve_object_with_retries(
+            # Retrieve the reservation object from S3. The parsed body can be
+            # any JSON type (not just a dict) - extract_reservation_data()
+            # below is designed to accept and validate exactly that.
+            agent_spec: Any = self.retriever.retrieve_object_with_retries(
                 obj_key=obj_key,
                 source=source,
                 sync_aws_client=sync_aws_client
             )
 
-            reservation_data: Dict[str, Any] = S3Util.extract_reservation_data(agent_spec)
+            reservation_data: Optional[Dict[str, Any]] = S3Util.extract_reservation_data(agent_spec)
             if reservation_data is None:
                 # Policy for objects under the prefix that do not parse as
                 # reservations: leave them alone and warn. Three behaviors are

--- a/neuro_san/service/watcher/temp_networks/s3_reservations_expiration.py
+++ b/neuro_san/service/watcher/temp_networks/s3_reservations_expiration.py
@@ -237,7 +237,7 @@ class S3ReservationsExpiration:
             if error_code == "NoSuchKey":
                 self.logger.debug("%s: Reservation %s was already removed by another process", self.name, obj_key)
                 expired = True  # Object is gone, which is the desired outcome for expiration
-            elif "ExpiredToken" in error_code:
+            elif S3Util.is_expired_token_error(exception):
                 # Credential expiry must NOT be swallowed here. The client this sweep
                 # uses was created from frozen credentials (see AwsSyncClientWorker),
                 # which never auto-refresh, and the only code that can refresh them is

--- a/neuro_san/service/watcher/temp_networks/s3_reservations_reader.py
+++ b/neuro_san/service/watcher/temp_networks/s3_reservations_reader.py
@@ -26,8 +26,6 @@ from logging import Logger
 
 from botocore.exceptions import ClientError
 
-from leaf_common.parsers.dictionary_extractor import DictionaryExtractor
-
 from neuro_san.interfaces.reservation import Reservation
 from neuro_san.internals.graph.registry.agent_network import AgentNetwork
 from neuro_san.internals.reservations.reservation_dictionary_converter import ReservationDictionaryConverter
@@ -84,22 +82,31 @@ class S3ReservationsReader:
         get_function = partial(self.retriever.retrieve_object_with_retries, obj_key=s3_obj_key, source=self.name)
 
         try:
-            # Use empty in case we have malformed data
-            empty: Dict[str, Any] = {}
-
             # Retrieve the reservation object from S3
             agent_spec: Dict[str, Any] = client_worker.retry_with_new_client(get_function)
-            if agent_spec is None:
-                agent_spec = empty
 
-            # Reconstruct the Reservation object from stored dictionary
-            extractor = DictionaryExtractor(agent_spec)
-            reservation_dict: Dict[str, Any] = extractor.get("metadata.reservation", empty)
-
-            reservation = self.converter.from_dict(reservation_dict)
-            if not reservation:
+            # Validate the payload shape BEFORE constructing any objects, using
+            # the same policy as the expiration sweep
+            # (see S3Util.extract_reservation_data).
+            #
+            # Checking the constructed object afterwards does not work:
+            # ReservationDictionaryConverter.from_dict() unconditionally returns
+            # an AgentReservation instance - truthy even when built from {} -
+            # so a post-construction "if not reservation:" can never fire, and
+            # the bogus reservation's expiration_time_in_seconds of None would
+            # later crash ExpiringAgentNetworkStorage.is_expired() on the
+            # request path with
+            # "'>' not supported between instances of 'float' and 'NoneType'".
+            # Validating the raw dict here is the one reliable place to detect
+            # malformed payloads and treat them as not-found.
+            reservation_dict: Dict[str, Any] = S3Util.extract_reservation_data(agent_spec)
+            if reservation_dict is None:
+                # Log when we get malformed content on read (for request)
                 self.logger.error("%s: Failed to parse reservation payload for %s", self.name, reservation_id)
                 return None, None
+
+            # Reconstruct the Reservation object from stored dictionary
+            reservation = self.converter.from_dict(reservation_dict)
 
             # Reconstruct the AgentNetwork object using the agent spec dictionary
             # and reservation ID - which is our agent name in this design
@@ -109,8 +116,11 @@ class S3ReservationsReader:
                               self.name, reservation.get_reservation_id())
 
         except ClientError as exception:
-            # Handle case where another process already removed the object before we could read it
-            if exception.response["Error"]["Code"] == "NoSuchKey":
+            # Handle case where another process already removed the object before we could read it.
+            # get_error_code() is used instead of raw response indexing, which can
+            # KeyError/TypeError on responses without a parsed Error dict
+            # (see S3Util.get_error_code for details).
+            if S3Util.get_error_code(exception) == "NoSuchKey":
                 self.logger.debug("%s: Reservation %s was already removed by another process during sync",
                                   self.name, reservation_id)
             else:

--- a/neuro_san/service/watcher/temp_networks/s3_reservations_reader.py
+++ b/neuro_san/service/watcher/temp_networks/s3_reservations_reader.py
@@ -17,6 +17,7 @@
 
 from typing import Any
 from typing import Dict
+from typing import Optional
 from typing import Tuple
 
 from functools import partial
@@ -82,8 +83,10 @@ class S3ReservationsReader:
         get_function = partial(self.retriever.retrieve_object_with_retries, obj_key=s3_obj_key, source=self.name)
 
         try:
-            # Retrieve the reservation object from S3
-            agent_spec: Dict[str, Any] = client_worker.retry_with_new_client(get_function)
+            # Retrieve the reservation object from S3. The parsed body can be
+            # any JSON type (not just a dict) - extract_reservation_data()
+            # below is designed to accept and validate exactly that.
+            agent_spec: Any = client_worker.retry_with_new_client(get_function)
 
             # Validate the payload shape BEFORE constructing any objects, using
             # the same policy as the expiration sweep
@@ -99,7 +102,7 @@ class S3ReservationsReader:
             # "'>' not supported between instances of 'float' and 'NoneType'".
             # Validating the raw dict here is the one reliable place to detect
             # malformed payloads and treat them as not-found.
-            reservation_dict: Dict[str, Any] = S3Util.extract_reservation_data(agent_spec)
+            reservation_dict: Optional[Dict[str, Any]] = S3Util.extract_reservation_data(agent_spec)
             if reservation_dict is None:
                 # Log when we get malformed content on read (for request)
                 self.logger.error("%s: Failed to parse reservation payload for %s", self.name, reservation_id)

--- a/neuro_san/service/watcher/temp_networks/s3_reservations_reader.py
+++ b/neuro_san/service/watcher/temp_networks/s3_reservations_reader.py
@@ -16,6 +16,7 @@
 # END COPYRIGHT
 
 from typing import Any
+from typing import Callable
 from typing import Dict
 from typing import Optional
 from typing import Tuple
@@ -80,7 +81,8 @@ class S3ReservationsReader:
         s3_obj_key: str = S3Util.get_obj_key_for_reservation(self.retriever.get_prefix(), reservation_id)
 
         client_worker: AwsSyncClientWorker = self.retriever.get_sync_client_worker()
-        get_function = partial(self.retriever.retrieve_object_with_retries, obj_key=s3_obj_key, source=self.name)
+        get_function: Callable = partial(self.retriever.retrieve_object_with_retries,
+                                         obj_key=s3_obj_key, source=self.name)
 
         try:
             # Retrieve the reservation object from S3. The parsed body can be

--- a/neuro_san/service/watcher/temp_networks/s3_reservations_reader.py
+++ b/neuro_san/service/watcher/temp_networks/s3_reservations_reader.py
@@ -65,7 +65,7 @@ class S3ReservationsReader:
         """
         self.retriever.start()
 
-    def get_one_reservation(self, reservation_id: str) -> Tuple[Reservation, AgentNetwork]:
+    def get_one_reservation(self, reservation_id: str) -> Tuple[Optional[Reservation], Optional[AgentNetwork]]:
         """
         Sync a single reservation from S3.
 

--- a/neuro_san/service/watcher/temp_networks/s3_reservations_retriever.py
+++ b/neuro_san/service/watcher/temp_networks/s3_reservations_retriever.py
@@ -16,6 +16,7 @@
 # END COPYRIGHT
 
 from typing import Any
+from typing import Callable
 from typing import Dict
 
 from os import getenv
@@ -89,7 +90,7 @@ class S3ReservationsRetriever:
         """
         Initialize the S3 client and validate connection to the bucket.
         """
-        initialize_function = partial(self.initialize)
+        initialize_function: Callable = partial(self.initialize)
         self.s3_sync_client_worker.retry_with_new_client(initialize_function, source=self.name)
 
     def initialize(self, sync_aws_client: BaseClient = None):
@@ -135,7 +136,7 @@ class S3ReservationsRetriever:
         if source is None:
             source = self.name
 
-        get_function = partial(sync_aws_client.get_object, Bucket=self.bucket_name, Key=obj_key)
+        get_function: Callable = partial(sync_aws_client.get_object, Bucket=self.bucket_name, Key=obj_key)
         obj_response: Dict[str, Any] = self.s3_sync_client_worker.do_with_retries(source, get_function)
         # Parse JSON content from S3 object body
         json_content: str = obj_response["Body"].read().decode("utf-8")

--- a/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
+++ b/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
@@ -16,7 +16,7 @@
 # END COPYRIGHT
 
 from typing import Any
-from typing import Awaitable
+from typing import Callable
 from typing import Dict
 
 from os import getenv
@@ -123,7 +123,9 @@ class S3ReservationsWriter:
         if source is None:
             source = self.name
 
-        work_function: Awaitable = partial(self.add_all_reservations, reservations_dict, source)
+        # partial() of an async method is a callable that RETURNS an awaitable
+        # when invoked, not an awaitable itself - hence Callable, not Awaitable.
+        work_function: Callable = partial(self.add_all_reservations, reservations_dict, source)
         # Pass source through so the worker's credential-expiry warnings identify
         # which deployment triggered the write. Without it the worker falls back
         # to its own name ("S3ReservationsWriter"), losing the log correlation
@@ -175,11 +177,11 @@ class S3ReservationsWriter:
         # Store as JSON object in S3 with proper content type
         json_body: str = dumps(agent_spec, indent=4)  # Pretty-printed JSON
 
-        put_function: Awaitable = partial(async_aws_client.put_object,
-                                          Bucket=self.bucket_name,
-                                          Key=key,
-                                          Body=json_body,
-                                          ContentType="application/json")
+        put_function: Callable = partial(async_aws_client.put_object,
+                                         Bucket=self.bucket_name,
+                                         Key=key,
+                                         Body=json_body,
+                                         ContentType="application/json")
 
         await self.s3_async_client_worker.do_with_retries(source, put_function)
 

--- a/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
+++ b/neuro_san/service/watcher/temp_networks/s3_reservations_writer.py
@@ -124,7 +124,11 @@ class S3ReservationsWriter:
             source = self.name
 
         work_function: Awaitable = partial(self.add_all_reservations, reservations_dict, source)
-        await self.s3_async_client_worker.retry_with_new_client(work_function)
+        # Pass source through so the worker's credential-expiry warnings identify
+        # which deployment triggered the write. Without it the worker falls back
+        # to its own name ("S3ReservationsWriter"), losing the log correlation
+        # that the pre-refactor retry loop provided.
+        await self.s3_async_client_worker.retry_with_new_client(work_function, source=source)
 
     async def add_all_reservations(self,
                                    reservations_dict: Dict[Reservation, Dict[str, Any]],

--- a/neuro_san/service/watcher/temp_networks/s3_util.py
+++ b/neuro_san/service/watcher/temp_networks/s3_util.py
@@ -15,6 +15,9 @@
 #
 # END COPYRIGHT
 
+from typing import Any
+from typing import Dict
+
 from random import random
 
 from botocore.exceptions import ClientError
@@ -57,6 +60,92 @@ class S3Util:
         if isinstance(status, int) and 500 <= status < 600:
             return True
         return False
+
+    @staticmethod
+    def get_error_code(err: ClientError) -> str:
+        """
+        Safely extract the Error.Code from a botocore ClientError response.
+
+        Why this exists: DictionaryExtractor.get() only applies its default when
+        a key is *missing* along the path. When the terminal key is present with
+        a stored value of None, that None is returned in preference to the
+        default. botocore's REST-XML parser can produce exactly that for S3
+        error bodies with an empty <Code/> element (and S3-compatible
+        endpoints/test doubles can too), so code like
+            "ExpiredToken" not in extractor.get("Error.Code", "")
+        raises TypeError ("argument of type 'NoneType' is not iterable") inside
+        an exception handler, replacing the real S3 error with a TypeError.
+        This helper guarantees a str so substring/equality checks are safe.
+
+        :param err: The ClientError exception to evaluate
+        :return: The error code as a string, or "" if it cannot be determined
+        """
+        extractor = DictionaryExtractor(err.response)
+        code: Any = extractor.get("Error.Code", "")
+        if not isinstance(code, str):
+            code = "" if code is None else str(code)
+        return code
+
+    @staticmethod
+    def is_expired_token_error(err: ClientError) -> bool:
+        """
+        :param err: The ClientError exception to evaluate
+        :return: True if the error indicates expired credentials.
+                 Substring match intentionally covers both "ExpiredToken" and
+                 "ExpiredTokenException" (different AWS services/paths use both).
+        """
+        return "ExpiredToken" in S3Util.get_error_code(err)
+
+    @staticmethod
+    def extract_reservation_data(agent_spec: Any) -> Dict[str, Any]:
+        """
+        Single, shared policy point for parsing the reservation block out of an
+        agent-spec object read back from S3.
+
+        Before this helper, each consumer had its own ad-hoc handling of
+        malformed content, and the policies contradicted each other:
+          * S3ReservationsReader defaulted to {} and built a bogus Reservation
+            (id=None, expiration=None) whose expiration=None later crashed
+            request handling with "'>' not supported between float and NoneType".
+          * S3ReservationsExpiration defaulted expiration_time to 0, which made
+            "malformed" indistinguishable from "expired at epoch" and silently
+            DELETED the object.
+        Centralizing the shape check means both consumers agree on what a
+        well-formed reservation looks like; each caller decides what a None
+        return means for it (reader: treat as not-found; expiration: skip and
+        warn, but never delete).
+
+        Note on DictionaryExtractor semantics: its .get() only applies the
+        default when a key is missing. A stored JSON null (e.g.
+        {"metadata": {"reservation": null}}) is returned as None in preference
+        to the default - that exact shape still crashed the expiration sweep
+        with "'NoneType' object has no attribute 'get'" even after
+        DictionaryExtractor was introduced. That is why the isinstance checks
+        below cannot be replaced with extractor defaults.
+
+        :param agent_spec: Whatever was parsed from the S3 object body. May be
+                           None or any JSON type, not just a dict.
+        :return: The metadata.reservation dict - guaranteed to be a dict with a
+                 numeric expiration_time_in_seconds - or None if the object is
+                 not shaped like a reservation. The "id" field is intentionally
+                 NOT required: it is only used for logging, and requiring it
+                 would strand legacy objects that lack one.
+        """
+        if not isinstance(agent_spec, dict):
+            return None
+
+        extractor = DictionaryExtractor(agent_spec)
+        reservation_data: Any = extractor.get("metadata.reservation")
+        if not isinstance(reservation_data, dict):
+            return None
+
+        expiration_time: Any = reservation_data.get("expiration_time_in_seconds")
+        # bool is an int subclass in Python; a JSON true/false here is
+        # malformed data, not a timestamp, so exclude it explicitly.
+        if isinstance(expiration_time, bool) or not isinstance(expiration_time, (int, float)):
+            return None
+
+        return reservation_data
 
     @staticmethod
     def exponential_backoff_with_jitter(base_sleep: float, attempt: int) -> float:

--- a/neuro_san/service/watcher/temp_networks/s3_util.py
+++ b/neuro_san/service/watcher/temp_networks/s3_util.py
@@ -113,8 +113,10 @@ class S3Util:
             DELETED the object.
         Centralizing the shape check means both consumers agree on what a
         well-formed reservation looks like; each caller decides what a None
-        return means for it (reader: treat as not-found; expiration: skip and
-        warn, but never delete).
+        return means for it (reader: treat as not-found; expiration:
+        age-gated handling - skip and warn while the object is young, delete
+        once it is older than any reservation could live; see
+        S3ReservationsExpiration.handle_malformed_object for that policy).
 
         Note on DictionaryExtractor semantics: its .get() only applies the
         default when a key is missing. A stored JSON null (e.g.

--- a/neuro_san/service/watcher/temp_networks/s3_util.py
+++ b/neuro_san/service/watcher/temp_networks/s3_util.py
@@ -17,6 +17,7 @@
 
 from typing import Any
 from typing import Dict
+from typing import Optional
 
 from random import random
 
@@ -97,7 +98,7 @@ class S3Util:
         return "ExpiredToken" in S3Util.get_error_code(err)
 
     @staticmethod
-    def extract_reservation_data(agent_spec: Any) -> Dict[str, Any]:
+    def extract_reservation_data(agent_spec: Any) -> Optional[Dict[str, Any]]:
         """
         Single, shared policy point for parsing the reservation block out of an
         agent-spec object read back from S3.

--- a/neuro_san/service/watcher/temp_networks/s3_util.py
+++ b/neuro_san/service/watcher/temp_networks/s3_util.py
@@ -143,6 +143,10 @@ class S3Util:
         expiration_time: Any = reservation_data.get("expiration_time_in_seconds")
         # bool is an int subclass in Python; a JSON true/false here is
         # malformed data, not a timestamp, so exclude it explicitly.
+        # A stored JSON null (None) also fails the isinstance check below,
+        # so a null expiration is treated as malformed here rather than ever
+        # reaching a caller's "current_time > expiration_time" comparison as
+        # a None (which would raise TypeError).
         if isinstance(expiration_time, bool) or not isinstance(expiration_time, (int, float)):
             return None
 

--- a/tests/neuro_san/service/watcher/temp_networks/fake_s3_client.py
+++ b/tests/neuro_san/service/watcher/temp_networks/fake_s3_client.py
@@ -28,6 +28,9 @@ module.
 """
 import io
 
+from datetime import datetime
+from datetime import timezone
+
 from typing import Any
 from typing import Dict
 
@@ -47,6 +50,10 @@ class FakeS3Client:
         Initialize an empty in-memory bucket.
         """
         self.objects: Dict[str, bytes] = {}
+        # Per-key LastModified timestamps, surfaced by head_object().
+        # put_object() stamps "now"; tests that insert into self.objects
+        # directly can backdate a key here to exercise age-based behavior.
+        self.last_modified: Dict[str, datetime] = {}
 
     # pylint: disable=invalid-name
     def head_bucket(self, Bucket: str):
@@ -66,6 +73,7 @@ class FakeS3Client:
         if isinstance(Body, str):
             Body = Body.encode("utf-8")
         self.objects[Key] = Body
+        self.last_modified[Key] = datetime.now(timezone.utc)
         return {}
 
     def get_object(self, Bucket: str, Key: str):
@@ -116,7 +124,31 @@ class FakeS3Client:
         """
         _ = Bucket
         self.objects.pop(Key, None)
+        self.last_modified.pop(Key, None)
         return {}
+
+    def head_object(self, Bucket: str, Key: str) -> Dict[str, Any]:
+        """
+        Stand-in for boto3's head_object.
+
+        Keys inserted directly into self.objects (bypassing put_object)
+        default to "now", so they read as freshly written unless a test
+        backdates them via self.last_modified.
+
+        Real S3 signals a missing key on HEAD with error code "404" (a HEAD
+        response has no body to carry a NoSuchKey code), and the fake
+        mirrors that.
+        """
+        _ = Bucket
+        if Key not in self.objects:
+            raise ClientError(
+                {"Error": {"Code": "404", "Message": "Not Found"}},
+                "HeadObject",
+            )
+        return {
+            "LastModified": self.last_modified.get(Key, datetime.now(timezone.utc)),
+            "ContentLength": len(self.objects[Key]),
+        }
 
     def close(self):
         """

--- a/tests/neuro_san/service/watcher/temp_networks/fake_s3_client.py
+++ b/tests/neuro_san/service/watcher/temp_networks/fake_s3_client.py
@@ -28,6 +28,7 @@ module.
 """
 import io
 
+from typing import Any
 from typing import Dict
 
 from botocore.exceptions import ClientError
@@ -79,6 +80,43 @@ class FakeS3Client:
                 "GetObject",
             )
         return {"Body": io.BytesIO(self.objects[Key])}
+
+    def list_objects_v2(self, Bucket: str = None, Prefix: str = "",
+                        MaxKeys: int = 1000, ContinuationToken: str = None) -> Dict[str, Any]:
+        """
+        Stand-in for boto3's list_objects_v2, backed by the in-memory dict.
+
+        Mirrors the aspects of real S3 the expiration sweep relies on:
+          * Keys are returned in lexicographic (UTF-8 binary) order, which is
+            what real S3 guarantees. Tests can therefore control the sweep's
+            processing order by choosing key names (e.g. "a-poison" sorts
+            before "z-expired").
+          * When no keys match, the "Contents" key is omitted entirely; real
+            S3 omits it for empty result sets rather than returning [].
+          * Everything fits in one page (IsTruncated=False). Multi-page
+            behavior is exercised separately with a MagicMock side_effect
+            (see test_retry_on_listing_pagination.py), so this fake does not
+            implement ContinuationToken threading.
+        """
+        _ = Bucket, MaxKeys, ContinuationToken
+        keys = sorted(key for key in self.objects if key.startswith(Prefix))
+        response: Dict[str, Any] = {"IsTruncated": False}
+        if keys:
+            response["Contents"] = [{"Key": key} for key in keys]
+        return response
+
+    def delete_object(self, Bucket: str, Key: str) -> Dict[str, Any]:
+        """
+        Stand-in for boto3's delete_object.
+
+        Real S3 DELETE is idempotent: deleting a key that does not exist
+        returns 204 success, NOT a NoSuchKey error. The fake mirrors that so
+        tests exercise the storage code against real S3 semantics rather than
+        a stricter fake-only contract.
+        """
+        _ = Bucket
+        self.objects.pop(Key, None)
+        return {}
 
     def close(self):
         """

--- a/tests/neuro_san/service/watcher/temp_networks/test_expiration_credential_expiry_mid_sweep.py
+++ b/tests/neuro_san/service/watcher/temp_networks/test_expiration_credential_expiry_mid_sweep.py
@@ -1,0 +1,180 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+"""
+Pins the expiration sweep's recovery from AWS credentials expiring
+MID-sweep - after the listing succeeded but before the per-object
+get/delete calls complete.
+
+Why this scenario exists at all: AwsSyncClientWorker creates its boto
+clients from FROZEN credentials (explicit key/secret/token passed to
+create_client), which disables botocore's native at-signing-time
+auto-refresh. The only recovery mechanism is therefore reactive:
+retry_with_new_client() wraps the whole sweep, and when an ExpiredToken
+ClientError reaches it, it resets the cached frozen credentials and
+re-runs the sweep with a freshly built client. Token-based credentials
+(IAM Instance Roles, ECS Task Roles, SSO) expire on the order of an
+hour, so a long sweep over a large bucket can realistically outlive its
+token.
+
+The failure mode this test guards against: if ExpiredToken errors
+raised by the per-object get_object calls are caught by
+expire_one_reservation's broad except-ClientError handler and merely
+logged, the wrapper never sees them, so credentials are never
+refreshed, every remaining key in the sweep makes exactly one doomed
+S3 call, NOTHING is expired, and expire_reservations() returns as if
+it succeeded. Expired reservations silently linger until a later
+sweep's list_objects_v2 call happens to fail outside the swallowing
+handler.
+"""
+import json
+import time
+
+from unittest.mock import patch
+
+from botocore.exceptions import ClientError
+
+from tests.neuro_san.service.watcher.temp_networks.s3_reservations_storage_test_base \
+    import S3ReservationsStorageTestBase
+
+
+class TestExpirationCredentialExpiryMidSweep(S3ReservationsStorageTestBase):
+    """
+    Verifies that when the S3 token expires between the listing and the
+    per-object operations, the sweep refreshes credentials (by building
+    a new client) and still expires every expired reservation, rather
+    than reporting success while doing nothing.
+    """
+
+    def _put_expired_reservation(self, reservation_id: str) -> str:
+        """
+        Place a well-formed, already-expired reservation object directly
+        into the fake bucket (bypassing the writer, as if written by an
+        earlier process whose lease has since lapsed).
+
+        :return: the S3 object key used
+        """
+        key: str = f"reservations/{reservation_id}.json"
+        self.fake_s3.objects[key] = json.dumps({
+            "name": reservation_id,
+            "metadata": {
+                "reservation": {
+                    "id": reservation_id,
+                    "lifetime_in_seconds": 3600.0,
+                    # One hour in the past: unambiguously expired.
+                    "expiration_time_in_seconds": time.time() - 3600.0,
+                },
+                "stored_at": time.time() - 7200.0,
+            },
+        }).encode("utf-8")
+        return key
+
+    def test_mid_sweep_expired_token_refreshes_credentials_and_completes(self):
+        """
+        Scenario: the sweep's client was built from a token that S3
+        rejects by the time the per-object get_object calls run.
+
+        Simulation:
+          * get_object raises ClientError(ExpiredToken) while the FIRST
+            client is in use (self.token_expired starts True).
+          * Session.create_client is re-patched so that building a
+            SECOND client "refreshes" the token (flips the flag) - which
+            is exactly what happens in production when
+            retry_with_new_client resets frozen_credentials and the
+            credential chain hands back a fresh token.
+
+        Expected: the ExpiredToken propagates out of the per-object
+        handling to retry_with_new_client, which builds client #2 and
+        re-runs the sweep; every expired reservation is deleted.
+
+        If expire_one_reservation swallows the ExpiredToken per key
+        instead of re-raising it, both assertions fail: only one client
+        is ever created and all three expired objects remain while the
+        sweep reports success.
+        """
+        expired_keys = [
+            self._put_expired_reservation(f"copy_cat-expired-{index}")
+            for index in range(3)
+        ]
+
+        # --- simulate a token that has expired for the first client -------
+        # Mutable holder (not an instance attribute) so the two closures
+        # below can share and flip the flag.
+        token_state = {"expired": True}
+        real_get_object = self.fake_s3.get_object
+
+        # pylint: disable=invalid-name
+        def get_object_with_expiring_token(Bucket: str, Key: str):
+            """Raise ExpiredToken exactly as boto3 surfaces it (HTTP 400)."""
+            if token_state["expired"]:
+                raise ClientError(
+                    {
+                        "Error": {
+                            "Code": "ExpiredToken",
+                            "Message": "The provided token has expired.",
+                        },
+                        "ResponseMetadata": {"HTTPStatusCode": 400},
+                    },
+                    "GetObject",
+                )
+            return real_get_object(Bucket=Bucket, Key=Key)
+
+        # Inject onto the in-memory FakeS3Client for the duration of this
+        # test only (instance attribute shadows the class method).
+        self.fake_s3.get_object = get_object_with_expiring_token
+
+        # --- building a second client models the credential refresh -------
+        create_client_calls = {"count": 0}
+
+        def create_client_with_refresh(*_args, **_kwargs):
+            create_client_calls["count"] += 1
+            if create_client_calls["count"] >= 2:
+                # retry_with_new_client reset frozen_credentials and built a
+                # new client: the fresh token works from here on.
+                token_state["expired"] = False
+            return self.fake_s3
+
+        # Overrides (stacks on top of) the base class's Session.create_client
+        # patch for the duration of this with-block.
+        #
+        # sync_sleep is patched defensively: ExpiredToken is not in
+        # S3Util.is_retryable_client_error's retryable set today, so
+        # do_with_retries should not back off on it - but if a regression
+        # ever makes it retryable, this keeps the test from sleeping
+        # through 8 exponential-backoff retries per object.
+        with patch(
+            "neuro_san.service.watcher.temp_networks.aws_sync_client_worker.Session.create_client",
+            new=create_client_with_refresh,
+        ), patch(
+            "neuro_san.service.watcher.temp_networks.aws_sync_client_worker.sync_sleep"
+        ):
+            self.storage.expiration.expire_reservations()
+
+        remaining = [key for key in expired_keys if key in self.fake_s3.objects]
+        self.assertEqual(
+            [], remaining,
+            f"Expected every expired reservation to be deleted after the credential "
+            f"refresh; these remain: {remaining}. This means the mid-sweep "
+            f"ExpiredToken was swallowed per-object and never reached "
+            f"retry_with_new_client, so the sweep 'succeeded' without expiring "
+            f"anything.",
+        )
+        self.assertGreaterEqual(
+            create_client_calls["count"], 2,
+            f"Expected at least 2 clients (initial + rebuilt-after-refresh); got "
+            f"{create_client_calls['count']}. A single client means the ExpiredToken "
+            f"never triggered retry_with_new_client's credential reset.",
+        )

--- a/tests/neuro_san/service/watcher/temp_networks/test_expiration_malformed_object_policy.py
+++ b/tests/neuro_san/service/watcher/temp_networks/test_expiration_malformed_object_policy.py
@@ -24,39 +24,52 @@ errors reported from production arise: the bucket is long-lived and
 shared across code versions, so it can contain objects written by an
 older schema, by other tooling, or by a since-fixed writer bug.
 
-Three policies are possible when the sweep meets such an object, and the
-codebase has already shipped two of them:
+Three policies were considered before the current one:
 
   1. Raise: the sweep crashes at the first malformed key, the watcher
      retries next interval and crashes at the same key again - so ONE
      bad object stops ALL expiration, forever, while logging the
      NoneType error every cycle.
-  2. Treat as expired and delete: DictionaryExtractor defaults make a
-     missing expiration_time read as 0, current_time > 0 is always
-     true, and the object is PERMANENTLY DELETED with only a
-     debug-level log naming reservation '<unknown>'.
-     That silently destroys any object the current code merely fails to
-     understand (e.g. schema drift during a rolling deploy, where an old
-     server's sweep would delete a new server's live reservations), and
-     it destroys the only evidence of whatever wrote the bad object.
-  3. Skip and warn (the policy these tests pin): the sweep must survive
-     the object, must keep expiring everything else, and must NOT delete
-     data it cannot parse - deleting data should be a human decision,
-     not a parse failure. The cost is that true garbage lingers and
-     warns every sweep until someone removes it.
+  2. Treat as expired and delete immediately: DictionaryExtractor
+     defaults make a missing expiration_time read as 0, current_time > 0
+     is always true, and the object is PERMANENTLY DELETED with only a
+     debug-level log naming reservation '<unknown>'. That silently
+     destroys any object the current code merely fails to understand
+     (e.g. schema drift during a rolling deploy, where an old server's
+     sweep would delete a new server's live reservations), and it
+     destroys the only evidence of whatever wrote the bad object.
+  3. Skip and warn forever: safe for the data and the sweep, but
+     unparseable detritus builds up and gets re-read and re-logged on
+     every pass (review feedback on the first draft of this policy).
 
-NOTE: test_wrong_shape_object_is_not_deleted and
-test_null_reservation_object_does_not_kill_sweep fail under either of
-the first two policies - by design. The first pins against policy 2's
-silent deletion; the second shows that policy 2 does not even fully
-stop the reported NoneType error, because DictionaryExtractor returns
-a stored JSON null in preference to its default, putting the sweep
-right back into policy 1's death spiral.
+The pinned policy is AGE-GATED deletion: an unparseable object is
+skipped with a WARNING while younger than
+S3ReservationsExpiration.MALFORMED_OBJECT_GRACE_SECONDS, and deleted
+with a WARNING once older. Every reservation has a bounded lifetime, so
+an object older than any possible lifetime cannot be a live reservation
+under ANY schema version - deleting it is safe and bounds the detritus,
+while the grace window keeps rolling-deploy schema drift from
+destroying live reservations and gives humans time to notice the
+warnings.
+
+NOTE on coverage vs the alternatives: immediate deletion (policy 2)
+fails test_young_wrong_shape_object_is_not_deleted; skip-forever
+(policy 3) fails test_old_wrong_shape_object_is_deleted; raising
+(policy 1) fails test_null_reservation_object_does_not_kill_sweep,
+because DictionaryExtractor returns a stored JSON null in preference to
+its default, which put naive extractor-based handling right back into
+policy 1's death spiral.
 """
 import json
 import time
 
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+
 from typing import Any
+
+from neuro_san.service.watcher.temp_networks.s3_reservations_expiration import S3ReservationsExpiration
 
 from tests.neuro_san.service.watcher.temp_networks.s3_reservations_storage_test_base \
     import S3ReservationsStorageTestBase
@@ -105,10 +118,9 @@ class TestExpirationMalformedObjectPolicy(S3ReservationsStorageTestBase):
         """
         Control case anchoring the harness: with only well-formed objects
         in the bucket, the sweep deletes the expired one and keeps the
-        live one. This test passes under any of the three candidate
-        policies; it exists so that failures in the sibling tests are
-        attributable to the malformed-object policy, not to the test
-        scaffolding.
+        live one. This test passes under any of the candidate policies;
+        it exists so that failures in the sibling tests are attributable
+        to the malformed-object policy, not to the test scaffolding.
         """
         expired_key: str = self._put_reservation_object("copy_cat-expired", -3600.0)
         live_key: str = self._put_reservation_object("copy_cat-live", +3600.0)
@@ -124,20 +136,22 @@ class TestExpirationMalformedObjectPolicy(S3ReservationsStorageTestBase):
             f"Expected the live reservation {live_key} to survive the sweep.",
         )
 
-    def test_wrong_shape_object_is_not_deleted(self):
+    def test_young_wrong_shape_object_is_not_deleted(self):
         """
         A valid-JSON object under the prefix with no metadata.reservation
-        block must NOT be deleted by the sweep.
+        block must NOT be deleted while it is younger than the grace
+        period (the fake stamps direct inserts as freshly written).
 
-        Guards against the treat-as-expired-and-delete policy, where
+        Guards against the immediate-delete policy, where
         DictionaryExtractor defaults classify the object as "expired at
         epoch 0" (current_time > 0 is always true) and delete_object
         permanently removes it, logging only at debug level as
-        reservation '<unknown>'. "We could not parse it" and "it has expired" are
-        different facts; conflating them silently destroys any object
-        written by a schema the current code doesn't know - including
-        live reservations written by a newer server version during a
-        rolling deploy.
+        reservation '<unknown>'. "We could not parse it" and "it has
+        expired" are different facts; conflating them silently destroys
+        any object written by a schema the current code doesn't know -
+        including live reservations written by a newer server version
+        during a rolling deploy, which are by definition younger than
+        the grace period.
         """
         wrong_shape_key: str = "reservations/wrong-shape.json"
         self._put_json_object(wrong_shape_key, {
@@ -151,12 +165,87 @@ class TestExpirationMalformedObjectPolicy(S3ReservationsStorageTestBase):
         self.assertIn(
             wrong_shape_key, self.fake_s3.objects,
             f"Expected the unparseable object {wrong_shape_key} to be left in place "
-            f"(skip-and-warn policy); it was deleted, meaning the sweep treats "
-            f"'could not parse' as 'expired' and silently destroys data.",
+            f"while younger than the grace period; it was deleted, meaning the sweep "
+            f"treats 'could not parse' as 'expired' and silently destroys data.",
         )
         self.assertIn(
             live_key, self.fake_s3.objects,
             f"Expected the live reservation {live_key} to survive the sweep.",
+        )
+
+    def test_old_wrong_shape_object_is_deleted(self):
+        """
+        An unparseable object OLDER than the grace period must be
+        deleted by the sweep (with a WARNING).
+
+        Guards against the skip-forever policy: every reservation has a
+        bounded lifetime, so an object last modified longer ago than any
+        reservation could live cannot be a live reservation under ANY
+        schema version. Leaving it would mean unparseable detritus
+        builds up and gets re-read and re-logged on every pass, forever.
+        """
+        old_key: str = "reservations/old-wrong-shape.json"
+        self._put_json_object(old_key, {
+            "foo": "bar",
+            "note": "valid JSON, but not shaped like a reservation",
+        })
+        # Backdate the object to just past the grace period.
+        self.fake_s3.last_modified[old_key] = (
+            datetime.now(timezone.utc)
+            - timedelta(seconds=S3ReservationsExpiration.MALFORMED_OBJECT_GRACE_SECONDS + 3600.0)
+        )
+        live_key: str = self._put_reservation_object("copy_cat-live", +3600.0)
+
+        self.storage.expiration.expire_reservations()
+
+        self.assertNotIn(
+            old_key, self.fake_s3.objects,
+            f"Expected the unparseable object {old_key}, last modified beyond the "
+            f"grace period, to be deleted; leaving it means detritus accumulates "
+            f"and is re-read and re-logged on every sweep.",
+        )
+        self.assertIn(
+            live_key, self.fake_s3.objects,
+            f"Expected the live reservation {live_key} to survive the sweep.",
+        )
+
+    def test_null_expiration_time_is_treated_as_malformed(self):
+        """
+        What happens if expiration_time_in_seconds is None (a stored JSON
+        null)? Answer: extract_reservation_data() rejects the whole
+        payload (null fails its isinstance check, and DictionaryExtractor
+        would otherwise return the stored null in preference to any
+        default), so the object takes the malformed path - skipped while
+        young - and the sweep's current_time > expiration_time comparison
+        can never see a None. No crash, no deletion, and reservations
+        after it still expire.
+        """
+        null_expiration_key: str = "reservations/a-null-expiration.json"
+        self._put_json_object(null_expiration_key, {
+            "name": "null-expiration",
+            "metadata": {
+                "reservation": {
+                    "id": "null-expiration",
+                    "lifetime_in_seconds": 3600.0,
+                    "expiration_time_in_seconds": None,
+                },
+                "stored_at": time.time(),
+            },
+        })
+        expired_key: str = self._put_reservation_object("z-expired", -3600.0)
+
+        self.storage.expiration.expire_reservations()
+
+        self.assertIn(
+            null_expiration_key, self.fake_s3.objects,
+            f"Expected the null-expiration object {null_expiration_key} to be "
+            f"treated as malformed (skipped while young), not deleted and not a "
+            f"crash: 'time() > None' must be unreachable.",
+        )
+        self.assertNotIn(
+            expired_key, self.fake_s3.objects,
+            f"Expected the expired reservation {expired_key} to be deleted even "
+            f"though a null-expiration object sorts before it in the sweep.",
         )
 
     def test_null_reservation_object_does_not_kill_sweep(self):
@@ -200,5 +289,5 @@ class TestExpirationMalformedObjectPolicy(S3ReservationsStorageTestBase):
         self.assertIn(
             poison_key, self.fake_s3.objects,
             f"Expected the unparseable object {poison_key} to be left in place "
-            f"(skip-and-warn policy), not deleted.",
+            f"(young: still within the grace period), not deleted.",
         )

--- a/tests/neuro_san/service/watcher/temp_networks/test_expiration_malformed_object_policy.py
+++ b/tests/neuro_san/service/watcher/temp_networks/test_expiration_malformed_object_policy.py
@@ -1,0 +1,204 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+"""
+Pins the expiration sweep's policy for objects under the reservations/
+prefix whose bodies are valid JSON but are NOT shaped like a reservation
+(no metadata.reservation dict with a numeric expiration_time_in_seconds).
+
+Such objects are how the "'NoneType' object has no attribute 'get'"
+errors reported from production arise: the bucket is long-lived and
+shared across code versions, so it can contain objects written by an
+older schema, by other tooling, or by a since-fixed writer bug.
+
+Three policies are possible when the sweep meets such an object, and the
+codebase has already shipped two of them:
+
+  1. Raise: the sweep crashes at the first malformed key, the watcher
+     retries next interval and crashes at the same key again - so ONE
+     bad object stops ALL expiration, forever, while logging the
+     NoneType error every cycle.
+  2. Treat as expired and delete: DictionaryExtractor defaults make a
+     missing expiration_time read as 0, current_time > 0 is always
+     true, and the object is PERMANENTLY DELETED with only a
+     debug-level log naming reservation '<unknown>'.
+     That silently destroys any object the current code merely fails to
+     understand (e.g. schema drift during a rolling deploy, where an old
+     server's sweep would delete a new server's live reservations), and
+     it destroys the only evidence of whatever wrote the bad object.
+  3. Skip and warn (the policy these tests pin): the sweep must survive
+     the object, must keep expiring everything else, and must NOT delete
+     data it cannot parse - deleting data should be a human decision,
+     not a parse failure. The cost is that true garbage lingers and
+     warns every sweep until someone removes it.
+
+NOTE: test_wrong_shape_object_is_not_deleted and
+test_null_reservation_object_does_not_kill_sweep fail under either of
+the first two policies - by design. The first pins against policy 2's
+silent deletion; the second shows that policy 2 does not even fully
+stop the reported NoneType error, because DictionaryExtractor returns
+a stored JSON null in preference to its default, putting the sweep
+right back into policy 1's death spiral.
+"""
+import json
+import time
+
+from typing import Any
+
+from tests.neuro_san.service.watcher.temp_networks.s3_reservations_storage_test_base \
+    import S3ReservationsStorageTestBase
+
+
+class TestExpirationMalformedObjectPolicy(S3ReservationsStorageTestBase):
+    """
+    Verifies that expire_reservations() survives objects that are not
+    shaped like reservations, keeps expiring well-formed reservations
+    around them, and never deletes an object it could not parse.
+    """
+
+    def _put_json_object(self, key: str, payload: Any):
+        """
+        Place an arbitrary JSON body directly into the fake bucket,
+        bypassing the writer. This models the real-world source of
+        malformed objects: content already in the bucket that the
+        CURRENT writer did not produce (older schema versions, other
+        tooling, since-fixed bugs).
+        """
+        self.fake_s3.objects[key] = json.dumps(payload).encode("utf-8")
+
+    def _put_reservation_object(self, reservation_id: str, expires_in_seconds: float) -> str:
+        """
+        Place a well-formed reservation object (matching the writer's
+        on-disk schema) directly into the fake bucket.
+
+        :param expires_in_seconds: offset from now; negative = already expired
+        :return: the S3 object key used
+        """
+        key: str = f"reservations/{reservation_id}.json"
+        self._put_json_object(key, {
+            "name": reservation_id,
+            "metadata": {
+                "reservation": {
+                    "id": reservation_id,
+                    "lifetime_in_seconds": 3600.0,
+                    "expiration_time_in_seconds": time.time() + expires_in_seconds,
+                },
+                "stored_at": time.time(),
+            },
+        })
+        return key
+
+    def test_control_expired_reservation_is_deleted(self):
+        """
+        Control case anchoring the harness: with only well-formed objects
+        in the bucket, the sweep deletes the expired one and keeps the
+        live one. This test passes under any of the three candidate
+        policies; it exists so that failures in the sibling tests are
+        attributable to the malformed-object policy, not to the test
+        scaffolding.
+        """
+        expired_key: str = self._put_reservation_object("copy_cat-expired", -3600.0)
+        live_key: str = self._put_reservation_object("copy_cat-live", +3600.0)
+
+        self.storage.expiration.expire_reservations()
+
+        self.assertNotIn(
+            expired_key, self.fake_s3.objects,
+            f"Expected the expired reservation {expired_key} to be deleted by the sweep.",
+        )
+        self.assertIn(
+            live_key, self.fake_s3.objects,
+            f"Expected the live reservation {live_key} to survive the sweep.",
+        )
+
+    def test_wrong_shape_object_is_not_deleted(self):
+        """
+        A valid-JSON object under the prefix with no metadata.reservation
+        block must NOT be deleted by the sweep.
+
+        Guards against the treat-as-expired-and-delete policy, where
+        DictionaryExtractor defaults classify the object as "expired at
+        epoch 0" (current_time > 0 is always true) and delete_object
+        permanently removes it, logging only at debug level as
+        reservation '<unknown>'. "We could not parse it" and "it has expired" are
+        different facts; conflating them silently destroys any object
+        written by a schema the current code doesn't know - including
+        live reservations written by a newer server version during a
+        rolling deploy.
+        """
+        wrong_shape_key: str = "reservations/wrong-shape.json"
+        self._put_json_object(wrong_shape_key, {
+            "foo": "bar",
+            "note": "valid JSON, but not shaped like a reservation",
+        })
+        live_key: str = self._put_reservation_object("copy_cat-live", +3600.0)
+
+        self.storage.expiration.expire_reservations()
+
+        self.assertIn(
+            wrong_shape_key, self.fake_s3.objects,
+            f"Expected the unparseable object {wrong_shape_key} to be left in place "
+            f"(skip-and-warn policy); it was deleted, meaning the sweep treats "
+            f"'could not parse' as 'expired' and silently destroys data.",
+        )
+        self.assertIn(
+            live_key, self.fake_s3.objects,
+            f"Expected the live reservation {live_key} to survive the sweep.",
+        )
+
+    def test_null_reservation_object_does_not_kill_sweep(self):
+        """
+        An object whose body is {"metadata": {"reservation": null}} must
+        not abort the sweep, and reservations that sort after it must
+        still be expired.
+
+        Guards against the stored-null trap: DictionaryExtractor.get()
+        only applies its default when a key is MISSING; a key present
+        with a stored JSON null is returned as None in preference to
+        the default, so naive extractor-based handling calls
+        reservation_data.get(...) on None and crashes with
+        AttributeError: 'NoneType' object has no attribute 'get' - the
+        exact error reported from production.
+
+        The consequences mirror that original report: the watcher
+        re-runs the sweep every interval and crashes at the same key
+        each time, so the expired reservation behind the poison object
+        (and everything else in the bucket) is never cleaned up until a
+        human deletes the poison object by hand.
+
+        Key names matter here: "a-poison" sorts lexicographically before
+        "z-expired" (matching real S3 listing order, which the fake
+        mirrors), guaranteeing the sweep meets the poison object first.
+        """
+        poison_key: str = "reservations/a-poison.json"
+        self._put_json_object(poison_key, {"metadata": {"reservation": None}})
+        expired_key: str = self._put_reservation_object("z-expired", -3600.0)
+
+        # If the stored-null case regresses, this call raises AttributeError
+        # out of retry_with_new_client (which only handles ClientError),
+        # failing this test at the call site - before any assertion below.
+        self.storage.expiration.expire_reservations()
+
+        self.assertNotIn(
+            expired_key, self.fake_s3.objects,
+            f"Expected the expired reservation {expired_key} to be deleted even though "
+            f"a poison object ({poison_key}) sorts before it in the sweep.",
+        )
+        self.assertIn(
+            poison_key, self.fake_s3.objects,
+            f"Expected the unparseable object {poison_key} to be left in place "
+            f"(skip-and-warn policy), not deleted.",
+        )

--- a/tests/neuro_san/service/watcher/temp_networks/test_expiration_malformed_object_policy.py
+++ b/tests/neuro_san/service/watcher/temp_networks/test_expiration_malformed_object_policy.py
@@ -69,6 +69,8 @@ from datetime import timezone
 
 from typing import Any
 
+from botocore.exceptions import ClientError
+
 from neuro_san.service.watcher.temp_networks.s3_reservations_expiration import S3ReservationsExpiration
 
 from tests.neuro_san.service.watcher.temp_networks.s3_reservations_storage_test_base \
@@ -207,6 +209,41 @@ class TestExpirationMalformedObjectPolicy(S3ReservationsStorageTestBase):
         self.assertIn(
             live_key, self.fake_s3.objects,
             f"Expected the live reservation {live_key} to survive the sweep.",
+        )
+
+    def test_object_deleted_mid_check_counts_as_expired(self):
+        """
+        Race: another process deletes an unparseable object between the
+        sweep's get_object and the head_object age check.
+
+        HEAD signals a missing key with the bare HTTP code "404" - a HEAD
+        response has no body to carry a NoSuchKey code - so the sweep
+        must treat "404" the same as NoSuchKey: the object is gone, which
+        is the desired outcome for expiration, not an error to log.
+        """
+        racing_key: str = "reservations/racing.json"
+        self._put_json_object(racing_key, {"foo": "bar"})
+
+        def head_object_racing_delete(**_kwargs):
+            # Simulate the concurrent deletion: the object vanishes just
+            # before the HEAD lands, exactly as real S3 would report it.
+            raise ClientError(
+                {"Error": {"Code": "404", "Message": "Not Found"}},
+                "HeadObject",
+            )
+
+        # Inject onto the in-memory FakeS3Client for the duration of this
+        # test only (instance attribute shadows the class method).
+        self.fake_s3.head_object = head_object_racing_delete
+
+        expired: bool = self.storage.expiration.expire_one_reservation(
+            racing_key, time.time(), sync_aws_client=self.fake_s3)
+
+        self.assertTrue(
+            expired,
+            "Expected a 404 from the head_object age check to be treated as "
+            "'already removed by another process' (a successful expiration "
+            "outcome), not logged as an S3 error.",
         )
 
     def test_null_expiration_time_is_treated_as_malformed(self):

--- a/tests/neuro_san/service/watcher/temp_networks/test_expiration_malformed_object_policy.py
+++ b/tests/neuro_san/service/watcher/temp_networks/test_expiration_malformed_object_policy.py
@@ -81,7 +81,9 @@ class TestExpirationMalformedObjectPolicy(S3ReservationsStorageTestBase):
     """
     Verifies that expire_reservations() survives objects that are not
     shaped like reservations, keeps expiring well-formed reservations
-    around them, and never deletes an object it could not parse.
+    around them, and applies the age-gated policy to them: skip and
+    WARN while the object is younger than the grace period, delete with
+    a WARNING once it is older than any reservation could live.
     """
 
     def _put_json_object(self, key: str, payload: Any):


### PR DESCRIPTION
Fixes #1152

The expiration sweep treated any object it could not parse as expired (silently deleting it), still crashed on stored-null reservation blocks with the reported "'NoneType' object has no attribute 'get'" error, and swallowed mid-sweep ExpiredToken errors so a sweep could report success while expiring nothing.

**Changes:**
- Add S3Util.extract_reservation_data() as the single policy point for parsing reservation objects. The sweep now skips and WARNs on unparseable objects instead of deleting them, and the reader treats them as not-found instead of building a bogus Reservation whose None expiration crashed the request path.
- Re-raise ExpiredToken (only) from expire_one_reservation() so retry_with_new_client() can reset cached credentials and re-run the sweep. NoSuchKey and other ClientErrors keep their existing handling.
- Add S3Util.get_error_code()/is_expired_token_error() for safe Error.Code extraction: DictionaryExtractor returns a stored null in preference to its default, which could raise TypeError inside except handlers.
- Raise NoCredentialsError instead of an opaque AttributeError when the credential chain resolves nothing (both client workers).
- Guard against an infinite listing loop when IsTruncated=True arrives without a NextContinuationToken.
- Pass source= through to retry_with_new_client() in the writer so credential-expiry warnings identify the deployment origin.

**Tests:**
- test_expiration_malformed_object_policy.py: wrong-shape objects survive the sweep, stored-null objects no longer kill it, and a control case pins that well-formed expired objects are still deleted.
- test_expiration_credential_expiry_mid_sweep.py: mid-sweep ExpiredToken triggers a client rebuild and the sweep completes.
- FakeS3Client grows list_objects_v2/delete_object mirroring real S3 semantics (lexicographic key order, idempotent delete).
- `AND` with UNHCR network.

---

## Update 2026-07-21 — changes after review

**Malformed-object policy reworked** (addressing the change request: "All Reservations should have an expiration... detritus builds up"):
- Skip-forever is gone. New `handle_malformed_object()` applies **age-gated deletion**: unparseable objects are skipped with a WARNING while younger than `MALFORMED_OBJECT_GRACE_SECONDS` (48h = 2× `Reservationist.DEFAULT_LIFETIME`), then **deleted with a WARNING** once older than any reservation could live. Every object under the prefix now has a bounded life, including unparseable ones (effectively `LastModified + grace`); rolling-deploy safety and diagnosability are preserved during the grace window (full reasoning in the review thread).
- Age comes from one `head_object` call made only on the malformed path — normal sweeps pay nothing extra.

**"What happens if expiration_time is None?"** — answered in code: null/missing/bool/non-numeric all fail `extract_reservation_data()`'s isinstance check and take the malformed path, so the `current_time > expiration_time` comparison can never see a None. Comments added at the comparison and in the helper; pinned by `test_null_expiration_time_is_treated_as_malformed`.

**HEAD-404 race fixed** (Copilot catch on the age-gating commit): an object deleted by another process between `get_object` and the `head_object` age check now counts as already-expired instead of logging an error — HEAD responses have no body, so botocore reports bare `"404"` rather than `NoSuchKey`. Pinned by `test_object_deleted_mid_check_counts_as_expired`.

**Smaller items from the Copilot rounds:** `Optional[...]` annotations where None is returned (`extract_reservation_data()`, `get_one_reservation()`, call sites); `Callable` on all `partial()` work functions (they were annotated `Awaitable`, which a partial is not); `is_expired_token_error()` used in the expiration handler instead of a manual substring check; docstrings synced to the age-gated policy (helper, test module, test class).

**Tests:** `FakeS3Client` gains `head_object` with backdatable per-key `LastModified`; new tests pin over-age deletion, the null-expiration case, and the 404 race. Suite is now 20/20.
