### PR TITLE
Http traffic tracer for neuro-san LLM connections.

### DIFF
--- a/neuro_san/deploy/Dockerfile
+++ b/neuro_san/deploy/Dockerfile
@@ -258,6 +258,30 @@ ENV AGENT_LOOP_TIMELINE_MAX_EVENTS="100000"
 # or signal handler at runtime).
 ENV AGENT_LOOP_TIMELINE_DUMP_PATH=""
 
+# Enable the httpx-level LLM traffic tracer. Emits structured JSON events
+# (http_llm_out / http_llm_in / http_llm_end / optional http_llm_chunk)
+# to the dedicated logger "neuro_san.diagnostics.http_llm_trace" so post-run
+# analysis can reconstruct outbound LLM traffic per user request. Each user
+# chat request is tagged with a short user_req_id that propagates through
+# every downstream LLM call via ContextVar; grep on user_req_id to get the
+# full LLM lifecycle of one request in time order.
+#
+# Overhead is negligible. Route the logger to a separate file in
+# logging.hocon for clean offline analysis.
+ENV AGENT_HTTP_LLM_TRACE="false"
+
+# When true, request and response bodies are logged verbatim on
+# http_llm_out and http_llm_end events (capped at 64 KB per body).
+# Prompts and completions are large and often sensitive; off by default.
+# Only consulted when AGENT_HTTP_LLM_TRACE is enabled.
+ENV AGENT_HTTP_LLM_TRACE_INCLUDE_BODIES="false"
+
+# When true, one http_llm_chunk event is emitted per received body
+# chunk. Massive log volume (dozens of chunks per LLM call); enable only
+# when investigating inter-chunk cadence specifically.
+# Only consulted when AGENT_HTTP_LLM_TRACE is enabled.
+ENV AGENT_HTTP_LLM_TRACE_CHUNKS="false"
+
 # Maximm number of requests that can be served at the same time
 # A value of 0 indicates unlimited requests are handled.
 ENV AGENT_MAX_CONCURRENT_REQUESTS="50"

--- a/neuro_san/service/http/handlers/streaming_chat_handler.py
+++ b/neuro_san/service/http/handlers/streaming_chat_handler.py
@@ -29,11 +29,13 @@ import contextlib
 import json
 from json.decoder import JSONDecodeError
 import time
+import uuid
 import tornado
 
 from neuro_san.internals.messages.chat_message_type import ChatMessageType
 from neuro_san.service.generic.async_agent_service import AsyncAgentService
 from neuro_san.service.http.handlers.base_request_handler import BaseRequestHandler
+from neuro_san.service.utils.http_llm_tracer import HttpxLlmTracer
 
 
 class StreamingChatHandler(BaseRequestHandler):
@@ -86,6 +88,13 @@ class StreamingChatHandler(BaseRequestHandler):
         """
         Implementation of POST request handler for streaming chat API call.
         """
+
+        # Tag every outbound LLM call made during this request with a
+        # short user_req_id so the HttpxLlmTracer's structured log lines
+        # can be grouped for post-run analysis. ContextVar propagates
+        # through asyncio + executor bridges, so downstream LLM calls
+        # inherit this id automatically. No-op if the tracer is disabled.
+        HttpxLlmTracer.set_user_request_id(uuid.uuid4().hex[:8])
 
         metadata: Dict[str, Any] = self.get_metadata()
         service: AsyncAgentService = await self.get_service(agent_name, metadata)

--- a/neuro_san/service/http/server/http_server.py
+++ b/neuro_san/service/http/server/http_server.py
@@ -59,6 +59,7 @@ from neuro_san.service.interfaces.agent_server import AgentServer
 from neuro_san.service.interfaces.event_loop_logger import EventLoopLogger
 from neuro_san.internals.interfaces.startable import Startable
 from neuro_san.service.mcp.handlers.mcp_root_handler import McpRootHandler
+from neuro_san.service.utils.http_llm_tracer import HttpxLlmTracer
 from neuro_san.service.utils.loop_timeline_tracer import LoopTimelineTracer
 from neuro_san.service.utils.server_context import ServerContext
 from neuro_san.service.utils.server_status import ServerStatus
@@ -229,6 +230,12 @@ class HttpServer(AgentStateListener):
         # runs synchronously on the same thread.
         self._maybe_start_loop_timeline_tracer()
 
+        # Optionally install the httpx-level LLM traffic tracer. Must run
+        # BEFORE any LLM SDK constructs its httpx.AsyncClient, which happens
+        # lazily on first LLM call, so installing here (before IOLoop.start)
+        # is safely ahead of any traffic.
+        self._maybe_install_http_llm_tracer()
+
         tornado.ioloop.IOLoop.current().start()
         self.logger.info({}, "Http server stopped.")
 
@@ -318,6 +325,49 @@ class HttpServer(AgentStateListener):
 
         # Start LAST so the tracer captures all callbacks executed after the loop starts running.
         self._loop_timeline_tracer.start()
+
+    def _maybe_install_http_llm_tracer(self) -> None:
+        """
+        Install the httpx-level LLM traffic tracer if AGENT_HTTP_LLM_TRACE
+        is truthy. Emits structured JSON events (http_llm_out /
+        http_llm_in / http_llm_end / optional http_llm_chunk) to the
+        dedicated logger "neuro_san.diagnostics.http_llm_trace" so
+        post-run analysis can reconstruct the LLM traffic lifecycle of
+        any user request via the user_req_id field.
+
+        Environment variables:
+          AGENT_HTTP_LLM_TRACE (bool, default false)
+              Enables the tracer. Off by default.
+          AGENT_HTTP_LLM_TRACE_INCLUDE_BODIES (bool, default false)
+              When true, request and response bodies are logged verbatim
+              (capped at 64 KB per body). Prompts + completions are large
+              and sensitive; off by default.
+          AGENT_HTTP_LLM_TRACE_CHUNKS (bool, default false)
+              When true, emits one http_llm_chunk event per received
+              body chunk. Massive log volume; enable only when
+              investigating inter-chunk cadence.
+
+        The tracer overhead is negligible (a few log writes per LLM
+        call). Route the "neuro_san.diagnostics.http_llm_trace" logger
+        to a separate file in logging.hocon for clean offline analysis.
+        """
+        if not ConfigUtil.get_bool(os.environ, "AGENT_HTTP_LLM_TRACE"):
+            return
+
+        include_bodies: bool = ConfigUtil.get_bool(
+            os.environ, "AGENT_HTTP_LLM_TRACE_INCLUDE_BODIES")
+        include_chunks: bool = ConfigUtil.get_bool(
+            os.environ, "AGENT_HTTP_LLM_TRACE_CHUNKS")
+
+        HttpxLlmTracer.install(
+            include_bodies=include_bodies,
+            include_chunks=include_chunks,
+        )
+        self.logger.info(
+            {},
+            "HttpxLlmTracer installed (include_bodies=%s include_chunks=%s)",
+            include_bodies, include_chunks,
+        )
 
     def resolve_health_probe_port(self) -> int:
         """

--- a/neuro_san/service/utils/http_llm_tracer.py
+++ b/neuro_san/service/utils/http_llm_tracer.py
@@ -1,0 +1,382 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+"""
+See class comment for details.
+"""
+from typing import Any
+from typing import AsyncIterator
+from typing import Callable
+from typing import Dict
+from typing import Optional
+
+import contextvars
+import datetime
+import json
+import logging
+import time
+import uuid
+
+
+class HttpxLlmTracer:
+    """
+    HTTP-layer tracer for outbound LLM traffic that flows through
+    httpx.AsyncClient. Emits structured JSON log events so post-run
+    analysis (grep, jq, pandas) can reconstruct per-request lifecycles.
+
+    Events emitted (one line each, via the dedicated logger
+    "neuro_san.diagnostics.http_llm_trace"):
+
+      - http_llm_out  : request sent. Fields include attempt_id,
+                        provider (host-inferred), method, url, req_bytes,
+                        user_req_id (from ContextVar).
+      - http_llm_in   : response HEADERS received. Fields include the
+                        same attempt_id, HTTP status, elapsed_ms since
+                        out, and server_req_id (from openai-request-id
+                        / x-request-id headers where present). For
+                        streaming responses this is TTFT, not stream end.
+      - http_llm_end  : response body FULLY consumed OR the response was
+                        closed. Fields include attempt_id, elapsed_ms
+                        (total), reason (stream_complete / aclose /
+                        stream_error:<ExcType> / stream_generator_exit),
+                        stream_bytes (total bytes read).
+      - http_llm_chunk: (optional, per-chunk) one line per received body
+                        chunk. Only emitted when
+                        AGENT_HTTP_LLM_TRACE_CHUNKS is enabled -- log
+                        volume is huge (dozens per LLM call).
+      - http_llm_err  : (implicit) if the response never arrives, only
+                        http_llm_out is emitted; readers detect missing
+                        http_llm_in / http_llm_end as errors. Explicit
+                        transport failures inside body iteration are
+                        surfaced via http_llm_end with reason
+                        "stream_error:...".
+
+    Every event carries "user_req_id" read from a ContextVar. Set the
+    ContextVar at the boundary of each user-facing request (e.g. in the
+    Tornado handler entry point) via set_user_request_id(); asyncio and
+    executor bridges propagate context automatically, so every LLM call
+    triggered downstream will inherit the same id.
+
+    Correlation:
+      grep 'user_req_id=<id>' http_llm_trace.log  gives the whole LLM
+      lifecycle of one user request in time order, with attempt_ids
+      grouping any retries.
+
+    Installation is one-shot: call install(...) once at server startup,
+    before any LLM client is constructed. install() monkey-patches
+    httpx.AsyncClient.__init__ to inject event_hooks on every future
+    client, regardless of which provider SDK creates it. Idempotent --
+    a second call is a no-op.
+    """
+
+    # Class-level singleton state. ContextVar behavior is per-context, not
+    # per-instance, so keeping this on the class is correct.
+    _user_req_id_var: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
+        "neuro_san_http_llm_trace_user_req_id", default=None
+    )
+    _installed: bool = False
+    _include_bodies: bool = False
+    _include_chunks: bool = False
+    _logger: Optional[logging.Logger] = None
+    # Sentinel-free "did we already emit end?" flag stored per response
+    # via response.extensions["_llm_trace_end_emitted"]. Prevents double
+    # emit when both aiter_* and aclose fire.
+
+    @classmethod
+    def install(cls,
+                include_bodies: bool = False,
+                include_chunks: bool = False) -> None:
+        """
+        Monkey-patch httpx.AsyncClient.__init__ so every future client
+        instance gets our event hooks. Must be called BEFORE any provider
+        SDK constructs its client (i.e. at server startup, before the
+        first LLM call).
+
+        :param include_bodies: When True, request and response bodies are
+                    logged verbatim on http_llm_out and http_llm_end.
+                    Prompts + completions are large and sensitive; off
+                    by default.
+        :param include_chunks: When True, one http_llm_chunk event is
+                    emitted per received body chunk. Massive log volume;
+                    off by default. Enable only when investigating
+                    inter-chunk cadence specifically.
+        """
+        if cls._installed:
+            return
+        cls._include_bodies = include_bodies
+        cls._include_chunks = include_chunks
+        cls._logger = logging.getLogger("neuro_san.diagnostics.http_llm_trace")
+
+        # Import here so the module can be imported without httpx present
+        # (httpx is a transitive dependency, always installed in neuro-san
+        # but keeping the import local reduces coupling for tests).
+        # pylint: disable=import-outside-toplevel
+        import httpx
+
+        original_init: Callable = httpx.AsyncClient.__init__
+
+        def patched_init(self, *args, **kwargs):
+            existing_hooks: Dict[str, list] = kwargs.pop("event_hooks", None) or {}
+            merged_hooks: Dict[str, list] = {
+                "request": [cls._on_request] + list(existing_hooks.get("request", [])),
+                "response": [cls._on_response] + list(existing_hooks.get("response", [])),
+            }
+            kwargs["event_hooks"] = merged_hooks
+            original_init(self, *args, **kwargs)
+
+        httpx.AsyncClient.__init__ = patched_init
+        cls._installed = True
+        cls._logger.info(
+            "HttpxLlmTracer installed (include_bodies=%s include_chunks=%s)",
+            include_bodies, include_chunks)
+
+    @classmethod
+    def set_user_request_id(cls, user_req_id: str) -> None:
+        """
+        Set the current user-request id on the ContextVar. Call this
+        at the entry point of each user-facing request (e.g. the top of
+        Tornado's post() method). asyncio and executor bridges propagate
+        the ContextVar automatically, so every httpx call made downstream
+        will pick up the same id.
+
+        :param user_req_id: Short identifier (typically a UUID prefix)
+                    used to correlate every LLM event in one user
+                    request. Include in log routing / grep as
+                    "user_req_id=<id>".
+        """
+        cls._user_req_id_var.set(user_req_id)
+
+    @classmethod
+    def get_user_request_id(cls) -> Optional[str]:
+        """
+        Return the current user-request id from the ContextVar, or None
+        if not set in the current context.
+        """
+        return cls._user_req_id_var.get()
+
+    # -------------------------------------------------------------------
+    # httpx event hooks
+    # -------------------------------------------------------------------
+
+    @classmethod
+    async def _on_request(cls, request) -> None:
+        """
+        httpx request hook: record the outbound request, attach a
+        unique attempt_id + start timestamp to the request extensions
+        so the paired response/end events can compute elapsed time.
+        """
+        attempt_id: str = uuid.uuid4().hex[:8]
+        start_ns: int = time.monotonic_ns()
+        request.extensions["_llm_trace_attempt_id"] = attempt_id
+        request.extensions["_llm_trace_start_ns"] = start_ns
+
+        fields: Dict[str, Any] = {
+            "attempt_id": attempt_id,
+            "provider": cls._infer_provider(request.url.host),
+            "host": request.url.host,
+            "method": request.method,
+            "url": str(request.url.copy_with(query=None)),
+            "req_bytes": len(request.content) if request.content else 0,
+        }
+        if cls._include_bodies and request.content:
+            fields["req_body"] = cls._safe_decode(request.content)
+        cls._emit("http_llm_out", **fields)
+
+    @classmethod
+    async def _on_response(cls, response) -> None:
+        """
+        httpx response hook: record that headers arrived, then wrap the
+        response body iterator + aclose so we can emit http_llm_end when
+        the body is fully consumed or the response is closed.
+        """
+        request = response.request
+        attempt_id: str = request.extensions.get("_llm_trace_attempt_id", "unknown")
+        start_ns: int = request.extensions.get("_llm_trace_start_ns", time.monotonic_ns())
+        elapsed_ms: float = (time.monotonic_ns() - start_ns) / 1e6
+
+        server_req_id: Optional[str] = (
+            response.headers.get("openai-request-id")
+            or response.headers.get("x-request-id")
+            or response.headers.get("x-amzn-requestid")
+        )
+        cls._emit(
+            "http_llm_in",
+            attempt_id=attempt_id,
+            status=response.status_code,
+            elapsed_ms=round(elapsed_ms, 3),
+            server_req_id=server_req_id,
+        )
+        cls._wrap_response_for_end(response, attempt_id, start_ns)
+
+    @classmethod
+    def _wrap_response_for_end(cls, response, attempt_id: str, start_ns: int) -> None:
+        """
+        Replace the response's aiter_raw and aclose with wrappers that
+        emit http_llm_end exactly once when the body is fully consumed
+        or the response is closed. aiter_bytes / aiter_text / aiter_lines
+        all funnel through aiter_raw in httpx, so wrapping aiter_raw is
+        sufficient to catch all body-iteration paths (including the
+        internal .aread() path used by non-streaming responses).
+
+        Firing rules (avoids httpx's aclose-during-iteration race):
+          - The wrapped iterator's own paths (complete / GeneratorExit /
+            other exception) always emit end. These are the authoritative
+            events for the response's lifecycle.
+          - aclose emits end only if the wrapped iterator was never
+            entered (i.e. response was closed without reading the body).
+            If iteration started, aclose trusts the iterator to emit end
+            via one of its own paths -- necessary because httpx invokes
+            aclose synchronously from inside the underlying stream's
+            exhaustion handling, BEFORE the wrapped iterator's post-loop
+            code has run.
+        """
+        # State kept on response.extensions so it travels with the
+        # response object and is trivially inspectable in debugger.
+        response.extensions["_llm_trace_end_emitted"] = False
+        response.extensions["_llm_trace_iter_started"] = False
+
+        def emit_end(reason: str, bytes_read: int) -> None:
+            if response.extensions.get("_llm_trace_end_emitted"):
+                return
+            response.extensions["_llm_trace_end_emitted"] = True
+            elapsed_ms: float = (time.monotonic_ns() - start_ns) / 1e6
+            fields: Dict[str, Any] = {
+                "attempt_id": attempt_id,
+                "elapsed_ms": round(elapsed_ms, 3),
+                "reason": reason,
+                "stream_bytes": bytes_read,
+            }
+            if cls._include_bodies:
+                # Response body is captured chunk-by-chunk in the wrapper
+                # and stashed on extensions so we can attach it here.
+                captured: Optional[bytes] = response.extensions.get("_llm_trace_body_buf")
+                if captured is not None:
+                    fields["resp_body"] = cls._safe_decode(captured)
+            cls._emit("http_llm_end", **fields)
+
+        original_aiter_raw: Callable = response.aiter_raw
+        original_aclose: Callable = response.aclose
+        include_chunks: bool = cls._include_chunks
+        include_bodies: bool = cls._include_bodies
+
+        async def wrapped_aiter_raw(*args, **kwargs) -> AsyncIterator[bytes]:
+            response.extensions["_llm_trace_iter_started"] = True
+            total: int = 0
+            body_buf: Optional[bytearray] = bytearray() if include_bodies else None
+            try:
+                async for chunk in original_aiter_raw(*args, **kwargs):
+                    total += len(chunk)
+                    if include_chunks:
+                        cls._emit(
+                            "http_llm_chunk",
+                            attempt_id=attempt_id,
+                            chunk_bytes=len(chunk),
+                            total_bytes=total,
+                            since_out_ms=round(
+                                (time.monotonic_ns() - start_ns) / 1e6, 3),
+                        )
+                    if body_buf is not None:
+                        # Cap the captured body to keep log lines bounded.
+                        if len(body_buf) < 65536:
+                            body_buf.extend(chunk[: 65536 - len(body_buf)])
+                    yield chunk
+                if body_buf is not None:
+                    response.extensions["_llm_trace_body_buf"] = bytes(body_buf)
+                emit_end("stream_complete", total)
+            except GeneratorExit:
+                if body_buf is not None:
+                    response.extensions["_llm_trace_body_buf"] = bytes(body_buf)
+                emit_end("stream_generator_exit", total)
+                raise
+            except BaseException as exc:  # pylint: disable=broad-exception-caught
+                if body_buf is not None:
+                    response.extensions["_llm_trace_body_buf"] = bytes(body_buf)
+                emit_end(f"stream_error:{type(exc).__name__}", total)
+                raise
+
+        async def wrapped_aclose() -> None:
+            # aclose emits end only if the iterator never started (i.e.
+            # response closed without reading the body). If the iterator
+            # started, its own completion / exception path emits end --
+            # aclose here would otherwise race with httpx's own aclose
+            # firing mid-iteration and swallow the real stream_complete.
+            if not response.extensions.get("_llm_trace_iter_started"):
+                emit_end("closed_without_iteration", 0)
+            await original_aclose()
+
+        response.aiter_raw = wrapped_aiter_raw
+        response.aclose = wrapped_aclose
+
+    # -------------------------------------------------------------------
+    # Emission helpers
+    # -------------------------------------------------------------------
+
+    @classmethod
+    def _emit(cls, event: str, **fields: Any) -> None:
+        """
+        Build the event dict and log it as a single JSON line. Never
+        raises: any error in formatting is swallowed so httpx traffic
+        is never disrupted by tracing failures.
+        """
+        try:
+            payload: Dict[str, Any] = {
+                "event": event,
+                "t_iso": datetime.datetime.utcnow().isoformat() + "Z",
+                "t_ns": time.monotonic_ns(),
+                "user_req_id": cls._user_req_id_var.get(),
+                **fields,
+            }
+            cls._logger.info(json.dumps(payload, default=str))
+        except Exception:  # pylint: disable=broad-exception-caught
+            # Best-effort tracer must never break the request. Silent
+            # swallow -- if the tracer itself is broken, the next dev
+            # cycle will notice via missing events, not via failed LLM
+            # traffic.
+            pass
+
+    @staticmethod
+    def _infer_provider(host: Optional[str]) -> str:
+        """
+        Best-effort provider name from the request host. Used only as a
+        readable label in log lines; unknown hosts default to "unknown".
+        """
+        if not host:
+            return "unknown"
+        if "openai.com" in host or "openai.azure.com" in host:
+            return "openai"
+        if "anthropic.com" in host:
+            return "anthropic"
+        if "googleapis.com" in host or "generativelanguage" in host:
+            return "google"
+        if "amazonaws.com" in host or "bedrock" in host:
+            return "aws"
+        if "nvcf.nvidia.com" in host or "integrate.api.nvidia.com" in host:
+            return "nvidia"
+        if "cohere.ai" in host:
+            return "cohere"
+        return "unknown"
+
+    @staticmethod
+    def _safe_decode(data: bytes) -> str:
+        """
+        Best-effort decode of bytes for logging. Truncates at 64 KB to
+        keep log lines bounded regardless of body size.
+        """
+        limit: int = 65536
+        if len(data) > limit:
+            snippet: bytes = data[:limit]
+            return snippet.decode("utf-8", errors="replace") + f"...<truncated {len(data) - limit} bytes>"
+        return data.decode("utf-8", errors="replace")

--- a/neuro_san/service/utils/http_llm_tracer.py
+++ b/neuro_san/service/utils/http_llm_tracer.py
@@ -21,6 +21,7 @@ from typing import Any
 from typing import AsyncIterator
 from typing import Callable
 from typing import Dict
+from typing import List
 from typing import Optional
 
 import contextvars
@@ -348,30 +349,40 @@ class HttpxLlmTracer:
             pass
 
     @staticmethod
+    def _host_matches(normalized_host: str, domains: List[str]) -> bool:
+        """
+        Return True if the normalized host matches the domain or is a subdomain of it
+        for any of the provided domains.
+        Used for provider inference.
+        """
+        for domain in domains:
+            if normalized_host == domain or normalized_host.endswith(f".{domain}"):
+                return True
+        return False
+
+    @staticmethod
     def _infer_provider(host: Optional[str]) -> str:
         """
         Best-effort provider name from the request host. Used only as a
         readable label in log lines; unknown hosts default to "unknown".
         """
+        # pylint: disable=too-many-return-statements
         if not host:
             return "unknown"
 
         normalized_host: str = host.strip().lower().rstrip(".")
 
-        def _host_matches(domain: str) -> bool:
-            return normalized_host == domain or normalized_host.endswith(f".{domain}")
-
-        if _host_matches("openai.com") or _host_matches("openai.azure.com"):
+        if HttpxLlmTracer._host_matches(normalized_host, ["openai.com", "openai.azure.com"]):
             return "openai"
-        if _host_matches("anthropic.com"):
+        if HttpxLlmTracer._host_matches(normalized_host, ["anthropic.com"]):
             return "anthropic"
-        if _host_matches("googleapis.com") or _host_matches("generativelanguage"):
+        if HttpxLlmTracer._host_matches(normalized_host, ["googleapis.com", "generativelanguage"]):
             return "google"
-        if _host_matches("amazonaws.com") or _host_matches("bedrock"):
+        if HttpxLlmTracer._host_matches(normalized_host, ["amazonaws.com", "bedrock"]):
             return "aws"
-        if _host_matches("nvcf.nvidia.com") or _host_matches("integrate.api.nvidia.com"):
+        if HttpxLlmTracer._host_matches(normalized_host, ["nvcf.nvidia.com", "integrate.api.nvidia.com"]):
             return "nvidia"
-        if _host_matches("cohere.ai"):
+        if HttpxLlmTracer._host_matches(normalized_host, ["cohere.ai"]):
             return "cohere"
         return "unknown"
 

--- a/neuro_san/service/utils/http_llm_tracer.py
+++ b/neuro_san/service/utils/http_llm_tracer.py
@@ -26,10 +26,12 @@ from typing import Optional
 
 import contextvars
 import datetime
+import functools
 import json
 import logging
 import time
 import uuid
+import httpx
 
 
 class HttpxLlmTracer:
@@ -90,6 +92,59 @@ class HttpxLlmTracer:
     AGENT_HTTP_LLM_TRACE_CHUNKS (default "false") — emit one event per received body chunk.
             Massive log volume (dozens of chunks per streaming LLM call);
             enable only when investigating inter-chunk cadence.
+
+    ================================================================
+    Coding-policy notes (per neuro-san team standards)
+    ================================================================
+    All helpers are class-level static or classmethods. No nested /
+    embedded functions inside methods -- state that would normally live
+    in closures instead lives on:
+      - response.extensions[...] : per-response state (end_emitted flag,
+                                   iter_started flag, saved original
+                                   aiter_raw / aclose, buffered body).
+      - request.extensions[...]  : per-request state (attempt_id, start_ns).
+      - class attributes         : per-installation state
+                                   (_original_httpx_init, _include_*, _logger).
+    functools.partial is used to bind response into the response-scoped
+    wrappers (_wrapped_aiter_raw, _wrapped_aclose) at assignment time.
+
+    ================================================================
+    Known limitations / future work
+    ================================================================
+    1. httpx transport only. Providers using non-httpx clients (notably
+       AWS Bedrock via aiobotocore, and any future gRPC-based provider
+       path such as Vertex AI direct) bypass this tracer. Extending to
+       Bedrock requires registering hooks on botocore's event system;
+       see BOTOCORE_SESSION.register('before-send.*', ...) as the
+       entry point.
+
+    2. Stream-body capture (when AGENT_HTTP_LLM_TRACE_INCLUDE_BODIES
+       is enabled) truncates each body at 64 KB. Increase the cap or
+       stream to a separate file if full-body capture is required.
+       The truncation is intentional to keep single log lines bounded
+       for downstream parsers (jq, pandas).
+
+    3. Free-threaded Python (cpython-3.14t) compatibility: the tracer
+       itself has no C dependencies and works cleanly on 3.14t. Some
+       dependent packages that the neuro-san dep graph pulls in
+       (notably orjson) refuse to build for the free-threaded ABI at
+       the time of writing. Use a stdlib-json shim for orjson or
+       wait for upstream support if running under free-threaded Python.
+
+    4. Tornado-loop-only ContextVar propagation is guaranteed by
+       Python's asyncio internals. Any future non-asyncio bridge
+       (e.g., a raw threading.Thread that runs LLM calls without
+       contextvars.copy_context) would drop the user_req_id and
+       events would emit with user_req_id=None. Not a current concern
+       for neuro-san, but flag it if such a bridge is added.
+
+    5. Per-attempt correlation only. This tracer does not add a
+       parent-span concept. Each httpx retry appears as an independent
+       attempt_id under the same user_req_id; post-processing must
+       infer retry chains by proximity and URL match. If tighter
+       correlation becomes necessary, add an "attempt_parent_id"
+       field populated from a request extension set by upstream SDK
+       retry logic (where available).
     """
 
     # Class-level singleton state. ContextVar behavior is per-context, not
@@ -101,9 +156,13 @@ class HttpxLlmTracer:
     _include_bodies: bool = False
     _include_chunks: bool = False
     _logger: Optional[logging.Logger] = None
-    # Sentinel-free "did we already emit end?" flag stored per response
-    # via response.extensions["_llm_trace_end_emitted"]. Prevents double
-    # emit when both aiter_* and aclose fire.
+    # Stash of the pre-patch httpx.AsyncClient.__init__ so the patched
+    # replacement can delegate to it.
+    _original_httpx_init: Optional[Callable[..., None]] = None
+
+    # Body-capture cap. Applied both to request bodies (immediate) and
+    # response bodies (accumulated during aiter_raw).
+    _BODY_CAP_BYTES: int = 65536
 
     @classmethod
     def install(cls,
@@ -130,27 +189,48 @@ class HttpxLlmTracer:
         cls._include_chunks = include_chunks
         cls._logger = logging.getLogger("neuro_san.diagnostics.http_llm_trace")
 
-        # Import here so the module can be imported without httpx present
-        # (httpx is a transitive dependency, always installed in neuro-san
-        # but keeping the import local reduces coupling for tests).
-        # pylint: disable=import-outside-toplevel
-        import httpx
+        cls._original_httpx_init = httpx.AsyncClient.__init__
+        # Assign the class-level replacement. staticmethod descriptor
+        # resolves to the underlying function on class access, so this
+        # sets AsyncClient.__init__ to a plain function that Python will
+        # invoke as a bound method (with client instance as first arg).
+        httpx.AsyncClient.__init__ = HttpxLlmTracer._patched_httpx_init
 
-        original_init: Callable = httpx.AsyncClient.__init__
-
-        def patched_init(self, *args, **kwargs):
-            existing_hooks: Dict[str, list] = kwargs.pop("event_hooks", None) or {}
-            merged_hooks: Dict[str, list] = dict(existing_hooks)
-            merged_hooks["request"] = [cls._on_request] + list(existing_hooks.get("request", []))
-            merged_hooks["response"] = [cls._on_response] + list(existing_hooks.get("response", []))
-            kwargs["event_hooks"] = merged_hooks
-            original_init(self, *args, **kwargs)
-
-        httpx.AsyncClient.__init__ = patched_init
         cls._installed = True
         cls._logger.info(
             "HttpxLlmTracer installed (include_bodies=%s include_chunks=%s)",
             include_bodies, include_chunks)
+
+    @staticmethod
+    def _patched_httpx_init(client_self, *args, **kwargs) -> None:
+        """
+        Replacement for httpx.AsyncClient.__init__. Injects our
+        request/response hooks alongside whatever the SDK already set.
+        Delegates to the original init captured at install() time.
+        """
+        existing_hooks: Dict[str, list] = kwargs.pop("event_hooks", None) or {}
+        merged_hooks: Dict[str, list] = dict(existing_hooks)
+        merged_hooks["request"] = (
+            [HttpxLlmTracer._on_request] + list(existing_hooks.get("request", []))
+        )
+        merged_hooks["response"] = (
+            [HttpxLlmTracer._on_response] + list(existing_hooks.get("response", []))
+        )
+        kwargs["event_hooks"] = merged_hooks
+
+        # install() sets _original_httpx_init BEFORE monkey-patching
+        # httpx.AsyncClient.__init__ to this method, so it's guaranteed
+        # non-None here. Runtime guard raises early if that invariant is
+        # ever broken (e.g. someone bypassed install() and directly
+        # assigned _patched_httpx_init to httpx.AsyncClient). The pylint
+        # suppression on the call is because pylint's not-callable
+        # checker doesn't infer callability from typing.Callable
+        # annotations even after None-narrowing (known pylint limitation).
+        original_init = HttpxLlmTracer._original_httpx_init
+        if original_init is None:
+            raise ValueError("HttpxLlmTracer.install() must be called before "
+                             "httpx.AsyncClient() can be constructed")
+        original_init(client_self, *args, **kwargs)  # pylint: disable=not-callable
 
     @classmethod
     def set_user_request_id(cls, user_req_id: str) -> None:
@@ -228,17 +308,15 @@ class HttpxLlmTracer:
             elapsed_ms=round(elapsed_ms, 3),
             server_req_id=server_req_id,
         )
-        cls._wrap_response_for_end(response, attempt_id, start_ns)
+        cls._wrap_response_for_end(response)
 
     @classmethod
-    def _wrap_response_for_end(cls, response, attempt_id: str, start_ns: int) -> None:
+    def _wrap_response_for_end(cls, response) -> None:
         """
-        Replace the response's aiter_raw and aclose with wrappers that
-        emit http_llm_end exactly once when the body is fully consumed
-        or the response is closed. aiter_bytes / aiter_text / aiter_lines
-        all funnel through aiter_raw in httpx, so wrapping aiter_raw is
-        sufficient to catch all body-iteration paths (including the
-        internal .aread() path used by non-streaming responses).
+        Replace the response's aiter_raw and aclose with class-level
+        wrappers, and stash the originals + firing-state flags on
+        response.extensions. Everything the wrappers need travels with
+        the response object -- no closures required.
 
         Firing rules (avoids httpx's aclose-during-iteration race):
           - The wrapped iterator's own paths (complete / GeneratorExit /
@@ -253,84 +331,115 @@ class HttpxLlmTracer:
             code has run.
         """
         # State kept on response.extensions so it travels with the
-        # response object and is trivially inspectable in debugger.
+        # response object and is trivially inspectable in the debugger.
         response.extensions["_llm_trace_end_emitted"] = False
         response.extensions["_llm_trace_iter_started"] = False
+        response.extensions["_llm_trace_original_aiter_raw"] = response.aiter_raw
+        response.extensions["_llm_trace_original_aclose"] = response.aclose
 
-        def emit_end(reason: str, bytes_read: int) -> None:
-            if response.extensions.get("_llm_trace_end_emitted"):
-                return
-            response.extensions["_llm_trace_end_emitted"] = True
-            elapsed_ms: float = (time.monotonic_ns() - start_ns) / 1e6
-            fields: Dict[str, Any] = {
-                "attempt_id": attempt_id,
-                "elapsed_ms": round(elapsed_ms, 3),
-                "reason": reason,
-                "stream_bytes": bytes_read,
-            }
-            if cls._include_bodies:
-                # Response body is captured chunk-by-chunk in the wrapper
-                # and stashed on extensions so we can attach it here.
-                captured: Optional[bytes] = response.extensions.get("_llm_trace_body_buf")
-                if captured is not None:
-                    fields["resp_body"] = cls._safe_decode(captured)
-            cls._emit("http_llm_end", **fields)
-
-        original_aiter_raw: Callable = response.aiter_raw
-        original_aclose: Callable = response.aclose
-        include_chunks: bool = cls._include_chunks
-        include_bodies: bool = cls._include_bodies
-
-        async def wrapped_aiter_raw(*args, **kwargs) -> AsyncIterator[bytes]:
-            response.extensions["_llm_trace_iter_started"] = True
-            total: int = 0
-            body_buf: Optional[bytearray] = bytearray() if include_bodies else None
-            try:
-                async for chunk in original_aiter_raw(*args, **kwargs):
-                    total += len(chunk)
-                    if include_chunks:
-                        cls._emit(
-                            "http_llm_chunk",
-                            attempt_id=attempt_id,
-                            chunk_bytes=len(chunk),
-                            total_bytes=total,
-                            since_out_ms=round(
-                                (time.monotonic_ns() - start_ns) / 1e6, 3),
-                        )
-                    if body_buf is not None:
-                        # Cap the captured body to keep log lines bounded.
-                        if len(body_buf) < 65536:
-                            body_buf.extend(chunk[: 65536 - len(body_buf)])
-                    yield chunk
-                if body_buf is not None:
-                    response.extensions["_llm_trace_body_buf"] = bytes(body_buf)
-                emit_end("stream_complete", total)
-            except GeneratorExit:
-                if body_buf is not None:
-                    response.extensions["_llm_trace_body_buf"] = bytes(body_buf)
-                emit_end("stream_generator_exit", total)
-                raise
-            except BaseException as exc:  # pylint: disable=broad-exception-caught
-                if body_buf is not None:
-                    response.extensions["_llm_trace_body_buf"] = bytes(body_buf)
-                emit_end(f"stream_error:{type(exc).__name__}", total)
-                raise
-
-        async def wrapped_aclose() -> None:
-            # aclose emits end only if the iterator never started (i.e.
-            # response closed without reading the body). If the iterator
-            # started, its own completion / exception path emits end --
-            # aclose here would otherwise race with httpx's own aclose
-            # firing mid-iteration and swallow the real stream_complete.
-            if not response.extensions.get("_llm_trace_iter_started"):
-                emit_end("closed_without_iteration", 0)
-            await original_aclose()
-
-        response.aiter_raw = wrapped_aiter_raw
-        response.aclose = wrapped_aclose
+        # Bind response into the class-level wrappers via functools.partial.
+        # No lambdas, no nested defs -- purely composition of top-level
+        # callables.
+        response.aiter_raw = functools.partial(cls._wrapped_aiter_raw, response)
+        response.aclose = functools.partial(cls._wrapped_aclose, response)
 
     # -------------------------------------------------------------------
-    # Emission helpers
+    # Response-scoped wrappers (bound to a response via functools.partial)
+    # -------------------------------------------------------------------
+
+    @staticmethod
+    async def _wrapped_aiter_raw(response, *args, **kwargs) -> AsyncIterator[bytes]:
+        """
+        Class-level replacement for httpx.Response.aiter_raw. Invoked via
+        functools.partial(_wrapped_aiter_raw, response), so the first arg
+        is the response object. Delegates to the original aiter_raw
+        (stashed on response.extensions) and emits chunk / end events
+        along the way.
+        """
+        response.extensions["_llm_trace_iter_started"] = True
+        request_ext = response.request.extensions
+        attempt_id: str = request_ext.get("_llm_trace_attempt_id", "unknown")
+        start_ns: int = request_ext.get("_llm_trace_start_ns", time.monotonic_ns())
+        original_aiter_raw: Callable = response.extensions["_llm_trace_original_aiter_raw"]
+        include_chunks: bool = HttpxLlmTracer._include_chunks
+        include_bodies: bool = HttpxLlmTracer._include_bodies
+        body_cap: int = HttpxLlmTracer._BODY_CAP_BYTES
+
+        total: int = 0
+        body_buf: Optional[bytearray] = bytearray() if include_bodies else None
+        try:
+            async for chunk in original_aiter_raw(*args, **kwargs):
+                total += len(chunk)
+                if include_chunks:
+                    HttpxLlmTracer._emit(
+                        "http_llm_chunk",
+                        attempt_id=attempt_id,
+                        chunk_bytes=len(chunk),
+                        total_bytes=total,
+                        since_out_ms=round(
+                            (time.monotonic_ns() - start_ns) / 1e6, 3),
+                    )
+                if body_buf is not None and len(body_buf) < body_cap:
+                    # Cap the captured body to keep log lines bounded.
+                    body_buf.extend(chunk[: body_cap - len(body_buf)])
+                yield chunk
+            if body_buf is not None:
+                response.extensions["_llm_trace_body_buf"] = bytes(body_buf)
+            HttpxLlmTracer._emit_end(response, "stream_complete", total)
+        except GeneratorExit:
+            if body_buf is not None:
+                response.extensions["_llm_trace_body_buf"] = bytes(body_buf)
+            HttpxLlmTracer._emit_end(response, "stream_generator_exit", total)
+            raise
+        except BaseException as exc:  # pylint: disable=broad-exception-caught
+            if body_buf is not None:
+                response.extensions["_llm_trace_body_buf"] = bytes(body_buf)
+            HttpxLlmTracer._emit_end(response, f"stream_error:{type(exc).__name__}", total)
+            raise
+
+    @staticmethod
+    async def _wrapped_aclose(response) -> None:
+        """
+        Class-level replacement for httpx.Response.aclose. Invoked via
+        functools.partial(_wrapped_aclose, response). Emits end only when
+        the wrapped iterator never started -- see _wrap_response_for_end's
+        firing-rules comment for why.
+        """
+        if not response.extensions.get("_llm_trace_iter_started"):
+            HttpxLlmTracer._emit_end(response, "closed_without_iteration", 0)
+        original_aclose: Callable = response.extensions["_llm_trace_original_aclose"]
+        await original_aclose()
+
+    @staticmethod
+    def _emit_end(response, reason: str, bytes_read: int) -> None:
+        """
+        Emit exactly-once http_llm_end for a response. Reads attempt_id
+        and start_ns from response.request.extensions and any buffered
+        body from response.extensions.
+        """
+        if response.extensions.get("_llm_trace_end_emitted"):
+            return
+        response.extensions["_llm_trace_end_emitted"] = True
+
+        request_ext = response.request.extensions
+        attempt_id: str = request_ext.get("_llm_trace_attempt_id", "unknown")
+        start_ns: int = request_ext.get("_llm_trace_start_ns", time.monotonic_ns())
+        elapsed_ms: float = (time.monotonic_ns() - start_ns) / 1e6
+
+        fields: Dict[str, Any] = {
+            "attempt_id": attempt_id,
+            "elapsed_ms": round(elapsed_ms, 3),
+            "reason": reason,
+            "stream_bytes": bytes_read,
+        }
+        if HttpxLlmTracer._include_bodies:
+            captured: Optional[bytes] = response.extensions.get("_llm_trace_body_buf")
+            if captured is not None:
+                fields["resp_body"] = HttpxLlmTracer._safe_decode(captured)
+        HttpxLlmTracer._emit("http_llm_end", **fields)
+
+    # -------------------------------------------------------------------
+    # Emission + provider inference helpers
     # -------------------------------------------------------------------
 
     @classmethod
@@ -397,10 +506,10 @@ class HttpxLlmTracer:
     @staticmethod
     def _safe_decode(data: bytes) -> str:
         """
-        Best-effort decode of bytes for logging. Truncates at 64 KB to
-        keep log lines bounded regardless of body size.
+        Best-effort decode of bytes for logging. Truncates at the class
+        body cap to keep log lines bounded regardless of body size.
         """
-        limit: int = 65536
+        limit: int = HttpxLlmTracer._BODY_CAP_BYTES
         if len(data) > limit:
             snippet: bytes = data[:limit]
             return snippet.decode("utf-8", errors="replace") + f"...<truncated {len(data) - limit} bytes>"

--- a/neuro_san/service/utils/http_llm_tracer.py
+++ b/neuro_san/service/utils/http_llm_tracer.py
@@ -81,6 +81,15 @@ class HttpxLlmTracer:
     httpx.AsyncClient.__init__ to inject event_hooks on every future
     client, regardless of which provider SDK creates it. Idempotent --
     a second call is a no-op.
+
+    Env vars:
+    AGENT_HTTP_LLM_TRACE (default "false") — master toggle. When enabled, installs the tracer on server startup.
+    AGENT_HTTP_LLM_TRACE_INCLUDE_BODIES (default "false") — capture request/response bodies verbatim
+            (capped at 64 KB each).
+            Prompts and completions are large and often sensitive; off by default.
+    AGENT_HTTP_LLM_TRACE_CHUNKS (default "false") — emit one event per received body chunk.
+            Massive log volume (dozens of chunks per streaming LLM call);
+            enable only when investigating inter-chunk cadence.
     """
 
     # Class-level singleton state. ContextVar behavior is per-context, not

--- a/neuro_san/service/utils/http_llm_tracer.py
+++ b/neuro_san/service/utils/http_llm_tracer.py
@@ -140,10 +140,9 @@ class HttpxLlmTracer:
 
         def patched_init(self, *args, **kwargs):
             existing_hooks: Dict[str, list] = kwargs.pop("event_hooks", None) or {}
-            merged_hooks: Dict[str, list] = {
-                "request": [cls._on_request] + list(existing_hooks.get("request", [])),
-                "response": [cls._on_response] + list(existing_hooks.get("response", [])),
-            }
+            merged_hooks: Dict[str, list] = dict(existing_hooks)
+            merged_hooks["request"] = [cls._on_request] + list(existing_hooks.get("request", []))
+            merged_hooks["response"] = [cls._on_response] + list(existing_hooks.get("response", []))
             kwargs["event_hooks"] = merged_hooks
             original_init(self, *args, **kwargs)
 

--- a/neuro_san/service/utils/http_llm_tracer.py
+++ b/neuro_san/service/utils/http_llm_tracer.py
@@ -355,17 +355,23 @@ class HttpxLlmTracer:
         """
         if not host:
             return "unknown"
-        if "openai.com" in host or "openai.azure.com" in host:
+
+        normalized_host: str = host.strip().lower().rstrip(".")
+
+        def _host_matches(domain: str) -> bool:
+            return normalized_host == domain or normalized_host.endswith(f".{domain}")
+
+        if _host_matches("openai.com") or _host_matches("openai.azure.com"):
             return "openai"
-        if "anthropic.com" in host:
+        if _host_matches("anthropic.com"):
             return "anthropic"
-        if "googleapis.com" in host or "generativelanguage" in host:
+        if _host_matches("googleapis.com") or _host_matches("generativelanguage"):
             return "google"
-        if "amazonaws.com" in host or "bedrock" in host:
+        if _host_matches("amazonaws.com") or _host_matches("bedrock"):
             return "aws"
-        if "nvcf.nvidia.com" in host or "integrate.api.nvidia.com" in host:
+        if _host_matches("nvcf.nvidia.com") or _host_matches("integrate.api.nvidia.com"):
             return "nvidia"
-        if "cohere.ai" in host:
+        if _host_matches("cohere.ai"):
             return "cohere"
         return "unknown"
 


### PR DESCRIPTION
Summary

  Adds an opt-in, structured-logging tracer for outbound LLM traffic at the httpx layer. Emits one JSON event per HTTP request lifecycle phase, tagged with a per-user-request id that propagates through asyncio and executor bridges automatically. Purpose: understand what
  neuro-san is actually doing when it talks to LLM providers — how many calls, in what order, for how long, with what retries, per user request — for offline analysis via grep / jq / pandas.

  Zero code changes required to enable per-provider. httpx.AsyncClient is monkey-patched once at server startup, so every LLM SDK (openai, anthropic, google-genai partial, nvidia, ollama, and any other httpx-based provider) is captured uniformly with no adapters. Bedrock
  (aiobotocore) is a known gap; documented as future work.

  What the tracer captures

  Every LLM HTTP call generates a triple of structured JSON events, plus optional per-chunk events:

  - http_llm_out — request sent. Includes attempt_id, provider (host-inferred), method, URL, request body size, user_req_id (from ContextVar).
  - http_llm_in — response headers received. Same attempt_id, HTTP status, elapsed-ms since out (~TTFT for streaming), server_req_id from provider headers (openai-request-id / x-request-id / x-amzn-requestid).
  - http_llm_end — response body fully consumed or closed. Same attempt_id, total elapsed-ms, reason (stream_complete / stream_generator_exit / stream_error:<ExcType> / closed_without_iteration), stream bytes.
  - http_llm_chunk — (optional, high volume) one event per received body chunk with byte count and since_out_ms.

  Optional body capture (both request and response, capped at 64 KB per body) via a second env var — off by default because prompts/completions are large and often sensitive.

  Correlation across the lifecycle

  Two IDs make the log analyzable:

  - attempt_id — unique per httpx request. Groups the 3-4 events belonging to one HTTP roundtrip. Retries fire as fresh httpx requests, so each retry gets its own attempt_id.
  - user_req_id — per user-facing chat request. Set via contextvars.ContextVar at the top of StreamingChatHandler.post(); asyncio and run_coroutine_threadsafe propagate context automatically, so every LLM call anywhere in the call chain (agent → sub-agent → tool → LLM)
  inherits the same id.

  grep 'user_req_id":"<id>"' log.jsonl | jq . reconstructs the full LLM traffic lifecycle of one user request in time order, with retries clearly identified as multiple attempt_ids under the same user.

  Files touched

  - neuro_san/service/utils/http_llm_tracer.py (new, 382 lines) — HttpxLlmTracer class. install() monkey-patches httpx; set_user_request_id() sets the ContextVar; internal event hooks emit structured events; response aiter_raw and aclose are wrapped to emit correct
  stream_complete / closed_without_iteration events.
  - neuro_san/service/http/server/http_server.py — _maybe_install_http_llm_tracer() invoked before IOLoop.start(), gated on AGENT_HTTP_LLM_TRACE.
  - neuro_san/service/http/handlers/streaming_chat_handler.py — set a short UUID as user_req_id at the top of post().
  - neuro_san/deploy/Dockerfile — documented three new env vars.

  Env vars

  - AGENT_HTTP_LLM_TRACE (default "false") — master toggle. When enabled, installs the tracer on server startup.
  - AGENT_HTTP_LLM_TRACE_INCLUDE_BODIES (default "false") — capture request/response bodies verbatim (capped at 64 KB each). Prompts and completions are large and often sensitive; off by default.
  - AGENT_HTTP_LLM_TRACE_CHUNKS (default "false") — emit one event per received body chunk. Massive log volume (dozens of chunks per streaming LLM call); enable only when investigating inter-chunk cadence.

  Log routing

  Events go to a dedicated logger, neuro_san.diagnostics.http_llm_trace. Recommended production wiring in logging.hocon:

  handlers {
      http_llm_trace_file {
          class = "logging.handlers.RotatingFileHandler"
          filename = "/var/log/neuro-san/http_llm_trace.jsonl"
          formatter = "raw_message"
          maxBytes = 104857600
          backupCount = 5
      }
  }
  loggers {
      "neuro_san.diagnostics.http_llm_trace" {
          handlers = ["http_llm_trace_file"]
          level = "INFO"
          propagate = false     # keeps events out of the main log
      }
  }

  Without propagate = false, events would echo to any root-level handler as well.

  Design decisions worth flagging

  1. Monkey-patch httpx.AsyncClient.__init__ rather than injecting hooks per-SDK. Catches every provider without touching provider-specific plumbing. Trade-off: touches httpx internals, and any new provider using a non-httpx transport (Bedrock/aiobotocore is the current known
  example) is invisible until a separate hook is added.
  2. Response iterator wrapping was tricky. httpx internally calls response.aclose() from within its own body-exhaustion path — before our wrapped generator's post-loop code runs. First implementation emitted reason=aclose and lost the real stream_complete. Fixed by tracking
  iter_started on response.extensions and having aclose emit an end event only when iteration never began. Details in the module docstring.
  3. set_user_request_id uses ContextVar rather than passing an ID through the call chain. ContextVar propagates through every await and every asyncio.create_task / run_coroutine_threadsafe boundary automatically. Setting it once at the top of post() is enough for every
  downstream LLM call to inherit the ID. No plumbing through the deep call stack.
  4. Best-effort emission — _emit() catches all exceptions and swallows them. If a bug in the tracer produces malformed events, the tracer stops emitting silently rather than crashing httpx requests. Diagnostic tools must never break the traffic they observe.
  5. Overhead is negligible — two dict allocations and one logger.info per request event. Cheap enough to leave on in production if the log volume and routing are acceptable.

  Explicit non-goals

  - Not a replacement for LangChain / OpenTelemetry / Langfuse. No spans, no trace-id, no cross-service correlation. Purpose-built for local diagnostic runs.
  - Not per-token latency — captures headers-received time (TTFT) and body-complete time. Per-token cadence needs AGENT_HTTP_LLM_TRACE_CHUNKS.
  - Not Bedrock. Documented as future work; needs a separate aiobotocore hook.

  Verification / usage

  Confirmed end-to-end via a smoke test (local Tornado echo server, streaming response, monkey-patched client): the tracer produces the expected sequence:

  http_llm_out    user_req_id=user_ABC  attempt_id=7a3590  t=0        POST .../v1/x
  http_llm_in     user_req_id=user_ABC  attempt_id=7a3590  t=7.8ms    status=200
  http_llm_chunk  user_req_id=user_ABC  attempt_id=7a3590  t=7.9ms    bytes=8
  http_llm_chunk  user_req_id=user_ABC  attempt_id=7a3590  t=8.1ms    bytes=8
  http_llm_chunk  user_req_id=user_ABC  attempt_id=7a3590  t=8.1ms    bytes=8
  http_llm_end    user_req_id=user_ABC  attempt_id=7a3590  t=8.3ms    reason=stream_complete  bytes=24

  Real-world usage in this branch has driven the load-analysis work in burst_analysis_25_50_100.md (companion doc in neuro-san-studio) — confirmed zero HTTP 429s across 25/50/100-burst runs, ruling out provider rate limits as the wall-time doubling cause, and revealed LiteLLM
  proxy behavior that would have been invisible without HTTP-layer visibility.

