### PR TITLE
Add AGENT_MANIFEST_CONCURRENCY_CONTEXT env var and ulimit hints to run.sh

### DIFF
--- a/neuro_san/deploy/Dockerfile
+++ b/neuro_san/deploy/Dockerfile
@@ -365,6 +365,8 @@ ENV AGENT_TOOL_EXECUTION_LOG_THRESHOLD_SECONDS=0
 #               but has potential to lead to deadlocks over repeated manifest reads.
 #               It can still be a reasonable option for server environments where the manifest
 #               is known never to change at all.
+# See https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods
+# for more details on "spawn" and "fork" concurrency models.
 ENV AGENT_MANIFEST_CONCURRENCY_CONTEXT="thread"
 
 # Optional URL describing how the server is to be referenced by the outside world.

--- a/neuro_san/deploy/Dockerfile
+++ b/neuro_san/deploy/Dockerfile
@@ -294,7 +294,7 @@ ENV AGENT_MANIFEST_UPDATE_PERIOD_SECONDS="0"
 # "fork":       uses a multi-process based concurrency model. It is actually the fastest option,
 #               but has potential to lead to deadlocks over repeated manifest reads.
 #               It can still be a reasonable option for server environments where the manifest
-#               is known never to change at all.
+#               is known never to change at all (AGENT_MANIFEST_UPDATE_PERIOD_SECONDS="0").
 # See https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods
 # for more details on "spawn" and "fork" concurrency models.
 ENV AGENT_MANIFEST_CONCURRENCY_CONTEXT="thread"

--- a/neuro_san/deploy/Dockerfile
+++ b/neuro_san/deploy/Dockerfile
@@ -281,6 +281,24 @@ ENV AGENT_REQUEST_LIMIT="-1"
 # if value is not specified or <= 0, no such dynamic updates will be executed.
 ENV AGENT_MANIFEST_UPDATE_PERIOD_SECONDS="0"
 
+# Describes the concurrency model used for the manifest file updates.
+# Valid values are "thread" (the default) and "spawn" and "fork".
+#
+# "thread":     uses the default threading concurrency model.  It is best for servers who
+#               know their manifest content will be changing over the course of their lifetime.
+#               It is slowest of all options, but has the least amount of overall memory overhead
+#               and is lightweight and generally the safest and problem-free.
+# "spawn":      uses a multi-process based concurrency model.  It is the safest option (avoiding deadlocks)
+#               for environments where the manifest is changing, but some speed is still desired
+#               (like development servers).
+# "fork":       uses a multi-process based concurrency model. It is actually the fastest option,
+#               but has potential to lead to deadlocks over repeated manifest reads.
+#               It can still be a reasonable option for server environments where the manifest
+#               is known never to change at all.
+# See https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods
+# for more details on "spawn" and "fork" concurrency models.
+ENV AGENT_MANIFEST_CONCURRENCY_CONTEXT="thread"
+
 # By default, the HTTP service reports the neuro-san library pip version in its health-check response.
 # It is possible to add other libraries to those results by listing them within this env var
 # below and separating them with spaces, like this: "langchain openai".
@@ -350,24 +368,6 @@ ENV AGENT_STREAM_KEEP_ALIVE_WITH_PROGRESS_INTERVAL_SECONDS=0
 # where your scale-up problems are with particular networks.  The default value of
 # 0 disables this feature.
 ENV AGENT_TOOL_EXECUTION_LOG_THRESHOLD_SECONDS=0
-
-# Describes the concurrency model used for the manifest file updates.
-# Valid values are "thread" (the default) and "spawn" and "fork".
-#
-# "thread":     uses the default threading concurrency model.  It is best for servers who
-#               know their manifest content will be changing over the course of their lifetime.
-#               It is slowest of all options, but has the least amount of overall memory overhead
-#               and is lightweight and generally the safest and problem-free.
-# "spawn":      uses a multi-process based concurrency model.  It is the safest option (avoiding deadlocks)
-#               for environments where the manifest is changing, but some speed is still desired
-#               (like development servers).
-# "fork":       uses a multi-process based concurrency model. It is actually the fastest option,
-#               but has potential to lead to deadlocks over repeated manifest reads.
-#               It can still be a reasonable option for server environments where the manifest
-#               is known never to change at all.
-# See https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods
-# for more details on "spawn" and "fork" concurrency models.
-ENV AGENT_MANIFEST_CONCURRENCY_CONTEXT="thread"
 
 # Optional URL describing how the server is to be referenced by the outside world.
 # This is useful when a server is behind a load-balancer as part of a larger cluster.

--- a/neuro_san/deploy/Dockerfile
+++ b/neuro_san/deploy/Dockerfile
@@ -295,8 +295,12 @@ ENV AGENT_MANIFEST_UPDATE_PERIOD_SECONDS="0"
 #               but has potential to lead to deadlocks over repeated manifest reads.
 #               It can still be a reasonable option for server environments where the manifest
 #               is known never to change at all (AGENT_MANIFEST_UPDATE_PERIOD_SECONDS="0").
+# "forkserver"  Is just like "fork" above, but forks from a clean process for memory conservation,
+#               More process overhead, but as quick but safer than "fork".
+#
 # See https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods
-# for more details on "spawn" and "fork" concurrency models.
+# for more details on "spawn", "fork" and "forkserver" concurrency models.
+# Not all are available on all OSes.
 ENV AGENT_MANIFEST_CONCURRENCY_CONTEXT="thread"
 
 # By default, the HTTP service reports the neuro-san library pip version in its health-check response.

--- a/neuro_san/deploy/Dockerfile
+++ b/neuro_san/deploy/Dockerfile
@@ -291,12 +291,12 @@ ENV AGENT_MANIFEST_UPDATE_PERIOD_SECONDS="0"
 # "spawn":      uses a multi-process based concurrency model.  It is the safest option (avoiding deadlocks)
 #               for environments where the manifest is changing, but some speed is still desired
 #               (like development servers).
+# "forkserver"  Is just like "fork" below, but forks from a clean process for memory conservation,
+#               More process overhead, not as quick but safer than "fork".
 # "fork":       uses a multi-process based concurrency model. It is actually the fastest option,
 #               but has potential to lead to deadlocks over repeated manifest reads.
 #               It can still be a reasonable option for server environments where the manifest
 #               is known never to change at all (AGENT_MANIFEST_UPDATE_PERIOD_SECONDS="0").
-# "forkserver"  Is just like "fork" above, but forks from a clean process for memory conservation,
-#               More process overhead, but as quick but safer than "fork".
 #
 # See https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods
 # for more details on "spawn", "fork" and "forkserver" concurrency models.

--- a/neuro_san/deploy/Dockerfile
+++ b/neuro_san/deploy/Dockerfile
@@ -351,6 +351,22 @@ ENV AGENT_STREAM_KEEP_ALIVE_WITH_PROGRESS_INTERVAL_SECONDS=0
 # 0 disables this feature.
 ENV AGENT_TOOL_EXECUTION_LOG_THRESHOLD_SECONDS=0
 
+# Describes the concurrency model used for the manifest file updates.
+# Valid values are "thread" (the default) and "spawn" and "fork".
+#
+# "thread":     uses the default threading concurrency model.  It is best for servers who
+#               know their manifest content will be changing over the course of their lifetime.
+#               It is slowest of all options, but has the least amount of overall memory overhead
+#               and is lightweight and generally the safest and problem-free.
+# "spawn":      uses a multi-process based concurrency model.  It is the safest option (avoiding deadlocks)
+#               for environments where the manifest is changing, but some speed is still desired
+#               (like development servers).
+# "fork":       uses a multi-process based concurrency model. It is actually the fastest option,
+#               but has potential to lead to deadlocks over repeated manifest reads.
+#               It can still be a reasonable option for server environments where the manifest
+#               is known never to change at all.
+ENV AGENT_MANIFEST_CONCURRENCY_CONTEXT="thread"
+
 # Optional URL describing how the server is to be referenced by the outside world.
 # This is useful when a server is behind a load-balancer as part of a larger cluster.
 ENV AGENT_EXTERNAL_SERVER_URL=""

--- a/neuro_san/deploy/run.sh
+++ b/neuro_san/deploy/run.sh
@@ -56,11 +56,17 @@ function run() {
     SERVICE_HTTP_PORT=$(grep ^EXPOSE < "${DOCKERFILE}" | head -1 | awk '{ print $2 }')
     echo "SERVICE_HTTP_PORT: ${SERVICE_HTTP_PORT}"
 
+    # Note that we have to set the equivalent of the ulimit -n via the docker run
+    # command line.  We don't want the ceiling of fds to interfere with how many
+    # requests we can serve in the container.
+    FILE_DESCRIPTOR_MAX=100000
+
     # Run the docker container in interactive mode
     #   Mount the 1st command line arg as the place where input files come from
     #   Slurp in the rest as environment variables, all of which are optional.
 
     docker_cmd="docker run --rm -it \
+        --ulimit nofile=${FILE_DESCRIPTOR_MAX}:${FILE_DESCRIPTOR_MAX} \
         --name=$SERVICE_NAME \
         --network=$network \
         -e OPENAI_API_KEY \

--- a/neuro_san/internals/graph/persistence/registry_manifest_restorer.py
+++ b/neuro_san/internals/graph/persistence/registry_manifest_restorer.py
@@ -212,7 +212,7 @@ class RegistryManifestRestorer(Restorer):
             # This is still a reasonable option for server environments where the manifest
             # is known never to change at all.
             #
-            # "forkserver" is a bit like "fork" but with a bit more safety.
+            # "forkserver" is a little slower than "fork" but with a bit more safety.
             # See https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods
             # for more details.
             executor_factory = partial(ProcessPoolExecutor, max_workers=max_workers,

--- a/neuro_san/internals/graph/persistence/registry_manifest_restorer.py
+++ b/neuro_san/internals/graph/persistence/registry_manifest_restorer.py
@@ -159,7 +159,7 @@ class RegistryManifestRestorer(Restorer):
 
         # The default of "thread" is the least heavyweight, but not necessarily the fastest
         # given the context of how/how often the manifest is read.
-        concurrency_context: str = os.environ.get("AGENT_MANIFEST_CONCURRENCY_CONTEXT", "thread").lower()
+        concurrency_context: str = os.environ.get("AGENT_MANIFEST_CONCURRENCY_CONTEXT", "thread").strip().lower()
 
         executor_factory = None
         if concurrency_context in ("spawn", "fork"):

--- a/neuro_san/internals/graph/persistence/registry_manifest_restorer.py
+++ b/neuro_san/internals/graph/persistence/registry_manifest_restorer.py
@@ -199,7 +199,7 @@ class RegistryManifestRestorer(Restorer):
         executor_factory = None
         concurrency_context = concurrency_context.strip().lower()
 
-        if concurrency_context in ("spawn", "fork"):
+        if concurrency_context in ("spawn", "fork", "forkserver"):
             # Use a ProcessPoolExecutor for "spawn" and "fork".
             # In cases of large manifests, a ProcessPoolExecutor ends up being more heavyweight,
             # yet still more time-efficient because of the parallelism sidestepping the GIL.
@@ -211,6 +211,10 @@ class RegistryManifestRestorer(Restorer):
             # "fork" is actually the fastest option, but has potential to lead to deadlocks.
             # This is still a reasonable option for server environments where the manifest
             # is known never to change at all.
+            #
+            # "forkserver" is a bit like "fork" but with a bit more safety.
+            # See https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods
+            # for more details.
             executor_factory = partial(ProcessPoolExecutor, max_workers=max_workers,
                                        mp_context=get_context(concurrency_context))
         elif concurrency_context == "thread":

--- a/neuro_san/internals/graph/persistence/registry_manifest_restorer.py
+++ b/neuro_san/internals/graph/persistence/registry_manifest_restorer.py
@@ -176,10 +176,16 @@ class RegistryManifestRestorer(Restorer):
             # is known never to change at all.
             executor_factory = partial(ProcessPoolExecutor, max_workers=max_workers,
                                        mp_context=get_context(concurrency_context))
-        else:
+        elif concurrency_context == "thread":
+            # Use a ThreadPoolExecutor for "thread".
             # The default of "thread" is best for servers who know their manifest content will be
             # changing over the course of their lifetime. It is slowest of all options, but has
             # the least amount of overall memory overhead and is lightweight and safe and problem-free.
+            executor_factory = partial(ThreadPoolExecutor, max_workers=max_workers)
+        else:
+            # Default to ThreadPoolExecutor
+            self.logger.warning("Unknown concurrency context %s. Defaulting to ThreadPoolExecutor.",
+                                concurrency_context)
             executor_factory = partial(ThreadPoolExecutor, max_workers=max_workers)
 
         try:

--- a/neuro_san/internals/graph/persistence/registry_manifest_restorer.py
+++ b/neuro_san/internals/graph/persistence/registry_manifest_restorer.py
@@ -156,18 +156,31 @@ class RegistryManifestRestorer(Restorer):
         # Avoid spawning an unbounded number of workers.
         cpu_count: int = os.cpu_count() or 1
         max_workers: int = min(len(one_manifest), cpu_count)
-        executor_factory = partial(ThreadPoolExecutor, max_workers=max_workers)
 
-        # By default use a ThreadPoolExecutor, but because of the GIL, in cases of large manifests,
-        # a ProcessPoolExecutor ends up being more heavyweight, yet still more efficient because of
-        # the GIL.  When we get to free-threading in Python 3.14T, this can be changed back to ThreadPoolExecutor.
-        process_threshold: int = 20     # Somewhat arbitrary
-        if len(one_manifest) > process_threshold:
-            # While "spawn" below is more correct for more OSes and more Python versions,
-            # it is not necessarily the fastest. "fork" can be faster, but could lead to deadlocks.
-            # See https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods
+        # The default of "thread" is the least heavyweight, but not necessarily the fastest
+        # given the context of how/how often the manifest is read.
+        concurrency_context: str = os.environ.get("AGENT_MANIFEST_CONCURRENCY_CONTEXT", "thread").lower()
+
+        executor_factory = None
+        if concurrency_context == "spawn" or concurrency_context == "fork":
+            # Use a ProcessPoolExecutor for "spawn" and "fork".
+            # In cases of large manifests, a ProcessPoolExecutor ends up being more heavyweight,
+            # yet still more time-efficient because of the parallelism sidestepping the GIL.
+            # When we get to free-threading in Python 3.14T, this can be all be changed back to ThreadPoolExecutor.
+            #
+            # "spawn" is the safest option (avoiding deadlocks) for environments where the manifest is changing,
+            # but some speed is still desired (like development servers).
+            #
+            # "fork" is actually the fastest option, but has potential to lead to deadlocks.
+            # This is still a reasonable option for server environments where the manifest
+            # is known never to change at all.
             executor_factory = partial(ProcessPoolExecutor, max_workers=max_workers,
-                                       mp_context=get_context("spawn"))
+                                       mp_context=get_context(concurrency_context))
+        else:
+            # The default of "thread" is best for servers who know their manifest content will be
+            # changing over the course of their lifetime. It is slowest of all options, but has
+            # the least amount of overall memory overhead and is lightweight and safe and problem-free.
+            executor_factory = partial(ThreadPoolExecutor, max_workers=max_workers)
 
         try:
             with executor_factory() as executor:

--- a/neuro_san/internals/graph/persistence/registry_manifest_restorer.py
+++ b/neuro_san/internals/graph/persistence/registry_manifest_restorer.py
@@ -162,7 +162,7 @@ class RegistryManifestRestorer(Restorer):
         concurrency_context: str = os.environ.get("AGENT_MANIFEST_CONCURRENCY_CONTEXT", "thread").lower()
 
         executor_factory = None
-        if concurrency_context == "spawn" or concurrency_context == "fork":
+        if concurrency_context in ("spawn", "fork"):
             # Use a ProcessPoolExecutor for "spawn" and "fork".
             # In cases of large manifests, a ProcessPoolExecutor ends up being more heavyweight,
             # yet still more time-efficient because of the parallelism sidestepping the GIL.

--- a/neuro_san/internals/graph/persistence/registry_manifest_restorer.py
+++ b/neuro_san/internals/graph/persistence/registry_manifest_restorer.py
@@ -159,36 +159,10 @@ class RegistryManifestRestorer(Restorer):
 
         # The default of "thread" is the least heavyweight, but not necessarily the fastest
         # given the context of how/how often the manifest is read.
-        concurrency_context: str = os.environ.get("AGENT_MANIFEST_CONCURRENCY_CONTEXT", "thread").strip().lower()
-
-        executor_factory = None
-        if concurrency_context in ("spawn", "fork"):
-            # Use a ProcessPoolExecutor for "spawn" and "fork".
-            # In cases of large manifests, a ProcessPoolExecutor ends up being more heavyweight,
-            # yet still more time-efficient because of the parallelism sidestepping the GIL.
-            # When we get to free-threading in Python 3.14T, this can be all be changed back to ThreadPoolExecutor.
-            #
-            # "spawn" is the safest option (avoiding deadlocks) for environments where the manifest is changing,
-            # but some speed is still desired (like development servers).
-            #
-            # "fork" is actually the fastest option, but has potential to lead to deadlocks.
-            # This is still a reasonable option for server environments where the manifest
-            # is known never to change at all.
-            executor_factory = partial(ProcessPoolExecutor, max_workers=max_workers,
-                                       mp_context=get_context(concurrency_context))
-        elif concurrency_context == "thread":
-            # Use a ThreadPoolExecutor for "thread".
-            # The default of "thread" is best for servers who know their manifest content will be
-            # changing over the course of their lifetime. It is slowest of all options, but has
-            # the least amount of overall memory overhead and is lightweight and safe and problem-free.
-            executor_factory = partial(ThreadPoolExecutor, max_workers=max_workers)
-        else:
-            # Default to ThreadPoolExecutor
-            self.logger.warning("Unknown concurrency context '%s'. Defaulting to ThreadPoolExecutor.",
-                                concurrency_context)
-            executor_factory = partial(ThreadPoolExecutor, max_workers=max_workers)
+        concurrency_context: str = os.environ.get("AGENT_MANIFEST_CONCURRENCY_CONTEXT", "thread")
 
         try:
+            executor_factory = self.find_executory_factory(concurrency_context, max_workers)
             with executor_factory() as executor:
 
                 read_one: Any = partial(self.read_one_agent_network,
@@ -215,6 +189,43 @@ class RegistryManifestRestorer(Restorer):
             self.logger.warning("Manifest file %s restored in %.2f seconds.", manifest_file, duration)
 
         return agent_networks
+
+    def find_executory_factory(self, concurrency_context: str, max_workers: int) -> Any:
+        """
+        :param concurrency_context: The concurrency context to use.
+        :param max_workers: The maximum number of workers to use.
+        :return: The executor factory to use as a no-args constructor.
+        """
+        executor_factory = None
+        concurrency_context = concurrency_context.strip().lower()
+
+        if concurrency_context in ("spawn", "fork"):
+            # Use a ProcessPoolExecutor for "spawn" and "fork".
+            # In cases of large manifests, a ProcessPoolExecutor ends up being more heavyweight,
+            # yet still more time-efficient because of the parallelism sidestepping the GIL.
+            # When we get to free-threading in Python 3.14T, this can be all be changed back to ThreadPoolExecutor.
+            #
+            # "spawn" is the safest option (avoiding deadlocks) for environments where the manifest is changing,
+            # but some speed is still desired (like development servers).
+            #
+            # "fork" is actually the fastest option, but has potential to lead to deadlocks.
+            # This is still a reasonable option for server environments where the manifest
+            # is known never to change at all.
+            executor_factory = partial(ProcessPoolExecutor, max_workers=max_workers,
+                                       mp_context=get_context(concurrency_context))
+        elif concurrency_context == "thread":
+            # Use a ThreadPoolExecutor for "thread".
+            # The default of "thread" is best for servers who know their manifest content will be
+            # changing over the course of their lifetime. It is slowest of all options, but has
+            # the least amount of overall memory overhead and is lightweight and safe and problem-free.
+            executor_factory = partial(ThreadPoolExecutor, max_workers=max_workers)
+        else:
+            # Default to ThreadPoolExecutor
+            self.logger.warning("Unknown concurrency context '%s'. Defaulting to ThreadPoolExecutor.",
+                                concurrency_context)
+            executor_factory = partial(ThreadPoolExecutor, max_workers=max_workers)
+
+        return executor_factory
 
     # pylint: disable=too-many-arguments,too-many-positional-arguments
     @staticmethod

--- a/neuro_san/internals/graph/persistence/registry_manifest_restorer.py
+++ b/neuro_san/internals/graph/persistence/registry_manifest_restorer.py
@@ -184,7 +184,7 @@ class RegistryManifestRestorer(Restorer):
             executor_factory = partial(ThreadPoolExecutor, max_workers=max_workers)
         else:
             # Default to ThreadPoolExecutor
-            self.logger.warning("Unknown concurrency context %s. Defaulting to ThreadPoolExecutor.",
+            self.logger.warning("Unknown concurrency context '%s'. Defaulting to ThreadPoolExecutor.",
                                 concurrency_context)
             executor_factory = partial(ThreadPoolExecutor, max_workers=max_workers)
 


### PR DESCRIPTION
Left the previous PR on this subject thinking that some deployments expecting manifest reloads could have adverse memory consequences from the default of ProcessExecutorPool:"spawn".  So I decided to change how this is done with this PR to avoid backwards compatibility train-wrecks.

* Add a new AGENT_MANIFEST_CONCURRENCY_CONTEXT to have control over just how concurrent manifest reads are done.  The default is "thread", the safest, but also slowest, because GIL.
* Other possibilities are "spawn" and "thread".
* Add docs to Dockerfile
* Add ulimits hint to deploy/run.sh