### PR TITLE
Fix non-deterministic registry parse failures by serializing HOCON parsing

### DIFF
--- a/neuro_san/internals/persistence/abstract_async_config_restorer.py
+++ b/neuro_san/internals/persistence/abstract_async_config_restorer.py
@@ -15,8 +15,10 @@
 #
 # END COPYRIGHT
 from typing import Any
+from typing import ContextManager
 from typing import Dict
 
+from contextlib import nullcontext
 from io import BytesIO
 from json.decoder import JSONDecodeError
 from logging import getLogger
@@ -33,6 +35,8 @@ from leaf_common.persistence.interface.restorer import Restorer
 from leaf_common.serialization.format.hocon_serialization_format import HoconSerializationFormat
 from leaf_common.serialization.format.json_serialization_format import JsonSerializationFormat
 from leaf_common.serialization.interface.serialization_format import SerializationFormat
+
+from neuro_san.internals.persistence.hocon_parse_lock import HoconParseLock
 
 
 class AbstractAsyncConfigRestorer(Restorer, ConfigFilter):
@@ -155,10 +159,14 @@ class AbstractAsyncConfigRestorer(Restorer, ConfigFilter):
 
         # Determine the serialization format
         serialization: SerializationFormat = None
+        parse_lock: ContextManager = nullcontext()
         if file_path.endswith(".hocon"):
             # Worth noting that includes within hocon files can only be done synchronously
             # The core pyhocon library does not support async includes.
             serialization = HoconSerializationFormat()
+            # pyhocon parsing mutates process-global pyparsing state and is not
+            # thread-safe. See HoconParseLock.
+            parse_lock = HoconParseLock()
         elif file_path.endswith(".json"):
             serialization = JsonSerializationFormat()
         else:
@@ -166,7 +174,8 @@ class AbstractAsyncConfigRestorer(Restorer, ConfigFilter):
 
         # Read the contents
         try:
-            config = serialization.to_object(bytes_file)
+            with parse_lock:
+                config = serialization.to_object(bytes_file)
         except (ParseException, ParseSyntaxException, JSONDecodeError, ConfigException) as exception:
             # Re-raise as ValueError, not pyparsing.ParseException, for two reasons:
             #

--- a/neuro_san/internals/persistence/hocon_parse_lock.py
+++ b/neuro_san/internals/persistence/hocon_parse_lock.py
@@ -48,10 +48,23 @@ class HoconParseLock:
     already prevents real parse parallelism between threads.
     ProcessPoolExecutor-based reads are unaffected because each worker process
     has its own copy of the lock.
+
+    Known trade-off: pyhocon resolves "include" directives (file or URL reads)
+    inside the parse, so that I/O happens while the lock is held. Ordinary
+    local-file includes (include "registries/foo.hocon") are fine: their reads
+    are sub-millisecond and their nested parse happens inside pyhocon, below
+    this lock, so there is no reentrancy. The hazard is unbounded I/O: pyhocon
+    fetches "include url(...)" with no timeout, and a file include on a hung
+    network mount blocks the same way, stalling every other HOCON parse (and
+    every fork, per the hooks below) instead of just its own thread. Do not
+    use "include url(...)" in served registries.
     """
 
     # One lock for the whole process, shared by all instances,
     # because the pyparsing state it guards is process-global.
+    # Never rebind this attribute: the register_at_fork hooks below capture
+    # bound methods of this exact object and cannot be re-registered, so a
+    # replacement lock would serialize parses without fork protection.
     lock: ClassVar[Lock] = Lock()
 
     if hasattr(os, "register_at_fork"):
@@ -59,16 +72,22 @@ class HoconParseLock:
         # Without this, an os.fork() happening while some thread holds the lock
         # (e.g. AGENT_MANIFEST_CONCURRENCY_CONTEXT="fork" while a watcher thread
         # is mid-parse) would give the child a lock that can never be released,
-        # deadlocking the child's first HOCON parse. Holding the lock across the
-        # fork means children always start with it released - the same treatment
-        # the standard library logging module gives its module lock.
-        # Windows has no fork, hence the hasattr guard.
-        # The bare "lock" reference is required: the HoconParseLock name is not
-        # bound until the class body finishes executing.
+        # deadlocking the child's first HOCON parse. This mirrors what the
+        # standard library logging module does for its module lock: acquire
+        # before the fork, release in the parent, and _at_fork_reinit() in the
+        # child. The child must reinit rather than release: on CPython <= 3.12
+        # platforms without POSIX semaphores (e.g. macOS), a waiter blocked in
+        # acquire() can hold the lock's internal pthread mutex at the fork
+        # instant, and a child-side release() would hang on that inherited
+        # mutex whose owner is dead (see bpo-40089). Windows has no fork,
+        # hence the hasattr guard.
+        # The bare "lock" references are required: the HoconParseLock name is
+        # not bound until the class body finishes executing.
         os.register_at_fork(
             before=lock.acquire,
             after_in_parent=lock.release,
-            after_in_child=lock.release,
+            # pylint: disable=no-member,protected-access
+            after_in_child=lock._at_fork_reinit,
         )
 
     def __enter__(self) -> "HoconParseLock":

--- a/neuro_san/internals/persistence/hocon_parse_lock.py
+++ b/neuro_san/internals/persistence/hocon_parse_lock.py
@@ -1,0 +1,92 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+from typing import Any
+from typing import ClassVar
+
+import os
+
+from threading import Lock
+
+
+class HoconParseLock:
+    """
+    Context manager serializing all in-process pyhocon parsing.
+
+    pyhocon's ConfigParser.parse() rebuilds its pyparsing grammar on every call
+    while temporarily overriding the process-global
+    pyparsing.ParserElement.DEFAULT_WHITE_CHARS (see set_default_white_spaces()
+    in pyhocon's config_parser.py). pyparsing elements capture that global at
+    construction time, so two HOCON parses running concurrently in the same
+    process can poison each other's grammar mid-build. Symptoms are
+    non-deterministic parse failures on perfectly valid files: spurious
+    ParseExceptions ("Expected end of text, found '\\n'"), empty parse results
+    (surfacing as "Nothing to validate." validation errors), or
+    ConfigWrongTypeExceptions.
+    See https://github.com/cognizant-ai-lab/neuro-san/issues/1183 and
+    https://github.com/pyparsing/pyparsing/issues/89 for details.
+
+    Every code path that parses HOCON must do so under "with HoconParseLock():".
+    JSON/YAML parsing shares no such global state and should not funnel through
+    this lock.
+
+    Serializing HOCON parsing does not sacrifice the speedup of parallel
+    manifest reads: pyhocon parsing is pure-Python and CPU-bound, so the GIL
+    already prevents real parse parallelism between threads.
+    ProcessPoolExecutor-based reads are unaffected because each worker process
+    has its own copy of the lock.
+    """
+
+    # One lock for the whole process, shared by all instances,
+    # because the pyparsing state it guards is process-global.
+    lock: ClassVar[Lock] = Lock()
+
+    if hasattr(os, "register_at_fork"):
+        # Runs once, when the class body is executed at import time.
+        # Without this, an os.fork() happening while some thread holds the lock
+        # (e.g. AGENT_MANIFEST_CONCURRENCY_CONTEXT="fork" while a watcher thread
+        # is mid-parse) would give the child a lock that can never be released,
+        # deadlocking the child's first HOCON parse. Holding the lock across the
+        # fork means children always start with it released - the same treatment
+        # the standard library logging module gives its module lock.
+        # Windows has no fork, hence the hasattr guard.
+        # The bare "lock" reference is required: the HoconParseLock name is not
+        # bound until the class body finishes executing.
+        os.register_at_fork(
+            before=lock.acquire,
+            after_in_parent=lock.release,
+            after_in_child=lock.release,
+        )
+
+    def __enter__(self) -> "HoconParseLock":
+        """
+        Acquire the process-wide parse lock.
+        :return: this instance
+        """
+        self.lock.acquire()
+        return self
+
+    def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> bool:
+        """
+        Release the process-wide parse lock.
+
+        :param exc_type: The type of any exception raised inside the with-block
+        :param exc_value: The exception instance, if any
+        :param traceback: The traceback, if any
+        :return: False, so any exception from the with-block propagates
+        """
+        self.lock.release()
+        return False

--- a/neuro_san/service/http/logging/logging_config_restorer.py
+++ b/neuro_san/service/http/logging/logging_config_restorer.py
@@ -26,6 +26,7 @@ from leaf_common.persistence.easy.easy_json_persistence import EasyJsonPersisten
 from leaf_common.persistence.easy.easy_yaml_persistence import EasyYamlPersistence
 
 from neuro_san import DEPLOY_DIR
+from neuro_san.internals.persistence.hocon_parse_lock import HoconParseLock
 
 
 class LoggingConfigRestorer(Restorer):
@@ -60,7 +61,10 @@ class LoggingConfigRestorer(Restorer):
         logging_config: Dict[str, Any] = {}
         if use_file_reference is not None:
             if use_file_reference.endswith(".hocon"):
-                logging_config = EasyHoconPersistence().restore(file_reference=use_file_reference)
+                # pyhocon parsing mutates process-global pyparsing state and is not
+                # thread-safe. See HoconParseLock.
+                with HoconParseLock():
+                    logging_config = EasyHoconPersistence().restore(file_reference=use_file_reference)
             if use_file_reference.endswith(".json"):
                 logging_config = EasyJsonPersistence().restore(file_reference=use_file_reference)
             if use_file_reference.endswith(".yaml") or use_file_reference.endswith(".yml"):

--- a/neuro_san/service/http/logging/logging_config_restorer.py
+++ b/neuro_san/service/http/logging/logging_config_restorer.py
@@ -59,16 +59,18 @@ class LoggingConfigRestorer(Restorer):
             use_file_reference = self.default_file_reference
 
         logging_config: Dict[str, Any] = {}
-        if use_file_reference is not None:
-            if use_file_reference.endswith(".hocon"):
-                # pyhocon parsing mutates process-global pyparsing state and is not
-                # thread-safe. See HoconParseLock.
-                with HoconParseLock():
-                    logging_config = EasyHoconPersistence().restore(file_reference=use_file_reference)
-            if use_file_reference.endswith(".json"):
-                logging_config = EasyJsonPersistence().restore(file_reference=use_file_reference)
-            if use_file_reference.endswith(".yaml") or use_file_reference.endswith(".yml"):
-                logging_config = EasyYamlPersistence().restore(file_reference=use_file_reference)
+        if use_file_reference is None:
+            raise ValueError("No logging config file specified")
+
+        if use_file_reference.endswith(".hocon"):
+            # pyhocon parsing mutates process-global pyparsing state and is not
+            # thread-safe. See HoconParseLock.
+            with HoconParseLock():
+                logging_config = EasyHoconPersistence().restore(file_reference=use_file_reference)
+        elif use_file_reference.endswith(".json"):
+            logging_config = EasyJsonPersistence().restore(file_reference=use_file_reference)
+        elif use_file_reference.endswith(".yaml") or use_file_reference.endswith(".yml"):
+            logging_config = EasyYamlPersistence().restore(file_reference=use_file_reference)
         else:
             raise ValueError(f"Unsupported logging config file type: {use_file_reference}")
 

--- a/neuro_san/test/driver/data_driven_agent_test_driver.py
+++ b/neuro_san/test/driver/data_driven_agent_test_driver.py
@@ -39,6 +39,7 @@ from leaf_common.time.timeout import Timeout
 from neuro_san.client.agent_session_factory import AgentSessionFactory
 from neuro_san.client.streaming_input_processor import StreamingInputProcessor
 from neuro_san.interfaces.agent_session import AgentSession
+from neuro_san.internals.persistence.hocon_parse_lock import HoconParseLock
 from neuro_san.message_processing.basic_message_processor import BasicMessageProcessor
 from neuro_san.session.direct_agent_session import DirectAgentSession
 from neuro_san.test.driver.assert_capture import AssertCapture
@@ -254,7 +255,11 @@ Need at least {num_need_success} to consider {hocon_file} test to be successful.
         if self.fixtures is not None:
             test_path = self.fixtures.get_file_in_basis(hocon_file)
         hocon = EasyHoconPersistence(must_exist=True)
-        test_case: Dict[str, Any] = hocon.restore(file_reference=test_path)
+        # pyhocon parsing mutates process-global pyparsing state and is not
+        # thread-safe. See HoconParseLock. Sessions driven by this class can
+        # leave background threads parsing agent hocons concurrently.
+        with HoconParseLock():
+            test_case: Dict[str, Any] = hocon.restore(file_reference=test_path)
         return test_case
 
     # pylint: disable=too-many-locals,too-many-arguments,too-many-positional-arguments

--- a/tests/neuro_san/internals/persistence/conftest.py
+++ b/tests/neuro_san/internals/persistence/conftest.py
@@ -1,0 +1,44 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+"""
+Scoped conftest for the persistence tests.
+
+The file name "conftest.py" is mandatory: pytest discovers this file by
+that exact name and applies it automatically to tests in this directory
+and below. It is never imported explicitly, so renaming it would
+silently disable everything in it.
+
+The project-wide tests/conftest.py declares an autouse fixture
+`configure_llm_provider_keys` that skips any test missing an
+OPENAI_API_KEY (or other provider key, depending on markers). Tests in
+this directory exercise config restorers and the HOCON parse lock with
+local fixture files and do not call any LLM provider, so the
+project-wide skip condition does not apply. This conftest overrides
+that fixture with a no-op for tests in this subtree only.
+"""
+import pytest
+
+
+# pylint: disable=unused-argument
+@pytest.fixture(autouse=True)
+def configure_llm_provider_keys(request, monkeypatch):
+    """
+    Override of the project-wide configure_llm_provider_keys fixture.
+    Persistence tests never call an LLM and therefore should not be
+    skipped when no provider key is set.
+    """
+    return None

--- a/tests/neuro_san/internals/persistence/restorer_test_helpers.py
+++ b/tests/neuro_san/internals/persistence/restorer_test_helpers.py
@@ -1,0 +1,36 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+"""
+Helpers shared by the restorer test files in this directory.
+"""
+from typing import Any
+from typing import Dict
+
+from pathlib import Path
+
+from neuro_san.internals.persistence.abstract_async_config_restorer import AbstractAsyncConfigRestorer
+
+
+class ConcreteRestorer(AbstractAsyncConfigRestorer):
+    """Minimal concrete subclass – inherits all behaviour from the abstract base."""
+
+
+# The dictionary the valid.json and valid.hocon fixture files deserialize to.
+VALID_DICT: Dict[str, Any] = {"key": "value", "nested": {"a": 1}}
+
+# Directory containing .json and .hocon fixture files used by the tests.
+FIXTURES_DIR: Path = Path(__file__).parent.parent.parent.parent / "fixtures"

--- a/tests/neuro_san/internals/persistence/test_abstract_async_config_restorer.py
+++ b/tests/neuro_san/internals/persistence/test_abstract_async_config_restorer.py
@@ -27,29 +27,11 @@ from unittest.mock import patch
 
 import pytest
 
-from neuro_san.internals.persistence.abstract_async_config_restorer import AbstractAsyncConfigRestorer
+from tests.neuro_san.internals.persistence.restorer_test_helpers import ConcreteRestorer
+from tests.neuro_san.internals.persistence.restorer_test_helpers import FIXTURES_DIR
+from tests.neuro_san.internals.persistence.restorer_test_helpers import VALID_DICT
 
 T = TypeVar("T")
-
-# ---------------------------------------------------------------------------
-# Concrete subclass used by all tests.
-# AbstractAsyncConfigRestorer inherits from abstract base
-# classes. ConcreteRestorer makes the test intent explicit at no cost.
-# ---------------------------------------------------------------------------
-
-
-class ConcreteRestorer(AbstractAsyncConfigRestorer):
-    """Minimal concrete subclass – inherits all behaviour from the abstract base."""
-
-
-# ---------------------------------------------------------------------------
-# Constants
-# ---------------------------------------------------------------------------
-
-VALID_DICT: Dict[str, Any] = {"key": "value", "nested": {"a": 1}}
-
-# Directory containing .json and .hocon fixture files used by the tests.
-FIXTURES_DIR: Path = Path(__file__).parent.parent.parent.parent / "fixtures"
 
 
 # pylint: disable=too-many-public-methods

--- a/tests/neuro_san/internals/persistence/test_hocon_parse_lock.py
+++ b/tests/neuro_san/internals/persistence/test_hocon_parse_lock.py
@@ -1,0 +1,174 @@
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+import os
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from io import BytesIO
+from pathlib import Path
+from typing import Any
+from typing import Dict
+from typing import List
+from unittest.mock import patch
+
+import pytest
+
+from leaf_common.serialization.format.hocon_serialization_format import HoconSerializationFormat
+
+from neuro_san.internals.persistence.abstract_async_config_restorer import AbstractAsyncConfigRestorer
+from neuro_san.internals.persistence.hocon_parse_lock import HoconParseLock
+
+
+class ConcreteRestorer(AbstractAsyncConfigRestorer):
+    """Minimal concrete subclass – inherits all behaviour from the abstract base."""
+
+
+VALID_DICT: Dict[str, Any] = {"key": "value", "nested": {"a": 1}}
+
+# Directory containing .json and .hocon fixture files used by the tests.
+FIXTURES_DIR: Path = Path(__file__).parent.parent.parent.parent / "fixtures"
+
+
+class TrackingHoconSerializationFormat(HoconSerializationFormat):
+    """
+    HoconSerializationFormat that records how many to_object() calls are in
+    flight simultaneously. Class-level state so the tracking survives the
+    per-call instantiation done by deserialize_file_contents().
+    """
+
+    counter_lock = threading.Lock()
+    in_flight: int = 0
+    max_in_flight: int = 0
+
+    @classmethod
+    def reset(cls):
+        """Reset the concurrency counters."""
+        cls.in_flight = 0
+        cls.max_in_flight = 0
+
+    def to_object(self, fileobj: BytesIO) -> Dict[str, Any]:
+        cls = TrackingHoconSerializationFormat
+        with cls.counter_lock:
+            cls.in_flight += 1
+            cls.max_in_flight = max(cls.max_in_flight, cls.in_flight)
+        # Widen the window so that unserialized concurrent parses would overlap.
+        time.sleep(0.05)
+        try:
+            return super().to_object(fileobj)
+        finally:
+            with cls.counter_lock:
+                cls.in_flight -= 1
+
+
+class TestHoconParseLock:
+    """
+    Tests that all HOCON deserialization is serialized through HoconParseLock.
+
+    pyhocon rebuilds its pyparsing grammar per parse call while mutating
+    process-global pyparsing state, so concurrent parses corrupt each other
+    (issue #1183). These tests pin the mutual-exclusion behavior without
+    depending on winning the underlying (rare) race.
+    """
+
+    @staticmethod
+    def deserialize(filename: str) -> Dict[str, Any]:
+        """Run a fixture file through deserialize_file_contents."""
+        restorer = ConcreteRestorer(file_purpose="test config")
+        path: Path = FIXTURES_DIR / filename
+        return restorer.deserialize_file_contents(str(path), path.read_bytes())
+
+    def test_concurrent_hocon_parses_are_mutually_exclusive(self) -> None:
+        """No two HOCON parses may ever be in flight at the same time."""
+        TrackingHoconSerializationFormat.reset()
+        target: str = "neuro_san.internals.persistence.abstract_async_config_restorer.HoconSerializationFormat"
+        with patch(target, TrackingHoconSerializationFormat):
+            with ThreadPoolExecutor(max_workers=8) as executor:
+                results: List[Dict[str, Any]] = list(
+                    executor.map(lambda _: self.deserialize("valid.hocon"), range(16)))
+
+        assert TrackingHoconSerializationFormat.max_in_flight == 1
+        for result in results:
+            assert result == VALID_DICT
+
+    def test_hocon_deserialize_waits_for_lock(self) -> None:
+        """A HOCON parse blocks while another thread holds HoconParseLock."""
+        done = threading.Event()
+
+        with HoconParseLock():
+            thread = threading.Thread(
+                target=lambda: (self.deserialize("valid.hocon"), done.set()), daemon=True)
+            thread.start()
+            # The parse must not complete while the lock is held.
+            assert not done.wait(timeout=0.3)
+
+        # Once released, the parse completes promptly.
+        assert done.wait(timeout=5.0)
+        thread.join(timeout=5.0)
+
+    def test_json_deserialize_does_not_use_lock(self) -> None:
+        """JSON parsing shares no pyparsing state and must not funnel through the lock."""
+        done = threading.Event()
+
+        with HoconParseLock():
+            thread = threading.Thread(
+                target=lambda: (self.deserialize("valid.json"), done.set()), daemon=True)
+            thread.start()
+            # The JSON parse completes even though the HOCON lock is held.
+            assert done.wait(timeout=5.0)
+        thread.join(timeout=5.0)
+
+    @pytest.mark.skipif(not hasattr(os, "fork"), reason="os.fork not available on this platform")
+    def test_fork_while_lock_held_leaves_child_usable(self) -> None:
+        """
+        A fork racing an in-flight parse must not deadlock the child
+        (AGENT_MANIFEST_CONCURRENCY_CONTEXT="fork" forks workers while other
+        threads may be parsing). The register_at_fork hooks hold the lock
+        across the fork so the child starts with it released.
+        """
+        hold_seconds: float = 0.5
+
+        def hold_lock():
+            with HoconParseLock():
+                time.sleep(hold_seconds)
+
+        holder = threading.Thread(target=hold_lock, daemon=True)
+        holder.start()
+        # Make sure the holder actually has the lock before forking.
+        while not HoconParseLock.lock.locked():
+            time.sleep(0.001)
+
+        start: float = time.monotonic()
+        pid: int = os.fork()
+        if pid == 0:
+            # Child: never return control to pytest; report via exit code.
+            try:
+                if not HoconParseLock.lock.acquire(timeout=5.0):  # pylint: disable=consider-using-with
+                    os._exit(1)
+                HoconParseLock.lock.release()
+                config: Dict[str, Any] = self.deserialize("valid.hocon")
+                os._exit(0 if config == VALID_DICT else 2)
+            except BaseException:   # pylint: disable=broad-except
+                os._exit(3)
+
+        # Parent: the before-fork hook must have waited out the holder.
+        assert time.monotonic() - start >= hold_seconds * 0.5
+
+        _, status = os.waitpid(pid, 0)
+        assert os.WEXITSTATUS(status) == 0
+
+        holder.join(timeout=5.0)
+        assert not HoconParseLock.lock.locked()

--- a/tests/neuro_san/internals/persistence/test_hocon_parse_lock.py
+++ b/tests/neuro_san/internals/persistence/test_hocon_parse_lock.py
@@ -15,8 +15,10 @@
 # END COPYRIGHT
 
 import os
+import signal
 import threading
 import time
+import traceback
 from concurrent.futures import ThreadPoolExecutor
 from io import BytesIO
 from pathlib import Path
@@ -29,18 +31,10 @@ import pytest
 
 from leaf_common.serialization.format.hocon_serialization_format import HoconSerializationFormat
 
-from neuro_san.internals.persistence.abstract_async_config_restorer import AbstractAsyncConfigRestorer
 from neuro_san.internals.persistence.hocon_parse_lock import HoconParseLock
-
-
-class ConcreteRestorer(AbstractAsyncConfigRestorer):
-    """Minimal concrete subclass – inherits all behaviour from the abstract base."""
-
-
-VALID_DICT: Dict[str, Any] = {"key": "value", "nested": {"a": 1}}
-
-# Directory containing .json and .hocon fixture files used by the tests.
-FIXTURES_DIR: Path = Path(__file__).parent.parent.parent.parent / "fixtures"
+from tests.neuro_san.internals.persistence.restorer_test_helpers import ConcreteRestorer
+from tests.neuro_san.internals.persistence.restorer_test_helpers import FIXTURES_DIR
+from tests.neuro_san.internals.persistence.restorer_test_helpers import VALID_DICT
 
 
 class TrackingHoconSerializationFormat(HoconSerializationFormat):
@@ -91,6 +85,30 @@ class TestHoconParseLock:
         path: Path = FIXTURES_DIR / filename
         return restorer.deserialize_file_contents(str(path), path.read_bytes())
 
+    @staticmethod
+    def reap_child(pid: int, timeout: float = 30.0) -> int:
+        """
+        Wait for a forked child with a deadline so a hung child cannot
+        stall the whole pytest run, killing it if the deadline passes.
+
+        :param pid: The child process id to wait for
+        :param timeout: Seconds to wait before SIGKILLing the child
+        :return: the raw waitpid status of the child
+        """
+        deadline: float = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            reaped, status = os.waitpid(pid, os.WNOHANG)
+            if reaped == pid:
+                return status
+            time.sleep(0.01)
+
+        # Child overran the deadline: kill and reap so nothing leaks.
+        # waitstatus_to_exitcode() will report -SIGKILL, failing the caller's
+        # assertion with a recognizable value instead of hanging the run.
+        os.kill(pid, signal.SIGKILL)
+        _, status = os.waitpid(pid, 0)
+        return status
+
     def test_concurrent_hocon_parses_are_mutually_exclusive(self) -> None:
         """No two HOCON parses may ever be in flight at the same time."""
         TrackingHoconSerializationFormat.reset()
@@ -106,18 +124,27 @@ class TestHoconParseLock:
 
     def test_hocon_deserialize_waits_for_lock(self) -> None:
         """A HOCON parse blocks while another thread holds HoconParseLock."""
+        started = threading.Event()
         done = threading.Event()
 
+        def parse_then_flag():
+            started.set()
+            self.deserialize("valid.hocon")
+            done.set()
+
         with HoconParseLock():
-            thread = threading.Thread(
-                target=lambda: (self.deserialize("valid.hocon"), done.set()), daemon=True)
+            thread = threading.Thread(target=parse_then_flag, daemon=True)
             thread.start()
+            # Confirm the worker is actually running before the negative wait,
+            # so a slow-to-schedule thread cannot false-pass the assertion below.
+            assert started.wait(timeout=5.0)
             # The parse must not complete while the lock is held.
             assert not done.wait(timeout=0.3)
 
         # Once released, the parse completes promptly.
         assert done.wait(timeout=5.0)
         thread.join(timeout=5.0)
+        assert not thread.is_alive()
 
     def test_json_deserialize_does_not_use_lock(self) -> None:
         """JSON parsing shares no pyparsing state and must not funnel through the lock."""
@@ -130,6 +157,7 @@ class TestHoconParseLock:
             # The JSON parse completes even though the HOCON lock is held.
             assert done.wait(timeout=5.0)
         thread.join(timeout=5.0)
+        assert not thread.is_alive()
 
     @pytest.mark.skipif(not hasattr(os, "fork"), reason="os.fork not available on this platform")
     def test_fork_while_lock_held_leaves_child_usable(self) -> None:
@@ -140,10 +168,14 @@ class TestHoconParseLock:
         across the fork so the child starts with it released.
         """
         hold_seconds: float = 0.5
+        released = threading.Event()
 
         def hold_lock():
             with HoconParseLock():
                 time.sleep(hold_seconds)
+                # Set strictly before the lock release that lets the
+                # before-fork hook's acquire (and hence the fork) proceed.
+                released.set()
 
         holder = threading.Thread(target=hold_lock, daemon=True)
         holder.start()
@@ -151,24 +183,36 @@ class TestHoconParseLock:
         while not HoconParseLock.lock.locked():
             time.sleep(0.001)
 
-        start: float = time.monotonic()
         pid: int = os.fork()
         if pid == 0:
             # Child: never return control to pytest; report via exit code.
             try:
-                if not HoconParseLock.lock.acquire(timeout=5.0):  # pylint: disable=consider-using-with
+                # pylint: disable=consider-using-with
+                if not HoconParseLock.lock.acquire(timeout=5.0):
                     os._exit(1)
                 HoconParseLock.lock.release()
                 config: Dict[str, Any] = self.deserialize("valid.hocon")
                 os._exit(0 if config == VALID_DICT else 2)
             except BaseException:   # pylint: disable=broad-except
+                # Surface the real error on inherited stderr before exiting,
+                # so CI failures are not just an opaque exit code.
+                traceback.print_exc()
                 os._exit(3)
 
-        # Parent: the before-fork hook must have waited out the holder.
-        assert time.monotonic() - start >= hold_seconds * 0.5
+        # Parent: capture hook-ordering evidence at the instant fork returned,
+        # then always reap (deadline-bounded) before asserting anything.
+        released_at_fork: bool = released.is_set()
+        status: int = self.reap_child(pid)
 
-        _, status = os.waitpid(pid, 0)
-        assert os.WEXITSTATUS(status) == 0
+        # The before-fork hook must have waited out the holder: released is
+        # set inside the holder's with-block, so it is visible by the time
+        # the hook's acquire() let the fork proceed. No wall-clock arithmetic.
+        assert released_at_fork
+        # waitstatus_to_exitcode() distinguishes signal deaths (negative
+        # values) from clean exits, unlike bare WEXITSTATUS which reads 0
+        # for a child killed by SIGABRT/SIGSEGV/SIGKILL.
+        assert os.waitstatus_to_exitcode(status) == 0
 
         holder.join(timeout=5.0)
+        assert not holder.is_alive()
         assert not HoconParseLock.lock.locked()

--- a/tests/neuro_san/internals/persistence/test_hocon_parse_lock.py
+++ b/tests/neuro_san/internals/persistence/test_hocon_parse_lock.py
@@ -54,7 +54,9 @@ class TrackingHoconSerializationFormat(HoconSerializationFormat):
         cls.in_flight = 0
         cls.max_in_flight = 0
 
-    def to_object(self, fileobj: BytesIO) -> Dict[str, Any]:
+    def to_object(self, fileobj: BytesIO, *args: Any, **kwargs: Any) -> Dict[str, Any]:
+        # Variadics forward any extra parameters so this override tracks the
+        # base class signature across leaf-common versions.
         cls = TrackingHoconSerializationFormat
         with cls.counter_lock:
             cls.in_flight += 1
@@ -62,7 +64,7 @@ class TrackingHoconSerializationFormat(HoconSerializationFormat):
         # Widen the window so that unserialized concurrent parses would overlap.
         time.sleep(0.05)
         try:
-            return super().to_object(fileobj)
+            return super().to_object(fileobj, *args, **kwargs)
         finally:
             with cls.counter_lock:
                 cls.in_flight -= 1
@@ -179,8 +181,12 @@ class TestHoconParseLock:
 
         holder = threading.Thread(target=hold_lock, daemon=True)
         holder.start()
-        # Make sure the holder actually has the lock before forking.
+        # Make sure the holder actually has the lock before forking, with a
+        # deadline so a regression cannot hang the whole pytest run here.
+        acquire_deadline: float = time.monotonic() + 5.0
         while not HoconParseLock.lock.locked():
+            if time.monotonic() > acquire_deadline:
+                pytest.fail("Holder thread never acquired HoconParseLock")
             time.sleep(0.001)
 
         pid: int = os.fork()


### PR DESCRIPTION
## Problem

Since #1177 parallelized manifest reads, registry loading intermittently fails on perfectly valid files:

```
Parse error in registry item music_nerd_pro_sly.hocon. Skipping. - Expected end of text, found '\n'  (at char 5295), (line:118, col:2)
manifest registry gist.hocon has validation errors. Skipping. Errors: [ "Nothing to validate." ]
```

Root cause: pyhocon's `ConfigParser.parse()` rebuilds its pyparsing grammar on every call while temporarily overriding the **process-global** `ParserElement.DEFAULT_WHITE_CHARS`. pyparsing elements capture that global at construction time, so when one thread restores the default while another thread is mid-grammar-build, the second thread's grammar is partially poisoned (newlines become skippable whitespace). Reproduced deterministically by flipping the global at controlled construction indices — the exact reported error (char 5295, line 118, col 2) matches character-for-character. See #1183 for the full analysis and pyparsing/pyparsing#89 for upstream acknowledgment that this state is not thread-safe.

## Fix

* **`HoconParseLock`** (new): a context manager over a single process-wide `threading.Lock` that all in-process HOCON parsing must hold. JSON parsing shares no pyparsing state and does not funnel through it. No throughput is lost: pyhocon parsing is pure-Python and CPU-bound, so the GIL already prevented real parse parallelism between threads, and `ProcessPoolExecutor` workers each have their own copy of the lock.
* **Fork safety**: `os.register_at_fork` hooks acquire the lock before any fork, release it in the parent, and `_at_fork_reinit()` it in the child — the same treatment stdlib `logging` gives its module lock. Reinit (not release) matters: on CPython ≤ 3.12 platforms without POSIX semaphores (e.g. macOS), a waiter blocked in `acquire()` can hold the lock's internal pthread mutex at the fork instant, and a child-side `release()` would hang on that inherited mutex (bpo-40089).
* **Lock taken at all three in-repo parse sites**: `AbstractAsyncConfigRestorer.deserialize_file_contents` (covers registries, manifests, llm/toolbox/MCP configs), `LoggingConfigRestorer`, and `DataDrivenAgentTestDriver.parse_hocon_test_case`.
* **Drive-by fix** in `LoggingConfigRestorer`: the "Unsupported logging config file type" `ValueError` was attached to an unreachable branch, so unsupported extensions silently returned `{}`; it now raises at the source.
* **Regression tests**: mutual exclusion (16 parses / 8 threads, max-in-flight must be 1), lock blocking with a started-handshake, JSON bypass, and fork-during-parse child usability (deadline-bounded reaping, `waitstatus_to_exitcode`, deterministic Event-based ordering assertion). A scoped `conftest.py` exempts these LLM-free unit tests from the project-wide `OPENAI_API_KEY` skip so they actually run on secret-less CI.

## Verification

* Threaded soak: 30 consecutive full-manifest restores with a concurrent HOCON-parsing churn thread — 33/33 networks every round, zero parse errors (previously intermittent failures).
* All three `AGENT_MANIFEST_CONCURRENCY_CONTEXT` modes (`thread`, `spawn`, `fork`) restore identical results under churn; fork mode stressed 10/10 runs.
* Child-deadlock scenario for the fork hooks reproduced on Python 3.12/macOS with `release()` and verified fixed with `_at_fork_reinit()`.
* flake8 clean, pylint 10.00/10, full persistence/graph/service suites pass (123 tests).

## Known trade-offs (deliberate, documented in the class docstring)

* pyhocon resolves `include` directives inside the parse, so include I/O happens under the lock. Local file includes are unaffected (sub-millisecond); `include url(...)` is fetched by pyhocon with **no timeout** and must not be used in served registries.
* The lock is applied per call site rather than at a structural chokepoint — see the follow-up plan below.

## Next step: move the fix upstream to leaf-common

Tracked in **cognizant-ai-lab/leaf-common#168**.

The structural home for this lock is leaf-common: `HoconSerializationFormat.to_object` contains the only `ConfigFactory.parse_string` call in the entire library, and every HOCON path (including `EasyHoconPersistence`) funnels through it. Acquiring the lock there makes the invariant unbypassable for every consumer, instead of the per-call-site convention this PR uses (which the review behind this PR already caught being violated once in-repo).

This PR still locks per call site so the registry flakiness is fixed now, without waiting on a leaf-common release. Once leaf-common#168 ships (lock inside `to_object` + the `register_at_fork`/`_at_fork_reinit` fork hooks + ported tests), a follow-up PR here bumps the leaf-common minimum, deletes `hocon_parse_lock.py`, and removes the three `with HoconParseLock():` blocks — as a coordinated swap, since a leaf-common lock plus these call-site locks on the same non-reentrant `Lock` pattern would double-acquire. Full migration plan and design details are in the issue.

## Downstream impact (neuro-san-studio designer tools)

The Agent Network Designer's `get_subnetwork` and `get_toolbox` coded tools parse HOCON exclusively through `RegistryManifestRestorer`/`RawManifestRestorer` and `ToolboxInfoRestorer` — all subclasses of `AbstractAsyncConfigRestorer`, so both are covered by the lock taken there.

* **Correctness**: those tools were exposed to this race. Their process-wide caches (neuro-san-studio#1282) make parsing rare but don't close the window — the cache's once-gate is per event loop, so two sessions on different threads can still trigger the same cold-load parse concurrently, and `get_subnetwork` parses many registry files in one load. Before this PR one of those parses could sporadically fail on a valid file (the cache's publish-only-on-success contract keeps the bad result out of the cache, but that call degrades). This PR removes that failure mode.
* **Performance**: no regression. The warm path (the common case with the caches) never parses and never touches the lock; cold-start parses were already effectively serial under the GIL.

The two changes are complementary: the caches make parsing rare, this lock makes the rare parse safe.

Fixes #1183
