### PR TITLE
Reuse the service's loaded toolbox factory for connectivity reporting

### DIFF
--- a/neuro_san/internals/chat/connectivity_reporter.py
+++ b/neuro_san/internals/chat/connectivity_reporter.py
@@ -60,6 +60,12 @@ class ConnectivityReporter:
         Constructor
 
         :param inspector: The AgentNetworkInspector to use.
+        :param toolbox_factory: An optional ContextTypeToolboxFactory to consult
+                        for display_as information about toolbox tools.
+                        This should have been built from the same config as the
+                        inspector's agent network and may be passed pre-loaded
+                        so toolbox info files are not re-read per report.
+                        If None, one is created from the inspector's config.
         """
 
         self.inspector: AgentNetworkInspector = inspector

--- a/neuro_san/internals/chat/connectivity_reporter.py
+++ b/neuro_san/internals/chat/connectivity_reporter.py
@@ -19,6 +19,8 @@ from typing import Dict
 from typing import List
 from typing import Set
 
+import logging
+
 from leaf_common.parsers.dictionary_extractor import DictionaryExtractor
 
 from neuro_san.internals.interfaces.context_type_toolbox_factory import ContextTypeToolboxFactory
@@ -72,6 +74,9 @@ class ConnectivityReporter:
         self.toolbox_factory: ContextTypeToolboxFactory = toolbox_factory
 
         if self.inspector is not None and self.toolbox_factory is None:
+            logger = logging.getLogger(self.__class__.__name__)
+            logger.info("No toolbox_factory provided. Building one from the agent network config. "
+                        "Pass a pre-loaded factory to avoid re-reading toolbox info files per report.")
             config: Dict[str, Any] = self.inspector.get_config()
             self.toolbox_factory = MasterToolboxFactory.create_toolbox_factory(config)
 

--- a/neuro_san/internals/chat/connectivity_reporter.py
+++ b/neuro_san/internals/chat/connectivity_reporter.py
@@ -57,6 +57,10 @@ class ConnectivityReporter:
         Maybe someday.
     """
 
+    # Set once the self-build fallback below has been logged, so per-request
+    # reporter construction cannot flood the logs.
+    self_build_logged: bool = False
+
     def __init__(self, inspector: AgentNetworkInspector, toolbox_factory: ContextTypeToolboxFactory = None):
         """
         Constructor
@@ -74,9 +78,12 @@ class ConnectivityReporter:
         self.toolbox_factory: ContextTypeToolboxFactory = toolbox_factory
 
         if self.inspector is not None and self.toolbox_factory is None:
-            logger = logging.getLogger(self.__class__.__name__)
-            logger.info("No toolbox_factory provided. Building one from the agent network config. "
-                        "Pass a pre-loaded factory to avoid re-reading toolbox info files per report.")
+            if not ConnectivityReporter.self_build_logged:
+                ConnectivityReporter.self_build_logged = True
+                logger = logging.getLogger(self.__class__.__name__)
+                logger.info("No toolbox_factory provided. Building one from the agent network config. "
+                            "Pass a pre-loaded factory to avoid re-reading toolbox info files per report. "
+                            "(Logged once per process.)")
             config: Dict[str, Any] = self.inspector.get_config()
             self.toolbox_factory = MasterToolboxFactory.create_toolbox_factory(config)
 

--- a/neuro_san/internals/run_context/langchain/toolbox/toolbox_factory.py
+++ b/neuro_san/internals/run_context/langchain/toolbox/toolbox_factory.py
@@ -120,6 +120,9 @@ class ToolboxFactory(ContextTypeToolboxFactory):
         if self.loaded:
             return
 
+        # Double-checked locking: the test above keeps the per-report load()
+        # call cheap once loaded; the re-test under the lock makes the first
+        # load exclusive when a not-yet-loaded factory is shared by threads.
         with self.load_lock:
             if self.loaded:
                 return

--- a/neuro_san/internals/run_context/langchain/toolbox/toolbox_factory.py
+++ b/neuro_san/internals/run_context/langchain/toolbox/toolbox_factory.py
@@ -109,6 +109,10 @@ class ToolboxFactory(ContextTypeToolboxFactory):
     def load(self):
         """
         Loads the base tool information from hocon files.
+
+        Only the first call does any work.  Subsequent calls on the same
+        instance are no-ops, so a shared factory can be load()-ed cheaply
+        on every use.
         """
         if self.loaded:
             return

--- a/neuro_san/internals/run_context/langchain/toolbox/toolbox_factory.py
+++ b/neuro_san/internals/run_context/langchain/toolbox/toolbox_factory.py
@@ -27,6 +27,8 @@ from typing import Union
 import logging
 import os
 
+from threading import Lock
+
 from langchain_core.tools.base import BaseTool
 from langchain_core.tools.base import BaseToolkit
 from pydantic import BaseModel
@@ -85,6 +87,7 @@ class ToolboxFactory(ContextTypeToolboxFactory):
         self.toolbox_infos: Dict[str, Any] = {}
         self.overlayer = DictionaryOverlay()
         self.loaded: bool = False
+        self.load_lock: Lock = Lock()
 
         # Get user toolbox info file path with the following priority:
         # 1. "toolbox_info_file" from agent network hocon
@@ -112,20 +115,27 @@ class ToolboxFactory(ContextTypeToolboxFactory):
 
         Only the first call does any work.  Subsequent calls on the same
         instance are no-ops, so a shared factory can be load()-ed cheaply
-        on every use.
+        on every use, even from multiple threads.
         """
         if self.loaded:
             return
 
-        restorer = ToolboxInfoRestorer()
-        self.toolbox_infos = restorer.restore()
+        with self.load_lock:
+            if self.loaded:
+                return
 
-        # Mix in user-specified toolbox info, if available.
-        if self.toolbox_info_file:
-            extra_toolbox_infos: Dict[str, Any] = restorer.restore(file_reference=self.toolbox_info_file)
-            self.toolbox_infos = self.overlayer.overlay(self.toolbox_infos, extra_toolbox_infos)
+            restorer = ToolboxInfoRestorer()
+            toolbox_infos: Dict[str, Any] = restorer.restore()
 
-        self.loaded = True
+            # Mix in user-specified toolbox info, if available.
+            if self.toolbox_info_file:
+                extra_toolbox_infos: Dict[str, Any] = restorer.restore(file_reference=self.toolbox_info_file)
+                toolbox_infos = self.overlayer.overlay(toolbox_infos, extra_toolbox_infos)
+
+            # Publish the fully-assembled infos in a single assignment so that
+            # lock-free readers never observe a partially-overlaid dictionary.
+            self.toolbox_infos = toolbox_infos
+            self.loaded = True
 
     def create_tool_from_toolbox(
             self,

--- a/neuro_san/service/generic/agent_service.py
+++ b/neuro_san/service/generic/agent_service.py
@@ -206,6 +206,9 @@ class AgentService:
 
         # Delegate to Direct*Session
         agent_network: AgentNetwork = self.agent_network_provider.get_agent_network()
+        # Pass the toolbox factory that was created and loaded once at service
+        # construction, so connectivity reporting does not re-read toolbox
+        # info files on every request.
         session = DirectAgentSession(agent_network=agent_network,
                                      invocation_context=None,
                                      metadata=metadata,

--- a/neuro_san/service/generic/agent_service.py
+++ b/neuro_san/service/generic/agent_service.py
@@ -209,7 +209,8 @@ class AgentService:
         session = DirectAgentSession(agent_network=agent_network,
                                      invocation_context=None,
                                      metadata=metadata,
-                                     security_cfg=self.security_cfg)
+                                     security_cfg=self.security_cfg,
+                                     toolbox_factory=self.toolbox_factory)
         response_dict = session.connectivity(request_dict)
 
         if request_log is not None:

--- a/neuro_san/service/generic/async_agent_service.py
+++ b/neuro_san/service/generic/async_agent_service.py
@@ -110,12 +110,16 @@ class AsyncAgentService:
         """
         agent_network: AgentNetwork = self.agent_network_provider.get_agent_network()
         config: Dict[str, Any] = agent_network.get_config()
-        self.llm_factory: ContextTypeLlmFactory = MasterLlmFactory.create_llm_factory(config)
-        self.toolbox_factory: ContextTypeToolboxFactory = MasterToolboxFactory.create_toolbox_factory(config)
+        llm_factory: ContextTypeLlmFactory = MasterLlmFactory.create_llm_factory(config)
+        toolbox_factory: ContextTypeToolboxFactory = MasterToolboxFactory.create_toolbox_factory(config)
 
-        # Load once.
-        self.llm_factory.load()
-        self.toolbox_factory.load()
+        # Load once, before publishing to the fields that request paths read,
+        # so no request can ever see an unloaded factory.
+        llm_factory.load()
+        toolbox_factory.load()
+
+        self.llm_factory: ContextTypeLlmFactory = llm_factory
+        self.toolbox_factory: ContextTypeToolboxFactory = toolbox_factory
 
     def get_agent_network(self) -> AgentNetwork:
         """

--- a/neuro_san/service/generic/async_agent_service.py
+++ b/neuro_san/service/generic/async_agent_service.py
@@ -216,7 +216,8 @@ class AsyncAgentService:
                 agent_network=agent_network,
                 invocation_context=None,
                 metadata=metadata,
-                security_cfg=self.security_cfg)
+                security_cfg=self.security_cfg,
+                toolbox_factory=self.toolbox_factory)
         response_dict = await session.connectivity(request_dict)
 
         if do_log:

--- a/neuro_san/service/generic/async_agent_service.py
+++ b/neuro_san/service/generic/async_agent_service.py
@@ -215,6 +215,9 @@ class AsyncAgentService:
 
         # Delegate to Direct*Session
         agent_network: AgentNetwork = self.agent_network_provider.get_agent_network()
+        # Pass the toolbox factory that was created and loaded once at service
+        # construction, so connectivity reporting does not re-read toolbox
+        # info files on every request.
         session: AsyncDirectAgentSession =\
             AsyncDirectAgentSession(
                 agent_network=agent_network,

--- a/neuro_san/session/async_direct_agent_session.py
+++ b/neuro_san/session/async_direct_agent_session.py
@@ -50,6 +50,8 @@ class AsyncDirectAgentSession(AsyncAgentSession):
                  invocation_context: Optional[SessionInvocationContext],
                  metadata: Dict[str, Any] = None,
                  security_cfg: Dict[str, Any] = None,
+                 # Keyword-only: the sync and async session signatures diverge
+                 # above this point, so positional passing would misbind.
                  *,
                  toolbox_factory: ContextTypeToolboxFactory = None):
         """
@@ -82,6 +84,10 @@ class AsyncDirectAgentSession(AsyncAgentSession):
         self.invocation_context: SessionInvocationContext = invocation_context
         self.agent_network: AgentNetwork = agent_network
         self.request_id: str = None
+        # Resolve the toolbox factory once at construction: an invocation
+        # context's factory is fixed when the context is built, and resolving
+        # here keeps connectivity() working even after close() sets
+        # self.invocation_context to None.
         self.toolbox_factory: ContextTypeToolboxFactory = toolbox_factory
         if self.toolbox_factory is None and invocation_context is not None:
             self.toolbox_factory = invocation_context.get_toolbox_factory()

--- a/neuro_san/session/async_direct_agent_session.py
+++ b/neuro_san/session/async_direct_agent_session.py
@@ -49,6 +49,7 @@ class AsyncDirectAgentSession(AsyncAgentSession):
                  invocation_context: SessionInvocationContext,
                  metadata: Dict[str, Any] = None,
                  security_cfg: Dict[str, Any] = None,
+                 *,
                  toolbox_factory: ContextTypeToolboxFactory = None):
         """
         Constructor
@@ -62,11 +63,14 @@ class AsyncDirectAgentSession(AsyncAgentSession):
                         secure the TLS and the authentication of the gRPC
                         connection.  Supplying this implies use of a secure
                         GRPC Channel.  If None, uses insecure channel.
-        :param toolbox_factory: An optional already-loaded ContextTypeToolboxFactory
-                        built from the same agent network's config, so connectivity
-                        reporting does not have to re-read toolbox info files.
+        :param toolbox_factory: An optional ContextTypeToolboxFactory built from
+                        the same agent network's config, so connectivity reporting
+                        does not have to re-read toolbox info files per request.
+                        May be passed pre-loaded; connectivity reporting will
+                        load() it (a no-op if already loaded).
                         If None, the invocation_context's toolbox factory is used
-                        when available.
+                        when available; failing that, connectivity reporting
+                        builds one from the agent network's config.
         """
         # These aren't used yet
         self._metadata: Dict[str, Any] = metadata
@@ -76,6 +80,8 @@ class AsyncDirectAgentSession(AsyncAgentSession):
         self.agent_network: AgentNetwork = agent_network
         self.request_id: str = None
         self.toolbox_factory: ContextTypeToolboxFactory = toolbox_factory
+        if self.toolbox_factory is None and invocation_context is not None:
+            self.toolbox_factory = invocation_context.get_toolbox_factory()
         if metadata is not None:
             self.request_id = metadata.get("request_id")
         self.logger = logging.getLogger(self.__class__.__name__)
@@ -132,10 +138,7 @@ class AsyncDirectAgentSession(AsyncAgentSession):
         response_dict: Dict[str, Any] = {
         }
 
-        toolbox_factory: ContextTypeToolboxFactory = self.toolbox_factory
-        if toolbox_factory is None and self.invocation_context is not None:
-            toolbox_factory = self.invocation_context.get_toolbox_factory()
-        reporter = ConnectivityReporter(self.agent_network, toolbox_factory)
+        reporter = ConnectivityReporter(self.agent_network, self.toolbox_factory)
         config: Dict[str, Any] = self.agent_network.get_config()
         metadata: Dict[str, Any] = config.get("metadata")
         connectivity_info: List[Dict[str, Any]] = reporter.report_network_connectivity()

--- a/neuro_san/session/async_direct_agent_session.py
+++ b/neuro_san/session/async_direct_agent_session.py
@@ -19,6 +19,7 @@ from typing import Any
 from typing import Dict
 from typing import AsyncGenerator
 from typing import List
+from typing import Optional
 
 from asyncio import Task
 from contextlib import suppress
@@ -46,7 +47,7 @@ class AsyncDirectAgentSession(AsyncAgentSession):
     # pylint: disable=too-many-arguments,too-many-positional-arguments
     def __init__(self,
                  agent_network: AgentNetwork,
-                 invocation_context: SessionInvocationContext,
+                 invocation_context: Optional[SessionInvocationContext],
                  metadata: Dict[str, Any] = None,
                  security_cfg: Dict[str, Any] = None,
                  *,
@@ -57,6 +58,8 @@ class AsyncDirectAgentSession(AsyncAgentSession):
         :param agent_network: The AgentNetwork to use for the session.
         :param invocation_context: The SessionInvocationContext to use to consult
                         for policy objects scoped at the invocation level.
+                        May be None for sessions that only serve connectivity()
+                        or function(); chat methods require a real instance.
         :param metadata: A dictionary of request metadata to be forwarded
                         to subsequent yet-to-be-made requests.
         :param security_cfg: A dictionary of parameters used to

--- a/neuro_san/session/async_direct_agent_session.py
+++ b/neuro_san/session/async_direct_agent_session.py
@@ -32,6 +32,7 @@ from neuro_san.internals.chat.connectivity_reporter import ConnectivityReporter
 from neuro_san.internals.chat.data_driven_chat_session import DataDrivenChatSession
 from neuro_san.internals.chat.queue_filter import QueueFilter
 from neuro_san.internals.graph.registry.agent_network import AgentNetwork
+from neuro_san.internals.interfaces.context_type_toolbox_factory import ContextTypeToolboxFactory
 from neuro_san.session.session_invocation_context import SessionInvocationContext
 
 
@@ -47,7 +48,8 @@ class AsyncDirectAgentSession(AsyncAgentSession):
                  agent_network: AgentNetwork,
                  invocation_context: SessionInvocationContext,
                  metadata: Dict[str, Any] = None,
-                 security_cfg: Dict[str, Any] = None):
+                 security_cfg: Dict[str, Any] = None,
+                 toolbox_factory: ContextTypeToolboxFactory = None):
         """
         Constructor
 
@@ -60,6 +62,11 @@ class AsyncDirectAgentSession(AsyncAgentSession):
                         secure the TLS and the authentication of the gRPC
                         connection.  Supplying this implies use of a secure
                         GRPC Channel.  If None, uses insecure channel.
+        :param toolbox_factory: An optional already-loaded ContextTypeToolboxFactory
+                        built from the same agent network's config, so connectivity
+                        reporting does not have to re-read toolbox info files.
+                        If None, the invocation_context's toolbox factory is used
+                        when available.
         """
         # These aren't used yet
         self._metadata: Dict[str, Any] = metadata
@@ -68,6 +75,7 @@ class AsyncDirectAgentSession(AsyncAgentSession):
         self.invocation_context: SessionInvocationContext = invocation_context
         self.agent_network: AgentNetwork = agent_network
         self.request_id: str = None
+        self.toolbox_factory: ContextTypeToolboxFactory = toolbox_factory
         if metadata is not None:
             self.request_id = metadata.get("request_id")
         self.logger = logging.getLogger(self.__class__.__name__)
@@ -124,7 +132,10 @@ class AsyncDirectAgentSession(AsyncAgentSession):
         response_dict: Dict[str, Any] = {
         }
 
-        reporter = ConnectivityReporter(self.agent_network)
+        toolbox_factory: ContextTypeToolboxFactory = self.toolbox_factory
+        if toolbox_factory is None and self.invocation_context is not None:
+            toolbox_factory = self.invocation_context.get_toolbox_factory()
+        reporter = ConnectivityReporter(self.agent_network, toolbox_factory)
         config: Dict[str, Any] = self.agent_network.get_config()
         metadata: Dict[str, Any] = config.get("metadata")
         connectivity_info: List[Dict[str, Any]] = reporter.report_network_connectivity()

--- a/neuro_san/session/direct_agent_session.py
+++ b/neuro_san/session/direct_agent_session.py
@@ -33,6 +33,7 @@ from neuro_san.internals.chat.connectivity_reporter import ConnectivityReporter
 from neuro_san.internals.chat.data_driven_chat_session import DataDrivenChatSession
 from neuro_san.internals.chat.queue_filter import QueueFilter
 from neuro_san.internals.graph.registry.agent_network import AgentNetwork
+from neuro_san.internals.interfaces.context_type_toolbox_factory import ContextTypeToolboxFactory
 from neuro_san.session.session_invocation_context import SessionInvocationContext
 
 
@@ -48,7 +49,8 @@ class DirectAgentSession(AgentSession):
                  invocation_context: SessionInvocationContext,
                  metadata: Dict[str, Any] = None,
                  security_cfg: Dict[str, Any] = None,
-                 umbrella_timeout: Timeout = None):
+                 umbrella_timeout: Timeout = None,
+                 toolbox_factory: ContextTypeToolboxFactory = None):
         """
         Constructor
 
@@ -63,6 +65,11 @@ class DirectAgentSession(AgentSession):
                         GRPC Channel.  If None, uses insecure channel.
         :param umbrella_timeout: A Timeout object to periodically check in loops.
                         Default is None (no timeout).
+        :param toolbox_factory: An optional already-loaded ContextTypeToolboxFactory
+                        built from the same agent network's config, so connectivity
+                        reporting does not have to re-read toolbox info files.
+                        If None, the invocation_context's toolbox factory is used
+                        when available.
         """
         # These aren't used yet
         self._metadata: Dict[str, Any] = metadata
@@ -72,6 +79,7 @@ class DirectAgentSession(AgentSession):
         self.agent_network: AgentNetwork = agent_network
         self.request_id: str = None
         self.umbrella_timeout: Timeout = umbrella_timeout
+        self.toolbox_factory: ContextTypeToolboxFactory = toolbox_factory
         if metadata is not None:
             self.request_id = metadata.get("request_id")
 
@@ -114,7 +122,10 @@ class DirectAgentSession(AgentSession):
         response_dict: Dict[str, Any] = {
         }
 
-        reporter = ConnectivityReporter(self.agent_network)
+        toolbox_factory: ContextTypeToolboxFactory = self.toolbox_factory
+        if toolbox_factory is None and self.invocation_context is not None:
+            toolbox_factory = self.invocation_context.get_toolbox_factory()
+        reporter = ConnectivityReporter(self.agent_network, toolbox_factory)
         config: Dict[str, Any] = self.agent_network.get_config()
         metadata: Dict[str, Any] = config.get("metadata")
         connectivity_info: List[Dict[str, Any]] = reporter.report_network_connectivity()

--- a/neuro_san/session/direct_agent_session.py
+++ b/neuro_san/session/direct_agent_session.py
@@ -50,6 +50,7 @@ class DirectAgentSession(AgentSession):
                  metadata: Dict[str, Any] = None,
                  security_cfg: Dict[str, Any] = None,
                  umbrella_timeout: Timeout = None,
+                 *,
                  toolbox_factory: ContextTypeToolboxFactory = None):
         """
         Constructor
@@ -65,11 +66,14 @@ class DirectAgentSession(AgentSession):
                         GRPC Channel.  If None, uses insecure channel.
         :param umbrella_timeout: A Timeout object to periodically check in loops.
                         Default is None (no timeout).
-        :param toolbox_factory: An optional already-loaded ContextTypeToolboxFactory
-                        built from the same agent network's config, so connectivity
-                        reporting does not have to re-read toolbox info files.
+        :param toolbox_factory: An optional ContextTypeToolboxFactory built from
+                        the same agent network's config, so connectivity reporting
+                        does not have to re-read toolbox info files per request.
+                        May be passed pre-loaded; connectivity reporting will
+                        load() it (a no-op if already loaded).
                         If None, the invocation_context's toolbox factory is used
-                        when available.
+                        when available; failing that, connectivity reporting
+                        builds one from the agent network's config.
         """
         # These aren't used yet
         self._metadata: Dict[str, Any] = metadata
@@ -80,6 +84,8 @@ class DirectAgentSession(AgentSession):
         self.request_id: str = None
         self.umbrella_timeout: Timeout = umbrella_timeout
         self.toolbox_factory: ContextTypeToolboxFactory = toolbox_factory
+        if self.toolbox_factory is None and invocation_context is not None:
+            self.toolbox_factory = invocation_context.get_toolbox_factory()
         if metadata is not None:
             self.request_id = metadata.get("request_id")
 
@@ -122,10 +128,7 @@ class DirectAgentSession(AgentSession):
         response_dict: Dict[str, Any] = {
         }
 
-        toolbox_factory: ContextTypeToolboxFactory = self.toolbox_factory
-        if toolbox_factory is None and self.invocation_context is not None:
-            toolbox_factory = self.invocation_context.get_toolbox_factory()
-        reporter = ConnectivityReporter(self.agent_network, toolbox_factory)
+        reporter = ConnectivityReporter(self.agent_network, self.toolbox_factory)
         config: Dict[str, Any] = self.agent_network.get_config()
         metadata: Dict[str, Any] = config.get("metadata")
         connectivity_info: List[Dict[str, Any]] = reporter.report_network_connectivity()

--- a/neuro_san/session/direct_agent_session.py
+++ b/neuro_san/session/direct_agent_session.py
@@ -51,6 +51,8 @@ class DirectAgentSession(AgentSession):
                  metadata: Dict[str, Any] = None,
                  security_cfg: Dict[str, Any] = None,
                  umbrella_timeout: Timeout = None,
+                 # Keyword-only: the sync and async session signatures diverge
+                 # above this point, so positional passing would misbind.
                  *,
                  toolbox_factory: ContextTypeToolboxFactory = None):
         """
@@ -86,6 +88,10 @@ class DirectAgentSession(AgentSession):
         self.agent_network: AgentNetwork = agent_network
         self.request_id: str = None
         self.umbrella_timeout: Timeout = umbrella_timeout
+        # Resolve the toolbox factory once at construction: an invocation
+        # context's factory is fixed when the context is built, and resolving
+        # here keeps connectivity() working even after close() sets
+        # self.invocation_context to None.
         self.toolbox_factory: ContextTypeToolboxFactory = toolbox_factory
         if self.toolbox_factory is None and invocation_context is not None:
             self.toolbox_factory = invocation_context.get_toolbox_factory()

--- a/neuro_san/session/direct_agent_session.py
+++ b/neuro_san/session/direct_agent_session.py
@@ -19,6 +19,7 @@ from typing import Any
 from typing import Dict
 from typing import Generator
 from typing import List
+from typing import Optional
 
 from asyncio import Task
 from contextlib import suppress
@@ -46,7 +47,7 @@ class DirectAgentSession(AgentSession):
     # pylint: disable=too-many-arguments,too-many-positional-arguments
     def __init__(self,
                  agent_network: AgentNetwork,
-                 invocation_context: SessionInvocationContext,
+                 invocation_context: Optional[SessionInvocationContext],
                  metadata: Dict[str, Any] = None,
                  security_cfg: Dict[str, Any] = None,
                  umbrella_timeout: Timeout = None,
@@ -58,6 +59,8 @@ class DirectAgentSession(AgentSession):
         :param agent_network: The AgentNetwork to use for the session.
         :param invocation_context: The SessionInvocationContext to use to consult
                         for policy objects scoped at the invocation level.
+                        May be None for sessions that only serve connectivity()
+                        or function(); chat methods require a real instance.
         :param metadata: A dictionary of request metadata to be forwarded
                         to subsequent yet-to-be-made requests.
         :param security_cfg: A dictionary of parameters used to

--- a/tests/neuro_san/internals/chat/test_connectivity_reporter.py
+++ b/tests/neuro_san/internals/chat/test_connectivity_reporter.py
@@ -24,6 +24,7 @@ from neuro_san import REGISTRIES_DIR
 from neuro_san.internals.chat.connectivity_reporter import ConnectivityReporter
 from neuro_san.internals.graph.registry.agent_network import AgentNetwork
 from neuro_san.internals.graph.persistence.agent_network_restorer import AgentNetworkRestorer
+from neuro_san.internals.run_context.langchain.toolbox.toolbox_factory import ToolboxFactory
 
 
 class TestConnectivityReporter(TestCase):
@@ -76,6 +77,21 @@ class TestConnectivityReporter(TestCase):
         tools: List[str] = connectivity.get("tools")
         self.assertIsNotNone(tools)
         self.assertEqual(len(tools), 0)
+
+    def test_injected_toolbox_factory_is_used(self):
+        """
+        Tests that a toolbox factory passed to the constructor is used as-is
+        rather than being replaced by one built from the inspector's config,
+        and that reporting loads it.
+        """
+        agent_network: AgentNetwork = self.get_sample_registry("hello_world.hocon")
+        toolbox_factory = ToolboxFactory()
+        reporter = ConnectivityReporter(agent_network, toolbox_factory)
+        self.assertIs(reporter.toolbox_factory, toolbox_factory)
+
+        messages: List[Dict[str, Any]] = reporter.report_network_connectivity()
+        self.assertEqual(len(messages), 2)
+        self.assertTrue(toolbox_factory.loaded)
 
     def test_assemble_tool_list_args_tools_dict(self):
         """

--- a/tests/neuro_san/internals/chat/test_connectivity_reporter.py
+++ b/tests/neuro_san/internals/chat/test_connectivity_reporter.py
@@ -18,7 +18,10 @@ from typing import Any
 from typing import Dict
 from typing import List
 
+import os
+
 from unittest import TestCase
+from unittest.mock import patch
 
 from neuro_san import REGISTRIES_DIR
 from neuro_san.internals.chat.connectivity_reporter import ConnectivityReporter
@@ -54,9 +57,13 @@ class TestConnectivityReporter(TestCase):
         Tests the connectivity of the hello world hocon
         """
         agent_network: AgentNetwork = self.get_sample_registry("hello_world.hocon")
-        reporter = ConnectivityReporter(agent_network)
 
-        messages: List[Dict[str, Any]] = reporter.report_network_connectivity()
+        # The reporter's self-built factory reads AGENT_TOOLBOX_INFO_FILE at
+        # construction. Keep the test hermetic against the environment.
+        with patch.dict(os.environ):
+            os.environ.pop("AGENT_TOOLBOX_INFO_FILE", None)
+            reporter = ConnectivityReporter(agent_network)
+            messages: List[Dict[str, Any]] = reporter.report_network_connectivity()
         self.assertEqual(len(messages), 2)
 
         # First guy is the front-man and he only has a single tool
@@ -86,12 +93,41 @@ class TestConnectivityReporter(TestCase):
         """
         agent_network: AgentNetwork = self.get_sample_registry("hello_world.hocon")
         toolbox_factory = ToolboxFactory()
+        # Keep the test hermetic: no user toolbox info file from the environment.
+        toolbox_factory.toolbox_info_file = None
         reporter = ConnectivityReporter(agent_network, toolbox_factory)
         self.assertIs(reporter.toolbox_factory, toolbox_factory)
 
         messages: List[Dict[str, Any]] = reporter.report_network_connectivity()
         self.assertEqual(len(messages), 2)
         self.assertTrue(toolbox_factory.loaded)
+
+    def test_injected_toolbox_factory_data_is_consulted(self):
+        """
+        Tests that display_as information comes from the injected factory's
+        toolbox infos, not from a factory built behind the scenes.
+        """
+        agent_network: AgentNetwork = self.get_sample_registry("requests_get.hocon")
+        toolbox_factory = ToolboxFactory()
+        # Keep the test hermetic: no user toolbox info file from the environment.
+        toolbox_factory.toolbox_info_file = None
+        # Seed distinctive tool info and mark loaded so load() keeps it as-is.
+        # A self-built or bundled factory would report "langchain_tool" instead.
+        toolbox_factory.toolbox_infos = {
+            "requests_get": {
+                "class": "mock_package.mock_module.MockTool",
+                "display_as": "injected_tool",
+            }
+        }
+        toolbox_factory.loaded = True
+
+        reporter = ConnectivityReporter(agent_network, toolbox_factory)
+        messages: List[Dict[str, Any]] = reporter.report_network_connectivity()
+
+        display_as_by_origin: Dict[str, str] = {
+            message.get("origin"): message.get("display_as") for message in messages
+        }
+        self.assertEqual(display_as_by_origin.get("web_browse_tool"), "injected_tool")
 
     def test_assemble_tool_list_args_tools_dict(self):
         """

--- a/tests/neuro_san/internals/run_context/langchain/toolbox/test_toolbox_factory.py
+++ b/tests/neuro_san/internals/run_context/langchain/toolbox/test_toolbox_factory.py
@@ -39,6 +39,29 @@ class TestToolboxFactory:
         """Fixture to provide a fresh instance of ToolboxFactory."""
         return ToolboxFactory()
 
+    def test_load_only_loads_once(self, factory):
+        """Test that load() reads hocon files on the first call only."""
+        # Keep the test hermetic: no user toolbox info file from the environment.
+        factory.toolbox_info_file = None
+        restorer_path = (
+            "neuro_san.internals.run_context.langchain.toolbox."
+            "toolbox_factory.ToolboxInfoRestorer"
+        )
+        infos = {"some_tool": {"class": "mock_package.mock_module.SomeTool"}}
+        with patch(restorer_path) as mock_restorer:
+            mock_restorer.return_value.restore.return_value = infos
+
+            assert not factory.loaded
+            factory.load()
+            assert factory.loaded
+            assert factory.toolbox_infos == infos
+
+            # A second load() must be a no-op: no further file reads,
+            # and the previously loaded infos are kept.
+            factory.load()
+            mock_restorer.return_value.restore.assert_called_once()
+            assert factory.toolbox_infos == infos
+
     def test_create_toolbox_returns_single_base_tool(self, factory):
         """Test that the tool is resolved with correct arguments."""
 

--- a/tests/neuro_san/session/test_direct_agent_session_connectivity.py
+++ b/tests/neuro_san/session/test_direct_agent_session_connectivity.py
@@ -1,0 +1,120 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+from typing import Any
+from typing import Dict
+
+from asyncio import run
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+from neuro_san import REGISTRIES_DIR
+from neuro_san.internals.graph.persistence.agent_network_restorer import AgentNetworkRestorer
+from neuro_san.internals.graph.registry.agent_network import AgentNetwork
+from neuro_san.internals.run_context.langchain.toolbox.toolbox_factory import ToolboxFactory
+from neuro_san.session.async_direct_agent_session import AsyncDirectAgentSession
+from neuro_san.session.direct_agent_session import DirectAgentSession
+
+
+class TestDirectAgentSessionConnectivity(TestCase):
+    """
+    Unit tests for the toolbox factory wiring in the connectivity() methods
+    of DirectAgentSession and AsyncDirectAgentSession.
+    """
+
+    def get_sample_registry(self, hocon_file: str) -> AgentNetwork:
+        """
+        :param hocon_file: A hocon file reference within this repo
+        """
+        file_reference = REGISTRIES_DIR.get_file_in_basis(hocon_file)
+        restorer = AgentNetworkRestorer()
+        agent_network: AgentNetwork = restorer.restore(file_reference=file_reference)
+        return agent_network
+
+    def make_toolbox_factory(self) -> ToolboxFactory:
+        """
+        :return: A ToolboxFactory unaffected by the environment.
+        """
+        toolbox_factory = ToolboxFactory()
+        # Keep the test hermetic: no user toolbox info file from the environment.
+        toolbox_factory.toolbox_info_file = None
+        return toolbox_factory
+
+    def test_connectivity_uses_injected_toolbox_factory(self):
+        """
+        Tests that a toolbox factory passed to the sync session constructor
+        reaches the ConnectivityReporter and is loaded by reporting.
+        """
+        agent_network: AgentNetwork = self.get_sample_registry("hello_world.hocon")
+        toolbox_factory: ToolboxFactory = self.make_toolbox_factory()
+        session = DirectAgentSession(agent_network=agent_network,
+                                     invocation_context=None,
+                                     toolbox_factory=toolbox_factory)
+        self.assertIs(session.toolbox_factory, toolbox_factory)
+
+        response: Dict[str, Any] = session.connectivity({})
+        self.assertIn("connectivity_info", response)
+        self.assertTrue(toolbox_factory.loaded)
+
+    def test_connectivity_falls_back_to_invocation_context_factory(self):
+        """
+        Tests that with no factory passed, the sync session uses the
+        invocation context's toolbox factory.
+        """
+        agent_network: AgentNetwork = self.get_sample_registry("hello_world.hocon")
+        toolbox_factory: ToolboxFactory = self.make_toolbox_factory()
+        invocation_context = MagicMock()
+        invocation_context.get_toolbox_factory.return_value = toolbox_factory
+        session = DirectAgentSession(agent_network=agent_network,
+                                     invocation_context=invocation_context)
+        self.assertIs(session.toolbox_factory, toolbox_factory)
+
+        response: Dict[str, Any] = session.connectivity({})
+        self.assertIn("connectivity_info", response)
+        self.assertTrue(toolbox_factory.loaded)
+
+    def test_async_connectivity_uses_injected_toolbox_factory(self):
+        """
+        Tests that a toolbox factory passed to the async session constructor
+        reaches the ConnectivityReporter and is loaded by reporting.
+        """
+        agent_network: AgentNetwork = self.get_sample_registry("hello_world.hocon")
+        toolbox_factory: ToolboxFactory = self.make_toolbox_factory()
+        session = AsyncDirectAgentSession(agent_network=agent_network,
+                                          invocation_context=None,
+                                          toolbox_factory=toolbox_factory)
+        self.assertIs(session.toolbox_factory, toolbox_factory)
+
+        response: Dict[str, Any] = run(session.connectivity({}))
+        self.assertIn("connectivity_info", response)
+        self.assertTrue(toolbox_factory.loaded)
+
+    def test_async_connectivity_falls_back_to_invocation_context_factory(self):
+        """
+        Tests that with no factory passed, the async session uses the
+        invocation context's toolbox factory.
+        """
+        agent_network: AgentNetwork = self.get_sample_registry("hello_world.hocon")
+        toolbox_factory: ToolboxFactory = self.make_toolbox_factory()
+        invocation_context = MagicMock()
+        invocation_context.get_toolbox_factory.return_value = toolbox_factory
+        session = AsyncDirectAgentSession(agent_network=agent_network,
+                                          invocation_context=invocation_context)
+        self.assertIs(session.toolbox_factory, toolbox_factory)
+
+        response: Dict[str, Any] = run(session.connectivity({}))
+        self.assertIn("connectivity_info", response)
+        self.assertTrue(toolbox_factory.loaded)


### PR DESCRIPTION
Fixes #1166

## Problem

Every `connectivity()` request built a fresh `ToolboxFactory` and re-read the toolbox info hocon files from disk, even though `AgentService` / `AsyncAgentService` already build and load a factory once at startup for chat. On the async HTTP path the per-request file read + parse ran synchronously inside the event loop. See #1166 for the full analysis.

## Changes

**Wiring (zero file I/O per connectivity request)**
- `DirectAgentSession` and `AsyncDirectAgentSession` accept an optional, keyword-only `toolbox_factory`. It is resolved once in the constructor: explicit param → `invocation_context.get_toolbox_factory()` → `None` (in which case `ConnectivityReporter` keeps its existing self-build fallback).
- `AgentService.connectivity()` and `AsyncAgentService.connectivity()` pass their already-loaded `self.toolbox_factory` into the session. Library sessions created by `DirectAgentSessionFactory` reuse the factory their invocation context already carries.
- `ConnectivityReporter` accepts the injected factory and logs when it has to self-build one, so any future call site that forgets the parameter is observable instead of silently regressing to per-request reads.

**Thread-safety / hardening**
- `ToolboxFactory.load()` is now load-once and thread-safe: double-checked `Lock` (same idiom as `LangChainMcpAdapter`), and the assembled infos are published in a single assignment so lock-free readers never observe a partially-overlaid dict.
- `AsyncAgentService.reload_factories()` loads factories into locals before assigning the fields request paths read, so a request can never see an unloaded factory.

**Tests**
- New `tests/neuro_san/session/` suite covers the actual wiring: injected-factory and invocation-context-fallback paths in both session twins (sync and async).
- New reporter test proves the injected factory's data is consulted (a distinctive `display_as` value appears in the report) rather than merely stored.
- `ToolboxFactory` test asserts a second `load()` performs no additional file reads.
- Connectivity reporter tests are hermetic against a set `AGENT_TOOLBOX_INFO_FILE` env var (including the pre-existing `test_hello_world`, which had the same exposure through the reporter's self-build path).

## Behavior notes

- Connectivity now uses the same construction-time factory as chat. After an agent-network hot-reload, the async provider rebuilds the service (and factory) via `reset_service()`, so reports stay consistent; in-flight requests during the swap window may briefly report with the prior factory, matching existing chat semantics.
- Sessions created by `ExternalAgentSessionFactory` carry the calling network's invocation context; nothing calls `connectivity()` on those sessions today, but if cross-network connectivity reporting is ever added, the factory-vs-network pairing there deserves a look.

## Testing

- `pytest tests/neuro_san/internals tests/neuro_san/session tests/neuro_san/service tests/neuro_san/client tests/neuro_san/middleware` — 369 passed.
- Affected tests also pass with a hostile `AGENT_TOOLBOX_INFO_FILE=/nonexistent/path.hocon` exported, verifying hermeticity.