### PR TITLE
Only do structure parsing on AGENT_FRAMEWORK messages that could be the answer

### DIFF
--- a/neuro_san/message_processing/structure_message_processor.py
+++ b/neuro_san/message_processing/structure_message_processor.py
@@ -63,6 +63,10 @@ class StructureMessageProcessor(MessageProcessor):
         :param chat_message_dict: The ChatMessage dictionary to process.
         :param message_type: The ChatMessageType of the chat_message_dictionary to process.
         """
+        if message_type != ChatMessageType.AGENT_FRAMEWORK:
+            # No formats to look for
+            return
+
         text: str = chat_message_dict.get("text")
         structure: Dict[str, Any] = chat_message_dict.get("structure")
 


### PR DESCRIPTION
Not doing structure parsing on every message saves us a bit of time.