### PR TITLE
Get rid of the QueueFilter task

### DIFF
--- a/neuro_san/internals/chat/queue_filter.py
+++ b/neuro_san/internals/chat/queue_filter.py
@@ -38,17 +38,13 @@ class QueueFilter:
     We want the work done in filter_queue() to be done off the main server thread.
     """
 
-    def __init__(self, invocation_context: InvocationContext,
-                 chat_filter: Dict[str, Any],
-                 agent_network: AgentNetwork):
+    def __init__(self, chat_filter: Dict[str, Any], agent_network: AgentNetwork):
         """
         Constructor
 
-        :param invocation_context: An instance of InvocationContext
         :param chat_filter: A dictionary form of chat.ChatFilter
         :param agent_network: An instance of AgentNetwork
         """
-        self.invocation_context: InvocationContext = invocation_context
         self.message_filter: MessageFilter = MessageFilterFactory.create_message_filter(chat_filter)
         self.message_processor: MessageProcessor = self.create_outgoing_message_processor(agent_network)
 
@@ -74,10 +70,10 @@ class QueueFilter:
         message_processor = StructureMessageProcessor(structure_formats)
         return message_processor
 
-    def apply_to_journal(self):
+    def apply_to_journal(self, invocation_context: InvocationContext):
         """
         Apply the filter and processor to the message journal
         """
-        message_journal: MessageJournal = self.invocation_context.get_journal()
+        message_journal: MessageJournal = invocation_context.get_journal()
         message_journal.set_message_filter(self.message_filter)
         message_journal.set_message_processor(self.message_processor)

--- a/neuro_san/internals/chat/queue_filter.py
+++ b/neuro_san/internals/chat/queue_filter.py
@@ -31,11 +31,9 @@ from neuro_san.message_processing.structure_message_processor import StructureMe
 
 class QueueFilter:
     """
-    Filters messages from the input queue (the one from the MessageJournal)
-    to be sure they are suitable to be sent to the client on the output queue.
-
-    The main entrypoint to this class is filter_queue().
-    We want the work done in filter_queue() to be done off the main server thread.
+    Prepares MessageFilter and MessageProcessors for use by the MessageJournal
+    to be sure the output prodduced by the MessageJournal is suitable given the parameters
+    of the request.
     """
 
     def __init__(self, chat_filter: Dict[str, Any], agent_network: AgentNetwork):
@@ -72,7 +70,7 @@ class QueueFilter:
 
     def apply_to_journal(self, invocation_context: InvocationContext):
         """
-        Apply the filter and processor to the message journal
+        Apply the filter and processor to the MessageJournal
         """
         message_journal: MessageJournal = invocation_context.get_journal()
         message_journal.set_message_filter(self.message_filter)

--- a/neuro_san/internals/chat/queue_filter.py
+++ b/neuro_san/internals/chat/queue_filter.py
@@ -23,7 +23,6 @@ from typing import Union
 from neuro_san.internals.filters.message_filter import MessageFilter
 from neuro_san.internals.filters.message_filter_factory import MessageFilterFactory
 from neuro_san.internals.graph.registry.agent_network import AgentNetwork
-from neuro_san.internals.interfaces.invocation_context import InvocationContext
 from neuro_san.internals.journals.message_journal import MessageJournal
 from neuro_san.message_processing.message_processor import MessageProcessor
 from neuro_san.message_processing.structure_message_processor import StructureMessageProcessor
@@ -68,10 +67,9 @@ class QueueFilter:
         message_processor = StructureMessageProcessor(structure_formats)
         return message_processor
 
-    def apply_to_journal(self, invocation_context: InvocationContext):
+    def apply_to_journal(self, message_journal: MessageJournal):
         """
         Apply the filter and processor to the MessageJournal
         """
-        message_journal: MessageJournal = invocation_context.get_journal()
         message_journal.set_message_filter(self.message_filter)
         message_journal.set_message_processor(self.message_processor)

--- a/neuro_san/internals/chat/queue_filter.py
+++ b/neuro_san/internals/chat/queue_filter.py
@@ -20,14 +20,11 @@ from typing import Dict
 from typing import List
 from typing import Union
 
-from copy import copy
-
-from neuro_san.internals.chat.async_collating_queue import AsyncCollatingQueue
 from neuro_san.internals.filters.message_filter import MessageFilter
 from neuro_san.internals.filters.message_filter_factory import MessageFilterFactory
 from neuro_san.internals.graph.registry.agent_network import AgentNetwork
 from neuro_san.internals.interfaces.invocation_context import InvocationContext
-from neuro_san.internals.messages.chat_message_type import ChatMessageType
+from neuro_san.internals.journals.message_journal import MessageJournal
 from neuro_san.message_processing.message_processor import MessageProcessor
 from neuro_san.message_processing.structure_message_processor import StructureMessageProcessor
 
@@ -42,21 +39,16 @@ class QueueFilter:
     """
 
     def __init__(self, invocation_context: InvocationContext,
-                 template_response_dict: Dict[str, Any],
                  chat_filter: Dict[str, Any],
                  agent_network: AgentNetwork):
         """
         Constructor
 
         :param invocation_context: An instance of InvocationContext
-        :param template_response_dict: A dictionary form of chat.ChatResponse
         :param chat_filter: A dictionary form of chat.ChatFilter
         :param agent_network: An instance of AgentNetwork
         """
-        self.input_queue: AsyncCollatingQueue = invocation_context.get_queue()
-        self.output_queue: AsyncCollatingQueue = invocation_context.get_filtered_queue()
-        self.template_response_dict: Dict[str, Any] = template_response_dict
-
+        self.invocation_context: InvocationContext = invocation_context
         self.message_filter: MessageFilter = MessageFilterFactory.create_message_filter(chat_filter)
         self.message_processor: MessageProcessor = self.create_outgoing_message_processor(agent_network)
 
@@ -82,42 +74,10 @@ class QueueFilter:
         message_processor = StructureMessageProcessor(structure_formats)
         return message_processor
 
-    async def filter_queue(self):
+    def apply_to_journal(self):
         """
-        Main task entry point for DirectAgentSession.
-        Filter the messages coming off the input queue so that they can be sent to the client
-        via the output queue.
-        We'd rather this work be done off the main server thread.
+        Apply the filter and processor to the message journal
         """
-        try:
-            async for message in self.input_queue:
-                response_dict = await self.process_queue_message(message)
-                if response_dict is not None:
-                    await self.output_queue.put(response_dict, synchronous=True)
-        finally:
-            # Always signal completion so consumers don't hang if processing fails mid-stream.
-            try:
-                await self.output_queue.put_final_item(synchronous=True)
-            # pylint: disable=broad-except
-            except Exception:
-                pass
-
-    async def process_queue_message(self, message: Dict[str, Any]) -> Dict[str, Any]:
-        """
-        Process the single message and return an appropriate response dictionary
-
-        :param message: A dictionary form of chat.ChatMessage
-        :return: A dictionary form of chat.ChatResponse
-        """
-        if not self.message_filter.allow(message):
-            return None
-
-        # We expect the message to be a dictionary form of chat.ChatMessage
-        if self.message_processor is not None:
-            message_type: ChatMessageType = message.get("type")
-            # Can modify message
-            await self.message_processor.async_process_message(message, message_type)
-
-        response_dict: Dict[str, Any] = copy(self.template_response_dict)
-        response_dict["response"] = message
-        return response_dict
+        message_journal: MessageJournal = self.invocation_context.get_journal()
+        message_journal.set_message_filter(self.message_filter)
+        message_journal.set_message_processor(self.message_processor)

--- a/neuro_san/internals/interfaces/invocation_context.py
+++ b/neuro_san/internals/interfaces/invocation_context.py
@@ -89,13 +89,6 @@ class InvocationContext(LingeringResource):
         """
         raise NotImplementedError
 
-    def get_filtered_queue(self) -> AsyncCollatingQueue:
-        """
-        :return: The AsyncCollatingQueue instance via which messages are streamed to the
-                AgentSession mechanics
-        """
-        raise NotImplementedError
-
     def get_metadata(self) -> Dict[str, str]:
         """
         :return: The metadata to pass along with any request

--- a/neuro_san/internals/journals/message_journal.py
+++ b/neuro_san/internals/journals/message_journal.py
@@ -45,7 +45,6 @@ class MessageJournal(Journal):
         self.hopper: AsyncHopper = hopper
         self.message_filter: MessageFilter = MaximalMessageFilter()
         self.message_processor: MessageProcessor = None
-        self.issue_response_dicts: bool = True
 
     def set_message_filter(self, message_filter: MessageFilter):
         """
@@ -81,9 +80,7 @@ class MessageJournal(Journal):
             # Can modify message_dict
             await self.message_processor.async_process_message(message_dict, message_type)
 
-        outgoing_dict: Dict[str, Any] = message_dict
-        if self.issue_response_dicts:
-            outgoing_dict = {"response": message_dict}
+        outgoing_dict = {"response": message_dict}
 
         # Queue Producer from this:
         #   https://stackoverflow.com/questions/74130544/asyncio-yielding-results-from-multiple-futures-as-they-arrive

--- a/neuro_san/internals/journals/message_journal.py
+++ b/neuro_san/internals/journals/message_journal.py
@@ -20,9 +20,13 @@ from typing import List
 
 from langchain_core.messages.base import BaseMessage
 
+from neuro_san.internals.filters.maximal_message_filter import MaximalMessageFilter
+from neuro_san.internals.filters.message_filter import MessageFilter
 from neuro_san.internals.interfaces.async_hopper import AsyncHopper
 from neuro_san.internals.journals.journal import Journal
 from neuro_san.internals.messages.base_message_dictionary_converter import BaseMessageDictionaryConverter
+from neuro_san.internals.messages.chat_message_type import ChatMessageType
+from neuro_san.message_processing.message_processor import MessageProcessor
 
 
 class MessageJournal(Journal):
@@ -39,6 +43,21 @@ class MessageJournal(Journal):
                        any message will be put().
         """
         self.hopper: AsyncHopper = hopper
+        self.message_filter: MessageFilter = MaximalMessageFilter()
+        self.message_processor: MessageProcessor = None
+        self.issue_response_dicts: bool = True
+
+    def set_message_filter(self, message_filter: MessageFilter):
+        """
+        Sets the message filter for this journal.
+        """
+        self.message_filter = message_filter
+
+    def set_message_processor(self, message_processor: MessageProcessor):
+        """
+        Sets the message processor for this journal.
+        """
+        self.message_processor = message_processor
 
     async def write_message(self, message: BaseMessage, origin: List[Dict[str, Any]]):
         """
@@ -53,6 +72,18 @@ class MessageJournal(Journal):
         """
         converter = BaseMessageDictionaryConverter(origin=origin)
         message_dict: Dict[str, Any] = converter.to_dict(message)
+        message_type: ChatMessageType = message_dict.get("type")
+
+        if not self.message_filter.allow_message(message_dict, message_type):
+            return
+
+        if self.message_processor is not None:
+            # Can modify message_dict
+            await self.message_processor.async_process_message(message_dict, message_type)
+
+        outgoing_dict: Dict[str, Any] = message_dict
+        if self.issue_response_dicts:
+            outgoing_dict = {"response": message_dict}
 
         # Queue Producer from this:
         #   https://stackoverflow.com/questions/74130544/asyncio-yielding-results-from-multiple-futures-as-they-arrive
@@ -60,4 +91,4 @@ class MessageJournal(Journal):
         # as the journal messages come from inside a separate event loop from that request. The lock
         # taken here ends up being harmless in the synchronous request case (like for gRPC) because
         # we would only be blocking our own event loop.
-        await self.hopper.put(message_dict, synchronous=True)
+        await self.hopper.put(outgoing_dict, synchronous=True)

--- a/neuro_san/session/async_direct_agent_session.py
+++ b/neuro_san/session/async_direct_agent_session.py
@@ -199,7 +199,7 @@ class AsyncDirectAgentSession(AsyncAgentSession):
 
         # Task for late-stage conversions for any and all messages
         queue_filter = QueueFilter(chat_filter, self.agent_network)
-        queue_filter.apply_to_journal(self.invocation_context)
+        queue_filter.apply_to_journal(self.invocation_context.get_journal())
 
         # Create an asynchronous background task to process the user input.
         # This might take a few minutes, which can be longer than some

--- a/neuro_san/session/async_direct_agent_session.py
+++ b/neuro_san/session/async_direct_agent_session.py
@@ -185,15 +185,13 @@ class AsyncDirectAgentSession(AsyncAgentSession):
         _ = task
 
         # Task for late-stage conversions for any and all messages
-        queue_filter = QueueFilter(self.invocation_context, template_response_dict, chat_filter, self.agent_network)
-        task: Task = asyncio_executor.submit(self.request_id, queue_filter.filter_queue)
-        # Ignore the future. Live in the now.
-        _ = task
+        queue_filter = QueueFilter(self.invocation_context, chat_filter, self.agent_network)
+        queue_filter.apply_to_journal()
 
         # The generator below will asynchronously block waiting for
         # chat.ChatMessage dictionaries to come back asynchronously from the submit()
         # above until there are no more from the input.
-        queue_generator = self.invocation_context.get_filtered_queue()
+        queue_generator = self.invocation_context.get_queue()
         try:
             message: Dict[str, Any] = None
             async for message in queue_generator:

--- a/neuro_san/session/async_direct_agent_session.py
+++ b/neuro_san/session/async_direct_agent_session.py
@@ -197,6 +197,10 @@ class AsyncDirectAgentSession(AsyncAgentSession):
         chat_context: Dict[str, Any] = request_dict.get("chat_context")
         sly_data: Dict[str, Any] = request_dict.get("sly_data")
 
+        # Task for late-stage conversions for any and all messages
+        queue_filter = QueueFilter(chat_filter, self.agent_network)
+        queue_filter.apply_to_journal(self.invocation_context)
+
         # Create an asynchronous background task to process the user input.
         # This might take a few minutes, which can be longer than some
         # sockets stay open.
@@ -206,10 +210,6 @@ class AsyncDirectAgentSession(AsyncAgentSession):
                                              chat_context)
         # Ignore the future. Live in the now.
         _ = task
-
-        # Task for late-stage conversions for any and all messages
-        queue_filter = QueueFilter(chat_filter, self.agent_network)
-        queue_filter.apply_to_journal(self.invocation_context)
 
         # The generator below will asynchronously block waiting for
         # chat.ChatMessage dictionaries to come back asynchronously from the submit()

--- a/neuro_san/session/async_direct_agent_session.py
+++ b/neuro_san/session/async_direct_agent_session.py
@@ -185,8 +185,8 @@ class AsyncDirectAgentSession(AsyncAgentSession):
         _ = task
 
         # Task for late-stage conversions for any and all messages
-        queue_filter = QueueFilter(self.invocation_context, chat_filter, self.agent_network)
-        queue_filter.apply_to_journal()
+        queue_filter = QueueFilter(chat_filter, self.agent_network)
+        queue_filter.apply_to_journal(self.invocation_context)
 
         # The generator below will asynchronously block waiting for
         # chat.ChatMessage dictionaries to come back asynchronously from the submit()

--- a/neuro_san/session/direct_agent_session.py
+++ b/neuro_san/session/direct_agent_session.py
@@ -175,8 +175,8 @@ class DirectAgentSession(AgentSession):
         _ = task
 
         # Task for late-stage conversions for any and all messages
-        queue_filter = QueueFilter(self.invocation_context, chat_filter, self.agent_network)
-        queue_filter.apply_to_journal()
+        queue_filter = QueueFilter(chat_filter, self.agent_network)
+        queue_filter.apply_to_journal(self.invocation_context)
 
         # The synchronously_iterate() method below will synchronously block waiting for
         # chat.ChatMessage dictionaries to come back asynchronously from the submit()

--- a/neuro_san/session/direct_agent_session.py
+++ b/neuro_san/session/direct_agent_session.py
@@ -175,10 +175,8 @@ class DirectAgentSession(AgentSession):
         _ = task
 
         # Task for late-stage conversions for any and all messages
-        queue_filter = QueueFilter(self.invocation_context, template_response_dict, chat_filter, self.agent_network)
-        task: Task = asyncio_executor.submit(self.request_id, queue_filter.filter_queue)
-        # Ignore the future. Live in the now.
-        _ = task
+        queue_filter = QueueFilter(self.invocation_context, chat_filter, self.agent_network)
+        queue_filter.apply_to_journal()
 
         # The synchronously_iterate() method below will synchronously block waiting for
         # chat.ChatMessage dictionaries to come back asynchronously from the submit()
@@ -198,7 +196,7 @@ class DirectAgentSession(AgentSession):
             #    interrupted by caller-side "close" method.
             # 3. And we suppress all exceptions while deleting resources to keep things quieter.
             message: Dict[str, Any] = None
-            for message in generator.synchronously_iterate(self.invocation_context.get_filtered_queue()):
+            for message in generator.synchronously_iterate(self.invocation_context.get_queue()):
                 if message is not None:
                     yield message
         finally:

--- a/neuro_san/session/direct_agent_session.py
+++ b/neuro_san/session/direct_agent_session.py
@@ -187,6 +187,10 @@ class DirectAgentSession(AgentSession):
         chat_context: Dict[str, Any] = request_dict.get("chat_context")
         sly_data: Dict[str, Any] = request_dict.get("sly_data")
 
+        # Task for late-stage conversions for any and all messages
+        queue_filter = QueueFilter(chat_filter, self.agent_network)
+        queue_filter.apply_to_journal(self.invocation_context)
+
         # Create an asynchronous background task to process the user input.
         # This might take a few minutes, which can be longer than some
         # sockets stay open.
@@ -196,10 +200,6 @@ class DirectAgentSession(AgentSession):
                                              chat_context)
         # Ignore the future. Live in the now.
         _ = task
-
-        # Task for late-stage conversions for any and all messages
-        queue_filter = QueueFilter(chat_filter, self.agent_network)
-        queue_filter.apply_to_journal(self.invocation_context)
 
         # The synchronously_iterate() method below will synchronously block waiting for
         # chat.ChatMessage dictionaries to come back asynchronously from the submit()

--- a/neuro_san/session/direct_agent_session.py
+++ b/neuro_san/session/direct_agent_session.py
@@ -189,7 +189,7 @@ class DirectAgentSession(AgentSession):
 
         # Task for late-stage conversions for any and all messages
         queue_filter = QueueFilter(chat_filter, self.agent_network)
-        queue_filter.apply_to_journal(self.invocation_context)
+        queue_filter.apply_to_journal(self.invocation_context.get_journal())
 
         # Create an asynchronous background task to process the user input.
         # This might take a few minutes, which can be longer than some

--- a/neuro_san/session/session_invocation_context.py
+++ b/neuro_san/session/session_invocation_context.py
@@ -110,7 +110,6 @@ class SessionInvocationContext(InvocationContext):
         # Anything that has to do with the queue will need a new instance in
         # safe_shallow_copy() below to keep AsyncDirectAgentSessions happy.
         self.queue: AsyncCollatingQueue = AsyncCollatingQueue()
-        self.filtered_queue: AsyncCollatingQueue = AsyncCollatingQueue()
         self.journal: Journal = MessageJournal(self.queue)
         self.resources: List[LingeringResource] = []
         self.work_done_event: Event = Event()
@@ -171,13 +170,6 @@ class SessionInvocationContext(InvocationContext):
         """
         return self.queue
 
-    def get_filtered_queue(self) -> AsyncCollatingQueue:
-        """
-        :return: The AsyncCollatingQueue instance via which messages are streamed to the
-                AgentSession mechanics
-        """
-        return self.filtered_queue
-
     def get_metadata(self) -> Dict[str, str]:
         """
         :return: The metadata to pass along with any request
@@ -200,10 +192,6 @@ class SessionInvocationContext(InvocationContext):
         if self.queue is not None:
             self.queue.close()
             self.queue = None
-
-        if self.filtered_queue is not None:
-            self.filtered_queue.close()
-            self.filtered_queue = None
 
         for resource in self.resources:
             await resource.close_of_request()
@@ -282,12 +270,6 @@ class SessionInvocationContext(InvocationContext):
             self.queue = AsyncCollatingQueue()
             self.journal: Journal = MessageJournal(self.queue)
 
-        if self.filtered_queue is not None:
-            self.filtered_queue.reset()
-        else:
-            # filtered_queue is independent of the MessageJournal; just create a new instance.
-            self.filtered_queue = AsyncCollatingQueue()
-
         # Be sure we have an executor
         if self.asyncio_executor is None:
             self.asyncio_executor = self.async_executors_pool.get_executor()
@@ -321,7 +303,6 @@ class SessionInvocationContext(InvocationContext):
 
         # We need a different queue in order to call external agents with direct sessions.
         invocation_context.queue: AsyncCollatingQueue = AsyncCollatingQueue()
-        invocation_context.filtered_queue: AsyncCollatingQueue = AsyncCollatingQueue()
 
         # Now that the queue has changed, we need a new Journal as well
         # to be sure that the messages are sent to the correct queue.

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 # requirements-build.txt
 
 # In-house dependencies
-leaf-common>=1.2.47
+leaf-common>=1.2.49
 leaf-server-common>=0.1.25
 
 # Downgraded secondary dependencies for error-free pip installs


### PR DESCRIPTION
Filtering is now done before anything gets thrown onto the hopper in MessageJournal.
And now we don't need 2 queues.
The MessageJournal queue itself now contains client-ready message dicts instead of need-to-be-processed BaseMessages.

Also: Use the latest leaf-common==1.2.49 for eager task factory.