### PR TITLE
Refactor RegistryManifestRestorer to parallelize synchronous reads making server startup and nsflow iteration faster

### DIFF
--- a/neuro_san/internals/graph/persistence/registry_manifest_restorer.py
+++ b/neuro_san/internals/graph/persistence/registry_manifest_restorer.py
@@ -19,6 +19,7 @@ from typing import Dict
 from typing import List
 from typing import Sequence
 from typing import Tuple
+from typing import Type
 from typing import Union
 
 import os
@@ -176,7 +177,7 @@ class RegistryManifestRestorer(Restorer):
 
         # Determine how many threads to use and which style of executor to use
         max_workers: int = len(one_manifest)
-        pool_executor: Executor = ThreadPoolExecutor
+        pool_executor: Type[Executor] = ThreadPoolExecutor
 
         # By default use a ThreadPoolExecutor, but because of the GIL, in cases of large manifests,
         # a ProcessPoolExecutor ends up being more heavyweight, yet still more efficient because of

--- a/neuro_san/internals/graph/persistence/registry_manifest_restorer.py
+++ b/neuro_san/internals/graph/persistence/registry_manifest_restorer.py
@@ -18,6 +18,7 @@ from typing import Any
 from typing import Dict
 from typing import List
 from typing import Sequence
+from typing import Tuple
 from typing import Union
 
 import os
@@ -169,24 +170,55 @@ class RegistryManifestRestorer(Restorer):
 
         # At this point only hocon files we are going to serve up are in the one_manifest.
         for manifest_key, manifest_dict in one_manifest.items():
-
-            usable_network: bool = isinstance(manifest_dict, dict) and manifest_dict.get("serve", False)
-
-            # We'll need to use an agent mapper to get to this agent definition file.
-            agent_filepath: str = self.agent_mapper.agent_name_to_filepath(manifest_key)
-            network_name: str = self.agent_mapper.filepath_to_agent_network_name(agent_filepath)
-            validator = ManifestNetworkValidator(
-                external_network_names,
-                network_name=network_name)
             agent_network: AgentNetwork = None
-            if usable_network:
-                agent_network = self.restore_one_agent_network(manifest_dir, agent_filepath, manifest_key)
+            network_name: str = None
+            agent_network, network_name = self.read_one_agent_network(manifest_dir, manifest_file,
+                                                                      manifest_key, manifest_dict,
+                                                                      external_network_names)
+            if agent_network is not None:
 
-            self.process_one_agent_network(agent_network, usable_network, agent_filepath,
-                                           manifest_file, manifest_key, manifest_dict,
-                                           validator, agent_networks)
+                # Figure out where we want to put the network per the network's manifest dictionary
+                storage: str = StorageClass.PUBLIC
+                if not manifest_dict.get(StorageClass.PUBLIC):
+                    storage = StorageClass.PROTECTED
+                if manifest_dict.get("periodic", False):
+                    self.periodic_configs[network_name] = manifest_dict["periodic"]
+
+                agent_networks[storage][network_name] = agent_network
 
         return agent_networks
+
+    # pylint: disable=too-many-arguments,too-many-positional-arguments
+    def read_one_agent_network(
+                self,
+                manifest_dir: str,
+                manifest_file: str,
+                manifest_key: str,
+                manifest_dict: Dict[str, Any],
+                external_network_names: List[str]
+            ) -> Tuple[AgentNetwork, str]:
+        """
+        :param manifest_dir: The directory of the manifest file.
+        :param manifest_file: The file reference to use when restoring.
+        :param manifest_key: The key in the manifest file.
+        :param manifest_dict: The dictionary of the manifest file.
+        :param external_network_names: The list of external network names
+        :return: a nested map of storage type -> (mapping of name -> agent networks)
+        """
+        usable_network: bool = isinstance(manifest_dict, dict) and manifest_dict.get("serve", False)
+
+        # We'll need to use an agent mapper to get to this agent definition file.
+        agent_filepath: str = self.agent_mapper.agent_name_to_filepath(manifest_key)
+        network_name: str = self.agent_mapper.filepath_to_agent_network_name(agent_filepath)
+        validator = ManifestNetworkValidator(external_network_names, network_name=network_name)
+
+        agent_network: AgentNetwork = None
+        if usable_network:
+            agent_network = self.restore_one_agent_network(manifest_dir, agent_filepath, manifest_key)
+
+        self.process_one_agent_network(agent_network, usable_network, agent_filepath,
+                                       manifest_file, manifest_key, manifest_dict, validator)
+        return agent_network, network_name
 
     # pylint: disable=too-many-locals
     async def async_restore_one_manifest(self, manifest_file: str) -> Dict[str, Dict[str, AgentNetwork]]:
@@ -213,30 +245,60 @@ class RegistryManifestRestorer(Restorer):
 
         # At this point only hocon files we are going to serve up are in the one_manifest.
         for manifest_key, manifest_dict in one_manifest.items():
-
-            usable_network: bool = isinstance(manifest_dict, dict) and manifest_dict.get("serve", False)
-
-            # We'll need to use an agent mapper to get to this agent definition file.
-            agent_filepath: str = self.agent_mapper.agent_name_to_filepath(manifest_key)
-            network_name: str = self.agent_mapper.filepath_to_agent_network_name(agent_filepath)
-            validator = ManifestNetworkValidator(
-                external_network_names,
-                network_name=network_name)
             agent_network: AgentNetwork = None
-            if usable_network:
-                agent_network = await self.async_restore_one_agent_network(manifest_dir, agent_filepath, manifest_key)
+            network_name: str = None
+            agent_network, network_name = await self.async_read_one_agent_network(manifest_dir, manifest_file,
+                                                                                  manifest_key, manifest_dict,
+                                                                                  external_network_names)
+            if agent_network is not None:
 
-            self.process_one_agent_network(agent_network, usable_network, agent_filepath,
-                                           manifest_file, manifest_key, manifest_dict,
-                                           validator, agent_networks)
+                # Figure out where we want to put the network per the network's manifest dictionary
+                storage: str = StorageClass.PUBLIC
+                if not manifest_dict.get(StorageClass.PUBLIC):
+                    storage = StorageClass.PROTECTED
+                if manifest_dict.get("periodic", False):
+                    self.periodic_configs[network_name] = manifest_dict["periodic"]
+
+                agent_networks[storage][network_name] = agent_network
 
         return agent_networks
 
     # pylint: disable=too-many-arguments,too-many-positional-arguments
+    async def async_read_one_agent_network(
+                self,
+                manifest_dir: str,
+                manifest_file: str,
+                manifest_key: str,
+                manifest_dict: Dict[str, Any],
+                external_network_names: List[str]
+            ) -> Tuple[AgentNetwork, str]:
+        """
+        :param manifest_dir: The directory of the manifest file.
+        :param manifest_file: The file reference to use when restoring.
+        :param manifest_key: The key in the manifest file.
+        :param manifest_dict: The dictionary of the manifest file.
+        :param external_network_names: The list of external network names
+        :return: a nested map of storage type -> (mapping of name -> agent networks)
+        """
+        usable_network: bool = isinstance(manifest_dict, dict) and manifest_dict.get("serve", False)
+
+        # We'll need to use an agent mapper to get to this agent definition file.
+        agent_filepath: str = self.agent_mapper.agent_name_to_filepath(manifest_key)
+        network_name: str = self.agent_mapper.filepath_to_agent_network_name(agent_filepath)
+        validator = ManifestNetworkValidator(external_network_names, network_name=network_name)
+        agent_network: AgentNetwork = None
+        if usable_network:
+            agent_network = await self.async_restore_one_agent_network(manifest_dir, agent_filepath, manifest_key)
+
+        agent_network = self.process_one_agent_network(agent_network, usable_network, agent_filepath,
+                                                       manifest_file, manifest_key, manifest_dict, validator)
+
+        return agent_network, network_name
+
+    # pylint: disable=too-many-arguments,too-many-positional-arguments
     def process_one_agent_network(self, agent_network: AgentNetwork, usable_network: bool, agent_filepath: str,
                                   manifest_file: str, manifest_key: str, manifest_dict: Dict[str, Any],
-                                  validator: ManifestNetworkValidator,
-                                  agent_networks: Dict[str, Dict[str, AgentNetwork]]):
+                                  validator: ManifestNetworkValidator) -> AgentNetwork:
         """
         :param agent_network: The agent network to process.
         :param usable_network: Is this agent network usable?
@@ -245,7 +307,6 @@ class RegistryManifestRestorer(Restorer):
         :param manifest_key: The manifest key.
         :param manifest_dict: The manifest dictionary.
         :param validator: The validator.
-        :param agent_networks: The accumulated agent networks
         """
         network_name: str = self.agent_mapper.filepath_to_agent_network_name(agent_filepath)
 
@@ -257,24 +318,17 @@ class RegistryManifestRestorer(Restorer):
                                   agent_filepath,
                                   json.dumps(validation_errors, indent=4, sort_keys=True))
                 agent_network = None
-                return
+                return agent_network
 
         if usable_network and agent_network is None:
             self.logger.error("manifest registry %s not found in %s", manifest_key, manifest_file)
-            return
+            return agent_network
 
         # Check if this agent network has been declared as MCP tool:
         if usable_network and manifest_dict.get("mcp", False):
             agent_network.set_as_mcp_tool()
 
-        # Figure out where we want to put the network per the network's manifest dictionary
-        storage: str = StorageClass.PUBLIC
-        if not manifest_dict.get(StorageClass.PUBLIC):
-            storage = StorageClass.PROTECTED
-        if manifest_dict.get("periodic", False):
-            self.periodic_configs[network_name] = manifest_dict["periodic"]
-
-        agent_networks[storage][network_name] = agent_network
+        return agent_network
 
     def restore_one_agent_network(self, manifest_dir: str, agent_filepath: str, manifest_key: str) -> AgentNetwork:
         """

--- a/neuro_san/internals/graph/persistence/registry_manifest_restorer.py
+++ b/neuro_san/internals/graph/persistence/registry_manifest_restorer.py
@@ -24,7 +24,8 @@ from typing import Union
 
 import os
 import json
-import logging
+from logging import getLogger
+from logging import Logger
 
 from concurrent.futures import Executor
 from concurrent.futures import ProcessPoolExecutor
@@ -94,7 +95,7 @@ class RegistryManifestRestorer(Restorer):
         else:
             self.manifest_files = manifest_files
 
-        self.logger = logging.getLogger(self.__class__.__name__)
+        self.logger: Logger = getLogger(self.__class__.__name__)
 
     def restore_from_files(self, file_references: Sequence[str]) -> Dict[str, Dict[str, AgentNetwork]]:
         """
@@ -191,17 +192,13 @@ class RegistryManifestRestorer(Restorer):
         if len(one_manifest) > process_threshold:
             pool_executor = ProcessPoolExecutor
 
-        # ProcessPoolExecutor requires the mapped callable (and any captured state) to be picklable.
-        # `read_one_agent_network` is a bound method and captures `self`, so fall back to threads unless
-        # this gets refactored to use a module-level worker function.
-        if pool_executor is ProcessPoolExecutor:
-            pool_executor = ThreadPoolExecutor
         with pool_executor(max_workers=max_workers) as executor:
 
             read_one: Any = partial(self.read_one_agent_network,
                                     manifest_file=manifest_file,
                                     manifest_dir=manifest_dir,
-                                    external_network_names=external_network_names)
+                                    external_network_names=external_network_names,
+                                    agent_mapper=self.agent_mapper)
             manifest_keys: List[str] = list(one_manifest.keys())
             manifest_dicts: List[Dict[str, Any]] = list(one_manifest.values())
 
@@ -219,13 +216,14 @@ class RegistryManifestRestorer(Restorer):
         return agent_networks
 
     # pylint: disable=too-many-arguments,too-many-positional-arguments
+    @staticmethod
     def read_one_agent_network(
-                self,
                 manifest_key: str,
                 manifest_dict: Dict[str, Any],
                 manifest_file: str = None,
                 manifest_dir: str = None,
-                external_network_names: List[str] = None
+                external_network_names: List[str] = None,
+                agent_mapper: AgentFileTreeMapper = None
             ) -> Tuple[AgentNetwork, str, Dict[str, Any]]:
         """
         :param manifest_dir: The directory of the manifest file.
@@ -233,21 +231,26 @@ class RegistryManifestRestorer(Restorer):
         :param manifest_key: The key in the manifest file.
         :param manifest_dict: The dictionary of the manifest file.
         :param external_network_names: The list of external network names
+        :param agent_mapper: The AgentFileTreeMapper to use
         :return: A tuple of (agent_network, network_name, manifest_dict)
         """
         usable_network: bool = isinstance(manifest_dict, dict) and manifest_dict.get("serve", False)
 
         # We'll need to use an agent mapper to get to this agent definition file.
-        agent_filepath: str = self.agent_mapper.agent_name_to_filepath(manifest_key)
-        network_name: str = self.agent_mapper.filepath_to_agent_network_name(agent_filepath)
+        agent_filepath: str = agent_mapper.agent_name_to_filepath(manifest_key)
+        network_name: str = agent_mapper.filepath_to_agent_network_name(agent_filepath)
         validator = ManifestNetworkValidator(external_network_names, network_name=network_name)
 
         agent_network: AgentNetwork = None
         if usable_network:
-            agent_network = self.restore_one_agent_network(manifest_dir, agent_filepath, manifest_key)
+            agent_network = RegistryManifestRestorer.restore_one_agent_network(
+                manifest_dir, agent_filepath, manifest_key, agent_mapper
+            )
 
-        agent_network = self.process_one_agent_network(
-            agent_network, usable_network, agent_filepath, manifest_file, manifest_key, manifest_dict, validator
+        agent_network = RegistryManifestRestorer.process_one_agent_network(
+            agent_network, usable_network, agent_filepath,
+            manifest_file, manifest_key, manifest_dict,
+            validator, agent_mapper
         )
         return agent_network, network_name, manifest_dict
 
@@ -319,7 +322,8 @@ class RegistryManifestRestorer(Restorer):
                 manifest_dict: Dict[str, Any],
                 manifest_file: str = None,
                 manifest_dir: str = None,
-                external_network_names: List[str] = None
+                external_network_names: List[str] = None,
+                agent_mapper: AgentFileTreeMapper = None
             ) -> Tuple[AgentNetwork, str, Dict[str, Any]]:
         """
         :param manifest_dir: The directory of the manifest file.
@@ -332,22 +336,34 @@ class RegistryManifestRestorer(Restorer):
         usable_network: bool = isinstance(manifest_dict, dict) and manifest_dict.get("serve", False)
 
         # We'll need to use an agent mapper to get to this agent definition file.
-        agent_filepath: str = self.agent_mapper.agent_name_to_filepath(manifest_key)
-        network_name: str = self.agent_mapper.filepath_to_agent_network_name(agent_filepath)
+        agent_filepath: str = agent_mapper.agent_name_to_filepath(manifest_key)
+        network_name: str = agent_mapper.filepath_to_agent_network_name(agent_filepath)
         validator = ManifestNetworkValidator(external_network_names, network_name=network_name)
         agent_network: AgentNetwork = None
         if usable_network:
-            agent_network = await self.async_restore_one_agent_network(manifest_dir, agent_filepath, manifest_key)
+            agent_network = await RegistryManifestRestorer.async_restore_one_agent_network(
+                manifest_dir, agent_filepath, manifest_key, agent_mapper
+            )
 
-        agent_network = self.process_one_agent_network(agent_network, usable_network, agent_filepath,
-                                                       manifest_file, manifest_key, manifest_dict, validator)
+        agent_network = self.process_one_agent_network(
+            agent_network, usable_network, agent_filepath,
+            manifest_file, manifest_key, manifest_dict, validator, agent_mapper
+        )
 
         return agent_network, network_name, manifest_dict
 
     # pylint: disable=too-many-arguments,too-many-positional-arguments
-    def process_one_agent_network(self, agent_network: AgentNetwork, usable_network: bool, agent_filepath: str,
-                                  manifest_file: str, manifest_key: str, manifest_dict: Dict[str, Any],
-                                  validator: ManifestNetworkValidator) -> AgentNetwork:
+    @staticmethod
+    def process_one_agent_network(
+                agent_network: AgentNetwork,
+                usable_network: bool,
+                agent_filepath: str,
+                manifest_file: str,
+                manifest_key: str,
+                manifest_dict: Dict[str, Any],
+                validator: ManifestNetworkValidator,
+                agent_mapper: AgentFileTreeMapper
+            ) -> AgentNetwork:
         """
         :param agent_network: The agent network to process.
         :param usable_network: Is this agent network usable?
@@ -356,21 +372,24 @@ class RegistryManifestRestorer(Restorer):
         :param manifest_key: The manifest key.
         :param manifest_dict: The manifest dictionary.
         :param validator: The validator.
+        :param agent_mapper: The agent mapper.
+        :return: The agent network
         """
-        network_name: str = self.agent_mapper.filepath_to_agent_network_name(agent_filepath)
+        network_name: str = agent_mapper.filepath_to_agent_network_name(agent_filepath)
+        logger: Logger = getLogger(__name__)
 
         if agent_network is not None:
-            self.logger.info("Validating %s agent network...", network_name)
+            logger.info("Validating %s agent network...", network_name)
             validation_errors: List[str] = validator.validate(agent_network.get_config())
             if len(validation_errors) > 0:
-                self.logger.error("manifest registry %s has validation errors. Skipping. Errors: %s",
-                                  agent_filepath,
-                                  json.dumps(validation_errors, indent=4, sort_keys=True))
+                logger.error("manifest registry %s has validation errors. Skipping. Errors: %s",
+                             agent_filepath,
+                             json.dumps(validation_errors, indent=4, sort_keys=True))
                 agent_network = None
                 return agent_network
 
         if usable_network and agent_network is None:
-            self.logger.error("manifest registry %s not found in %s", manifest_key, manifest_file)
+            logger.error("manifest registry %s not found in %s", manifest_key, manifest_file)
             return agent_network
 
         # Check if this agent network has been declared as MCP tool:
@@ -379,21 +398,24 @@ class RegistryManifestRestorer(Restorer):
 
         return agent_network
 
-    def restore_one_agent_network(self, manifest_dir: str, agent_filepath: str, manifest_key: str) -> AgentNetwork:
+    @staticmethod
+    def restore_one_agent_network(manifest_dir: str, agent_filepath: str, manifest_key: str,
+                                  agent_mapper: AgentFileTreeMapper) -> AgentNetwork:
         """
         :param manifest_dir: The directory of the manifest file
         :param agent_filepath: The file reference for the agent network description to restore
         :param manifest_key: the key to use when restoring
+        :param agent_mapper: the agent mapper
         :return: a built map of agent networks
         """
 
         agent_network: AgentNetwork = None
-        registry_restorer = AgentNetworkRestorer(registry_dir=manifest_dir, agent_mapper=self.agent_mapper)
+        registry_restorer = AgentNetworkRestorer(registry_dir=manifest_dir, agent_mapper=agent_mapper)
         try:
             agent_network = registry_restorer.restore(file_reference=agent_filepath)
         except FileNotFoundError as exception:
             message: str = f"Failed to restore registry item {manifest_key}. Skipping. - {str(exception)}"
-            sensitive_logger = SensitiveLogger(self.logger)
+            sensitive_logger = SensitiveLogger(getLogger(__name__))
             sensitive_logger.error(message)
             agent_network = None
         except (ParseException, ParseSyntaxException, JSONDecodeError, ValueError) as exception:
@@ -409,28 +431,31 @@ class RegistryManifestRestorer(Restorer):
                 use_exception = exception.__cause__
 
             message: str = f"Parse error in registry item {manifest_key}. Skipping. - {str(use_exception)}"
-            sensitive_logger = SensitiveLogger(self.logger)
+            sensitive_logger = SensitiveLogger(getLogger(__name__))
             sensitive_logger.error(message)
             agent_network = None
 
         return agent_network
 
-    async def async_restore_one_agent_network(self, manifest_dir: str, agent_filepath: str, manifest_key: str) \
+    @staticmethod
+    async def async_restore_one_agent_network(manifest_dir: str, agent_filepath: str,
+                                              manifest_key: str, agent_mapper: AgentFileTreeMapper) \
             -> AgentNetwork:
         """
         :param manifest_dir: The directory of the manifest file
         :param agent_filepath: The file reference for the agent network description to restore
         :param manifest_key: the key to use when restoring
+        :param agent_mapper: the agent mapper
         :return: a built map of agent networks
         """
 
         agent_network: AgentNetwork = None
-        registry_restorer = AgentNetworkRestorer(registry_dir=manifest_dir, agent_mapper=self.agent_mapper)
+        registry_restorer = AgentNetworkRestorer(registry_dir=manifest_dir, agent_mapper=agent_mapper)
         try:
             agent_network = await registry_restorer.async_restore(file_reference=agent_filepath)
         except FileNotFoundError as exception:
             message: str = f"Failed to restore registry item {manifest_key}. Skipping. - {str(exception)}"
-            sensitive_logger = SensitiveLogger(self.logger)
+            sensitive_logger = SensitiveLogger(getLogger(__name__))
             sensitive_logger.error(message)
             agent_network = None
         except (ParseException, ParseSyntaxException, JSONDecodeError, ValueError) as exception:
@@ -446,7 +471,7 @@ class RegistryManifestRestorer(Restorer):
                 use_exception = exception.__cause__
 
             message: str = f"Parse error in registry item {manifest_key}. Skipping. - {str(use_exception)}"
-            sensitive_logger = SensitiveLogger(self.logger)
+            sensitive_logger = SensitiveLogger(getLogger(__name__))
             sensitive_logger.error(message)
             agent_network = None
 

--- a/neuro_san/internals/graph/persistence/registry_manifest_restorer.py
+++ b/neuro_san/internals/graph/persistence/registry_manifest_restorer.py
@@ -266,8 +266,13 @@ class RegistryManifestRestorer(Restorer):
         :param agent_networks: a nested map of storage type -> (mapping of name -> agent networks)
                                 potentially modified
         """
-        if agent_network is None:
+        if agent_network is None and isinstance(manifest_dict, dict) and manifest_dict.get("serve", False):
+            # Restore/validation failure - never stored, same as before
             return
+
+        # At this point even if agent_network is None, we still have a store to do.
+        # With a None agent_network, we just don't store anythin so a later manifest version
+        # can override an earlier one, per ServerdManifiestConfigFilter.
 
         # Figure out where we want to put the network per the network's manifest dictionary
         storage: str = StorageClass.PUBLIC

--- a/neuro_san/internals/graph/persistence/registry_manifest_restorer.py
+++ b/neuro_san/internals/graph/persistence/registry_manifest_restorer.py
@@ -306,11 +306,7 @@ class RegistryManifestRestorer(Restorer):
             agent_network: AgentNetwork = None
             network_name: str = None
             agent_network, network_name, manifest_dict = await self.async_read_one_agent_network(
-                manifest_key,
-                manifest_dict,
-                manifest_file,
-                manifest_dir,
-                external_network_names
+                manifest_key, manifest_dict, manifest_file, manifest_dir, external_network_names, self.agent_mapper
             )
             self.maybe_store_agent_network(agent_network, network_name, manifest_dict, agent_networks)
 

--- a/neuro_san/internals/graph/persistence/registry_manifest_restorer.py
+++ b/neuro_san/internals/graph/persistence/registry_manifest_restorer.py
@@ -243,6 +243,8 @@ class RegistryManifestRestorer(Restorer):
     def maybe_store_agent_network(self, agent_network: AgentNetwork, network_name: str, manifest_dict: Dict[str, Any],
                                   agent_networks: Dict[str, Dict[str, AgentNetwork]]):
         """
+        Determine whether and where to store the agent network
+
         :param agent_network: The agent network to store
         :param network_name: The name of the network
         :param manifest_dict: The manifest dictionary

--- a/neuro_san/internals/graph/persistence/registry_manifest_restorer.py
+++ b/neuro_san/internals/graph/persistence/registry_manifest_restorer.py
@@ -249,7 +249,6 @@ class RegistryManifestRestorer(Restorer):
         :param agent_networks: a nested map of storage type -> (mapping of name -> agent networks)
                                 potentially modified
         """
-
         if agent_network is None:
             return
 

--- a/neuro_san/internals/graph/persistence/registry_manifest_restorer.py
+++ b/neuro_san/internals/graph/persistence/registry_manifest_restorer.py
@@ -189,6 +189,8 @@ class RegistryManifestRestorer(Restorer):
         # the GIL.  When we get to free-threading in Python 3.14T, this can be changed back to ThreadPoolExecutor.
         process_threshold: int = 20     # Somewhat arbitrary
         if len(one_manifest) > process_threshold:
+            # While "spawn" below is more correct for more OSes and more Python versions,
+            # it is not necessarily the fastest.
             executor_factory = partial(ProcessPoolExecutor, max_workers=max_workers,
                                        mp_context=get_context("spawn"))
 

--- a/neuro_san/internals/graph/persistence/registry_manifest_restorer.py
+++ b/neuro_san/internals/graph/persistence/registry_manifest_restorer.py
@@ -223,7 +223,7 @@ class RegistryManifestRestorer(Restorer):
         :param manifest_key: The key in the manifest file.
         :param manifest_dict: The dictionary of the manifest file.
         :param external_network_names: The list of external network names
-        :return: a nested map of storage type -> (mapping of name -> agent networks)
+        :return: A tuple of (agent_network, network_name, manifest_dict)
         """
         usable_network: bool = isinstance(manifest_dict, dict) and manifest_dict.get("serve", False)
 
@@ -315,7 +315,7 @@ class RegistryManifestRestorer(Restorer):
         :param manifest_key: The key in the manifest file.
         :param manifest_dict: The dictionary of the manifest file.
         :param external_network_names: The list of external network names
-        :return: a nested map of storage type -> (mapping of name -> agent networks)
+        :return: A tuple of (agent_network, network_name, manifest_dict)
         """
         usable_network: bool = isinstance(manifest_dict, dict) and manifest_dict.get("serve", False)
 

--- a/neuro_san/internals/graph/persistence/registry_manifest_restorer.py
+++ b/neuro_san/internals/graph/persistence/registry_manifest_restorer.py
@@ -190,7 +190,8 @@ class RegistryManifestRestorer(Restorer):
         process_threshold: int = 20     # Somewhat arbitrary
         if len(one_manifest) > process_threshold:
             # While "spawn" below is more correct for more OSes and more Python versions,
-            # it is not necessarily the fastest.
+            # it is not necessarily the fastest. "fork" can be faster, but could lead to deadlocks.
+            # See https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods
             executor_factory = partial(ProcessPoolExecutor, max_workers=max_workers,
                                        mp_context=get_context("spawn"))
 

--- a/neuro_san/internals/graph/persistence/registry_manifest_restorer.py
+++ b/neuro_san/internals/graph/persistence/registry_manifest_restorer.py
@@ -25,6 +25,8 @@ import os
 import json
 import logging
 
+from concurrent.futures import ThreadPoolExecutor as PoolExecutor
+from functools import partial
 from json.decoder import JSONDecodeError
 from pyparsing.exceptions import ParseException
 from pyparsing.exceptions import ParseSyntaxException
@@ -94,7 +96,6 @@ class RegistryManifestRestorer(Restorer):
         :param file_references: The sequence of file references to use when restoring.
         :return: a nested map of storage type -> (mapping of name -> agent networks)
         """
-
         all_agent_networks: Dict[str, Dict[str, AgentNetwork]] = {}
         overlayer = DictionaryOverlay()
 
@@ -146,7 +147,6 @@ class RegistryManifestRestorer(Restorer):
         :param manifest_file: The file reference to use when restoring.
         :return: a nested map of storage type -> (mapping of name -> agent networks)
         """
-
         agent_networks: Dict[str, Dict[str, AgentNetwork]] = {}
         for storage_class in StorageClass.ALL_PERMANENT:
             agent_networks[storage_class] = {}
@@ -168,35 +168,46 @@ class RegistryManifestRestorer(Restorer):
 
         external_network_names: List[str] = self.find_external_network_names(one_manifest)
 
-        # At this point only hocon files we are going to serve up are in the one_manifest.
-        for manifest_key, manifest_dict in one_manifest.items():
-            agent_network: AgentNetwork = None
-            network_name: str = None
-            agent_network, network_name = self.read_one_agent_network(manifest_dir, manifest_file,
-                                                                      manifest_key, manifest_dict,
-                                                                      external_network_names)
-            if agent_network is not None:
+        max_workers: int = len(one_manifest)
+        with PoolExecutor(max_workers=max_workers) as executor:
 
-                # Figure out where we want to put the network per the network's manifest dictionary
-                storage: str = StorageClass.PUBLIC
-                if not manifest_dict.get(StorageClass.PUBLIC):
-                    storage = StorageClass.PROTECTED
-                if manifest_dict.get("periodic", False):
-                    self.periodic_configs[network_name] = manifest_dict["periodic"]
+            read_one: Any = partial(self.read_one_agent_network,
+                                    manifest_file=manifest_file,
+                                    manifest_dir=manifest_dir,
+                                    external_network_names=external_network_names)
+            manifest_keys: List[str] = list(one_manifest.keys())
+            manifest_dicts: List[Dict[str, Any]] = list(one_manifest.values())
 
-                agent_networks[storage][network_name] = agent_network
+            results: List[Tuple[AgentNetwork, str, Dict[str, Any]]] = executor.map(read_one, manifest_keys,
+                                                                                   manifest_dicts)
+            result: Tuple[AgentNetwork, str, Dict[str, Any]] = None
+            for result in results:
+
+                agent_network: AgentNetwork = result[0]
+                network_name: str = result[1]
+                manifest_dict: Dict[str, Any] = result[2]
+                if agent_network is not None:
+
+                    # Figure out where we want to put the network per the network's manifest dictionary
+                    storage: str = StorageClass.PUBLIC
+                    if not manifest_dict.get(StorageClass.PUBLIC):
+                        storage = StorageClass.PROTECTED
+                    if manifest_dict.get("periodic", False):
+                        self.periodic_configs[network_name] = manifest_dict["periodic"]
+
+                    agent_networks[storage][network_name] = agent_network
 
         return agent_networks
 
     # pylint: disable=too-many-arguments,too-many-positional-arguments
     def read_one_agent_network(
                 self,
-                manifest_dir: str,
-                manifest_file: str,
                 manifest_key: str,
                 manifest_dict: Dict[str, Any],
-                external_network_names: List[str]
-            ) -> Tuple[AgentNetwork, str]:
+                manifest_file: str = None,
+                manifest_dir: str = None,
+                external_network_names: List[str] = None
+            ) -> Tuple[AgentNetwork, str, Dict[str, Any]]:
         """
         :param manifest_dir: The directory of the manifest file.
         :param manifest_file: The file reference to use when restoring.
@@ -218,7 +229,7 @@ class RegistryManifestRestorer(Restorer):
 
         self.process_one_agent_network(agent_network, usable_network, agent_filepath,
                                        manifest_file, manifest_key, manifest_dict, validator)
-        return agent_network, network_name
+        return agent_network, network_name, manifest_dict
 
     # pylint: disable=too-many-locals
     async def async_restore_one_manifest(self, manifest_file: str) -> Dict[str, Dict[str, AgentNetwork]]:

--- a/neuro_san/internals/graph/persistence/registry_manifest_restorer.py
+++ b/neuro_san/internals/graph/persistence/registry_manifest_restorer.py
@@ -25,9 +25,13 @@ import os
 import json
 import logging
 
-from concurrent.futures import ThreadPoolExecutor as PoolExecutor
+from concurrent.futures import Executor
+from concurrent.futures import ProcessPoolExecutor
+from concurrent.futures import ThreadPoolExecutor
 from functools import partial
 from json.decoder import JSONDecodeError
+from time import perf_counter
+
 from pyparsing.exceptions import ParseException
 from pyparsing.exceptions import ParseSyntaxException
 
@@ -147,6 +151,8 @@ class RegistryManifestRestorer(Restorer):
         :param manifest_file: The file reference to use when restoring.
         :return: a nested map of storage type -> (mapping of name -> agent networks)
         """
+        start: float = perf_counter()
+
         agent_networks: Dict[str, Dict[str, AgentNetwork]] = {}
         for storage_class in StorageClass.ALL_PERMANENT:
             agent_networks[storage_class] = {}
@@ -168,8 +174,18 @@ class RegistryManifestRestorer(Restorer):
 
         external_network_names: List[str] = self.find_external_network_names(one_manifest)
 
+        # Determine how many threads to use and which style of executor to use
         max_workers: int = len(one_manifest)
-        with PoolExecutor(max_workers=max_workers) as executor:
+        pool_executor: Executor = ThreadPoolExecutor
+
+        # By default use a ThreadPoolExecutor, but because of the GIL, in cases of large manifests,
+        # a ProcessPoolExecutor ends up being more heavyweight, yet still more efficient because of
+        # the GIL.  When we get to free-threading in Python 3.14T, this can be changed back to ThreadPoolExecutor.
+        process_threshold: int = 20     # Somewhat arbitrary
+        if max_workers > process_threshold:
+            pool_executor = ProcessPoolExecutor
+
+        with pool_executor(max_workers=max_workers) as executor:
 
             read_one: Any = partial(self.read_one_agent_network,
                                     manifest_file=manifest_file,
@@ -196,6 +212,11 @@ class RegistryManifestRestorer(Restorer):
                         self.periodic_configs[network_name] = manifest_dict["periodic"]
 
                     agent_networks[storage][network_name] = agent_network
+
+        stop: float = perf_counter()
+        duration: float = stop - start
+        if duration > 5.0:
+            self.logger.warning("Manifest file %s restored in %.2f seconds.", manifest_file, duration)
 
         return agent_networks
 

--- a/neuro_san/internals/graph/persistence/registry_manifest_restorer.py
+++ b/neuro_san/internals/graph/persistence/registry_manifest_restorer.py
@@ -19,7 +19,6 @@ from typing import Dict
 from typing import List
 from typing import Sequence
 from typing import Tuple
-from typing import Type
 from typing import Union
 
 import os
@@ -27,11 +26,11 @@ import json
 from logging import getLogger
 from logging import Logger
 
-from concurrent.futures import Executor
 from concurrent.futures import ProcessPoolExecutor
 from concurrent.futures import ThreadPoolExecutor
 from functools import partial
 from json.decoder import JSONDecodeError
+from multiprocessing import get_context
 from time import perf_counter
 
 from pyparsing.exceptions import ParseException
@@ -183,16 +182,17 @@ class RegistryManifestRestorer(Restorer):
         # Avoid spawning an unbounded number of workers.
         cpu_count: int = os.cpu_count() or 1
         max_workers: int = min(len(one_manifest), cpu_count)
-        pool_executor: Type[Executor] = ThreadPoolExecutor
+        executor_factory = partial(ThreadPoolExecutor, max_workers=max_workers)
 
         # By default use a ThreadPoolExecutor, but because of the GIL, in cases of large manifests,
         # a ProcessPoolExecutor ends up being more heavyweight, yet still more efficient because of
         # the GIL.  When we get to free-threading in Python 3.14T, this can be changed back to ThreadPoolExecutor.
         process_threshold: int = 20     # Somewhat arbitrary
         if len(one_manifest) > process_threshold:
-            pool_executor = ProcessPoolExecutor
+            executor_factory = partial(ProcessPoolExecutor, max_workers=max_workers,
+                                       mp_context=get_context("spawn"))
 
-        with pool_executor(max_workers=max_workers) as executor:
+        with executor_factory() as executor:
 
             read_one: Any = partial(self.read_one_agent_network,
                                     manifest_file=manifest_file,

--- a/neuro_san/internals/graph/persistence/registry_manifest_restorer.py
+++ b/neuro_san/internals/graph/persistence/registry_manifest_restorer.py
@@ -192,21 +192,25 @@ class RegistryManifestRestorer(Restorer):
             executor_factory = partial(ProcessPoolExecutor, max_workers=max_workers,
                                        mp_context=get_context("spawn"))
 
-        with executor_factory() as executor:
+        try:
+            with executor_factory() as executor:
 
-            read_one: Any = partial(self.read_one_agent_network,
-                                    manifest_file=manifest_file,
-                                    manifest_dir=manifest_dir,
-                                    external_network_names=external_network_names,
-                                    agent_mapper=self.agent_mapper)
-            manifest_keys: List[str] = list(one_manifest.keys())
-            manifest_dicts: List[Dict[str, Any]] = list(one_manifest.values())
+                read_one: Any = partial(self.read_one_agent_network,
+                                        manifest_file=manifest_file,
+                                        manifest_dir=manifest_dir,
+                                        external_network_names=external_network_names,
+                                        agent_mapper=self.agent_mapper)
+                manifest_keys: List[str] = list(one_manifest.keys())
+                manifest_dicts: List[Dict[str, Any]] = list(one_manifest.values())
 
-            results: List[Tuple[AgentNetwork, str, Dict[str, Any]]] = executor.map(read_one, manifest_keys,
-                                                                                   manifest_dicts)
-            result: Tuple[AgentNetwork, str, Dict[str, Any]] = None
-            for result in results:
-                self.maybe_store_agent_network(result[0], result[1], result[2], agent_networks)
+                results: List[Tuple[AgentNetwork, str, Dict[str, Any]]] = executor.map(read_one, manifest_keys,
+                                                                                       manifest_dicts)
+                result: Tuple[AgentNetwork, str, Dict[str, Any]] = None
+                for result in results:
+                    self.maybe_store_agent_network(result[0], result[1], result[2], agent_networks)
+        except Exception:     # pylint: disable=broad-except
+            sensitive_logger = SensitiveLogger(self.logger)
+            sensitive_logger.exception("Manifest file %s could not be restored.", manifest_file)
 
         stop: float = perf_counter()
         duration: float = stop - start
@@ -243,16 +247,26 @@ class RegistryManifestRestorer(Restorer):
         validator = ManifestNetworkValidator(external_network_names, network_name=network_name)
 
         agent_network: AgentNetwork = None
-        if usable_network:
-            agent_network = RegistryManifestRestorer.restore_one_agent_network(
-                manifest_dir, agent_filepath, manifest_key, agent_mapper
-            )
 
-        agent_network = RegistryManifestRestorer.process_one_agent_network(
-            agent_network, usable_network, agent_filepath,
-            manifest_file, manifest_key, manifest_dict,
-            validator, agent_mapper
-        )
+        try:
+            if usable_network:
+                agent_network = RegistryManifestRestorer.restore_one_agent_network(
+                    manifest_dir, agent_filepath, manifest_key, agent_mapper
+                )
+
+            agent_network = RegistryManifestRestorer.process_one_agent_network(
+                agent_network, usable_network, agent_filepath,
+                manifest_file, manifest_key, manifest_dict,
+                validator, agent_mapper
+            )
+        except Exception as ex:     # pylint: disable=broad-except
+            # None-out the agent_network.
+            # This will mean that the failed read will skip the network without blowing anything else up.
+            agent_network = None
+            sensitive_logger = SensitiveLogger(getLogger(__name__))
+            sensitive_logger.error("Failed to restore agent_network %s from %s. Skipping. - %s",
+                                   manifest_key, manifest_file, str(ex))
+
         return agent_network, network_name, manifest_dict
 
     def maybe_store_agent_network(self, agent_network: AgentNetwork, network_name: str, manifest_dict: Dict[str, Any],

--- a/neuro_san/internals/graph/persistence/registry_manifest_restorer.py
+++ b/neuro_san/internals/graph/persistence/registry_manifest_restorer.py
@@ -176,16 +176,26 @@ class RegistryManifestRestorer(Restorer):
         external_network_names: List[str] = self.find_external_network_names(one_manifest)
 
         # Determine how many threads to use and which style of executor to use
-        max_workers: int = len(one_manifest)
+        if not one_manifest:
+            return agent_networks
+
+        # Avoid spawning an unbounded number of workers.
+        cpu_count: int = os.cpu_count() or 1
+        max_workers: int = min(len(one_manifest), cpu_count)
         pool_executor: Type[Executor] = ThreadPoolExecutor
 
         # By default use a ThreadPoolExecutor, but because of the GIL, in cases of large manifests,
         # a ProcessPoolExecutor ends up being more heavyweight, yet still more efficient because of
         # the GIL.  When we get to free-threading in Python 3.14T, this can be changed back to ThreadPoolExecutor.
         process_threshold: int = 20     # Somewhat arbitrary
-        if max_workers > process_threshold:
+        if len(one_manifest) > process_threshold:
             pool_executor = ProcessPoolExecutor
 
+        # ProcessPoolExecutor requires the mapped callable (and any captured state) to be picklable.
+        # `read_one_agent_network` is a bound method and captures `self`, so fall back to threads unless
+        # this gets refactored to use a module-level worker function.
+        if pool_executor is ProcessPoolExecutor:
+            pool_executor = ThreadPoolExecutor
         with pool_executor(max_workers=max_workers) as executor:
 
             read_one: Any = partial(self.read_one_agent_network,

--- a/neuro_san/internals/graph/persistence/registry_manifest_restorer.py
+++ b/neuro_san/internals/graph/persistence/registry_manifest_restorer.py
@@ -199,20 +199,7 @@ class RegistryManifestRestorer(Restorer):
                                                                                    manifest_dicts)
             result: Tuple[AgentNetwork, str, Dict[str, Any]] = None
             for result in results:
-
-                agent_network: AgentNetwork = result[0]
-                network_name: str = result[1]
-                manifest_dict: Dict[str, Any] = result[2]
-                if agent_network is not None:
-
-                    # Figure out where we want to put the network per the network's manifest dictionary
-                    storage: str = StorageClass.PUBLIC
-                    if not manifest_dict.get(StorageClass.PUBLIC):
-                        storage = StorageClass.PROTECTED
-                    if manifest_dict.get("periodic", False):
-                        self.periodic_configs[network_name] = manifest_dict["periodic"]
-
-                    agent_networks[storage][network_name] = agent_network
+                self.maybe_store_agent_network(result[0], result[1], result[2], agent_networks)
 
         stop: float = perf_counter()
         duration: float = stop - start
@@ -253,6 +240,28 @@ class RegistryManifestRestorer(Restorer):
                                        manifest_file, manifest_key, manifest_dict, validator)
         return agent_network, network_name, manifest_dict
 
+    def maybe_store_agent_network(self, agent_network: AgentNetwork, network_name: str, manifest_dict: Dict[str, Any],
+                                  agent_networks: Dict[str, Dict[str, AgentNetwork]]):
+        """
+        :param agent_network: The agent network to store
+        :param network_name: The name of the network
+        :param manifest_dict: The manifest dictionary
+        :param agent_networks: a nested map of storage type -> (mapping of name -> agent networks)
+                                potentially modified
+        """
+
+        if agent_network is None:
+            return
+
+        # Figure out where we want to put the network per the network's manifest dictionary
+        storage: str = StorageClass.PUBLIC
+        if not manifest_dict.get(StorageClass.PUBLIC):
+            storage = StorageClass.PROTECTED
+        if manifest_dict.get("periodic", False):
+            self.periodic_configs[network_name] = manifest_dict["periodic"]
+
+        agent_networks[storage][network_name] = agent_network
+
     # pylint: disable=too-many-locals
     async def async_restore_one_manifest(self, manifest_file: str) -> Dict[str, Dict[str, AgentNetwork]]:
         """
@@ -280,31 +289,26 @@ class RegistryManifestRestorer(Restorer):
         for manifest_key, manifest_dict in one_manifest.items():
             agent_network: AgentNetwork = None
             network_name: str = None
-            agent_network, network_name = await self.async_read_one_agent_network(manifest_dir, manifest_file,
-                                                                                  manifest_key, manifest_dict,
-                                                                                  external_network_names)
-            if agent_network is not None:
-
-                # Figure out where we want to put the network per the network's manifest dictionary
-                storage: str = StorageClass.PUBLIC
-                if not manifest_dict.get(StorageClass.PUBLIC):
-                    storage = StorageClass.PROTECTED
-                if manifest_dict.get("periodic", False):
-                    self.periodic_configs[network_name] = manifest_dict["periodic"]
-
-                agent_networks[storage][network_name] = agent_network
+            agent_network, network_name, manifest_dict = await self.async_read_one_agent_network(
+                manifest_key,
+                manifest_dict,
+                manifest_file,
+                manifest_dir,
+                external_network_names
+            )
+            self.maybe_store_agent_network(agent_network, network_name, manifest_dict, agent_networks)
 
         return agent_networks
 
     # pylint: disable=too-many-arguments,too-many-positional-arguments
     async def async_read_one_agent_network(
                 self,
-                manifest_dir: str,
-                manifest_file: str,
                 manifest_key: str,
                 manifest_dict: Dict[str, Any],
-                external_network_names: List[str]
-            ) -> Tuple[AgentNetwork, str]:
+                manifest_file: str = None,
+                manifest_dir: str = None,
+                external_network_names: List[str] = None
+            ) -> Tuple[AgentNetwork, str, Dict[str, Any]]:
         """
         :param manifest_dir: The directory of the manifest file.
         :param manifest_file: The file reference to use when restoring.
@@ -326,7 +330,7 @@ class RegistryManifestRestorer(Restorer):
         agent_network = self.process_one_agent_network(agent_network, usable_network, agent_filepath,
                                                        manifest_file, manifest_key, manifest_dict, validator)
 
-        return agent_network, network_name
+        return agent_network, network_name, manifest_dict
 
     # pylint: disable=too-many-arguments,too-many-positional-arguments
     def process_one_agent_network(self, agent_network: AgentNetwork, usable_network: bool, agent_filepath: str,

--- a/neuro_san/internals/graph/persistence/registry_manifest_restorer.py
+++ b/neuro_san/internals/graph/persistence/registry_manifest_restorer.py
@@ -211,6 +211,7 @@ class RegistryManifestRestorer(Restorer):
         stop: float = perf_counter()
         duration: float = stop - start
         if duration > 5.0:
+            # DEF - for some reason infos don't show up in the logs at server start time. :shrug:
             self.logger.warning("Manifest file %s restored in %.2f seconds.", manifest_file, duration)
 
         return agent_networks

--- a/neuro_san/internals/graph/persistence/registry_manifest_restorer.py
+++ b/neuro_san/internals/graph/persistence/registry_manifest_restorer.py
@@ -236,8 +236,9 @@ class RegistryManifestRestorer(Restorer):
         if usable_network:
             agent_network = self.restore_one_agent_network(manifest_dir, agent_filepath, manifest_key)
 
-        self.process_one_agent_network(agent_network, usable_network, agent_filepath,
-                                       manifest_file, manifest_key, manifest_dict, validator)
+        agent_network = self.process_one_agent_network(
+            agent_network, usable_network, agent_filepath, manifest_file, manifest_key, manifest_dict, validator
+        )
         return agent_network, network_name, manifest_dict
 
     def maybe_store_agent_network(self, agent_network: AgentNetwork, network_name: str, manifest_dict: Dict[str, Any],

--- a/neuro_san/internals/graph/persistence/registry_manifest_restorer.py
+++ b/neuro_san/internals/graph/persistence/registry_manifest_restorer.py
@@ -313,8 +313,8 @@ class RegistryManifestRestorer(Restorer):
         return agent_networks
 
     # pylint: disable=too-many-arguments,too-many-positional-arguments
+    @staticmethod
     async def async_read_one_agent_network(
-                self,
                 manifest_key: str,
                 manifest_dict: Dict[str, Any],
                 manifest_file: str = None,
@@ -342,7 +342,7 @@ class RegistryManifestRestorer(Restorer):
                 manifest_dir, agent_filepath, manifest_key, agent_mapper
             )
 
-        agent_network = self.process_one_agent_network(
+        agent_network = RegistryManifestRestorer.process_one_agent_network(
             agent_network, usable_network, agent_filepath,
             manifest_file, manifest_key, manifest_dict, validator, agent_mapper
         )


### PR DESCRIPTION
It had been bugging me how long server startup was taking, and apparently it had been bugging @kaushik-cognizant how long watcher re-reads were taking when using nsflow.

* Refactor RegistryManifestRestorer so that read_one_manifest() can be parallelized.
* Use ThreadPoolExecutor for the synchronous parallelization by default, however if the number of agent networks is high, use a ProcessPoolExecutor instead because even though it's heavyweight, it's faster cuz no GIL and no filesystem lock contention.
* Still make the async path reflect the changes in the sync path, but don't parallelize that just yet, cuz it's probably pointless
* Consolidate some policy.
* Make some methods lower down the stack static so ProcessPoolExectuor won't have state problems when attempting to pickle "self" 

Note that the notion of "high number of agent networks" is currently an arbitrary 20 to use the ProcessPoolExecutor
Can iterate on that number as better data comes in.

Also, when we should revisit the ProcessPoolExeuctor approach when we get to Python 3.14T - the free-threading version which has no GIL.  At that point the lighter weight ThreadPoolExecutor should prevail.

This helps speed up server startup and watcher restore of neuro-san-studio from ~20 secs to ~3 secs using fork.
However, that is not as robust across OSes and python versions and can lead to deadlock. So with the more correct spawn, we get ~8 secs.

@Noravee : Can we get rid of async path in RegistryManifestRestorer now that AND doesn't use it any more?

Fixes #1147 