### PR TITLE
Fall back to the "use_model_name" entry when pricing short-name LLMs

### DIFF
--- a/neuro_san/internals/run_context/langchain/token_counting/llm_token_callback_handler.py
+++ b/neuro_san/internals/run_context/langchain/token_counting/llm_token_callback_handler.py
@@ -226,10 +226,19 @@ class LlmTokenCallbackHandler(AsyncCallbackHandler):
         :param price_key: keyword to look in llm info for price
         :return: Token cost
         """
-        if model_name not in self.llm_infos:
+        llm_info: Dict[str, Any] = self.llm_infos.get(model_name)
+        if llm_info is None:
             return None
 
-        price = self.llm_infos.get(model_name).get(price_key)
+        price: Optional[float] = llm_info.get(price_key)
+
+        # Alias entries (e.g. "gpt-5.2") carry no price of their own; fall back to the
+        # concrete model they point to via "use_model_name" (e.g. "gpt-5.2-2025-12-11").
+        if price is None:
+            use_model_name: Optional[str] = llm_info.get("use_model_name")
+            if use_model_name is not None:
+                price = self.llm_infos.get(use_model_name, {}).get(price_key)
+
         return (num_tokens / 1000) * price if price is not None else None
 
     def _init_model_entry(self, model_name: str):

--- a/tests/neuro_san/internals/run_context/langchain/token_counting/test_llm_token_callback_handler.py
+++ b/tests/neuro_san/internals/run_context/langchain/token_counting/test_llm_token_callback_handler.py
@@ -94,6 +94,38 @@ class TestLlmTokenCallbackHandler:
             for record in caplog.records
         )
 
+    def test_calculate_token_costs_use_model_name_fallback(self, handler_with_model_infos):
+        """Test that an alias entry without prices falls back to its "use_model_name" entry."""
+        handler = handler_with_model_infos
+        handler.llm_infos["gpt-4-alias"] = {
+            "use_model_name": "gpt-4"
+        }
+        handler.provider_class = "openai"
+
+        cost = handler.calculate_token_costs("gpt-4-alias", 1000, 2000)
+
+        # Expected: same as "gpt-4": (1000/1000 * 0.03) + (2000/1000 * 0.01) = 0.05
+        assert cost == 0.05
+
+    def test_calculate_token_costs_use_model_name_missing_target(self, handler_with_empty_infos, caplog):
+        """Test that an alias pointing to a nonexistent entry warns and defaults to 0 instead of raising."""
+        handler = handler_with_empty_infos
+        handler.llm_infos = {
+            "dangling-alias": {
+                "use_model_name": "no-such-model"
+            }
+        }
+        handler.provider_class = "custom"
+
+        with caplog.at_level(logging.WARNING):
+            cost = handler.calculate_token_costs("dangling-alias", 1000, 2000)
+
+        assert cost == 0.0
+        assert any(
+            record.levelno == logging.WARNING and "No price info found for model dangling-alias" in record.getMessage()
+            for record in caplog.records
+        )
+
     def test_calculate_token_costs_zero_tokens(self, handler_with_model_infos):
         """Test with zero tokens."""
         handler = handler_with_model_infos


### PR DESCRIPTION
Alias entries in the llm info hocon (e.g. "gpt-5.2") carry no price of their own, so models reported by their short name were costed at 0 with a warning. When an entry has no price, look up the concrete model it points to via `"use_model_name"` and use that entry's price instead.

Fix #1160 