### PR TITLE
Add set_default_headers to preserve CORS on error responses

### DIFF
--- a/neuro_san/service/http/handlers/base_request_handler.py
+++ b/neuro_san/service/http/handlers/base_request_handler.py
@@ -75,15 +75,30 @@ class BaseRequestHandler(RequestHandler):
         self.show_absent: bool = os.environ.get("SHOW_ABSENT_METADATA") is not None
         self.request_id: int = 0
 
+        self._set_cors_headers()
+
+    def _set_cors_headers(self, allowed_methods: str = "GET, POST, OPTIONS"):
+        """
+        Set CORS response headers when AGENT_ALLOW_CORS_HEADERS is configured.
+        :param allowed_methods: comma-separated list of allowed HTTP methods.
+        """
         if os.environ.get("AGENT_ALLOW_CORS_HEADERS") is not None:
             self.set_header("Access-Control-Allow-Origin", "*")
-            self.set_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+            self.set_header("Access-Control-Allow-Methods", allowed_methods)
             headers: str = "Content-Type, Transfer-Encoding"
-            metadata_headers: str = ", ".join(self.forwarded_request_metadata)
+            forwarded: List[str] = getattr(self, "forwarded_request_metadata", [])
+            metadata_headers: str = ", ".join(forwarded)
             if len(metadata_headers) > 0:
                 headers += f", {metadata_headers}"
             # Set all allowed headers:
             self.set_header("Access-Control-Allow-Headers", headers)
+
+    def set_default_headers(self):
+        """
+        Called by Tornado when headers are reset, including by send_error().
+        Ensures CORS headers are present on error responses.
+        """
+        self._set_cors_headers()
 
     def get_metadata(self) -> Dict[str, Any]:
         """

--- a/neuro_san/service/http/handlers/health_check_handler.py
+++ b/neuro_san/service/http/handlers/health_check_handler.py
@@ -60,6 +60,7 @@ class HealthCheckHandler(RequestHandler):
                    do not have to re-resolve importlib metadata on every probe.
         """
         self.logger = HttpLogger(forwarded_request_metadata, logging_config)
+        self.forwarded_request_metadata: List[str] = forwarded_request_metadata
         if op == "ready":
             self.status = server_status.is_server_ready()
         else:
@@ -67,10 +68,24 @@ class HealthCheckHandler(RequestHandler):
         self.server_name = server_status.get_server_name()
         self.versions = versions
 
+        self._set_cors_headers()
+
+    def _set_cors_headers(self, allowed_methods: str = "GET, OPTIONS"):
+        """
+        Set CORS response headers when AGENT_ALLOW_CORS_HEADERS is configured.
+        :param allowed_methods: comma-separated list of allowed HTTP methods.
+        """
         if os.environ.get("AGENT_ALLOW_CORS_HEADERS") is not None:
             self.set_header("Access-Control-Allow-Origin", "*")
-            self.set_header("Access-Control-Allow-Methods", "GET, OPTIONS")
+            self.set_header("Access-Control-Allow-Methods", allowed_methods)
             self.set_header("Access-Control-Allow-Headers", "Content-Type, Transfer-Encoding")
+
+    def set_default_headers(self):
+        """
+        Called by Tornado when headers are reset, including by send_error().
+        Ensures CORS headers are present on error responses.
+        """
+        self._set_cors_headers()
 
     async def get(self):
         """

--- a/neuro_san/service/http/server/http_server_app.py
+++ b/neuro_san/service/http/server/http_server_app.py
@@ -91,7 +91,9 @@ class HttpServerApp(Application):
         :param forwarded_request_metadata: list of client metadata keys
         """
         # Call the base constructor
-        super().__init__(handlers=handlers, default_handler_class=CorsErrorHandler)
+        super().__init__(handlers=handlers,
+                         default_handler_class=CorsErrorHandler,
+                         default_handler_args={"status_code": HTTPStatus.NOT_FOUND})
         self.total: int = 0
         self.num_processing: int = 0
         self.requests_stats: Dict[str, int] = {}

--- a/neuro_san/service/http/server/http_server_app.py
+++ b/neuro_san/service/http/server/http_server_app.py
@@ -26,6 +26,7 @@ import time
 
 from http import HTTPStatus
 
+import os
 from threading import Lock
 from threading import Thread
 
@@ -35,6 +36,35 @@ from tornado.ioloop import IOLoop
 
 from neuro_san.service.http.handlers.base_request_handler import BaseRequestHandler
 from neuro_san.service.interfaces.event_loop_logger import EventLoopLogger
+
+
+class CorsErrorHandler(ErrorHandler):
+    """
+    Default error handler that adds CORS headers to 404/405 responses.
+    Tornado's send_error() resets headers before generating the error page,
+    so CORS must be restored via set_default_headers().
+    """
+
+    def set_default_headers(self):
+        """
+        Set CORS response headers when AGENT_ALLOW_CORS_HEADERS is configured.
+        """
+        if os.environ.get("AGENT_ALLOW_CORS_HEADERS") is not None:
+            forwarded: List[str] = getattr(self.application, "forwarded_request_metadata", [])
+            metadata_headers: str = ", ".join(forwarded)
+            headers: str = "Content-Type, Transfer-Encoding"
+            if metadata_headers:
+                headers += f", {metadata_headers}"
+            self.set_header("Access-Control-Allow-Origin", "*")
+            self.set_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+            self.set_header("Access-Control-Allow-Headers", headers)
+
+    def data_received(self, chunk):
+        """
+        Method overrides abstract method of RequestHandler
+        with no-op implementation.
+        """
+        return
 
 
 class HttpServerApp(Application):
@@ -61,7 +91,7 @@ class HttpServerApp(Application):
         :param forwarded_request_metadata: list of client metadata keys
         """
         # Call the base constructor
-        super().__init__(handlers=handlers)
+        super().__init__(handlers=handlers, default_handler_class=CorsErrorHandler)
         self.total: int = 0
         self.num_processing: int = 0
         self.requests_stats: Dict[str, int] = {}

--- a/neuro_san/service/mcp/handlers/mcp_root_handler.py
+++ b/neuro_san/service/mcp/handlers/mcp_root_handler.py
@@ -68,14 +68,14 @@ class McpRootHandler(BaseRequestHandler):
         # For tool requests, we need to validate tool call arguments:
         self.tool_request_validator: ToolRequestValidator = ToolRequestValidator(self.openapi_service_spec)
 
-        self.set_header("Access-Control-Allow-Origin", "*")
-        self.set_header("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS")
-        headers: str = "Content-Type, Transfer-Encoding"
-        metadata_headers: str = ", ".join(self.forwarded_request_metadata)
-        if len(metadata_headers) > 0:
-            headers += f", {metadata_headers}"
-        # Set all allowed headers:
-        self.set_header("Access-Control-Allow-Headers", headers)
+        self._set_cors_headers("GET, POST, DELETE, OPTIONS")
+
+    def set_default_headers(self):
+        """
+        Called by Tornado when headers are reset, including by send_error().
+        Ensures MCP CORS headers are present on error responses.
+        """
+        self._set_cors_headers("GET, POST, DELETE, OPTIONS")
 
     async def post(self):
         """


### PR DESCRIPTION
## Summary

First requests to `neuro-san-dev.decisionai.ml` were intermittently failing with CORS errors in the browser, then succeeding on retry. The root cause is that Tornado's `send_error()` calls `clear()` before rendering an error page, which wipes out the `Access-Control-Allow-*` headers set in `initialize()`. Browsers therefore report a CORS error even when the real failure is a 404/405/500.

This change makes CORS headers survive `send_error()` by moving them to `set_default_headers()`, which Tornado re-invokes after `clear()`. It also registers `CorsErrorHandler` as the application's default handler so unregistered paths return CORS headers too.

### Changed handlers
- `BaseRequestHandler` – new `_set_cors_headers()` helper and `set_default_headers()` override
- `HealthCheckHandler` – same pattern for `/`, `/healthz`, `/readyz`, `/livez`
- `McpRootHandler` – same pattern, preserving `DELETE` in allowed methods
- `HttpServerApp` – new `CorsErrorHandler` default handler class

`initialize()` still calls `_set_cors_headers()` so normal responses continue to get the full metadata-aware `Access-Control-Allow-Headers` value.


Link to Devin session: https://app.devin.ai/sessions/b52897ef6009463b9a315e92c0c214fb
Requested by: @donn-leaf
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cognizant-ai-lab/neuro-san/pull/1168" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->