### PR TITLE
Fix request-level token accounting double-counting; report main-network and request totals separately

### DIFF
--- a/neuro_san/internals/interfaces/invocation_context.py
+++ b/neuro_san/internals/interfaces/invocation_context.py
@@ -119,6 +119,19 @@ class InvocationContext(LingeringResource):
         """
         raise NotImplementedError
 
+    def is_cloned(self) -> bool:
+        """
+        :return: True if this instance is a clone of a request's original
+                InvocationContext, created to invoke an external agent network
+                on the same server via a direct session.
+                False for the original InvocationContext of a request.
+
+        Note: Not raising NotImplementedError here on purpose.
+        Never being cloned is a reasonable default for implementations
+        that do not deal in same-server external agents.
+        """
+        return False
+
     def get_llm_factory(self) -> ContextTypeLlmFactory:
         """
         :return: The ContextTypeLlmFactory instance for the session

--- a/neuro_san/internals/interfaces/invocation_context.py
+++ b/neuro_san/internals/interfaces/invocation_context.py
@@ -125,12 +125,8 @@ class InvocationContext(LingeringResource):
                 InvocationContext, created to invoke an external agent network
                 on the same server via a direct session.
                 False for the original InvocationContext of a request.
-
-        Note: Not raising NotImplementedError here on purpose.
-        Never being cloned is a reasonable default for implementations
-        that do not deal in same-server external agents.
         """
-        return False
+        raise NotImplementedError
 
     def get_llm_factory(self) -> ContextTypeLlmFactory:
         """

--- a/neuro_san/internals/run_context/langchain/token_counting/get_llm_token_callback.py
+++ b/neuro_san/internals/run_context/langchain/token_counting/get_llm_token_callback.py
@@ -22,10 +22,9 @@ from typing import Dict
 
 from neuro_san.internals.run_context.langchain.token_counting.llm_token_callback_handler \
     import LlmTokenCallbackHandler
-# Re-exported for backwards compatibility: the ContextVar (and its langchain
-# configure-hook registration) lives with the handler class so the handler can
-# consult it to attribute events to their owning agent.
-# pylint: disable=unused-import
+# The ContextVar (and its langchain configure-hook registration) lives with the
+# handler class so the handler can consult it to attribute events to their
+# owning agent.
 from neuro_san.internals.run_context.langchain.token_counting.llm_token_callback_handler \
     import llm_token_callback_var
 

--- a/neuro_san/internals/run_context/langchain/token_counting/get_llm_token_callback.py
+++ b/neuro_san/internals/run_context/langchain/token_counting/get_llm_token_callback.py
@@ -17,6 +17,7 @@
 
 from collections.abc import Generator
 from contextlib import contextmanager
+from contextvars import Token
 from typing import Any
 from typing import Dict
 
@@ -48,11 +49,18 @@ def get_llm_token_callback(llm_infos: Dict[str, Any]) -> Generator[LlmTokenCallb
     # Create a new callback handler instance for tracking token usage
     cb = LlmTokenCallbackHandler(llm_infos)
 
-    # Set the context variable to the newly created callback handler
-    llm_token_callback_var.set(cb)
+    # Set the context variable to the newly created callback handler,
+    # keeping the token so the previous value can be restored on exit.
+    token: Token = llm_token_callback_var.set(cb)
 
-    # Yield the callback handler to the context block
-    yield cb
-
-    # Reset the context variable to None when the context exits
-    llm_token_callback_var.set(None)
+    try:
+        # Yield the callback handler to the context block
+        yield cb
+    finally:
+        # Restore the context variable to the value it had on entry - even if
+        # the block raised.  In practice each agent scope runs its work in its
+        # own copied Context (see LangChainTokenCounter.count_tokens()), so no
+        # other scope ever observes this mutation, but restoring (rather than
+        # clobbering to None) keeps this context manager correct on its own,
+        # independent of how callers arrange their contexts.
+        llm_token_callback_var.reset(token)

--- a/neuro_san/internals/run_context/langchain/token_counting/get_llm_token_callback.py
+++ b/neuro_san/internals/run_context/langchain/token_counting/get_llm_token_callback.py
@@ -17,21 +17,17 @@
 
 from collections.abc import Generator
 from contextlib import contextmanager
-from contextvars import ContextVar
 from typing import Any
 from typing import Dict
-from typing import Optional
-
-from langchain_core.tracers.context import register_configure_hook
 
 from neuro_san.internals.run_context.langchain.token_counting.llm_token_callback_handler \
     import LlmTokenCallbackHandler
-
-
-llm_token_callback_var: ContextVar[Optional[LlmTokenCallbackHandler]] = (
-        ContextVar("llm_token_callback", default=None)
-    )
-register_configure_hook(llm_token_callback_var, inheritable=True)
+# Re-exported for backwards compatibility: the ContextVar (and its langchain
+# configure-hook registration) lives with the handler class so the handler can
+# consult it to attribute events to their owning agent.
+# pylint: disable=unused-import
+from neuro_san.internals.run_context.langchain.token_counting.llm_token_callback_handler \
+    import llm_token_callback_var
 
 
 @contextmanager

--- a/neuro_san/internals/run_context/langchain/token_counting/langchain_token_counter.py
+++ b/neuro_san/internals/run_context/langchain/token_counting/langchain_token_counter.py
@@ -41,13 +41,41 @@ from neuro_san.internals.journals.journal import Journal
 from neuro_san.internals.messages.agent_message import AgentMessage
 from neuro_san.internals.messages.origination import Origination
 from neuro_san.internals.run_context.langchain.token_counting.get_llm_token_callback import get_llm_token_callback
-from neuro_san.internals.run_context.langchain.token_counting.get_llm_token_callback import llm_token_callback_var
+from neuro_san.internals.run_context.langchain.token_counting.llm_token_callback_handler import llm_token_callback_var
 
 # Keep a ContextVar for the origin info.  We do this because the
 # langchain callbacks this stuff is based on also uses ContextVars
 # and we want to be sure these are in sync.
 # See: https://docs.python.org/3/library/contextvars.html
 ORIGIN_INFO: ContextVar[str] = ContextVar('origin_info', default=None)
+
+# Baseline for aggregated token stats.  Aggregations start from these zeros so
+# request-level accounting always carries the standard keys even when no LLM
+# usage was recorded - clients key off "total_tokens" being present
+# (see TokenAccountingMessageFilter).
+ZERO_TOKEN_STATS: Dict[str, Any] = {
+    "total_tokens": 0,
+    "prompt_tokens": 0,
+    "completion_tokens": 0,
+    "successful_requests": 0,
+    "empty_responses": 0,
+    "total_cost": 0.0,
+}
+
+# Caveats shared by every token accounting message.
+COMMON_CAVEATS: List[str] = [
+    "Token counts are approximate and estimated using tiktoken.",
+    "time_taken_in_seconds includes overhead from Langchain and Neuro SAN"
+]
+
+# Coverage statements for the two request-level accountings.
+MAIN_NETWORK_CAVEAT: str = \
+    "Token usage from agents of the main agent network only. " \
+    "Usage from external agents is not included."
+TOTAL_CAVEAT: str = \
+    "Request total: includes token usage from external agents invoked via direct " \
+    "sessions on this server. Usage from external agents reached over the network " \
+    "is not included."
 
 
 class LangChainTokenCounter:
@@ -129,6 +157,12 @@ class LangChainTokenCounter:
         #   with each call counted exactly once, no matter how deeply agents nest.
         # * External agents on *remote* servers handle their own requests in a separate
         #   context and are not seen by this handler at all.
+        # Note on cancellation: if this task is cancelled outright (e.g. client
+        # disconnect), CancelledError propagates and report() below never runs -
+        # by design, since journaling from a cancelled task would fail anyway.
+        # The timeout path does report.  Descendant scopes cancelled mid-run are
+        # accounted for by the "unattributed tokens" caveat the front man adds
+        # in report().
         timed_out: bool = False
         with get_llm_token_callback(llm_infos) as callback:
             # Create a new context for different ContextVar values
@@ -216,53 +250,68 @@ class LangChainTokenCounter:
         total_accounting: Dict[str, Any] = request_reporting.get("total_token_accounting", {})
         models_token_dict: Dict[str, Any] = \
             self.merge_dicts(total_accounting.get("models", {}), callback.models_token_dict)
-        network_token_dict: Dict[str, Any] = self.sum_all_tokens(models_token_dict, time_taken_in_seconds)
+
+        # The request latency is owned by the main network's front man - always the
+        # last main-network agent to finish.  A cloned (external) agent completing
+        # late (e.g. "event" invocations that outlive the request) must not re-stamp
+        # it with its own duration.
+        total_time: float = time_taken_in_seconds
+        if self.invocation_context.is_cloned():
+            total_time = total_accounting.get("time_taken_in_seconds", time_taken_in_seconds)
+
+        network_token_dict: Dict[str, Any] = self.sum_all_tokens(models_token_dict, total_time)
         # Provide sligtly different "caveats" for the network token accounting.
-        network_token_dict["caveats"] = [
-            "Request total: includes token usage from same-server external agents. "
-            "Usage from external agents on remote servers is not included.",
-            "Token counts are approximate and estimated using tiktoken.",
-            "time_taken_in_seconds includes overhead from Langchain and Neuro SAN"
-        ]
+        network_token_dict["caveats"] = [TOTAL_CAVEAT] + COMMON_CAVEATS
 
         # Maintain the accounting covering only the main (top-level) agent network.
         # Agents of external networks invoked via direct sessions run on cloned
         # InvocationContexts, so they contribute to the totals but not to this one.
         main_accounting: Dict[str, Any] = request_reporting.get("token_accounting", {})
         if not self.invocation_context.is_cloned():
-            # This agent's own contribution, summed across its per-model stats.
+            # Add this agent's own contribution (summed across its per-model stats)
+            # to the scalars accumulated so far.  The merge also sums the previous
+            # time_taken_in_seconds, but that is not a summable metric, so it is
+            # simply re-stamped below with the latest reporter's - which for the
+            # last one out, the front man, is the whole request's latency.
             contribution: Dict[str, Any] = self.sum_all_tokens(callback.models_token_dict,
                                                                time_taken_in_seconds)
-            # Add it to the scalars accumulated so far.  Caveats and time are not
-            # summable: the time stamped below is the latest reporter's, which for
-            # the last one out - the front man - is the whole request's latency.
-            previous: Dict[str, Any] = {key: value for key, value in main_accounting.items()
-                                        if key not in ("caveats", "time_taken_in_seconds")}
-            del contribution["time_taken_in_seconds"]
-            main_accounting = self.merge_dicts(previous, contribution)
+            main_accounting = self.merge_dicts(main_accounting, contribution)
             main_accounting["time_taken_in_seconds"] = time_taken_in_seconds
-            main_accounting["caveats"] = [
-                "Token usage from agents of the main agent network only. "
-                "Usage from external agents is not included.",
-                "Token counts are approximate and estimated using tiktoken.",
-                "time_taken_in_seconds includes overhead from Langchain and Neuro SAN"
-            ]
+            main_accounting["caveats"] = [MAIN_NETWORK_CAVEAT] + COMMON_CAVEATS
+        elif not main_accounting:
+            # An external agent completed before any main-network agent reported.
+            # Publish an explicit zero entry rather than an empty dictionary.
+            main_accounting = self.sum_all_tokens({}, 0.0)
+            main_accounting["caveats"] = [MAIN_NETWORK_CAVEAT] + COMMON_CAVEATS
 
-        # Re-insert both entries to pin their order (main first, total last)
-        # no matter which agent happened to report first.
-        request_reporting.pop("token_accounting", None)
-        request_reporting.pop("total_token_accounting", None)
+        # Assignment preserves key insertion order (main first, total last, as the
+        # first reporter established) so the server log always prints them that way.
         request_reporting["token_accounting"] = main_accounting
         request_reporting["total_token_accounting"] = \
             {**network_token_dict, "models": models_token_dict}
 
+        # Figure out whether we are the front man of the main network:
+        # * Only front men sit at the root of the origin path (single-element origin).
+        # * Front men of same-server external networks invoked via direct sessions
+        #   also have single-element origins, but they run on a cloned InvocationContext.
+        is_main_front_man: bool = \
+            self.origin is not None and len(self.origin) == 1 and \
+            not self.invocation_context.is_cloned()
+
+        if is_main_front_man:
+            # This front man's scalar totals cover everything its handler heard
+            # (its whole subtree).  Anything above what completed scopes merged
+            # into the total (e.g. LLM calls of agents cancelled mid-run) is
+            # unattributed - say so rather than silently under-reporting.
+            total_token_dict: Dict[str, Any] = request_reporting["total_token_accounting"]
+            unattributed_tokens: int = callback.total_tokens - total_token_dict["total_tokens"]
+            if unattributed_tokens > 0:
+                total_token_dict["caveats"] = total_token_dict["caveats"] + [
+                    f"An additional {unattributed_tokens} tokens were used by agents "
+                    "that did not complete and are not included."
+                ]
+
         if self.journal is not None:
-            # Figure out whether we are the front man of the main network:
-            # * Only front men have origins with no "." in them.
-            # * Front men of same-server external networks invoked via direct sessions
-            #   also have dot-less origins, but they run on a cloned InvocationContext.
-            is_main_front_man: bool = \
-                "." not in ORIGIN_INFO.get() and not self.invocation_context.is_cloned()
             if is_main_front_man:
                 # The front man of the main network reports the two request-level
                 # accountings as two complementary messages - main network first,
@@ -306,10 +355,8 @@ class LangChainTokenCounter:
             "time_taken_in_seconds": time_taken_in_seconds,
             "caveats": [
                 "Token usage is tracked at the agent level. "
-                "Counts include usage from any downstream agents called on this agent's behalf.",
-                "Token counts are approximate and estimated using tiktoken.",
-                "time_taken_in_seconds includes overhead from Langchain and Neuro SAN"
-            ]
+                "Counts include usage from any downstream agents called on this agent's behalf."
+            ] + COMMON_CAVEATS
         }
 
         return agent_token_dict
@@ -320,9 +367,11 @@ class LangChainTokenCounter:
         Sum all token metrics across providers and models, **excluding time**.
         :param token_dict: Models token dict to aggregate into network stats
         :param time_value: Time taken for frontman to finish
-        :return: Token stats of the entire network, either cumulative or single iteration
+        :return: Token stats of the entire network, either cumulative or single iteration.
+                Always contains the standard metric keys (zeros when there is
+                nothing to aggregate) so downstream consumers can rely on them.
         """
-        aggregated: Dict[str, Any] = {}
+        aggregated: Dict[str, Any] = dict(ZERO_TOKEN_STATS)
         for models in token_dict.values():
             for model_stats in models.values():
                 for metric, value in model_stats.items():

--- a/neuro_san/internals/run_context/langchain/token_counting/langchain_token_counter.py
+++ b/neuro_san/internals/run_context/langchain/token_counting/langchain_token_counter.py
@@ -260,7 +260,7 @@ class LangChainTokenCounter:
             total_time = total_accounting.get("time_taken_in_seconds", time_taken_in_seconds)
 
         network_token_dict: Dict[str, Any] = self.sum_all_tokens(models_token_dict, total_time)
-        # Provide sligtly different "caveats" for the network token accounting.
+        # Provide slightly different "caveats" for the network token accounting.
         network_token_dict["caveats"] = [TOTAL_CAVEAT] + COMMON_CAVEATS
 
         # Maintain the accounting covering only the main (top-level) agent network.

--- a/neuro_san/internals/run_context/langchain/token_counting/langchain_token_counter.py
+++ b/neuro_san/internals/run_context/langchain/token_counting/langchain_token_counter.py
@@ -114,17 +114,21 @@ class LangChainTokenCounter:
         # Use the context manager to count tokens as per
         #   https://python.langchain.com/docs/how_to/llm_token_usage_tracking/#using-callbacks
         #
-        # Caveats:
-        # * In using this context manager approach, any tool that is called
-        #   also has its token counts contributing to its callers for better or worse.
-        # * As of 2/21/25, it seems that tool-calling agents (branch nodes) are not
-        #   registering their tokens correctly. Not sure if this is a bug in langchain
-        #   or there is something we are not doing in that scenario that we should be.
-        # * As of 8/21/25, placing the journaling callback in the invoke config instead of llm
-        #   appears to change the context manager’s behavior. The returned tokens from callback
-        #   are now limited to the calling agent only, and no longer include those
-        #   from downstream (chained) agents. However, `models_token_dict` is added
-        #   to the `LlmTokenCallbackHandler` to collect token stats of each model call.
+        # How the counting behaves:
+        # * The context manager sets a fresh handler in a ContextVar which langchain's
+        #   register_configure_hook() attaches to runs as an *inheritable* callback.
+        #   Since descendant agent invocations merge the ambient config (see
+        #   RunContextRunnable.run_it()), this agent's handler also receives events for
+        #   LLM calls made by all downstream agents - including agents of same-server
+        #   external networks invoked through direct sessions. The handler's scalar
+        #   totals (total_tokens et al) are therefore cumulative over this agent's
+        #   whole subtree, and a front man's totals cover the entire request.
+        # * The handler's models_token_dict is different: it only counts LLM calls
+        #   belonging to this agent itself (see LlmTokenCallbackHandler._is_own_call()),
+        #   so that report() below can accumulate per-model stats into request_reporting
+        #   with each call counted exactly once, no matter how deeply agents nest.
+        # * External agents on *remote* servers handle their own requests in a separate
+        #   context and are not seen by this handler at all.
         timed_out: bool = False
         with get_llm_token_callback(llm_infos) as callback:
             # Create a new context for different ContextVar values
@@ -186,45 +190,95 @@ class LangChainTokenCounter:
         """
 
         # Accumulate what we learned about tokens to request reporting.
-        # For now we just overwrite the one key because we know
-        # the last one out will be the front man, and as of 2/21/25 his stats
-        # are cumulative.  At some point we might want a finer-grained breakdown
-        # that perhaps contributes to a service/er-wide periodic token stats breakdown
-        # of some kind.  For now, get something going.
         #
-        # Update (8/21/25):
-        # Placing the journaling callback in the invoke config instead of llm changes the context
-        # manager’s behavior. The returned tokens from the callback are now limited
-        # to the calling agent only, not downstream (chained) agents.
-        # Instead, `models` have been added to `request_reporting["token_accounting"]` to collect per-model stats
-        # which are combined into network token stats.
-        # Since the frontman is always the last to finish, by the time it exits,
-        # `request_reporting["token_accounting"]` is complete and ready to report.
+        # Every agent's count_tokens() ends up here when its invocation completes.
+        # callback.models_token_dict contains per-model stats for only this agent's
+        # own LLM calls (see LlmTokenCallbackHandler), so merging each agent's
+        # contribution counts every LLM call in the request exactly once, no matter
+        # how deeply agents nest.  This includes agents of same-server external
+        # networks invoked via direct sessions, whose cloned InvocationContexts
+        # intentionally share this request_reporting dictionary (see
+        # SessionInvocationContext.safe_shallow_copy()).
+        # Since the front man is always the last to finish, by the time it exits,
+        # the request reporting covers the whole request and is ready to report.
+        #
+        # Two accountings are kept in request_reporting - in this order, so the
+        # server log prints the main network first and the request total last:
+        # * "token_accounting": usage from agents of the main (top-level) network
+        #   only, as this key's caveat has always advertised.  No per-model breakdown.
+        # * "total_token_accounting": the request total - everything that ran
+        #   in-process, including same-server external agents - with the
+        #   per-model breakdown.
+        # The front man of the main network streams these two dictionaries verbatim
+        # as its two accounting messages, so the server log and the client-visible
+        # messages read the same.
         request_reporting: Dict[str, Any] = self.invocation_context.get_request_reporting()
-        token_accounting: Dict[str, Any] = request_reporting.get("token_accounting", {})
+        total_accounting: Dict[str, Any] = request_reporting.get("total_token_accounting", {})
         models_token_dict: Dict[str, Any] = \
-            self.merge_dicts(token_accounting.get("models", {}), callback.models_token_dict)
+            self.merge_dicts(total_accounting.get("models", {}), callback.models_token_dict)
         network_token_dict: Dict[str, Any] = self.sum_all_tokens(models_token_dict, time_taken_in_seconds)
         # Provide sligtly different "caveats" for the network token accounting.
         network_token_dict["caveats"] = [
-            "External agent token usage is not included.",
+            "Request total: includes token usage from same-server external agents. "
+            "Usage from external agents on remote servers is not included.",
             "Token counts are approximate and estimated using tiktoken.",
             "time_taken_in_seconds includes overhead from Langchain and Neuro SAN"
         ]
-        request_reporting["token_accounting"] = \
+
+        # Maintain the accounting covering only the main (top-level) agent network.
+        # Agents of external networks invoked via direct sessions run on cloned
+        # InvocationContexts, so they contribute to the totals but not to this one.
+        main_accounting: Dict[str, Any] = request_reporting.get("token_accounting", {})
+        if not self.invocation_context.is_cloned():
+            # This agent's own contribution, summed across its per-model stats.
+            contribution: Dict[str, Any] = self.sum_all_tokens(callback.models_token_dict,
+                                                               time_taken_in_seconds)
+            # Add it to the scalars accumulated so far.  Caveats and time are not
+            # summable: the time stamped below is the latest reporter's, which for
+            # the last one out - the front man - is the whole request's latency.
+            previous: Dict[str, Any] = {key: value for key, value in main_accounting.items()
+                                        if key not in ("caveats", "time_taken_in_seconds")}
+            del contribution["time_taken_in_seconds"]
+            main_accounting = self.merge_dicts(previous, contribution)
+            main_accounting["time_taken_in_seconds"] = time_taken_in_seconds
+            main_accounting["caveats"] = [
+                "Token usage from agents of the main agent network only. "
+                "Usage from external agents is not included.",
+                "Token counts are approximate and estimated using tiktoken.",
+                "time_taken_in_seconds includes overhead from Langchain and Neuro SAN"
+            ]
+
+        # Re-insert both entries to pin their order (main first, total last)
+        # no matter which agent happened to report first.
+        request_reporting.pop("token_accounting", None)
+        request_reporting.pop("total_token_accounting", None)
+        request_reporting["token_accounting"] = main_accounting
+        request_reporting["total_token_accounting"] = \
             {**network_token_dict, "models": models_token_dict}
 
-        # Token counting results are collected in the callback.
-        # Create a token counting dictionary for each agent
-        agent_token_dict: Dict[str, Any] = self._generate_agent_token_dict(callback, time_taken_in_seconds)
         if self.journal is not None:
-            # We actually have a token dictionary to report, so go there.
-            agent_message = AgentMessage(structure=agent_token_dict)
-            await self.journal.write_message(agent_message)
-            # For frontman (origin with no ".") write both network token dict and model token dict
-            if "." not in ORIGIN_INFO.get():
-                network_token_message = AgentMessage(structure=request_reporting["token_accounting"])
-                await self.journal.write_message(network_token_message)
+            # Figure out whether we are the front man of the main network:
+            # * Only front men have origins with no "." in them.
+            # * Front men of same-server external networks invoked via direct sessions
+            #   also have dot-less origins, but they run on a cloned InvocationContext.
+            is_main_front_man: bool = \
+                "." not in ORIGIN_INFO.get() and not self.invocation_context.is_cloned()
+            if is_main_front_man:
+                # The front man of the main network reports the two request-level
+                # accountings as two complementary messages - main network first,
+                # request total second - each stating its coverage in its caveats.
+                # External front men do not do this: their tokens are already merged into
+                # the shared request_reporting above, and a request-level message from them
+                # mid-request would report a partial (and potentially sibling-polluted) total.
+                await self.journal.write_message(
+                    AgentMessage(structure=request_reporting["token_accounting"]))
+                await self.journal.write_message(
+                    AgentMessage(structure=request_reporting["total_token_accounting"]))
+            else:
+                # Every other agent reports the token usage of its own subtree.
+                agent_token_dict: Dict[str, Any] = \
+                    self._generate_agent_token_dict(callback, time_taken_in_seconds)
+                await self.journal.write_message(AgentMessage(structure=agent_token_dict))
 
     def _generate_agent_token_dict(
             self,
@@ -251,7 +305,8 @@ class LangChainTokenCounter:
             "total_cost": callback.total_cost,
             "time_taken_in_seconds": time_taken_in_seconds,
             "caveats": [
-                "Token usage is tracked at the agent level.",
+                "Token usage is tracked at the agent level. "
+                "Counts include usage from any downstream agents called on this agent's behalf.",
                 "Token counts are approximate and estimated using tiktoken.",
                 "time_taken_in_seconds includes overhead from Langchain and Neuro SAN"
             ]

--- a/neuro_san/internals/run_context/langchain/token_counting/llm_token_callback_handler.py
+++ b/neuro_san/internals/run_context/langchain/token_counting/llm_token_callback_handler.py
@@ -168,7 +168,7 @@ class LlmTokenCallbackHandler(AsyncCallbackHandler):
         self.start_time = time()
 
     @staticmethod
-    def _extract_usage(response: LLMResult) -> Tuple[UsageMetadata, str, bool]:
+    def _extract_usage(response: LLMResult) -> Tuple[Optional[UsageMetadata], str, bool]:
         """
         Pull usage information out of an LLMResult.
         :param response: Output from chat model

--- a/neuro_san/internals/run_context/langchain/token_counting/llm_token_callback_handler.py
+++ b/neuro_san/internals/run_context/langchain/token_counting/llm_token_callback_handler.py
@@ -37,8 +37,13 @@ from langchain_core.tracers.context import register_configure_hook
 # attach the ContextVar's current value to every run as an *inheritable* callback,
 # so an agent's handler also receives events for LLM calls made by any downstream
 # agents it calls.  At event time the ContextVar holds the handler of the *nearest*
-# enclosing agent scope, which is what lets a handler tell its own agent's LLM
-# calls apart from downstream ones (see LlmTokenCallbackHandler._is_own_call()).
+# enclosing agent scope - the call's owner - which is what lets a handler tell its
+# own agent's LLM calls apart from downstream ones (see _is_own_call()).  Since
+# every LLM call has exactly one nearest enclosing scope, exactly one of the
+# handlers listening to that call considers it its own.  This exactly-once
+# ownership is what LangChainTokenCounter.report() relies on to merge each
+# agent's per-model tallies into the request-wide accounting without
+# double-counting, no matter how deeply agents nest.
 llm_token_callback_var: ContextVar[Optional["LlmTokenCallbackHandler"]] = (
         ContextVar("llm_token_callback", default=None)
     )
@@ -134,7 +139,10 @@ class LlmTokenCallbackHandler(AsyncCallbackHandler):
                 handler's own agent.  False for calls made by downstream agents, whose
                 events this handler also receives because handlers are inheritable
                 callbacks.  At event time, llm_token_callback_var holds the handler
-                of the nearest enclosing agent scope - the call's owner.
+                of the nearest enclosing agent scope - the call's owner - so for any
+                given LLM call this is True for exactly one of the handlers listening
+                to it.  That exactly-once ownership is what keeps the request-wide
+                merge in LangChainTokenCounter.report() free of double-counting.
         """
         return llm_token_callback_var.get() is self
 

--- a/neuro_san/internals/run_context/langchain/token_counting/llm_token_callback_handler.py
+++ b/neuro_san/internals/run_context/langchain/token_counting/llm_token_callback_handler.py
@@ -162,7 +162,7 @@ class LlmTokenCallbackHandler(AsyncCallbackHandler):
             # handler tracks per-model state for it.
             return
 
-        # Chat moddel class of the LLM is in the last item of the id list
+        # Chat model class of the LLM is in the last item of the id list
         chat_model_class: str = serialized.get("id")[-1]
         # Match the chat model class with neuro-san model class
         self.provider_class = CLASS_TABLE.get(chat_model_class)

--- a/neuro_san/internals/run_context/langchain/token_counting/llm_token_callback_handler.py
+++ b/neuro_san/internals/run_context/langchain/token_counting/llm_token_callback_handler.py
@@ -16,11 +16,13 @@
 # END COPYRIGHT
 
 from asyncio import Lock as AsyncLock
+from contextvars import ContextVar
 import logging
 from time import time
 from typing import Any
 from typing import Dict
 from typing import Optional
+from typing import Tuple
 from typing_extensions import override
 
 from langchain_core.callbacks import AsyncCallbackHandler
@@ -28,6 +30,19 @@ from langchain_core.messages import AIMessage
 from langchain_core.messages import BaseMessage
 from langchain_core.messages.ai import UsageMetadata
 from langchain_core.outputs import ChatGeneration, LLMResult
+from langchain_core.tracers.context import register_configure_hook
+
+# Each agent's token counting scope sets this ContextVar to its own handler
+# (see get_llm_token_callback()).  register_configure_hook() below makes langchain
+# attach the ContextVar's current value to every run as an *inheritable* callback,
+# so an agent's handler also receives events for LLM calls made by any downstream
+# agents it calls.  At event time the ContextVar holds the handler of the *nearest*
+# enclosing agent scope, which is what lets a handler tell its own agent's LLM
+# calls apart from downstream ones (see LlmTokenCallbackHandler._is_own_call()).
+llm_token_callback_var: ContextVar[Optional["LlmTokenCallbackHandler"]] = (
+        ContextVar("llm_token_callback", default=None)
+    )
+register_configure_hook(llm_token_callback_var, inheritable=True)
 
 EMPTY = ""
 CLASS_TABLE = {
@@ -62,6 +77,17 @@ class LlmTokenCallbackHandler(AsyncCallbackHandler):
 
     This handler tracks these values internally and is compatible with models that populate "usage_metadata",
     regardless of provider.
+
+    Attribution semantics:
+    Because handlers are registered as inheritable langchain callbacks (see llm_token_callback_var above),
+    one instance receives events both for its own agent's LLM calls and for calls made by downstream
+    agents.  The two kinds of tallies kept here treat those differently:
+    - The scalar totals ("total_tokens", "successful_requests", etc.) count *every* event received,
+      so they are cumulative over the agent's whole subtree.  These feed the per-agent accounting
+      messages, where a front man's totals cover the entire request.
+    - "models_token_dict" only counts the agent's *own* LLM calls (see _is_own_call()), so that
+      LangChainTokenCounter.report() can merge each agent's contribution into the request-wide
+      accounting with every LLM call counted exactly once, no matter how deeply agents nest.
 
     Note:
     Token cost is calculated using prices from the LLM info file
@@ -102,6 +128,16 @@ class LlmTokenCallbackHandler(AsyncCallbackHandler):
             f"Model Info: {self.models_token_dict}"
         )
 
+    def _is_own_call(self) -> bool:
+        """
+        :return: True if the event being handled belongs to an LLM call made by this
+                handler's own agent.  False for calls made by downstream agents, whose
+                events this handler also receives because handlers are inheritable
+                callbacks.  At event time, llm_token_callback_var holds the handler
+                of the nearest enclosing agent scope - the call's owner.
+        """
+        return llm_token_callback_var.get() is self
+
     @override
     async def on_chat_model_start(
         self,
@@ -113,6 +149,11 @@ class LlmTokenCallbackHandler(AsyncCallbackHandler):
         Extract the LLM class and start timer when chat model starts.
         :param serialized: Dictionary of metadata of the invoked model
         """
+        if not self._is_own_call():
+            # A downstream agent's chat model is starting.  Only that agent's own
+            # handler tracks per-model state for it.
+            return
+
         # Chat moddel class of the LLM is in the last item of the id list
         chat_model_class: str = serialized.get("id")[-1]
         # Match the chat model class with neuro-san model class
@@ -126,16 +167,14 @@ class LlmTokenCallbackHandler(AsyncCallbackHandler):
         # Start timer
         self.start_time = time()
 
-    @override
-    async def on_llm_end(self, response: LLMResult, **kwargs: Any):
+    @staticmethod
+    def _extract_usage(response: LLMResult) -> Tuple[UsageMetadata, str, bool]:
         """
-        Collect token usage when llm ends.
+        Pull usage information out of an LLMResult.
         :param response: Output from chat model
+        :return: A tuple of (usage_metadata, model_name, is_empty_response).
+                usage_metadata is None when the response carries none.
         """
-        # Calculate time latency for each llm
-        # Note that this will be slightly lower time taken by the agent
-        time_taken_in_seconds: float = time() - self.start_time
-
         # Check for usage_metadata (Only work for langchain-core >= 0.2.2)
         try:
             generation = response.generations[0][0]
@@ -152,7 +191,7 @@ class LlmTokenCallbackHandler(AsyncCallbackHandler):
                 if isinstance(message, AIMessage):
                     # Token info is in an attribute of AIMessage called "usage_metadata".
                     usage_metadata = message.usage_metadata
-                    is_empty_response = self._is_empty_response(message)
+                    is_empty_response = LlmTokenCallbackHandler._is_empty_response(message)
                     # Get model name so that cost can be determined if needed.
                     response_metadata = message.response_metadata
                     if response_metadata:
@@ -165,6 +204,27 @@ class LlmTokenCallbackHandler(AsyncCallbackHandler):
             except AttributeError:
                 pass
 
+        return usage_metadata, model_name, is_empty_response
+
+    @override
+    async def on_llm_end(self, response: LLMResult, **kwargs: Any):
+        """
+        Collect token usage when llm ends.
+        :param response: Output from chat model
+        """
+        # Per-model stats are only tracked for this agent's own LLM calls.
+        # Downstream agents' calls still contribute to the scalar subtree totals below.
+        is_own_call: bool = self._is_own_call()
+
+        # Calculate time latency for each llm
+        # Note that this will be slightly lower time taken by the agent
+        # The timer is only started (on_chat_model_start) for this agent's own calls.
+        time_taken_in_seconds: float = 0.0
+        if is_own_call and self.start_time is not None:
+            time_taken_in_seconds = time() - self.start_time
+
+        usage_metadata, model_name, is_empty_response = self._extract_usage(response)
+
         if usage_metadata:
             total_tokens: int = usage_metadata.get("total_tokens", 0)
             completion_tokens: int = usage_metadata.get("output_tokens", 0)
@@ -175,23 +235,24 @@ class LlmTokenCallbackHandler(AsyncCallbackHandler):
 
             # Update shared state behind lock
             async with self._lock:
-                # Initialize model entry if this is the first time we see this model
-                if model_name not in self.models_token_dict[self.provider_class]:
-                    self._init_model_entry(model_name)
+                if is_own_call:
+                    # Initialize model entry if this is the first time we see this model
+                    if model_name not in self.models_token_dict[self.provider_class]:
+                        self._init_model_entry(model_name)
 
-                # Update per-model stats.
-                self.models_token_dict[self.provider_class][model_name]["total_tokens"] += total_tokens
-                self.models_token_dict[self.provider_class][model_name]["prompt_tokens"] += prompt_tokens
-                self.models_token_dict[self.provider_class][model_name]["completion_tokens"] += \
-                    completion_tokens
-                self.models_token_dict[self.provider_class][model_name]["successful_requests"] += 1
-                self.models_token_dict[self.provider_class][model_name]["empty_responses"] += \
-                    int(is_empty_response)
-                self.models_token_dict[self.provider_class][model_name]["total_cost"] += total_cost
-                self.models_token_dict[self.provider_class][model_name]["time_taken_in_seconds"] += \
-                    time_taken_in_seconds
+                    # Update per-model stats (this agent's own calls only).
+                    self.models_token_dict[self.provider_class][model_name]["total_tokens"] += total_tokens
+                    self.models_token_dict[self.provider_class][model_name]["prompt_tokens"] += prompt_tokens
+                    self.models_token_dict[self.provider_class][model_name]["completion_tokens"] += \
+                        completion_tokens
+                    self.models_token_dict[self.provider_class][model_name]["successful_requests"] += 1
+                    self.models_token_dict[self.provider_class][model_name]["empty_responses"] += \
+                        int(is_empty_response)
+                    self.models_token_dict[self.provider_class][model_name]["total_cost"] += total_cost
+                    self.models_token_dict[self.provider_class][model_name]["time_taken_in_seconds"] += \
+                        time_taken_in_seconds
 
-                # Update per-agent stats
+                # Update per-agent stats (own + downstream agents' calls)
                 self.total_tokens += total_tokens
                 self.prompt_tokens += prompt_tokens
                 self.completion_tokens += completion_tokens

--- a/neuro_san/session/session_invocation_context.py
+++ b/neuro_san/session/session_invocation_context.py
@@ -307,6 +307,11 @@ class SessionInvocationContext(InvocationContext):
         # * request_reporting - so token accounting for external agent networks
         #   invoked on this server contributes to the request-wide totals, with
         #   each LLM call counted exactly once (see LangChainTokenCounter.report()).
+        #   Deliberately NOT reset or replaced here: pointing the clone at a fresh
+        #   dictionary would orphan the external network's usage from the request
+        #   totals.  Staleness across exchanges is handled by reset() instead,
+        #   which clears the shared dictionary in place at the start of each
+        #   exchange.
         # * origination - so tool instantiation indices stay consistent across
         #   the whole request.
 

--- a/neuro_san/session/session_invocation_context.py
+++ b/neuro_san/session/session_invocation_context.py
@@ -272,6 +272,11 @@ class SessionInvocationContext(InvocationContext):
         # in subsequent interactions with the same network.
         self.origination.reset()
 
+        # Token accounting is per-exchange ("Request total"), so clear it for the
+        # next exchange rather than accumulating across turns.  Clear in place:
+        # the dictionary instance is shared by reference with any clones.
+        self.request_reporting.clear()
+
         if self.queue is not None:
             self.queue.reset()
         else:

--- a/neuro_san/session/session_invocation_context.py
+++ b/neuro_san/session/session_invocation_context.py
@@ -114,7 +114,7 @@ class SessionInvocationContext(InvocationContext):
         self.resources: List[LingeringResource] = []
         self.work_done_event: Event = Event()
         self.request_finished: bool = False
-        self.is_cloned: bool = False
+        self.cloned: bool = False
 
     def start(self):
         """
@@ -212,7 +212,7 @@ class SessionInvocationContext(InvocationContext):
 
         # Now that we are done, tell the Reservationist that we used for this request
         # that there will be no more Reservations to corral.
-        if not self.is_cloned and \
+        if not self.cloned and \
                 self.reservationist is not None and \
                 isinstance(self.reservationist, LingeringResource):
             await self.reservationist.close_of_work()
@@ -222,6 +222,15 @@ class SessionInvocationContext(InvocationContext):
         :return: The request reporting dictionary
         """
         return self.request_reporting
+
+    def is_cloned(self) -> bool:
+        """
+        :return: True if this instance is a clone created by safe_shallow_copy()
+                to invoke an external agent network on the same server via a
+                direct session.
+                False for the original InvocationContext of a request.
+        """
+        return self.cloned
 
     def get_llm_factory(self) -> ContextTypeLlmFactory:
         """
@@ -288,10 +297,18 @@ class SessionInvocationContext(InvocationContext):
 
         invocation_context: SessionInvocationContext = copy(self)
 
+        # Note: being a *shallow* copy, the clone intentionally shares some state
+        # with the original.  Notably:
+        # * request_reporting - so token accounting for external agent networks
+        #   invoked on this server contributes to the request-wide totals, with
+        #   each LLM call counted exactly once (see LangChainTokenCounter.report()).
+        # * origination - so tool instantiation indices stay consistent across
+        #   the whole request.
+
         # Mark the invocation context as cloned
         # This tells us that it is not the original/root and will prevent
         # mis-happenings like returning the executor to the pool too early.
-        invocation_context.is_cloned = True
+        invocation_context.cloned = True
 
         # We need a different Event to signal work is done
         # Work being all done on a sub-invocation is not the same as work all done on the root.
@@ -382,7 +399,7 @@ class SessionInvocationContext(InvocationContext):
         """
         self._run_in_executor_until_complete(submitter_id, self.close_of_work())
 
-        if self.is_cloned:
+        if self.cloned:
             # Clones via safe_shallow_copy() share the same AsyncioExecutor,
             # so don't return it back to the pool just yet. Let the mama do that.
             return

--- a/tests/neuro_san/internals/run_context/langchain/token_counting/test_langchain_token_counter.py
+++ b/tests/neuro_san/internals/run_context/langchain/token_counting/test_langchain_token_counter.py
@@ -28,6 +28,19 @@ from langchain_core.messages.ai import AIMessage
 
 from neuro_san.internals.messages.agent_message import AgentMessage
 from neuro_san.internals.run_context.langchain.token_counting.langchain_token_counter import LangChainTokenCounter
+from neuro_san.internals.run_context.langchain.token_counting.langchain_token_counter import ORIGIN_INFO
+
+
+@contextmanager
+def origin_scope(origin_str: str):
+    """
+    Set the ORIGIN_INFO ContextVar the way count_tokens() does before calling report().
+    """
+    token = ORIGIN_INFO.set(origin_str)
+    try:
+        yield
+    finally:
+        ORIGIN_INFO.reset(token)
 
 
 # pylint: disable=too-many-public-methods
@@ -411,6 +424,8 @@ class TestLangChainTokenCounter:
         mock_invocation_context = MagicMock()
         mock_invocation_context.get_llm_factory.return_value.llm_infos = {}
         mock_invocation_context.get_request_reporting.return_value = {}
+        # Not a clone: report() writes the network token message for front men.
+        mock_invocation_context.is_cloned.return_value = False
 
         # The executor wraps the awaitable in a real asyncio.Task so
         # asyncio.wait_for() actually times out and cancels it.
@@ -607,3 +622,174 @@ class TestLangChainTokenCounter:
         assert gpt4["empty_responses"] == 2
         assert gpt4["successful_requests"] == 2
         assert gpt4["total_tokens"] == 150
+
+
+class TestReport:
+    """
+    Test cases for report(): request-level accumulation and network-message gating.
+
+    Each agent's report() merges its callback's models_token_dict (that agent's own
+    LLM calls only) into the shared request_reporting, so request-level totals must
+    count every LLM call exactly once regardless of agent nesting.  The request-level
+    network message must only be written by the top-level front man: dot-less origin
+    and a non-cloned InvocationContext.
+    """
+
+    def _make_counter(self, request_reporting, cloned, journal):
+        """Build a LangChainTokenCounter around a shared request_reporting dict."""
+        mock_invocation_context = MagicMock()
+        mock_invocation_context.get_request_reporting.return_value = request_reporting
+        mock_invocation_context.is_cloned.return_value = cloned
+        return LangChainTokenCounter(
+            llm=MagicMock(),
+            invocation_context=mock_invocation_context,
+            journal=journal,
+            origin=[{"tool": "test_agent", "instantiation_index": 0}],
+        )
+
+    def _make_callback(self, own_tokens, own_requests, subtree_tokens=None, subtree_requests=None):
+        """
+        Build a callback stand-in mirroring LlmTokenCallbackHandler semantics:
+        models_token_dict covers only the agent's own calls, while the scalar
+        totals cover the agent's whole subtree.
+        """
+        callback = MagicMock()
+        callback.models_token_dict = {
+            "openai": {
+                "gpt-4": {
+                    "total_tokens": own_tokens,
+                    "prompt_tokens": own_tokens,
+                    "completion_tokens": 0,
+                    "successful_requests": own_requests,
+                    "empty_responses": 0,
+                    "total_cost": 0.0,
+                    "time_taken_in_seconds": 1.0
+                }
+            }
+        }
+        callback.total_tokens = subtree_tokens if subtree_tokens is not None else own_tokens
+        callback.prompt_tokens = callback.total_tokens
+        callback.completion_tokens = 0
+        callback.successful_requests = subtree_requests if subtree_requests is not None else own_requests
+        callback.empty_responses = 0
+        callback.total_cost = 0.0
+        return callback
+
+    @pytest.mark.asyncio
+    async def test_report_counts_each_agents_own_calls_exactly_once(self):
+        """
+        Nested completions must not double count: even though the front man's
+        subtree scalars include the downstream agent's tokens, only each agent's
+        own (exclusive) per-model stats are merged into request_reporting.
+        """
+        request_reporting = {}
+
+        # A downstream agent finishes first: 15 tokens / 1 call of its own.
+        downstream = self._make_counter(request_reporting, cloned=False, journal=None)
+        with origin_scope("front_man.downstream"):
+            await downstream.report(self._make_callback(own_tokens=15, own_requests=1), 1.0)
+
+        # The front man finishes last: 30 tokens / 2 calls of its own,
+        # 45 tokens / 3 calls across its subtree.
+        front_man = self._make_counter(request_reporting, cloned=False, journal=None)
+        with origin_scope("front_man"):
+            await front_man.report(
+                self._make_callback(own_tokens=30, own_requests=2, subtree_tokens=45, subtree_requests=3),
+                2.0)
+
+        # Request-level totals equal the sum of each agent's own calls: no double count.
+        total_accounting = request_reporting["total_token_accounting"]
+        assert total_accounting["total_tokens"] == 45
+        assert total_accounting["successful_requests"] == 3
+        assert total_accounting["models"]["openai"]["gpt-4"]["total_tokens"] == 45
+        assert total_accounting["models"]["openai"]["gpt-4"]["successful_requests"] == 3
+        # The last reporter (the front man) stamps the request latency.
+        assert total_accounting["time_taken_in_seconds"] == 2.0
+        # With no external agents in play, the main network accounting matches the totals.
+        main_accounting = request_reporting["token_accounting"]
+        assert main_accounting["total_tokens"] == 45
+        assert main_accounting["successful_requests"] == 3
+
+    @pytest.mark.asyncio
+    async def test_report_separates_main_network_from_total(self):
+        """
+        Agents of same-server external networks (cloned InvocationContexts)
+        contribute to the request totals but not to the "main_network" breakdown.
+        """
+        request_reporting = {}
+
+        # An external network's front man finishes first: 15 tokens / 1 call.
+        external = self._make_counter(request_reporting, cloned=True, journal=None)
+        with origin_scope("external_front_man"):
+            await external.report(self._make_callback(own_tokens=15, own_requests=1), 1.0)
+
+        # The main network's front man finishes last: 30 tokens / 2 calls of its own.
+        front_man = self._make_counter(request_reporting, cloned=False, journal=None)
+        with origin_scope("front_man"):
+            await front_man.report(
+                self._make_callback(own_tokens=30, own_requests=2, subtree_tokens=45, subtree_requests=3),
+                2.0)
+
+        # Totals cover main network + same-server external agents, exactly once each.
+        total_accounting = request_reporting["total_token_accounting"]
+        assert total_accounting["total_tokens"] == 45
+        assert total_accounting["successful_requests"] == 3
+        # "token_accounting" keeps its historically-documented meaning: the main
+        # network only, excluding external agents (and no per-model breakdown).
+        main_accounting = request_reporting["token_accounting"]
+        assert main_accounting["total_tokens"] == 30
+        assert main_accounting["successful_requests"] == 2
+        assert "models" not in main_accounting
+        # The server log prints the main network accounting first and the request
+        # total last, even though an external agent reported first here.
+        assert list(request_reporting.keys()) == \
+            ["token_accounting", "total_token_accounting"]
+
+    @pytest.mark.asyncio
+    async def test_report_network_message_gating(self):
+        """
+        Only the front man of the main network (dot-less origin, non-cloned
+        InvocationContext) writes the two complementary accounting messages:
+        main network first, request total second.  Every other agent writes its
+        per-agent subtree message, and everyone merges into request_reporting.
+        """
+        cases = [
+            # (origin string, cloned, expected journal writes)
+            ("front_man.internal_agent", False, 1),   # internal agent: agent message only
+            ("external_front_man", True, 1),          # direct-session external front man: agent message only
+            ("front_man", False, 2),                  # main front man: main-network + total messages
+        ]
+        for origin_str, cloned, expected_writes in cases:
+            request_reporting = {}
+            journal = MagicMock()
+            journal.write_message = AsyncMock()
+
+            counter = self._make_counter(request_reporting, cloned=cloned, journal=journal)
+            with origin_scope(origin_str):
+                await counter.report(self._make_callback(own_tokens=10, own_requests=1), 1.0)
+
+            assert journal.write_message.call_count == expected_writes, \
+                f"origin={origin_str} cloned={cloned}"
+            # The merge into request_reporting happens for everyone.
+            assert request_reporting["total_token_accounting"]["total_tokens"] == 10
+
+        # For the main front man (last case), the two messages are exactly the two
+        # accounting entries of request_reporting, so the client-visible accounting
+        # and the server log read the same.
+
+        # The first message covers the main network only - no models breakdown,
+        # same shape as the per-agent messages.
+        main_message = journal.write_message.call_args_list[0].args[0]
+        assert isinstance(main_message, AgentMessage)
+        assert main_message.structure == request_reporting["token_accounting"]
+        assert main_message.structure.get("total_tokens") == 10
+        assert "models" not in main_message.structure
+        assert "main agent network only" in main_message.structure["caveats"][0]
+
+        # The second message is the request total with the per-model breakdown.
+        total_message = journal.write_message.call_args_list[1].args[0]
+        assert isinstance(total_message, AgentMessage)
+        assert total_message.structure == request_reporting["total_token_accounting"]
+        assert total_message.structure.get("total_tokens") == 10
+        assert total_message.structure.get("models") is not None
+        assert "Request total" in total_message.structure["caveats"][0]

--- a/tests/neuro_san/internals/run_context/langchain/token_counting/test_langchain_token_counter.py
+++ b/tests/neuro_san/internals/run_context/langchain/token_counting/test_langchain_token_counter.py
@@ -28,19 +28,6 @@ from langchain_core.messages.ai import AIMessage
 
 from neuro_san.internals.messages.agent_message import AgentMessage
 from neuro_san.internals.run_context.langchain.token_counting.langchain_token_counter import LangChainTokenCounter
-from neuro_san.internals.run_context.langchain.token_counting.langchain_token_counter import ORIGIN_INFO
-
-
-@contextmanager
-def origin_scope(origin_str: str):
-    """
-    Set the ORIGIN_INFO ContextVar the way count_tokens() does before calling report().
-    """
-    token = ORIGIN_INFO.set(origin_str)
-    try:
-        yield
-    finally:
-        ORIGIN_INFO.reset(token)
 
 
 # pylint: disable=too-many-public-methods
@@ -85,6 +72,7 @@ class TestLangChainTokenCounter:
             "prompt_tokens": 80,
             "completion_tokens": 20,
             "successful_requests": 1,
+            "empty_responses": 0,
             "total_cost": 0.05,
             "time_taken_in_seconds": 3.0  # Uses the time_value parameter
         }
@@ -121,6 +109,7 @@ class TestLangChainTokenCounter:
             "prompt_tokens": 230,
             "completion_tokens": 70,
             "successful_requests": 3,
+            "empty_responses": 0,
             "total_cost": 0.08,
             "time_taken_in_seconds": 4.5
         }
@@ -167,6 +156,7 @@ class TestLangChainTokenCounter:
             "prompt_tokens": 340,
             "completion_tokens": 110,
             "successful_requests": 4,
+            "empty_responses": 0,
             "total_cost": 0.20,
             "time_taken_in_seconds": 7.0
         }
@@ -174,19 +164,29 @@ class TestLangChainTokenCounter:
         assert result == expected
 
     def test_sum_all_tokens_empty_dict(self, token_counter):
-        """Test aggregation with empty token dictionary."""
+        """
+        Aggregation of an empty token dictionary yields explicit zeros.
+        The standard metric keys must always be present: downstream consumers
+        (e.g. TokenAccountingMessageFilter) rely on "total_tokens" existing.
+        """
         token_dict = {}
 
         result = token_counter.sum_all_tokens(token_dict, 1.5)
 
         expected = {
+            "total_tokens": 0,
+            "prompt_tokens": 0,
+            "completion_tokens": 0,
+            "successful_requests": 0,
+            "empty_responses": 0,
+            "total_cost": 0.0,
             "time_taken_in_seconds": 1.5
         }
 
         assert result == expected
 
     def test_sum_all_tokens_empty_models(self, token_counter):
-        """Test aggregation with empty models in providers."""
+        """Test aggregation with empty models in providers yields explicit zeros."""
         token_dict = {
             "openai": {},
             "anthropic": {}
@@ -195,6 +195,12 @@ class TestLangChainTokenCounter:
         result = token_counter.sum_all_tokens(token_dict, 2.0)
 
         expected = {
+            "total_tokens": 0,
+            "prompt_tokens": 0,
+            "completion_tokens": 0,
+            "successful_requests": 0,
+            "empty_responses": 0,
+            "total_cost": 0.0,
             "time_taken_in_seconds": 2.0
         }
 
@@ -239,6 +245,7 @@ class TestLangChainTokenCounter:
             "prompt_tokens": 0,
             "completion_tokens": 0,
             "successful_requests": 0,
+            "empty_responses": 0,
             "total_cost": 0.0,
             "time_taken_in_seconds": 0.1
         }
@@ -439,8 +446,8 @@ class TestLangChainTokenCounter:
             llm=MagicMock(),
             invocation_context=mock_invocation_context,
             journal=mock_journal,
-            # Single-element origin -> no "." in the full name, so report()
-            # exercises both the per-agent and network token-message branches.
+            # Single-element origin on a non-cloned context -> report() takes the
+            # main-front-man branch and writes the two request-level messages.
             origin=[{"tool": "test_agent", "instantiation_index": 0}],
         )
 
@@ -476,15 +483,82 @@ class TestLangChainTokenCounter:
         )
         assert "max_execution_seconds" in first.content
 
-        # 2) Any subsequent messages should be token-accounting AgentMessages
-        #    (report() writes per-agent and, for the frontman, network token messages).
-        assert len(written_messages) >= 2, (
-            "Expected token-accounting AgentMessage(s) after the timeout AIMessage"
+        # 2) The subsequent messages are the front man's two token-accounting
+        #    AgentMessages (main network, then request total).
+        assert len(written_messages) == 3, (
+            "Expected the two request-level AgentMessages after the timeout AIMessage"
         )
         for msg in written_messages[1:]:
             assert isinstance(msg, AgentMessage), (
                 f"Expected AgentMessage after AIMessage, got {type(msg).__name__}"
             )
+
+    @pytest.mark.asyncio
+    async def test_count_tokens_timeout_agent_branch_writes_per_agent_message(self):
+        """
+        A timed-out non-front-man agent (multi-element origin) still writes its
+        per-agent token accounting message after the synthesized AIMessage.
+        """
+        written_messages = []
+
+        async def record(msg, *_args, **_kwargs):
+            written_messages.append(msg)
+
+        mock_journal = MagicMock()
+        mock_journal.write_message = AsyncMock(side_effect=record)
+
+        mock_invocation_context = MagicMock()
+        mock_invocation_context.get_llm_factory.return_value.llm_infos = {}
+        mock_invocation_context.get_request_reporting.return_value = {}
+        mock_invocation_context.is_cloned.return_value = False
+
+        mock_executor = MagicMock()
+        mock_executor.create_task.side_effect = (
+            lambda awaitable, _origin_str: asyncio.create_task(awaitable)
+        )
+        mock_invocation_context.get_asyncio_executor.return_value = mock_executor
+
+        counter = LangChainTokenCounter(
+            llm=MagicMock(),
+            invocation_context=mock_invocation_context,
+            journal=mock_journal,
+            # Multi-element origin -> report() takes the per-agent else-branch.
+            origin=[
+                {"tool": "front_man", "instantiation_index": 0},
+                {"tool": "slow_agent", "instantiation_index": 0},
+            ],
+        )
+
+        async def slow_awaitable():
+            await asyncio.sleep(10)
+
+        @contextmanager
+        def fake_callback_cm(_llm_infos):
+            cb = MagicMock()
+            cb.models_token_dict = {}
+            cb.total_tokens = 0
+            cb.prompt_tokens = 0
+            cb.completion_tokens = 0
+            cb.successful_requests = 0
+            cb.empty_responses = 0
+            cb.total_cost = 0.0
+            yield cb
+
+        callback_path = (
+            "neuro_san.internals.run_context.langchain.token_counting."
+            "langchain_token_counter.get_llm_token_callback"
+        )
+
+        with patch(callback_path, fake_callback_cm):
+            with pytest.raises(asyncio.TimeoutError):
+                await counter.count_tokens(slow_awaitable(), max_execution_seconds=0.05)
+
+        # Timeout AIMessage first, then exactly one per-agent AgentMessage.
+        assert len(written_messages) == 2
+        assert isinstance(written_messages[0], AIMessage)
+        agent_message = written_messages[1]
+        assert isinstance(agent_message, AgentMessage)
+        assert "tracked at the agent level" in agent_message.structure["caveats"][0]
 
     def test_merge_dicts_complex_token_scenario(self, token_counter):
         """Test merging with a realistic token counting scenario."""
@@ -624,6 +698,14 @@ class TestLangChainTokenCounter:
         assert gpt4["total_tokens"] == 150
 
 
+FRONT_MAN_ORIGIN = [{"tool": "front_man", "instantiation_index": 0}]
+INTERNAL_AGENT_ORIGIN = [
+    {"tool": "front_man", "instantiation_index": 0},
+    {"tool": "internal_agent", "instantiation_index": 0},
+]
+EXTERNAL_FRONT_MAN_ORIGIN = [{"tool": "external_front_man", "instantiation_index": 0}]
+
+
 class TestReport:
     """
     Test cases for report(): request-level accumulation and network-message gating.
@@ -631,11 +713,11 @@ class TestReport:
     Each agent's report() merges its callback's models_token_dict (that agent's own
     LLM calls only) into the shared request_reporting, so request-level totals must
     count every LLM call exactly once regardless of agent nesting.  The request-level
-    network message must only be written by the top-level front man: dot-less origin
-    and a non-cloned InvocationContext.
+    messages must only be written by the front man of the main network: a
+    single-element origin and a non-cloned InvocationContext.
     """
 
-    def _make_counter(self, request_reporting, cloned, journal):
+    def _make_counter(self, request_reporting, cloned, journal, origin=None):
         """Build a LangChainTokenCounter around a shared request_reporting dict."""
         mock_invocation_context = MagicMock()
         mock_invocation_context.get_request_reporting.return_value = request_reporting
@@ -644,7 +726,7 @@ class TestReport:
             llm=MagicMock(),
             invocation_context=mock_invocation_context,
             journal=journal,
-            origin=[{"tool": "test_agent", "instantiation_index": 0}],
+            origin=origin if origin is not None else FRONT_MAN_ORIGIN,
         )
 
     def _make_callback(self, own_tokens, own_requests, subtree_tokens=None, subtree_requests=None):
@@ -685,17 +767,16 @@ class TestReport:
         request_reporting = {}
 
         # A downstream agent finishes first: 15 tokens / 1 call of its own.
-        downstream = self._make_counter(request_reporting, cloned=False, journal=None)
-        with origin_scope("front_man.downstream"):
-            await downstream.report(self._make_callback(own_tokens=15, own_requests=1), 1.0)
+        downstream = self._make_counter(request_reporting, cloned=False, journal=None,
+                                        origin=INTERNAL_AGENT_ORIGIN)
+        await downstream.report(self._make_callback(own_tokens=15, own_requests=1), 1.0)
 
         # The front man finishes last: 30 tokens / 2 calls of its own,
         # 45 tokens / 3 calls across its subtree.
         front_man = self._make_counter(request_reporting, cloned=False, journal=None)
-        with origin_scope("front_man"):
-            await front_man.report(
-                self._make_callback(own_tokens=30, own_requests=2, subtree_tokens=45, subtree_requests=3),
-                2.0)
+        await front_man.report(
+            self._make_callback(own_tokens=30, own_requests=2, subtree_tokens=45, subtree_requests=3),
+            2.0)
 
         # Request-level totals equal the sum of each agent's own calls: no double count.
         total_accounting = request_reporting["total_token_accounting"]
@@ -719,16 +800,21 @@ class TestReport:
         request_reporting = {}
 
         # An external network's front man finishes first: 15 tokens / 1 call.
-        external = self._make_counter(request_reporting, cloned=True, journal=None)
-        with origin_scope("external_front_man"):
-            await external.report(self._make_callback(own_tokens=15, own_requests=1), 1.0)
+        external = self._make_counter(request_reporting, cloned=True, journal=None,
+                                      origin=EXTERNAL_FRONT_MAN_ORIGIN)
+        await external.report(self._make_callback(own_tokens=15, own_requests=1), 1.0)
+
+        # Before any main-network agent reports, the main accounting is an
+        # explicit zero entry (not an empty dict), so a request that dies here
+        # still logs well-formed accounting.
+        assert request_reporting["token_accounting"]["total_tokens"] == 0
+        assert "caveats" in request_reporting["token_accounting"]
 
         # The main network's front man finishes last: 30 tokens / 2 calls of its own.
         front_man = self._make_counter(request_reporting, cloned=False, journal=None)
-        with origin_scope("front_man"):
-            await front_man.report(
-                self._make_callback(own_tokens=30, own_requests=2, subtree_tokens=45, subtree_requests=3),
-                2.0)
+        await front_man.report(
+            self._make_callback(own_tokens=30, own_requests=2, subtree_tokens=45, subtree_requests=3),
+            2.0)
 
         # Totals cover main network + same-server external agents, exactly once each.
         total_accounting = request_reporting["total_token_accounting"]
@@ -746,30 +832,73 @@ class TestReport:
             ["token_accounting", "total_token_accounting"]
 
     @pytest.mark.asyncio
+    async def test_report_late_external_does_not_restamp_request_latency(self):
+        """
+        A cloned (external) agent completing after the front man - e.g. an
+        "event" invocation that outlives the request - must not replace the
+        request latency the front man stamped on the total.
+        """
+        request_reporting = {}
+
+        front_man = self._make_counter(request_reporting, cloned=False, journal=None)
+        await front_man.report(self._make_callback(own_tokens=30, own_requests=2), 20.0)
+
+        late_external = self._make_counter(request_reporting, cloned=True, journal=None,
+                                           origin=EXTERNAL_FRONT_MAN_ORIGIN)
+        await late_external.report(self._make_callback(own_tokens=15, own_requests=1), 3.0)
+
+        total_accounting = request_reporting["total_token_accounting"]
+        # The late external's tokens still count toward the total ...
+        assert total_accounting["total_tokens"] == 45
+        # ... but the request latency remains the front man's.
+        assert total_accounting["time_taken_in_seconds"] == 20.0
+
+    @pytest.mark.asyncio
+    async def test_report_flags_unattributed_tokens(self):
+        """
+        When the front man's subtree scalars exceed what completed scopes merged
+        (e.g. agents cancelled mid-run), the total carries an explicit caveat
+        instead of silently under-reporting.
+        """
+        request_reporting = {}
+
+        front_man = self._make_counter(request_reporting, cloned=False, journal=None)
+        # Subtree heard 50 tokens, but only the front man's own 30 were merged:
+        # a downstream agent died before its report().
+        await front_man.report(
+            self._make_callback(own_tokens=30, own_requests=2, subtree_tokens=50, subtree_requests=3),
+            2.0)
+
+        total_accounting = request_reporting["total_token_accounting"]
+        assert total_accounting["total_tokens"] == 30
+        assert any("An additional 20 tokens" in caveat
+                   for caveat in total_accounting["caveats"])
+
+    @pytest.mark.asyncio
     async def test_report_network_message_gating(self):
         """
-        Only the front man of the main network (dot-less origin, non-cloned
+        Only the front man of the main network (single-element origin, non-cloned
         InvocationContext) writes the two complementary accounting messages:
         main network first, request total second.  Every other agent writes its
         per-agent subtree message, and everyone merges into request_reporting.
         """
         cases = [
-            # (origin string, cloned, expected journal writes)
-            ("front_man.internal_agent", False, 1),   # internal agent: agent message only
-            ("external_front_man", True, 1),          # direct-session external front man: agent message only
-            ("front_man", False, 2),                  # main front man: main-network + total messages
+            # (origin, cloned, expected journal writes)
+            (INTERNAL_AGENT_ORIGIN, False, 1),       # internal agent: agent message only
+            (EXTERNAL_FRONT_MAN_ORIGIN, True, 1),    # direct-session external front man: agent message only
+            (FRONT_MAN_ORIGIN, False, 2),            # main front man: main-network + total messages
         ]
-        for origin_str, cloned, expected_writes in cases:
+        for origin, cloned, expected_writes in cases:
             request_reporting = {}
             journal = MagicMock()
             journal.write_message = AsyncMock()
 
-            counter = self._make_counter(request_reporting, cloned=cloned, journal=journal)
-            with origin_scope(origin_str):
-                await counter.report(self._make_callback(own_tokens=10, own_requests=1), 1.0)
+            counter = self._make_counter(request_reporting, cloned=cloned, journal=journal,
+                                         origin=origin)
+            await counter.report(self._make_callback(own_tokens=10, own_requests=1), 1.0)
 
             assert journal.write_message.call_count == expected_writes, \
-                f"origin={origin_str} cloned={cloned}"
+                f"origin={origin} cloned={cloned}"
             # The merge into request_reporting happens for everyone.
             assert request_reporting["total_token_accounting"]["total_tokens"] == 10
 

--- a/tests/neuro_san/internals/run_context/langchain/token_counting/test_llm_token_callback_handler.py
+++ b/tests/neuro_san/internals/run_context/langchain/token_counting/test_llm_token_callback_handler.py
@@ -15,6 +15,7 @@
 #
 # END COPYRIGHT
 
+from contextlib import contextmanager
 import logging
 
 from time import time
@@ -26,6 +27,24 @@ from langchain_core.outputs import LLMResult
 import pytest
 
 from neuro_san.internals.run_context.langchain.token_counting.llm_token_callback_handler import LlmTokenCallbackHandler
+from neuro_san.internals.run_context.langchain.token_counting.llm_token_callback_handler import llm_token_callback_var
+
+
+@contextmanager
+def owning_agent_scope(handler: LlmTokenCallbackHandler):
+    """
+    Simulate the agent scope that owns the LLM call being handled.
+
+    In production, each agent's count_tokens() sets llm_token_callback_var to its
+    own handler, so at event time the var holds the handler of the nearest
+    enclosing agent scope.  The handler consults it to tell its own agent's LLM
+    calls apart from downstream agents' calls it also hears about.
+    """
+    token = llm_token_callback_var.set(handler)
+    try:
+        yield
+    finally:
+        llm_token_callback_var.reset(token)
 
 
 class TestLlmTokenCallbackHandler:
@@ -198,7 +217,8 @@ class TestEmptyResponseTracking:
     async def test_on_llm_end_counts_empty_response(self):
         """An empty response counts as a successful request AND an empty one."""
         handler = self._make_handler()
-        await handler.on_llm_end(self._make_result(content=""))
+        with owning_agent_scope(handler):
+            await handler.on_llm_end(self._make_result(content=""))
         assert handler.successful_requests == 1
         assert handler.empty_responses == 1
         assert handler.models_token_dict["ollama"]["gpt-oss:20B"]["empty_responses"] == 1
@@ -207,7 +227,83 @@ class TestEmptyResponseTracking:
     async def test_on_llm_end_does_not_count_nonempty_response(self):
         """A response with content is a successful request but not an empty one."""
         handler = self._make_handler()
-        await handler.on_llm_end(self._make_result(content="a real answer"))
+        with owning_agent_scope(handler):
+            await handler.on_llm_end(self._make_result(content="a real answer"))
         assert handler.successful_requests == 1
         assert handler.empty_responses == 0
         assert handler.models_token_dict["ollama"]["gpt-oss:20B"]["empty_responses"] == 0
+
+
+class TestExclusiveModelAttribution:
+    """
+    Test cases for the own-call vs downstream-call attribution in LlmTokenCallbackHandler.
+
+    Handlers are inheritable langchain callbacks, so an agent's handler also receives
+    events for LLM calls made by downstream agents.  Those events must update the
+    scalar subtree totals but NOT models_token_dict, so that merging every agent's
+    models_token_dict into the request-wide accounting counts each call exactly once.
+    """
+
+    CHAT_MODEL_START_SERIALIZED = {"id": ["langchain", "chat_models", "openai", "ChatOpenAI"]}
+
+    def _make_result(self) -> LLMResult:
+        """Build an LLMResult wrapping a single AIMessage with usage metadata."""
+        message = AIMessage(
+            content="an answer",
+            usage_metadata={"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+            response_metadata={"model_name": "gpt-4"},
+        )
+        return LLMResult(generations=[[ChatGeneration(message=message)]])
+
+    @pytest.mark.asyncio
+    async def test_own_call_updates_models_and_scalars(self):
+        """An LLM call belonging to this handler's own agent updates both tallies."""
+        handler = LlmTokenCallbackHandler(llm_infos={})
+        with owning_agent_scope(handler):
+            await handler.on_chat_model_start(self.CHAT_MODEL_START_SERIALIZED, [])
+            await handler.on_llm_end(self._make_result())
+
+        assert handler.total_tokens == 15
+        assert handler.successful_requests == 1
+        assert handler.models_token_dict["openai"]["gpt-4"]["total_tokens"] == 15
+        assert handler.models_token_dict["openai"]["gpt-4"]["successful_requests"] == 1
+
+    @pytest.mark.asyncio
+    async def test_downstream_call_updates_scalars_only(self):
+        """
+        A downstream agent's LLM call updates the subtree scalars of an ancestor
+        handler, but not its per-model (exclusive) stats.
+        """
+        ancestor_handler = LlmTokenCallbackHandler(llm_infos={})
+        downstream_handler = LlmTokenCallbackHandler(llm_infos={})
+
+        # At event time, the var holds the handler of the agent that owns the call:
+        # the downstream one.  The ancestor hears the same events through callback
+        # inheritance.
+        with owning_agent_scope(downstream_handler):
+            for handler in (downstream_handler, ancestor_handler):
+                await handler.on_chat_model_start(self.CHAT_MODEL_START_SERIALIZED, [])
+                await handler.on_llm_end(self._make_result())
+
+        # The owning agent counts the call in both tallies.
+        assert downstream_handler.total_tokens == 15
+        assert downstream_handler.models_token_dict["openai"]["gpt-4"]["total_tokens"] == 15
+
+        # The ancestor's subtree totals include the downstream call...
+        assert ancestor_handler.total_tokens == 15
+        assert ancestor_handler.successful_requests == 1
+        # ... but its per-model stats do not: the call is not its own.
+        assert not ancestor_handler.models_token_dict
+        # And its per-call timer state was never touched.
+        assert ancestor_handler.start_time is None
+
+    @pytest.mark.asyncio
+    async def test_call_outside_any_agent_scope_updates_scalars_only(self):
+        """With no owning agent scope at all, treat the call as not our own."""
+        handler = LlmTokenCallbackHandler(llm_infos={})
+
+        await handler.on_chat_model_start(self.CHAT_MODEL_START_SERIALIZED, [])
+        await handler.on_llm_end(self._make_result())
+
+        assert handler.total_tokens == 15
+        assert not handler.models_token_dict

--- a/tests/neuro_san/internals/run_context/langchain/token_counting/test_token_accounting_integration.py
+++ b/tests/neuro_san/internals/run_context/langchain/token_counting/test_token_accounting_integration.py
@@ -1,0 +1,240 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+import asyncio
+
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
+
+import pytest
+
+from langchain_core.callbacks import CallbackManagerForLLMRun
+from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.messages import AIMessage
+from langchain_core.messages import BaseMessage
+from langchain_core.outputs import ChatGeneration
+from langchain_core.outputs import ChatResult
+
+from neuro_san.internals.run_context.langchain.token_counting.langchain_token_counter import LangChainTokenCounter
+from neuro_san.internals.run_context.langchain.token_counting.llm_token_callback_handler import LlmTokenCallbackHandler
+from neuro_san.internals.run_context.langchain.token_counting.llm_token_callback_handler import llm_token_callback_var
+
+INPUT_TOKENS: int = 10
+OUTPUT_TOKENS: int = 5
+TOTAL_TOKENS: int = INPUT_TOKENS + OUTPUT_TOKENS
+MODEL_NAME: str = "fake-model"
+
+
+class FakeUsageChatModel(BaseChatModel):
+    """
+    Minimal chat model that reports usage_metadata like a real provider would,
+    so the real langchain callback machinery (configure hook, contexts, event
+    dispatch) can be exercised without any network access.
+    """
+
+    @property
+    def _llm_type(self) -> str:
+        return "fake-usage-chat-model"
+
+    # pylint: disable=unused-argument
+    def _generate(self, messages: List[BaseMessage],
+                  stop: Optional[List[str]] = None,
+                  run_manager: Optional[CallbackManagerForLLMRun] = None,
+                  **kwargs: Any) -> ChatResult:
+        message = AIMessage(
+            content="ok",
+            usage_metadata={
+                "input_tokens": INPUT_TOKENS,
+                "output_tokens": OUTPUT_TOKENS,
+                "total_tokens": TOTAL_TOKENS,
+            },
+            response_metadata={"model_name": MODEL_NAME},
+        )
+        return ChatResult(generations=[ChatGeneration(message=message)])
+
+
+class FakeAsyncioExecutor:
+    """
+    Stand-in for leaf_common's AsyncioExecutor that schedules on the running loop.
+    Like the real thing when called from within its own event loop, the created
+    task inherits the caller's (copied) contextvars Context.
+    """
+
+    # pylint: disable=unused-argument
+    def create_task(self, awaitable, submitter_id: str) -> asyncio.Task:
+        """Wrap the awaitable in a Task on the current event loop."""
+        return asyncio.get_running_loop().create_task(awaitable)
+
+
+class FakeInvocationContext:
+    """
+    Just enough InvocationContext for LangChainTokenCounter.count_tokens()/report().
+    A plain class (not a Mock) because it is consulted from multiple contextvars
+    Contexts.
+    """
+
+    class _FakeLlmFactory:
+        # Zero prices keep calculate_token_costs() from logging warnings.
+        llm_infos: Dict[str, Any] = {
+            MODEL_NAME: {
+                "price_per_1k_input_tokens": 0.0,
+                "price_per_1k_output_tokens": 0.0,
+            }
+        }
+
+    def __init__(self, request_reporting: Dict[str, Any] = None, cloned: bool = False):
+        # Like SessionInvocationContext.safe_shallow_copy(), a clone for a
+        # same-server external network shares the original's request_reporting.
+        self.request_reporting: Dict[str, Any] = \
+            request_reporting if request_reporting is not None else {}
+        self.cloned: bool = cloned
+        self.llm_factory = self._FakeLlmFactory()
+        self.executor = FakeAsyncioExecutor()
+
+    def get_request_reporting(self) -> Dict[str, Any]:
+        """:return: The request reporting dictionary"""
+        return self.request_reporting
+
+    def get_llm_factory(self):
+        """:return: The llm factory carrying llm_infos"""
+        return self.llm_factory
+
+    def get_asyncio_executor(self) -> FakeAsyncioExecutor:
+        """:return: The executor used by count_tokens to run the awaitable"""
+        return self.executor
+
+    def is_cloned(self) -> bool:
+        """:return: True for the clone backing an external network's direct session"""
+        return self.cloned
+
+
+class TestNestedTokenAccounting:
+    """
+    End-to-end test of the token accounting invariants through real langchain
+    event dispatch, mirroring how agents nest in production:
+
+    * An agent's handler hears downstream agents' LLM calls (callback inheritance),
+      so its scalar totals are cumulative over its subtree - the per-agent
+      accounting a front man reports covers the whole request.
+    * request_reporting accumulates each agent's own calls exactly once, so the
+      request-level totals match the front man's subtree totals instead of
+      multiply-counting nested agents (the pre-fix behavior).
+    * The "main_network" breakdown covers only the main network's agents, while
+      the top-level totals also include same-server external networks.
+    """
+
+    # A test this end-to-end legitimately needs a handful of actors and captures.
+    # pylint: disable=too-many-locals
+    @pytest.mark.asyncio
+    async def test_nested_agents_count_each_llm_call_exactly_once(self):
+        """
+        Three count_tokens() scopes with one LLM call each, shaped like a
+        passthrough network: a front man, an internal downstream agent, and an
+        external network's front man reached via a direct session.
+        """
+        invocation_context = FakeInvocationContext()
+        model = FakeUsageChatModel()
+
+        outer_origin = [{"tool": "front_man", "instantiation_index": 0}]
+        inner_origin = outer_origin + [{"tool": "inner_agent", "instantiation_index": 0}]
+
+        # Handlers are created inside count_tokens(); capture them for assertions.
+        captured: Dict[str, LlmTokenCallbackHandler] = {}
+
+        # An external network invoked through a direct session runs on a cloned
+        # invocation context that shares request_reporting with the original.
+        external_context = FakeInvocationContext(
+            request_reporting=invocation_context.get_request_reporting(), cloned=True)
+        external_origin = [{"tool": "external_front_man", "instantiation_index": 0}]
+
+        async def downstream_body(inherited_callbacks: List[LlmTokenCallbackHandler]):
+            # Passing the outer handler explicitly stands in for langchain's
+            # inheritable-callback propagation in the real agent stack, where
+            # RunContextRunnable.run_it() merges the ambient parent config.
+            await model.ainvoke("2 + 2?", config={"callbacks": inherited_callbacks})
+
+        async def inner_body(inherited_callbacks: List[LlmTokenCallbackHandler]):
+            captured["inner"] = llm_token_callback_var.get()
+            await downstream_body(inherited_callbacks)
+
+        async def external_body(inherited_callbacks: List[LlmTokenCallbackHandler]):
+            captured["external"] = llm_token_callback_var.get()
+            await downstream_body(inherited_callbacks)
+
+        async def outer_body():
+            outer_handler: LlmTokenCallbackHandler = llm_token_callback_var.get()
+            captured["outer"] = outer_handler
+
+            # The outer agent's own LLM call.
+            await model.ainvoke("What should I ask the inner agent?")
+
+            # A downstream agent of the same network, with its own token counting scope.
+            inner_counter = LangChainTokenCounter(model, invocation_context, None, inner_origin)
+            await inner_counter.count_tokens(inner_body([outer_handler]))
+
+            # An external network's front man invoked via a direct session.
+            external_counter = LangChainTokenCounter(model, external_context, None, external_origin)
+            await external_counter.count_tokens(external_body([outer_handler]))
+
+        outer_counter = LangChainTokenCounter(model, invocation_context, None, outer_origin)
+        await outer_counter.count_tokens(outer_body())
+
+        outer_handler: LlmTokenCallbackHandler = captured["outer"]
+        inner_handler: LlmTokenCallbackHandler = captured["inner"]
+        external_handler: LlmTokenCallbackHandler = captured["external"]
+        assert outer_handler is not None
+        assert inner_handler is not None
+        assert external_handler is not None
+        assert len({id(outer_handler), id(inner_handler), id(external_handler)}) == 3
+
+        # The downstream agents each saw only their own call, in both tallies.
+        for handler in (inner_handler, external_handler):
+            assert handler.total_tokens == TOTAL_TOKENS
+            assert handler.successful_requests == 1
+            handler_models = handler.models_token_dict["FakeUsageChatModel"][MODEL_NAME]
+            assert handler_models["total_tokens"] == TOTAL_TOKENS
+
+        # The outer agent's scalar totals cover its whole subtree
+        # (its own call + the inner agent's + the external network's) ...
+        assert outer_handler.total_tokens == 3 * TOTAL_TOKENS
+        assert outer_handler.successful_requests == 3
+        # ... but its per-model stats cover only its own call.
+        outer_models = outer_handler.models_token_dict["FakeUsageChatModel"][MODEL_NAME]
+        assert outer_models["total_tokens"] == TOTAL_TOKENS
+        assert outer_models["successful_requests"] == 1
+
+        # Request-level accounting counts each of the three LLM calls exactly once,
+        # matching the front man's subtree totals.
+        request_reporting: Dict[str, Any] = invocation_context.get_request_reporting()
+        total_accounting: Dict[str, Any] = request_reporting["total_token_accounting"]
+        assert total_accounting["total_tokens"] == 3 * TOTAL_TOKENS
+        assert total_accounting["successful_requests"] == 3
+        request_models = total_accounting["models"]["FakeUsageChatModel"][MODEL_NAME]
+        assert request_models["total_tokens"] == 3 * TOTAL_TOKENS
+        assert request_models["successful_requests"] == 3
+
+        # "token_accounting" keeps its historically-documented meaning: the main
+        # network only, excluding the external network's usage.  The server log
+        # prints it before the request total.
+        main_accounting: Dict[str, Any] = request_reporting["token_accounting"]
+        assert main_accounting["total_tokens"] == 2 * TOTAL_TOKENS
+        assert main_accounting["successful_requests"] == 2
+        assert "models" not in main_accounting
+        assert list(request_reporting.keys()) == \
+            ["token_accounting", "total_token_accounting"]

--- a/tests/neuro_san/session/test_session_invocation_context.py
+++ b/tests/neuro_san/session/test_session_invocation_context.py
@@ -1,0 +1,71 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+from unittest.mock import MagicMock
+
+from neuro_san.session.session_invocation_context import SessionInvocationContext
+
+
+class TestSafeShallowCopy:
+    """
+    Test cases for SessionInvocationContext.safe_shallow_copy(), which backs
+    direct sessions to external agent networks on the same server.
+    """
+
+    def _make_context(self) -> SessionInvocationContext:
+        pool = MagicMock()
+        pool.get_executor.return_value = MagicMock()
+        return SessionInvocationContext(
+            agent_name="test_agent",
+            async_session_factory=MagicMock(),
+            async_executors_pool=pool,
+            llm_factory=MagicMock(),
+        )
+
+    def test_clone_shares_request_reporting_and_origination(self):
+        """
+        The shallow copy intentionally shares request_reporting (so external
+        agents' token accounting contributes to the request-wide totals) and
+        origination (so instantiation indices stay consistent).
+        """
+        context = self._make_context()
+        clone = context.safe_shallow_copy()
+
+        assert clone.get_request_reporting() is context.get_request_reporting()
+        assert clone.get_origination() is context.get_origination()
+
+    def test_clone_gets_its_own_queue_and_journal(self):
+        """Message routing state must NOT be shared with the clone."""
+        context = self._make_context()
+        clone = context.safe_shallow_copy()
+
+        assert clone.get_queue() is not context.get_queue()
+        assert clone.get_journal() is not context.get_journal()
+        assert clone.get_work_done_event() is not context.get_work_done_event()
+
+    def test_clone_is_cloned(self):
+        """
+        Only the clone reports being cloned.  LangChainTokenCounter.report()
+        relies on this to let only the top-level front man (not front men of
+        external networks invoked via direct sessions) emit the request-level
+        token accounting message.
+        """
+        context = self._make_context()
+        clone = context.safe_shallow_copy()
+
+        assert clone.is_cloned() is True
+        assert context.is_cloned() is False


### PR DESCRIPTION
Fixes #1186

## Problem

Request-level token accounting (the "Request reporting" block in `server.log` and the final client-visible accounting message carrying the `models` key) is inflated for agent networks that call other agent networks. Verified on `agent_network_designer`: reported **1,192,157 tokens / 199 calls** vs. an actual **569,464 / 76**. Per-agent (per-origin) accounting messages are correct and unchanged.

## Root cause

Since commit `2646d20c` (v0.6.55) introduced `merge_configs(...)` for Langfuse trace parenting, every ancestor's `LlmTokenCallbackHandler` (registered as an inheritable callback) hears all descendant LLM calls, making each handler's tallies **subtree-cumulative**. `LangChainTokenCounter.report()` then merges each agent's `models_token_dict` into the shared `request_reporting` at **every** agent completion, so a call at nesting depth N is counted N times. External networks invoked via direct sessions on the same server share the same `request_reporting` dict (via `safe_shallow_copy()`), compounding the inflation.

## Fix

- **Exclusive attribution in `LlmTokenCallbackHandler`**: per-model tallies (`models_token_dict`) are only updated when the handler is the nearest enclosing agent scope (`llm_token_callback_var.get() is self`). Scalar tallies stay subtree-cumulative so per-agent accounting messages are untouched. Merging every agent's exclusive contribution now sums each LLM call exactly once.
- **`token_accounting` = main network only**: restored to its historically documented semantics ("usage from external agents is not included"), reported without a `models` key.
- **New `total_token_accounting` = request total**: includes external agents invoked via direct sessions on this server, carries the per-model `models` breakdown, and is written last. The main network's front man streams both dicts verbatim as its two accounting messages, so the server log and the client-side thinking file now agree.
- The client-side `TokenAccountingMessageProcessor` keeps the last qualifying front-man message, so client state still ends up with the request total (with `models`) — no client-side change needed.

### Hardening included

- Accounting messages always carry `total_tokens` (zero-seeded stats), so `TokenAccountingMessageFilter` never drops them when a provider returns no `usage_metadata`.
- Cloned (external) reporters preserve the front man's `time_taken_in_seconds` and seed zeroed accounting if they report first.
- Front-man detection is structural (`len(origin) == 1` and not cloned) instead of checking for `"."` in the origin string, so dotted agent names work.
- `SessionInvocationContext.reset()` clears `request_reporting` so totals are per-exchange in library mode.
- A caveat is appended when agents that did not complete leave tokens unattributed.

### Format note for log scrapers

`token_accounting.models` moved to `total_token_accounting.models`, and `token_accounting`'s numbers shrink to main-network-only.

## Testing

- New integration test builds a passthrough topology (front man + internal agent + cloned external network) with a fake usage-emitting chat model and asserts main = 30/2, total = 45/3, key order pinned.
- New unit tests for exclusive model attribution, front-man gating, cloned-reporter behavior, late-external latency preservation, unattributed-token caveat, and `safe_shallow_copy()` sharing semantics.
- Full suite: 348 passed / 2 skipped; pylint 10.00/10; flake8 clean.
