### PR TITLE
Add AGENT_TOOL_EXECUTION_LOG_THRESHOLD_SECONDS env var to log message for tools that take too long

### DIFF
--- a/neuro_san/deploy/Dockerfile
+++ b/neuro_san/deploy/Dockerfile
@@ -345,6 +345,12 @@ ENV AGENT_HTTP_RESOURCES_MONITOR_INTERVAL="0"
 # Typical production value is 25-30 (under the 60s defaults of common proxies).
 ENV AGENT_STREAM_KEEP_ALIVE_WITH_PROGRESS_INTERVAL_SECONDS=0
 
+# When any particular CodedTool execution takes longer than this many seconds,
+# the system issues a message in the log.  This is very useful for determining
+# where your scale-up problems are with particular networks.  The default value of
+# 0 disables this feature.
+ENV AGENT_TOOL_EXECUTION_LOG_THRESHOLD_SECONDS=0
+
 # Optional URL describing how the server is to be referenced by the outside world.
 # This is useful when a server is behind a load-balancer as part of a larger cluster.
 ENV AGENT_EXTERNAL_SERVER_URL=""

--- a/neuro_san/internals/graph/activations/abstract_class_activation.py
+++ b/neuro_san/internals/graph/activations/abstract_class_activation.py
@@ -186,7 +186,7 @@ class AbstractClassActivation(AbstractCallableActivation):
             # String not parseable as float. Fine, just ignore.
             pass
 
-        if threshold >= 0.0 and duration > threshold:
+        if duration > threshold > 0.0:
             self.logger.info("Execution of %s took %f seconds", full_class_ref, duration)
 
         # Change the result into a message

--- a/neuro_san/internals/graph/activations/abstract_class_activation.py
+++ b/neuro_san/internals/graph/activations/abstract_class_activation.py
@@ -25,6 +25,8 @@ from asyncio import AbstractEventLoop
 from copy import deepcopy
 from logging import getLogger
 from logging import Logger
+from os import environ
+from time import perf_counter
 import traceback
 
 from langchain_core.messages.ai import AIMessage
@@ -159,6 +161,8 @@ class AbstractClassActivation(AbstractCallableActivation):
         while module_name.endswith("."):
             module_name = module_name[:-1]
 
+        start: float = perf_counter()
+
         # Resolve the class and the method
         python_class: Type[Any] = self.resolve_class(class_name, module_name)
 
@@ -170,6 +174,20 @@ class AbstractClassActivation(AbstractCallableActivation):
             retval: Any = await self.attempt_invoke(coded_tool, self.arguments, self.sly_data)
         else:
             retval = f"Error: {full_class_ref} is not a CodedTool"
+
+        stop: float = perf_counter()
+        duration: float = stop - start
+
+        threshold_str: str = environ.get("AGENT_TOOL_EXECUTION_LOG_THRESHOLD_SECONDS", "0")
+        threshold: float = 0.0
+        try:
+            threshold = float(threshold_str)
+        except ValueError:
+            # String not parseable as float. Fine, just ignore.
+            pass
+
+        if threshold >= 0.0 and duration > threshold:
+            self.logger.info("Execution of %s took %f seconds", full_class_ref, duration)
 
         # Change the result into a message
         retval_str: str = f"{retval}"


### PR DESCRIPTION
Title kinda sez it all.

The new log message is useful for identifying CodedTools that take a long time.
Top offenders  don't always emerge in single-request runs, but in load-tests that blast multiple requests
at a single network, performance problems - particularly resource-bound problems like locking, or pooling issues - are much easier to surface with this threshold turned on.

For instance, this log message shows that our current top offenders for AND for a 50x run are:
* 14.935731 coded_tools.agent_network_editor.get_subnetwork.GetSubnetwork
* 6.898657 coded_tools.agent_network_editor.get_toolbox.GetToolbox
* 19.648594 coded_tools.agent_network_editor.get_mcp_tool.GetMcpTool