### PR TITLE
max_workers settings via env vars AGENT_MAX_CONCURRENT_REQUESTS and new AGENT_MAX_WORKERS_PER_REQUEST

### DIFF
--- a/neuro_san/deploy/Dockerfile
+++ b/neuro_san/deploy/Dockerfile
@@ -229,6 +229,10 @@ ENV AGENT_HEALTH_PROBE_PORT="8081"
 # A value of 0 indicates unlimited requests are handled.
 ENV AGENT_MAX_CONCURRENT_REQUESTS="50"
 
+# Maximum number of worker threads per request.
+# Default of <= 0 (or unset) indicates system default of (num_cpus + 4).
+ENV AGENT_MAX_WORKERS_PER_REQUEST="0"
+
 # Number of requests served before the server shuts down in an orderly fashion.
 # This is useful for testing response handling in clusters with duplicated pods.
 # A value of -1 indicates unlimited requests are handled.

--- a/neuro_san/deploy/entrypoint.sh
+++ b/neuro_san/deploy/entrypoint.sh
@@ -34,6 +34,31 @@ then
 fi
 export PYTHONPATH
 
+echo "Configuration information:"
+cat /proc/meminfo | grep MemTotal
+if [ -f /sys/fs/cgroup/memory/memory.limit_in_bytes ]
+then
+    cat /sys/fs/cgroup/memory/memory.limit_in_bytes
+fi
+if [ -f /sys/fs/cgroup/memory.max ]
+then
+    cat /sys/fs/cgroup/memory.max
+fi
+echo
+
+lscpu | grep "^CPU(s):"
+if [ -f /sys/fs/cgroup/cpu/cpu.cfs_quota_us ]
+then
+    cat /sys/fs/cgroup/cpu/cpu.cfs_quota_us
+fi
+if [ -f /sys/fs/cgroup/cpu.max ]
+then
+    cat /sys/fs/cgroup/cpu.max
+fi
+echo
+
+ulimit -a
+
 echo "Toolchain:"
 ${PYTHON} --version
 ${PIP} --version

--- a/neuro_san/deploy/entrypoint.sh
+++ b/neuro_san/deploy/entrypoint.sh
@@ -45,7 +45,10 @@ then
     cat /sys/fs/cgroup/memory.max
 fi
 
-lscpu | grep "^CPU(s):"
+if command -v lscpu >/dev/null 2>&1
+then
+    lscpu | grep "^CPU(s):"
+fi
 if [ -f /sys/fs/cgroup/cpu/cpu.cfs_quota_us ]
 then
     cat /sys/fs/cgroup/cpu/cpu.cfs_quota_us

--- a/neuro_san/deploy/entrypoint.sh
+++ b/neuro_san/deploy/entrypoint.sh
@@ -44,7 +44,6 @@ if [ -f /sys/fs/cgroup/memory.max ]
 then
     cat /sys/fs/cgroup/memory.max
 fi
-echo
 
 lscpu | grep "^CPU(s):"
 if [ -f /sys/fs/cgroup/cpu/cpu.cfs_quota_us ]
@@ -55,7 +54,6 @@ if [ -f /sys/fs/cgroup/cpu.max ]
 then
     cat /sys/fs/cgroup/cpu.max
 fi
-echo
 
 ulimit -a
 

--- a/neuro_san/deploy/entrypoint.sh
+++ b/neuro_san/deploy/entrypoint.sh
@@ -35,7 +35,7 @@ fi
 export PYTHONPATH
 
 echo "Configuration information:"
-cat /proc/meminfo | grep MemTotal
+grep MemTotal < /proc/meminfo
 if [ -f /sys/fs/cgroup/memory/memory.limit_in_bytes ]
 then
     cat /sys/fs/cgroup/memory/memory.limit_in_bytes

--- a/neuro_san/service/utils/server_context.py
+++ b/neuro_san/service/utils/server_context.py
@@ -20,6 +20,7 @@ from typing import Dict
 from typing import Optional
 
 from threading import Lock
+from os import environ
 
 from janus import Queue
 
@@ -90,10 +91,13 @@ class ServerContext(ServerContextLite):
                  than inheriting a dead reference from the parent.
         """
         if self.executor_pool is None:
+            # Default of None reverts to ThreadPoolExecutor default of (num_cpus + 4).
+            max_workers: int = environ.get("AGENT_MAX_WORKERS_PER_REQUEST", None)
             with self._executor_pool_lock:
                 if self.executor_pool is None:
                     self.executor_pool = AsyncioExecutorPool(reuse_mode=True,
-                                                             idle_timeout_seconds=30)
+                                                             idle_timeout_seconds=30,
+                                                             max_workers=max_workers)
         return self.executor_pool
 
     def set_server_status(self, server_status: ServerStatus):

--- a/neuro_san/service/utils/server_context.py
+++ b/neuro_san/service/utils/server_context.py
@@ -92,7 +92,17 @@ class ServerContext(ServerContextLite):
         """
         if self.executor_pool is None:
             # Default of None reverts to ThreadPoolExecutor default of (num_cpus + 4).
-            max_workers: int = environ.get("AGENT_MAX_WORKERS_PER_REQUEST", None)
+            max_workers: int = None
+            max_workers_str: str = environ.get("AGENT_MAX_WORKERS_PER_REQUEST", None)
+            if max_workers_str is not None:
+                try:
+                    max_workers = int(max_workers_str)
+                    if max_workers <= 0:
+                        # Revert to default
+                        max_workers = None
+                except ValueError:
+                    pass
+
             with self._executor_pool_lock:
                 if self.executor_pool is None:
                     self.executor_pool = AsyncioExecutorPool(reuse_mode=True,

--- a/neuro_san/service/watcher/temp_networks/temp_network_storage_updater.py
+++ b/neuro_san/service/watcher/temp_networks/temp_network_storage_updater.py
@@ -66,8 +66,17 @@ class TempNetworkStorageUpdater(Startable):
         self.reservationist: AbstractAgentReservationist = None
         self.executor: AsyncioExecutor = None
 
-        # Default when not set is None so as to fall back to ThreadPoolExecutor default of (num_cpus + 4)
-        self.max_workers: int = environ.get("AGENT_MAX_CONCURRENT_REQUESTS", None)
+        # Default when not set is None (or <= 0) so as to fall back to ThreadPoolExecutor default of (num_cpus + 4)
+        self.max_workers: int = None
+        max_workers_str: str = environ.get("AGENT_MAX_CONCURRENT_REQUESTS", None)
+        if max_workers_str is not None:
+            try:
+                self.max_workers = int(max_workers_str)
+                if self.max_workers <= 0:
+                    # Revert to default
+                    self.max_workers = None
+            except ValueError:
+                pass
 
         self.temp_storage: ReservationsStorage = network_storage_dict.get(StorageClass.TEMP)
         if self.temp_storage is not None:

--- a/neuro_san/service/watcher/temp_networks/temp_network_storage_updater.py
+++ b/neuro_san/service/watcher/temp_networks/temp_network_storage_updater.py
@@ -65,6 +65,10 @@ class TempNetworkStorageUpdater(Startable):
 
         self.reservationist: AbstractAgentReservationist = None
         self.executor: AsyncioExecutor = None
+
+        # Default when not set is None so as to fall back to ThreadPoolExecutor default of (num_cpus + 4)
+        self.max_workers: int = environ.get("AGENT_MAX_CONCURRENT_REQUESTS", None)
+
         self.temp_storage: ReservationsStorage = network_storage_dict.get(StorageClass.TEMP)
         if self.temp_storage is not None:
             # If we don't have temp storage, we don't got nothin'
@@ -106,7 +110,7 @@ class TempNetworkStorageUpdater(Startable):
         # 2. Processing the individual queues that come in,
         #    which involves processing the items that come in on those queues
         #    and deploying reservations to the temp storage, which is done by self.reservationist.
-        self.executor = AsyncioExecutor()
+        self.executor = AsyncioExecutor(max_workers=self.max_workers)
 
         # Start any Startables
         if isinstance(self.temp_storage, Startable):

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 # requirements-build.txt
 
 # In-house dependencies
-leaf-common>=1.2.45
+leaf-common>=1.2.47
 leaf-server-common>=0.1.25
 
 # Downgraded secondary dependencies for error-free pip installs


### PR DESCRIPTION
* Use latest leaf-common==1.2.47
* Allow for a AGENT_MAX_WORKERS_PER_REQUEST to be set which can change the number of max_workers available in a given request's AsyncioExecutor
* Update the Dockerfile for this new env var
* Use AGENT_MAX_CONCURRENT_REQUESTS as a cue for max_workers in the TempNetworkStorageUpdater, if set
* Update entrypoint.sh to spit out CPU/Memory/ulimit info