### PR TITLE
Remove some dependencies from requirements.txt

### DIFF
--- a/neuro_san/internals/run_context/langchain/core/run_context_runnable.py
+++ b/neuro_san/internals/run_context/langchain/core/run_context_runnable.py
@@ -166,6 +166,7 @@ class RunContextRunnable(NeuroSanRunnable):
             #       LangSmith, Langfuse, HoneyHive, or Arize Phoenix.
             # See the docs for Observability plugins in neuro-san-studio.
             # This was our only tie to langchain-classic, so make it optional in this case.
+            # pylint: disable=invalid-name
             LoggingCallbackHandler: Type[BaseCallbackHandler] = ResolverUtil.create_type(
                 "langchain_classic.callbacks.tracers.logging.LoggingCallbackHandler",
                 install_if_missing="langchain-classic"

--- a/neuro_san/internals/run_context/langchain/core/run_context_runnable.py
+++ b/neuro_san/internals/run_context/langchain/core/run_context_runnable.py
@@ -27,7 +27,6 @@ import traceback
 
 from pydantic import ConfigDict
 
-from langchain_classic.callbacks.tracers.logging import LoggingCallbackHandler
 from langchain_core.agents import AgentFinish
 from langchain_core.callbacks.base import BaseCallbackHandler
 from langchain_core.messages.ai import AIMessage
@@ -162,6 +161,15 @@ class RunContextRunnable(NeuroSanRunnable):
         if isinstance(verbose, str) and verbose.lower() in ("true", "extra", "logging"):
             # This particular class adds a *lot* of very detailed messages
             # to the logs.  Add this because some people are interested in it.
+            # If you find yourself curious about this setting, what you probably
+            # are really looking for is an Observability setup like:
+            #       LangSmith, Langfuse, HoneyHive, or Arize Phoenix.
+            # See the docs for Observability plugins in neuro-san-studio.
+            # This was our only tie to langchain-classic, so make it optional in this case.
+            LoggingCallbackHandler: Type[BaseCallbackHandler] = ResolverUtil.create_type(
+                "langchain_classic.callbacks.tracers.logging.LoggingCallbackHandler",
+                install_if_missing="langchain-classic"
+            )
             callbacks.append(LoggingCallbackHandler(self.logger))
 
         # Get the number of attempts from the spec.

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,6 @@ leaf-server-common>=0.1.25
 pyhocon>=0.3.60
 pyOpenSSL>=24.0.0
 
-boto3>=1.34.51
 botocore>=1.34.51
 aiobotocore>=3.7.0
 idna>=3.6
@@ -58,9 +57,6 @@ janus >= 2.0.0
 
 # Local filesystem watchdog
 watchdog>=6.0.0
-
-# For input validation
-validators>=0.22.0
 
 # For chat-based cli tools not used in deployment
 timedinput>=0.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,8 +31,6 @@ langchain>=1.2.0,<2.0
 # Floor 1.4.0: bind() on a chat model must return a chat-model-aware binding
 # (with bind_tools) for the Gemini AFC-disable in gemini_llm_policy.py to activate.
 langchain-core>=1.4.0,<2.0
-langchain-classic>=1.0.0,<2.0
-langchain-community>=0.4,<1.0
 bs4>=0.0.2,<0.1
 pydantic>=2.9.2,<3.0
 


### PR DESCRIPTION
Remove the following dependencies from requirements.txt:
* langchain-classic
* langchain-community
* boto3
* validators

This came from a "I bet we don't use these any more ..." inquiry.

Worth noting that the only things that tie us to plain-old "langchain" library (not langchain_core) are Middleware concepts and a single use of langchain.agents.factory.create_agent