### PR TITLE
Explicitly disable Gemini Automatic Function Calling (AFC) (#1096)

### DIFF
--- a/neuro_san/internals/run_context/langchain/llms/gemini_llm_policy.py
+++ b/neuro_san/internals/run_context/langchain/llms/gemini_llm_policy.py
@@ -47,6 +47,7 @@ class GeminiLlmPolicy(LlmPolicy):
         ChatGoogleGenerativeAI = self.resolver.resolve_class_in_module("ChatGoogleGenerativeAI",
                                                                        module_name="langchain_google_genai.chat_models",
                                                                        install_if_missing="langchain-google-genai")
+
         llm = ChatGoogleGenerativeAI(
             model=model_name,
             google_api_key=self.get_value_or_env(config, "google_api_key",
@@ -83,7 +84,58 @@ class GeminiLlmPolicy(LlmPolicy):
             # global verbose value) so that the warning is never triggered.
             verbose=False,
         )
-        return llm
+        return self._disable_afc(llm)
+
+    def _disable_afc(self, llm: BaseLanguageModel) -> Any:
+        """
+        Explicitly disable the google-genai SDK's Automatic Function Calling (AFC)
+        on the given llm, if the environment allows it.
+
+        AFC is a client-side convenience feature of the google-genai SDK that can
+        only auto-execute tools passed to the SDK as Python callables.  LangChain
+        binds tools as function declarations (schemas), so AFC can never execute
+        anything here -- function calling is governed entirely by neuro-san's own
+        agent loop.  However, when AFC is not explicitly disabled, the SDK logs a
+        misleading "AFC is enabled with max remote calls: 10." INFO banner on
+        LLM calls made with no tools bound (e.g. by agents with no down-chain
+        tools).  Disabling AFC is behaviorally a no-op that silences that banner.
+        See https://github.com/cognizant-ai-lab/neuro-san/issues/1096
+
+        ChatGoogleGenerativeAI has no constructor argument for this -- the setting
+        is only honored as a per-request kwarg -- hence bind().
+
+        Note that requests with tools bound do not inherit bind() kwargs, so they
+        do not carry the explicit disable.  They are banner-free regardless:
+        google-genai >= 1.48 skips its AFC path entirely for declaration-style
+        tools, and langchain-google-genai >= 4.1.2 (our floor) requires
+        google-genai >= 1.56.
+
+        :param llm: The ChatGoogleGenerativeAI instance to disable AFC on.
+        :return: llm.bind(...) with AFC disabled, which behaves like the original
+                llm.  The original llm is returned unchanged when the environment
+                cannot support the bind:
+                * Without the google-genai SDK (langchain-google-genai < 4.0 builds
+                  on google-ai-generativelanguage), there is no AFC to disable.
+                * On langchain-core < 1.4, bind() returns a generic RunnableBinding
+                  with no bind_tools() method, which would break agent creation for
+                  agents with tools.  There the cosmetic banner is left alone.
+        """
+        # Use lazy loading to prevent installing the world.
+        # google-genai comes with langchain-google-genai >= 4.0, so intentionally
+        # no install_if_missing here: an older stack has no AFC to disable.
+        # pylint: disable=invalid-name
+        AutomaticFunctionCallingConfig = self.resolver.resolve_class_in_module(
+            "AutomaticFunctionCallingConfig",
+            module_name="google.genai.types",
+            raise_if_not_found=False)
+        if AutomaticFunctionCallingConfig is None:
+            return llm
+
+        bound: Any = llm.bind(automatic_function_calling=AutomaticFunctionCallingConfig(disable=True))
+        if not hasattr(bound, "bind_tools"):
+            return llm
+
+        return bound
 
     async def delete_resources(self):
         """
@@ -120,15 +172,19 @@ class GeminiLlmPolicy(LlmPolicy):
         # https://reference.langchain.com/python/integrations/langchain_google_genai/ChatGoogleGenerativeAI/
         # #langchain_google_genai.ChatGoogleGenerativeAI.async_client
 
+        # The llm may be a bind() wrapper around the actual chat model
+        # (see _disable_afc), in which case the clients live on its "bound" attribute.
+        base_llm: Any = getattr(self.llm, "bound", self.llm)
+
         # Close sync client
-        if self.llm.client is not None:
+        if base_llm.client is not None:
             with suppress(Exception):
-                self.llm.client.close()
+                base_llm.client.close()
 
         # Close async client
-        if self.llm.async_client is not None:
+        if base_llm.async_client is not None:
             with suppress(Exception):
-                await self.llm.async_client.aclose()
+                await base_llm.async_client.aclose()
 
         # Let's not do this again, shall we?
         self.llm = None

--- a/neuro_san/internals/run_context/langchain/llms/gemini_llm_policy.py
+++ b/neuro_san/internals/run_context/langchain/llms/gemini_llm_policy.py
@@ -84,6 +84,8 @@ class GeminiLlmPolicy(LlmPolicy):
             # global verbose value) so that the warning is never triggered.
             verbose=False,
         )
+        # Cosmetic only: silences google-genai's misleading "AFC is enabled" log banner.
+        # Behavior is identical with or without this.
         return self._disable_afc(llm)
 
     def _disable_afc(self, llm: BaseLanguageModel) -> Any:
@@ -129,10 +131,14 @@ class GeminiLlmPolicy(LlmPolicy):
             module_name="google.genai.types",
             raise_if_not_found=False)
         if AutomaticFunctionCallingConfig is None:
+            # No google-genai SDK, so no AFC (and no banner) to worry about.
             return llm
 
+        # AFC can only be disabled per-request, so bind the setting onto every call.
         bound: Any = llm.bind(automatic_function_calling=AutomaticFunctionCallingConfig(disable=True))
         if not hasattr(bound, "bind_tools"):
+            # langchain-core < 1.4: bind() gives a generic RunnableBinding whose missing
+            # bind_tools() would break agent creation.  Keep the harmless banner instead.
             return llm
 
         return bound

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,9 @@ ruamel.yaml>=0.18.6
 # Keep all these guys limited for now, as it can be the wild wild west out there
 # We don't want to be on a dependencies treadmill with timing not of our choosing.
 langchain>=1.2.0,<2.0
-langchain-core>=1.2.5,<2.0
+# Floor 1.4.0: bind() on a chat model must return a chat-model-aware binding
+# (with bind_tools) for the Gemini AFC-disable in gemini_llm_policy.py to activate.
+langchain-core>=1.4.0,<2.0
 langchain-classic>=1.0.0,<2.0
 langchain-community>=0.4,<1.0
 bs4>=0.0.2,<0.1

--- a/tests/neuro_san/internals/run_context/langchain/llms/test_gemini_llm_policy.py
+++ b/tests/neuro_san/internals/run_context/langchain/llms/test_gemini_llm_policy.py
@@ -1,0 +1,135 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+# pylint: disable=protected-access
+
+import asyncio
+
+import pytest
+
+from neuro_san.internals.run_context.langchain.llms.gemini_llm_policy import GeminiLlmPolicy
+
+try:
+    from google.genai.types import AutomaticFunctionCallingConfig
+    HAS_GOOGLE_GENAI = True
+except ImportError:
+    HAS_GOOGLE_GENAI = False
+
+
+class _ChatModelLikeBinding:
+    """Stands in for langchain-core >= 1.4's chat-model-aware bind() result."""
+
+    def __init__(self, bound, kwargs):
+        self.bound = bound
+        self.kwargs = kwargs
+
+    def bind_tools(self, *args, **kwargs):
+        """Presence of this method marks the binding as chat-model-aware."""
+
+    def close(self):
+        """Recording close() so this can double as a client stub."""
+        self.bound.closed_clients.append("sync")
+
+    async def aclose(self):
+        """Recording aclose() so this can double as a client stub."""
+        self.bound.closed_clients.append("async")
+
+
+class _LegacyBinding:
+    """Stands in for older langchain-core's generic RunnableBinding (no bind_tools)."""
+
+    def __init__(self, bound, kwargs):
+        self.bound = bound
+        self.kwargs = kwargs
+
+
+class _StubChat:
+    """Stands in for ChatGoogleGenerativeAI."""
+
+    binding_class = _ChatModelLikeBinding
+
+    def __init__(self):
+        self.closed_clients = []
+        self.client = _ChatModelLikeBinding(self, {})
+        self.async_client = _ChatModelLikeBinding(self, {})
+
+    def bind(self, **kwargs):
+        """Mimic Runnable.bind(), recording the kwargs."""
+        return self.binding_class(self, kwargs)
+
+
+class _LegacyStubChat(_StubChat):
+    """Stands in for ChatGoogleGenerativeAI on an older langchain-core."""
+
+    binding_class = _LegacyBinding
+
+
+class TestGeminiLlmPolicyAfcDisabled:
+    """
+    Test cases for GeminiLlmPolicy._disable_afc().
+
+    Background: the google-genai SDK logs a misleading
+    "AFC is enabled with max remote calls: 10." banner unless Automatic
+    Function Calling is explicitly disabled per-request.
+    See https://github.com/cognizant-ai-lab/neuro-san/issues/1096
+    """
+
+    @pytest.mark.skipif(not HAS_GOOGLE_GENAI, reason="google-genai SDK not installed")
+    def test_binds_afc_disable(self):
+        """On a chat-model-aware langchain-core, the llm is bound with the AFC-disable setting."""
+        llm = _StubChat()
+        result = GeminiLlmPolicy()._disable_afc(llm)
+        assert isinstance(result, _ChatModelLikeBinding)
+        assert result.bound is llm
+        afc = result.kwargs.get("automatic_function_calling")
+        assert isinstance(afc, AutomaticFunctionCallingConfig)
+        assert afc.disable is True
+
+    @pytest.mark.skipif(not HAS_GOOGLE_GENAI, reason="google-genai SDK not installed")
+    def test_passthrough_on_legacy_langchain_core(self):
+        """When bind() yields a binding without bind_tools(), the raw llm is returned unchanged."""
+        llm = _LegacyStubChat()
+        result = GeminiLlmPolicy()._disable_afc(llm)
+        assert result is llm
+
+    @pytest.mark.skipif(HAS_GOOGLE_GENAI, reason="google-genai SDK is installed")
+    def test_passthrough_without_google_genai(self):
+        """Without the google-genai SDK there is no AFC, so the llm is returned unchanged."""
+        llm = _StubChat()
+        result = GeminiLlmPolicy()._disable_afc(llm)
+        assert result is llm
+
+    def test_delete_resources_unwraps_binding(self):
+        """delete_resources() must reach the clients through a bind() wrapper."""
+        llm = _StubChat()
+        policy = GeminiLlmPolicy()
+        policy.llm = llm.bind(automatic_function_calling="anything")
+
+        asyncio.run(policy.delete_resources())
+
+        assert llm.closed_clients == ["sync", "async"]
+        assert policy.llm is None
+
+    def test_delete_resources_works_unwrapped(self):
+        """delete_resources() must still work when the llm is not wrapped."""
+        llm = _StubChat()
+        policy = GeminiLlmPolicy()
+        policy.llm = llm
+
+        asyncio.run(policy.delete_resources())
+
+        assert llm.closed_clients == ["sync", "async"]
+        assert policy.llm is None


### PR DESCRIPTION
## TL;DR — this is a cosmetic fix

**Nothing about NeuroSan's behavior or performance changes.** Automatic Function Calling (AFC) is a google-genai SDK feature that never actually runs in NeuroSan. This PR only silences the misleading INFO banner the SDK prints:

```
AFC is enabled with max remote calls: 10.
```

## Why AFC never runs here

AFC only auto-executes tools passed to the SDK as *Python callables*. NeuroSan drives Gemini through LangChain, which binds tools as function declarations (schemas) — the SDK never has anything to execute, and function calling remains governed entirely by NeuroSan's own agent loop. The banner is printed before the SDK discovers it has nothing to do, on LLM calls made with no tools bound (e.g. by agents with no down-chain tools).

## What this PR does

- `GeminiLlmPolicy.create_llm()` now returns `llm.bind(automatic_function_calling=AutomaticFunctionCallingConfig(disable=True))` — the only way LangChain lets us pass the setting (`ChatGoogleGenerativeAI` has no constructor argument for it).
- `delete_resources()` unwraps the binding via its `bound` attribute so web client cleanup keeps working.
- The langchain-core floor is bumped to 1.4.0 — the first version whose `bind()` returns a chat-model-aware binding (with `bind_tools()`) — so the fix is active on every install the requirements permit.

## Graceful fallbacks (return the llm unchanged, i.e. today's behavior)

- Without the google-genai SDK (langchain-google-genai < 4.0 builds on google-ai-generativelanguage): there is no AFC, and no banner, to worry about.
- On langchain-core < 1.4 (e.g. overridden pins): `bind()` yields a generic `RunnableBinding` whose missing `bind_tools()` would break agent creation for agents with tools, so the cosmetic fix is skipped and the harmless banner stays.

## Note on tool-bound requests

Requests with tools bound do not inherit `bind()` kwargs, so they do not carry the explicit disable — but they are banner-free regardless: google-genai >= 1.48 skips its AFC path entirely for declaration-style tools, and our langchain-google-genai >= 4.1.2 floor requires google-genai >= 1.56.

Fixes #1096

🤖 Generated with [Claude Code](https://claude.com/claude-code)
