### PR TITLE
Profiling locks

### DIFF
--- a/neuro_san/internals/network_providers/agent_network_storage.py
+++ b/neuro_san/internals/network_providers/agent_network_storage.py
@@ -19,7 +19,7 @@ from typing import Dict
 from typing import List
 
 import logging
-import threading
+from threading import Lock
 
 from neuro_san.internals.graph.registry.agent_network import AgentNetwork
 from neuro_san.internals.interfaces.agent_network_provider import AgentNetworkProvider
@@ -39,7 +39,7 @@ class AgentNetworkStorage(AgentStorageSource):
     def __init__(self):
         self.agents_table: Dict[str, AgentNetwork] = {}
         self.logger = logging.getLogger(self.__class__.__name__)
-        self.lock = threading.Lock()
+        self.lock = Lock()
         self.listeners: List[AgentStateListener] = []
 
     def add_listener(self, listener: AgentStateListener):

--- a/neuro_san/internals/run_context/langchain/mcp/langchain_mcp_adapter.py
+++ b/neuro_san/internals/run_context/langchain/mcp/langchain_mcp_adapter.py
@@ -23,7 +23,7 @@ from typing import Optional
 import copy
 from logging import Logger
 from logging import getLogger
-import threading
+from threading import Lock
 
 from langchain_core.tools import BaseTool
 from langchain_mcp_adapters.client import MultiServerMCPClient
@@ -37,7 +37,7 @@ class LangChainMcpAdapter:
     LangChain-compatible tools. This class provides static methods for interacting with MCP servers.
     """
 
-    _mcp_info_lock: threading.Lock = threading.Lock()
+    _mcp_info_lock: Lock = Lock()
     _mcp_servers_info: Dict[str, Any] = None
 
     def __init__(self):

--- a/neuro_san/internals/run_context/langchain/token_counting/llm_token_callback_handler.py
+++ b/neuro_san/internals/run_context/langchain/token_counting/llm_token_callback_handler.py
@@ -15,7 +15,7 @@
 #
 # END COPYRIGHT
 
-import asyncio
+from asyncio import Lock as AsyncLock
 import logging
 from time import time
 from typing import Any
@@ -80,7 +80,7 @@ class LlmTokenCallbackHandler(AsyncCallbackHandler):
     def __init__(self, llm_infos: Dict[str, Any]):
         """Initialize the CallbackHandler."""
         super().__init__()
-        self._lock = asyncio.Lock()
+        self._lock = AsyncLock()
         self.llm_infos: Dict[str, Any] = llm_infos
         self.provider_class: str = None
         self.start_time: float = None

--- a/neuro_san/internals/utils/async_profiling_lock.py
+++ b/neuro_san/internals/utils/async_profiling_lock.py
@@ -70,6 +70,8 @@ class AsyncProfilingLock:
         """
         Acquire the lock
         """
+        if stats is None:
+            stats = []
         self.add_stat(self.INITIAL_STATE, stats)
         await self.lock.acquire()
         self.add_stat("acquired lock", stats)
@@ -90,7 +92,7 @@ class AsyncProfilingLock:
         stats: List[Tuple[str, float]] = self.stats_in_play
         self.stats_in_play = []
 
-        await self.lock.release()
+        self.lock.release()
 
         self.add_stat("released lock", stats)
         if self.show_stats:

--- a/neuro_san/internals/utils/async_profiling_lock.py
+++ b/neuro_san/internals/utils/async_profiling_lock.py
@@ -23,6 +23,7 @@ from typing import Tuple
 from asyncio import Lock as AsyncLock
 from logging import getLogger
 from logging import Logger
+from os import environ
 from time import perf_counter
 
 
@@ -47,6 +48,7 @@ class AsyncProfilingLock:
 
         self.logger: Logger = getLogger(name)
         self.stats_in_play: List[Tuple[str, float]] = []
+        self.show_stats: bool = environ.get("AGENT_LOCK_PROFILING", "false").lower() == "true"
 
     async def __aenter__(self) -> AsyncProfilingLock:
         """
@@ -91,7 +93,8 @@ class AsyncProfilingLock:
         await self.lock.release()
 
         self.add_stat("released lock", stats)
-        self.print_stats(stats)
+        if self.show_stats:
+            self.print_stats(stats)
 
     def print_stats(self, stats: List[Tuple[str, float]]):
         """

--- a/neuro_san/internals/utils/async_profiling_lock.py
+++ b/neuro_san/internals/utils/async_profiling_lock.py
@@ -110,4 +110,4 @@ class AsyncProfilingLock:
             if first_time == 0.0:
                 first_time = time
             else:
-                self.logger.info("%s:%s in %f secs", self.name, key, time - first_time)
+                self.logger.info("%s (%s):%s in %f secs", self.name, self.lock, key, time - first_time)

--- a/neuro_san/internals/utils/async_profiling_lock.py
+++ b/neuro_san/internals/utils/async_profiling_lock.py
@@ -48,10 +48,11 @@ class AsyncProfilingLock:
         self.logger: Logger = getLogger(name)
         self.stats_in_play: List[Tuple[str, float]] = []
 
-    def __enter__(self, stats: List[Tuple[str, float]]) -> AsyncProfilingLock:
+    def __enter__(self) -> AsyncProfilingLock:
         """
         Acquire the lock
         """
+        stats: List[Tuple[str, float]] = []
         self.acquire(stats)
         return self
 

--- a/neuro_san/internals/utils/async_profiling_lock.py
+++ b/neuro_san/internals/utils/async_profiling_lock.py
@@ -20,20 +20,20 @@ from __future__ import annotations
 from typing import List
 from typing import Tuple
 
+from asyncio import Lock as AsyncLock
 from logging import getLogger
 from logging import Logger
-from threading import Lock
 from time import perf_counter
 
 
-class ProfilingLock:
+class AsyncProfilingLock:
     """
-    Class that adds some profiling information to a synchronous lock.
+    Class that adds some profiling information to an asynchronous lock.
     """
 
     INITIAL_STATE: str = "waiting for lock"
 
-    def __init__(self, name: str, lock_in: Lock = None):
+    def __init__(self, name: str, lock_in: AsyncLock = None):
         """
         Constructor
 
@@ -41,34 +41,34 @@ class ProfilingLock:
         :param lock_in: The lock to wrap. If no lock is provided, a new one will be created.
         """
         self.name: str = name
-        self.lock: Lock = lock_in
+        self.lock: AsyncLock = lock_in
         if self.lock is None:
-            self.lock = Lock()
+            self.lock = AsyncLock()
 
         self.logger: Logger = getLogger(name)
         self.stats_in_play: List[Tuple[str, float]] = []
 
-    async def __aenter__(self, stats: List[Tuple[str, float]]) -> ProfilingLock:
+    def __enter__(self, stats: List[Tuple[str, float]]) -> AsyncProfilingLock:
         """
         Acquire the lock
         """
-        await self.acquire(stats)
+        self.acquire(stats)
         return self
 
-    async def __aexit__(self, exc_type, exc_val, exc_tb) -> bool:
+    def __exit__(self, exc_type, exc_val, exc_tb) -> bool:
         """
         Release the lock
         :return: True to suppress exception. False or None to propagate exception.
         """
-        await self.release()
+        self.release()
         return False
 
-    async def acquire(self, stats: List[Tuple[str, float]] = None):
+    def acquire(self, stats: List[Tuple[str, float]] = None):
         """
         Acquire the lock
         """
         self.add_stat(self.INITIAL_STATE, stats)
-        await self.lock.acquire()
+        self.lock.acquire()
         self.add_stat("acquired lock", stats)
         self.stats_in_play = stats
 
@@ -80,14 +80,14 @@ class ProfilingLock:
             stats = self.stats_in_play
         stats.append((key, perf_counter()))
 
-    async def release(self):
+    def release(self):
         """
         Release the lock
         """
         stats: List[Tuple[str, float]] = self.stats_in_play
         self.stats_in_play = []
 
-        await self.lock.release()
+        self.lock.release()
 
         self.add_stat("released lock", stats)
         self.print_stats(stats)

--- a/neuro_san/internals/utils/async_profiling_lock.py
+++ b/neuro_san/internals/utils/async_profiling_lock.py
@@ -108,4 +108,4 @@ class AsyncProfilingLock:
             if first_time == 0.0:
                 first_time = time
             else:
-                self.logger.info("%s in %f secs", key, time - first_time)
+                self.logger.info("%s:%s in %f secs", self.name, key, time - first_time)

--- a/neuro_san/internals/utils/async_profiling_lock.py
+++ b/neuro_san/internals/utils/async_profiling_lock.py
@@ -48,28 +48,28 @@ class AsyncProfilingLock:
         self.logger: Logger = getLogger(name)
         self.stats_in_play: List[Tuple[str, float]] = []
 
-    def __enter__(self) -> AsyncProfilingLock:
+    async def __aenter__(self) -> AsyncProfilingLock:
         """
         Acquire the lock
         """
         stats: List[Tuple[str, float]] = []
-        self.acquire(stats)
+        await self.acquire(stats)
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb) -> bool:
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> bool:
         """
         Release the lock
         :return: True to suppress exception. False or None to propagate exception.
         """
-        self.release()
+        await self.release()
         return False
 
-    def acquire(self, stats: List[Tuple[str, float]] = None):
+    async def acquire(self, stats: List[Tuple[str, float]] = None):
         """
         Acquire the lock
         """
         self.add_stat(self.INITIAL_STATE, stats)
-        self.lock.acquire()
+        await self.lock.acquire()
         self.add_stat("acquired lock", stats)
         self.stats_in_play = stats
 
@@ -81,14 +81,14 @@ class AsyncProfilingLock:
             stats = self.stats_in_play
         stats.append((key, perf_counter()))
 
-    def release(self):
+    async def release(self):
         """
         Release the lock
         """
         stats: List[Tuple[str, float]] = self.stats_in_play
         self.stats_in_play = []
 
-        self.lock.release()
+        await self.lock.release()
 
         self.add_stat("released lock", stats)
         self.print_stats(stats)

--- a/neuro_san/internals/utils/profiling_lock.py
+++ b/neuro_san/internals/utils/profiling_lock.py
@@ -70,6 +70,8 @@ class ProfilingLock:
         """
         Acquire the lock
         """
+        if stats is None:
+            stats = []
         self.add_stat(self.INITIAL_STATE, stats)
         self.lock.acquire()
         self.add_stat("acquired lock", stats)

--- a/neuro_san/internals/utils/profiling_lock.py
+++ b/neuro_san/internals/utils/profiling_lock.py
@@ -108,4 +108,4 @@ class ProfilingLock:
             if first_time == 0.0:
                 first_time = time
             else:
-                self.logger.info("%s in %f secs", key, time - first_time)
+                self.logger.info("%s:%s in %f secs", self.name, key, time - first_time)

--- a/neuro_san/internals/utils/profiling_lock.py
+++ b/neuro_san/internals/utils/profiling_lock.py
@@ -20,9 +20,9 @@ from __future__ import annotations
 from typing import List
 from typing import Tuple
 
+from theading import Lock
 from logging import getLogger
 from logging import Logger
-from threading import Lock
 from time import perf_counter
 
 
@@ -48,28 +48,28 @@ class ProfilingLock:
         self.logger: Logger = getLogger(name)
         self.stats_in_play: List[Tuple[str, float]] = []
 
-    async def __aenter__(self) -> ProfilingLock:
+    def __enter__(self) -> ProfilingLock:
         """
         Acquire the lock
         """
         stats: List[Tuple[str, float]] = []
-        await self.acquire(stats)
+        self.acquire(stats)
         return self
 
-    async def __aexit__(self, exc_type, exc_val, exc_tb) -> bool:
+    def __exit__(self, exc_type, exc_val, exc_tb) -> bool:
         """
         Release the lock
         :return: True to suppress exception. False or None to propagate exception.
         """
-        await self.release()
+        self.release()
         return False
 
-    async def acquire(self, stats: List[Tuple[str, float]] = None):
+    def acquire(self, stats: List[Tuple[str, float]] = None):
         """
         Acquire the lock
         """
         self.add_stat(self.INITIAL_STATE, stats)
-        await self.lock.acquire()
+        self.lock.acquire()
         self.add_stat("acquired lock", stats)
         self.stats_in_play = stats
 
@@ -81,14 +81,14 @@ class ProfilingLock:
             stats = self.stats_in_play
         stats.append((key, perf_counter()))
 
-    async def release(self):
+    def release(self):
         """
         Release the lock
         """
         stats: List[Tuple[str, float]] = self.stats_in_play
         self.stats_in_play = []
 
-        await self.lock.release()
+        self.lock.release()
 
         self.add_stat("released lock", stats)
         self.print_stats(stats)

--- a/neuro_san/internals/utils/profiling_lock.py
+++ b/neuro_san/internals/utils/profiling_lock.py
@@ -28,7 +28,7 @@ from time import perf_counter
 
 class ProfilingLock:
     """
-    Class that adds some profiling information to a syncronous lock.
+    Class that adds some profiling information to a synchronous lock.
     """
 
     INITIAL_STATE: str = "waiting for lock"

--- a/neuro_san/internals/utils/profiling_lock.py
+++ b/neuro_san/internals/utils/profiling_lock.py
@@ -23,7 +23,7 @@ from typing import Tuple
 from logging import getLogger
 from logging import Logger
 from os import environ
-from theading import Lock
+from threading import Lock
 from time import perf_counter
 
 

--- a/neuro_san/internals/utils/profiling_lock.py
+++ b/neuro_san/internals/utils/profiling_lock.py
@@ -1,0 +1,107 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+from __future__ import annotations
+
+from typing import List
+from typing import Tuple
+
+from logging import getLogger
+from logging import Logger
+from threading import Lock
+from time import perf_counter
+
+
+class ProfilingLock:
+    """
+    Class that adds some profiling information to a syncronous lock.
+    """
+
+    INITIAL_STATE: str = "waiting for lock"
+
+    def __init__(self, name: str, lock_in: Lock = None):
+        """
+        Constructor
+
+        :param name: The name of the lock
+        :param lock_in: The lock to wrap. If no lock is provided, a new one will be created.
+        """
+        self.name = name
+        self.lock = lock_in
+        if self.lock is None:
+            self.lock = Lock()
+
+        self.logger: Logger = getLogger(name)
+        self.stats_in_play: List[Tuple[str, float]] = []
+
+    def __enter__(self, stats: List[Tuple[str, float]]) -> ProfilingLock:
+        """
+        Acquire the lock
+        """
+        self.acquire(stats)
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> bool:
+        """
+        Release the lock
+        :return: True to suppress exception. False or None to propagate exception.
+        """
+        self.release()
+        return False
+
+    def acquire(self, stats: List[Tuple[str, float]] = None):
+        """
+        Acquire the lock
+        """
+        self.add_stat(self.INITIAL_STATE, stats)
+        self.lock.acquire()
+        self.add_stat("acquired lock", stats)
+        self.stats_in_play = stats
+
+    def add_stat(self, key: str, stats: List[Tuple[str, float]] = None):
+        """
+        Add a stat to the lock
+        """
+        if stats is None:
+            stats = self.stats_in_play
+        stats.append((key, perf_counter()))
+
+    def release(self):
+        """
+        Release the lock
+        """
+        stats: List[Tuple[str, float]] = self.stats_in_play
+        self.stats_in_play = []
+
+        self.lock.release()
+
+        self.add_stat("released lock", stats)
+        self.print_stats(stats)
+
+    def print_stats(self, stats: List[Tuple[str, float]]):
+        """
+        Print the stats
+        """
+        first_time: float = 0.0
+        item: Tuple[str, float] = None
+        for item in stats:
+            key: str = item[0]
+            time: float = item[1]
+            if first_time == 0.0:
+                first_time = time
+            else:
+                self.logger.info("%s in %f secs", key, time - first_time)

--- a/neuro_san/internals/utils/profiling_lock.py
+++ b/neuro_san/internals/utils/profiling_lock.py
@@ -20,9 +20,10 @@ from __future__ import annotations
 from typing import List
 from typing import Tuple
 
-from theading import Lock
 from logging import getLogger
 from logging import Logger
+from os import environ
+from theading import Lock
 from time import perf_counter
 
 
@@ -47,6 +48,7 @@ class ProfilingLock:
 
         self.logger: Logger = getLogger(name)
         self.stats_in_play: List[Tuple[str, float]] = []
+        self.show_stats: bool = environ.get("AGENT_LOCK_PROFILING", "false").lower() == "true"
 
     def __enter__(self) -> ProfilingLock:
         """
@@ -91,7 +93,8 @@ class ProfilingLock:
         self.lock.release()
 
         self.add_stat("released lock", stats)
-        self.print_stats(stats)
+        if self.show_stats:
+            self.print_stats(stats)
 
     def print_stats(self, stats: List[Tuple[str, float]]):
         """

--- a/neuro_san/internals/utils/profiling_lock.py
+++ b/neuro_san/internals/utils/profiling_lock.py
@@ -48,10 +48,11 @@ class ProfilingLock:
         self.logger: Logger = getLogger(name)
         self.stats_in_play: List[Tuple[str, float]] = []
 
-    async def __aenter__(self, stats: List[Tuple[str, float]]) -> ProfilingLock:
+    async def __aenter__(self) -> ProfilingLock:
         """
         Acquire the lock
         """
+        stats: List[Tuple[str, float]] = []
         await self.acquire(stats)
         return self
 

--- a/neuro_san/internals/utils/profiling_lock.py
+++ b/neuro_san/internals/utils/profiling_lock.py
@@ -110,4 +110,4 @@ class ProfilingLock:
             if first_time == 0.0:
                 first_time = time
             else:
-                self.logger.info("%s:%s in %f secs", self.name, key, time - first_time)
+                self.logger.info("%s (%s):%s in %f secs", self.name, self.lock, key, time - first_time)

--- a/neuro_san/internals/utils/profiling_lock.py
+++ b/neuro_san/internals/utils/profiling_lock.py
@@ -40,8 +40,8 @@ class ProfilingLock:
         :param name: The name of the lock
         :param lock_in: The lock to wrap. If no lock is provided, a new one will be created.
         """
-        self.name = name
-        self.lock = lock_in
+        self.name: str = name
+        self.lock: Lock = lock_in
         if self.lock is None:
             self.lock = Lock()
 

--- a/neuro_san/service/http/handlers/streaming_chat_handler.py
+++ b/neuro_san/service/http/handlers/streaming_chat_handler.py
@@ -24,6 +24,7 @@ from typing import AsyncGenerator
 from http import HTTPStatus
 
 import asyncio
+from asyncio import Lock as AsyncLock
 import contextlib
 import json
 from json.decoder import JSONDecodeError
@@ -57,7 +58,7 @@ class StreamingChatHandler(BaseRequestHandler):
         self.keep_alive_frame: str = self._build_keep_alive_frame()
         self.last_send_ts = 0.0
         self.keep_alive_task: asyncio.Task = None
-        self.lock: asyncio.Lock = asyncio.Lock()  # protects request writes to output stream and last_send_ts updates
+        self.lock: AsyncLock = AsyncLock()  # protects request writes to output stream and last_send_ts updates
 
     @staticmethod
     def _build_keep_alive_frame() -> str:

--- a/neuro_san/service/http/server/http_server.py
+++ b/neuro_san/service/http/server/http_server.py
@@ -25,7 +25,7 @@ from typing import List
 import json
 import os
 import random
-import threading
+from threading import Lock
 
 import tornado
 
@@ -124,7 +124,7 @@ class HttpServer(AgentStateListener):
         self.logger = HttpLogger(self.forwarded_request_metadata, self.logging_config)
         self.allowed_agents: Dict[str, AsyncAgentServiceProvider] = {}
         self.authorization_policy: AgentAuthorizer = AgentAuthorizationPolicy(self.allowed_agents)
-        self.lock = threading.Lock()
+        self.lock = Lock()
 
         # Add listener to handle adding per-agent http service
         # (services map is defined by self.allowed_agents dictionary)

--- a/neuro_san/service/mcp/session/mcp_session_manager.py
+++ b/neuro_san/service/mcp/session/mcp_session_manager.py
@@ -17,12 +17,11 @@
 """
 See class comment for details
 """
-import threading
-
 from typing import Dict
 
-import uuid
 import base64
+from threading import Lock
+import uuid
 
 from neuro_san.service.mcp.interfaces.client_session_policy import ClientSessionPolicy
 from neuro_san.service.mcp.session.mcp_client_session import McpClientSession
@@ -38,7 +37,7 @@ class McpSessionManager(ClientSessionPolicy):
 
     def __init__(self):
         # Lock to protect access to the sessions dictionary
-        self.lock: threading.Lock = threading.Lock()
+        self.lock: Lock = Lock()
         self.sessions: Dict[str, McpClientSession] = {}
 
     def create_session(self) -> McpClientSession:

--- a/neuro_san/service/watcher/temp_networks/aws_async_client_worker.py
+++ b/neuro_san/service/watcher/temp_networks/aws_async_client_worker.py
@@ -126,7 +126,7 @@ class AwsAsyncClientWorker:
 
     def ensure_async_lock_exists(self):
         """
-        Be sure we have an asyncio Lock to get our sessions.
+        Be sure we have an asynchronous Lock to get our sessions.
         """
         # Note that none of this is async in and of itself.
         if self.async_aws_client_lock is None:


### PR DESCRIPTION
* Add classes to profile acquisition and release of sync and asynchronous locks.
* Standardize how we import Lock and asyncio.Lock so they are easier to find by grepping.

These ProfilingLocks are not actually hooked up to anything permanently.
I have used them and observed that we are generally not waiting for locks at all in neuro_san.internals.
I can say that AND's GetMcpTool does _hold_ its request-scoped lock for > 8 seconds (in 20 request run), but it does not take anything to actually acquire.

Note that there are locks deeper down in the system I have not yet tried to replace.