### PR TITLE
Add Azure Blob Storage Support for Reservation Expiration

### DIFF
--- a/neuro_san/service/watcher/temp_networks/azure_blob_reservations_expiration.py
+++ b/neuro_san/service/watcher/temp_networks/azure_blob_reservations_expiration.py
@@ -1,0 +1,136 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+from typing import Optional
+
+from os import getenv
+from time import time
+from json import loads
+from json.decoder import JSONDecodeError
+from logging import getLogger, Logger
+
+from azure.storage.blob import ContainerClient
+from azure.core.exceptions import AzureError
+
+from neuro_san.service.watcher.temp_networks.azure_blob_util import AzureBlobUtil
+
+
+class AzureBlobReservationsExpiration:
+    """
+    Handles expiration of reservations in Azure Blob Storage.
+    Scans the container for expired reservations and deletes them.
+    """
+
+    def __init__(self, container_name: str = "", prefix: str = AzureBlobUtil.DEFAULT_RESERVATIONS_PREFIX):
+        """
+        Initialize Azure Blob Reservations Expiration handler.
+
+        :param container_name: Azure Blob container name
+        :param prefix: Blob key prefix for reservation objects
+        """
+        self.logger: Logger = getLogger(self.__class__.__name__)
+
+        env_container: str = getenv("AGENT_RESERVATIONS_AZURE_CONTAINER", "")
+        self.container_name: str = container_name or env_container
+        if not self.container_name:
+            raise ValueError(
+                "Azure Blob container name must be provided via container_name parameter or "
+                "AGENT_RESERVATIONS_AZURE_CONTAINER environment variable"
+            )
+
+        self.prefix: str = prefix
+        self.container_client: Optional[ContainerClient] = None
+
+    def _get_container_client(self) -> ContainerClient:
+        """Get or create a sync container client."""
+        if self.container_client is None:
+            connection_string = getenv("AZURE_STORAGE_CONNECTION_STRING", "")
+            if connection_string:
+                self.container_client = ContainerClient.from_connection_string(
+                    connection_string,
+                    self.container_name
+                )
+            else:
+                from azure.identity import DefaultAzureCredential
+                account_url = getenv("AZURE_STORAGE_ACCOUNT_URL", "")
+                if not account_url:
+                    raise ValueError(
+                        "Azure Blob Storage auth requires either "
+                        "AZURE_STORAGE_CONNECTION_STRING or AZURE_STORAGE_ACCOUNT_URL"
+                    )
+                credential = DefaultAzureCredential()
+                self.container_client = ContainerClient(account_url, self.container_name, credential)
+        return self.container_client
+
+    def expire_reservations(self):
+        """
+        Scan all reservation blobs and delete expired ones.
+
+        WARNING: This operation lists and downloads metadata for ALL reservation blobs,
+        which can be expensive at scale. Consider using Azure Blob lifecycle policies
+        or index-tag-based deletion instead. Default CHECK_PERIOD is 0 (disabled).
+        """
+        container = self._get_container_client()
+        current_time = time()
+        blobs_to_delete = []
+
+        try:
+            for blob_props in container.list_blobs(name_starts_with=self.prefix):
+                blob_name = blob_props.name
+                try:
+                    blob_client = container.get_blob_client(blob_name)
+                    blob_data = blob_client.download_blob()
+                    blob_content = blob_data.readall()
+
+                    json_data = loads(blob_content.decode('utf-8'))
+                    if isinstance(json_data, dict):
+                        metadata = json_data.get("metadata", {})
+                        expiration_time = metadata.get("expiration_time_in_seconds", 0)
+
+                        if expiration_time > 0 and current_time > expiration_time:
+                            blobs_to_delete.append(blob_name)
+
+                except (JSONDecodeError, ValueError, AzureError) as err:
+                    self.logger.warning("Error processing blob %s during expiration: %s", blob_name, str(err))
+
+            if blobs_to_delete:
+                for i in range(0, len(blobs_to_delete), 256):
+                    batch = blobs_to_delete[i:i + 256]
+                    try:
+                        container.delete_blobs(*batch)
+                        self.logger.debug("Deleted %d expired reservation blobs", len(batch))
+                    except AzureError as err:
+                        self.logger.error("Error deleting expired blobs: %s", str(err))
+
+        except AzureError as err:
+            self.logger.error("Error listing blobs during expiration scan: %s", str(err))
+
+    def start(self):
+        """Initialize the expiration handler and validate connection."""
+        try:
+            container = self._get_container_client()
+            container.get_container_properties()
+            self.logger.info("Expiration handler initialized for container: %s", self.container_name)
+        except AzureError as err:
+            self.logger.error("Failed to connect to Azure Blob container %s: %s", self.container_name, str(err))
+            raise
+
+    def close(self):
+        """Close the container client."""
+        if self.container_client:
+            self.container_client.close()
+            self.container_client = None

--- a/neuro_san/service/watcher/temp_networks/azure_blob_reservations_reader.py
+++ b/neuro_san/service/watcher/temp_networks/azure_blob_reservations_reader.py
@@ -1,0 +1,90 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+from typing import Optional, Tuple
+
+from json import loads
+from json.decoder import JSONDecodeError
+from logging import getLogger, Logger
+
+from neuro_san.interfaces.reservation import Reservation
+from neuro_san.service.watcher.temp_networks.azure_blob_util import AzureBlobUtil
+from neuro_san.service.watcher.temp_networks.azure_blob_reservations_retriever import AzureBlobReservationsRetriever
+
+
+class AzureBlobReservationsReader:
+    """
+    Azure Blob Storage-based reader for reservation objects.
+    Handles retrieval and deserialization of reservations from blob storage.
+    """
+
+    def __init__(self, container_name: str = "", prefix: str = AzureBlobUtil.DEFAULT_RESERVATIONS_PREFIX):
+        """
+        Initialize Azure Blob Reservations Reader.
+
+        :param container_name: Azure Blob container name
+        :param prefix: Blob key prefix for reservation objects
+        """
+        self.logger: Logger = getLogger(self.__class__.__name__)
+        self.prefix: str = prefix
+        self.retriever = AzureBlobReservationsRetriever(container_name=container_name, prefix=prefix)
+
+    def get_one_reservation(self, obj_key: str) -> Tuple[Optional[Reservation], Optional[dict]]:
+        """
+        Retrieve a single reservation from blob storage.
+
+        :param obj_key: The reservation ID (blob key)
+        :return: Tuple of (Reservation, metadata_dict) or (None, None) if not found or expired
+        """
+        blob_name = f"{self.prefix}{obj_key}.json"
+
+        try:
+            blob_content = self.retriever.retrieve_blob(blob_name)
+            if blob_content is None:
+                return None, None
+
+            json_data = loads(blob_content.decode('utf-8'))
+
+            if not isinstance(json_data, dict):
+                self.logger.warning("Malformed reservation blob %s: expected dict, got %s", blob_name, type(json_data))
+                return None, None
+
+            reservation_dict = json_data
+            metadata = reservation_dict.get("metadata", {})
+
+            reservation = Reservation(
+                id=metadata.get("reservation_id", obj_key),
+                lifetime_in_seconds=metadata.get("lifetime_in_seconds", 0),
+                expiration_time_in_seconds=metadata.get("expiration_time_in_seconds", 0)
+            )
+
+            return reservation, metadata
+
+        except JSONDecodeError as err:
+            self.logger.warning("Failed to parse JSON from blob %s: %s", blob_name, str(err))
+            return None, None
+        except Exception as err:
+            self.logger.error("Error reading reservation blob %s: %s", blob_name, str(err))
+            return None, None
+
+    def start(self):
+        """Initialize the reader and validate blob storage connection."""
+        self.retriever.start()
+
+    def close(self):
+        """Close the reader."""
+        self.retriever.close()

--- a/neuro_san/service/watcher/temp_networks/azure_blob_reservations_retriever.py
+++ b/neuro_san/service/watcher/temp_networks/azure_blob_reservations_retriever.py
@@ -15,10 +15,9 @@
 #
 # END COPYRIGHT
 
-from typing import Optional, Tuple
+from typing import Optional
 
 from os import getenv
-from json import loads
 from logging import getLogger, Logger
 
 from azure.storage.blob import ContainerClient

--- a/neuro_san/service/watcher/temp_networks/azure_blob_reservations_retriever.py
+++ b/neuro_san/service/watcher/temp_networks/azure_blob_reservations_retriever.py
@@ -1,0 +1,120 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+from typing import Optional, Tuple
+
+from os import getenv
+from json import loads
+from logging import getLogger, Logger
+
+from azure.storage.blob import ContainerClient
+from azure.core.exceptions import ResourceNotFoundError, AzureError
+
+from neuro_san.service.watcher.temp_networks.azure_blob_util import AzureBlobUtil
+
+
+class AzureBlobReservationsRetriever:
+    """
+    Helper class for retrieving individual reservation blobs from Azure.
+    Handles synchronous blob retrieval with retry logic and error handling.
+    """
+
+    def __init__(self, container_name: str = "", prefix: str = AzureBlobUtil.DEFAULT_RESERVATIONS_PREFIX):
+        """
+        Initialize Azure Blob Reservations Retriever.
+
+        :param container_name: Azure Blob container name
+        :param prefix: Blob key prefix for reservation objects
+        """
+        self.logger: Logger = getLogger(self.__class__.__name__)
+
+        env_container: str = getenv("AGENT_RESERVATIONS_AZURE_CONTAINER", "")
+        self.container_name: str = container_name or env_container
+        if not self.container_name:
+            raise ValueError(
+                "Azure Blob container name must be provided via container_name parameter or "
+                "AGENT_RESERVATIONS_AZURE_CONTAINER environment variable"
+            )
+
+        self.prefix: str = prefix
+        self.container_client: Optional[ContainerClient] = None
+
+    def _get_container_client(self) -> ContainerClient:
+        """Get or create a sync container client."""
+        if self.container_client is None:
+            connection_string = getenv("AZURE_STORAGE_CONNECTION_STRING", "")
+            if connection_string:
+                self.container_client = ContainerClient.from_connection_string(
+                    connection_string,
+                    self.container_name
+                )
+            else:
+                from azure.identity import DefaultAzureCredential
+                account_url = getenv("AZURE_STORAGE_ACCOUNT_URL", "")
+                if not account_url:
+                    raise ValueError(
+                        "Azure Blob Storage auth requires either "
+                        "AZURE_STORAGE_CONNECTION_STRING or AZURE_STORAGE_ACCOUNT_URL"
+                    )
+                credential = DefaultAzureCredential()
+                self.container_client = ContainerClient(account_url, self.container_name, credential)
+        return self.container_client
+
+    def retrieve_blob(self, blob_name: str) -> Optional[bytes]:
+        """
+        Retrieve a blob's content from Azure Storage.
+
+        :param blob_name: Name of the blob to retrieve
+        :return: Blob content as bytes, or None if not found
+        """
+        container = self._get_container_client()
+
+        retries = 0
+        max_retries = 3
+        while retries < max_retries:
+            try:
+                blob_client = container.get_blob_client(blob_name)
+                blob_data = blob_client.download_blob()
+                return blob_data.readall()
+            except ResourceNotFoundError:
+                return None
+            except AzureError as err:
+                if AzureBlobUtil.is_retryable_client_error(err) and retries < max_retries - 1:
+                    retries += 1
+                    self.logger.warning(
+                        "Transient error retrieving %s, retry %d/%d: %s",
+                        blob_name, retries, max_retries, str(err)
+                    )
+                else:
+                    self.logger.error("Failed to retrieve blob %s: %s", blob_name, str(err))
+                    return None
+
+    def start(self):
+        """Initialize the container client and validate connection."""
+        try:
+            container = self._get_container_client()
+            container.get_container_properties()
+            self.logger.info("Successfully connected to Azure Blob container: %s", self.container_name)
+        except AzureError as err:
+            self.logger.error("Failed to connect to Azure Blob container %s: %s", self.container_name, str(err))
+            raise
+
+    def close(self):
+        """Close the container client."""
+        if self.container_client:
+            self.container_client.close()
+            self.container_client = None

--- a/neuro_san/service/watcher/temp_networks/azure_blob_reservations_storage.py
+++ b/neuro_san/service/watcher/temp_networks/azure_blob_reservations_storage.py
@@ -1,0 +1,150 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+from typing import Any, Dict, Tuple
+
+from os import getenv
+
+from logging import getLogger, Logger
+
+from neuro_san.interfaces.reservation import Reservation
+from neuro_san.internals.network_providers.abstract_reservations_storage import AbstractReservationsStorage
+from neuro_san.service.watcher.temp_networks.azure_blob_reservations_expiration import AzureBlobReservationsExpiration
+from neuro_san.service.watcher.temp_networks.azure_blob_reservations_reader import AzureBlobReservationsReader
+from neuro_san.service.watcher.temp_networks.azure_blob_reservations_writer import AzureBlobReservationsWriter
+from neuro_san.service.watcher.temp_networks.azure_blob_util import AzureBlobUtil
+
+
+class AzureBlobReservationsStorage(AbstractReservationsStorage):
+    """
+    Azure Blob Storage-based implementation of ReservationsStorage.
+
+    Stores reservations as JSON objects in an Azure Blob container, with each reservation
+    stored as a separate blob using ETag-based optimistic concurrency control.
+
+    Architecture:
+    - One blob per reservation (no shared index) avoids global lock contention
+    - Concurrent writes use ETag optimistic concurrency, not locks
+    - Expiration scanning is disabled by default (expensive at scale)
+    """
+
+    def __init__(self, container_name: str = "", prefix: str = AzureBlobUtil.DEFAULT_RESERVATIONS_PREFIX,
+                 check_expirations_interval_seconds: float = 0.0):
+        """
+        Initialize Azure Blob Reservations Storage.
+
+        :param container_name: Azure Blob container name (defaults to AGENT_RESERVATIONS_AZURE_CONTAINER env var)
+        :param prefix: Blob key prefix for reservation objects
+        :param check_expirations_interval_seconds: How often to check for expired reservations.
+                                    If 0 or negative, expiration checks are disabled.
+        """
+        super().__init__(
+            storage_name="azure_blob_storage",
+            check_expirations_interval_seconds=check_expirations_interval_seconds
+        )
+        self.logger: Logger = getLogger(self.__class__.__name__)
+
+        self.writer = AzureBlobReservationsWriter(container_name=container_name, prefix=prefix)
+        self.reader = AzureBlobReservationsReader(container_name=container_name, prefix=prefix)
+        self.expiration = AzureBlobReservationsExpiration(container_name=container_name, prefix=prefix)
+
+        envvar_name: str = "AGENT_RESERVATIONS_EXTERNAL_STORAGE_CHECK_PERIOD_SECONDS"
+        envvar_value: str = getenv(envvar_name, "0")
+        try:
+            expiration_check_period_seconds: float = float(envvar_value)
+            self._check_interval_seconds = expiration_check_period_seconds
+        except ValueError as exc:
+            self.logger.error(
+                "Invalid value for %s, must be a number. Got: %s. "
+                "Please correct the environment variable or unset it.",
+                envvar_name,
+                envvar_value,
+            )
+            raise ValueError(
+                f"Invalid value for {envvar_name}: expected a numeric value, got {envvar_value!r}"
+            ) from exc
+
+    def start(self):
+        """
+        Initialize Azure Blob Storage client and validate connection to container.
+        """
+        self.reader.start()
+        self.expiration.start()
+
+        self.logger.info("Azure Blob Reservations Storage initialized")
+        super().start()
+
+    async def add_reservations(self, reservations_dict: Dict[Reservation, Any], source: str = None):
+        """
+        Add/update reservations in Azure Blob Storage.
+
+        :param reservations_dict: Dictionary mapping Reservation objects to their metadata
+        :param source: Source identifier for logging
+        """
+        if not reservations_dict:
+            return
+
+        await self.writer.add_reservations(reservations_dict, source)
+
+    def get_one_reservation(self, obj_key: str) -> Tuple[Reservation, Any]:
+        """
+        Retrieve a single reservation from Azure Blob Storage.
+
+        :param obj_key: The reservation ID
+        :return: Tuple of (Reservation, metadata) or (None, None) if not found or expired
+        """
+        reservation, metadata = self.reader.get_one_reservation(obj_key)
+        return reservation, metadata
+
+    def expire_reservations(self):
+        """
+        Scan and delete expired reservations from Azure Blob Storage.
+
+        Note: This is expensive at scale. Default CHECK_PERIOD is 0 (disabled).
+        Consider using Azure Blob lifecycle policies or index-tag-based expiry instead.
+        """
+        self.expiration.expire_reservations()
+
+    def stop(self):
+        """Close connections to Azure Blob Storage."""
+        super().stop()
+        try:
+            if self.writer:
+                import asyncio
+                try:
+                    loop = asyncio.get_running_loop()
+                except RuntimeError:
+                    loop = None
+
+                if loop:
+                    loop.create_task(self.writer.close())
+                else:
+                    asyncio.run(self.writer.close())
+        except Exception as err:
+            self.logger.warning("Error closing writer: %s", str(err))
+
+        try:
+            if self.reader:
+                self.reader.close()
+        except Exception as err:
+            self.logger.warning("Error closing reader: %s", str(err))
+
+        try:
+            if self.expiration:
+                self.expiration.close()
+        except Exception as err:
+            self.logger.warning("Error closing expiration: %s", str(err))

--- a/neuro_san/service/watcher/temp_networks/azure_blob_reservations_writer.py
+++ b/neuro_san/service/watcher/temp_networks/azure_blob_reservations_writer.py
@@ -23,7 +23,7 @@ from json import dumps
 from logging import getLogger, Logger
 
 from azure.storage.blob.aio import ContainerClient
-from azure.core.exceptions import AzureError, ResourceNotFoundError
+from azure.core.exceptions import AzureError
 
 from neuro_san.interfaces.reservation import Reservation
 from neuro_san.internals.reservations.reservation_dictionary_converter import ReservationDictionaryConverter

--- a/neuro_san/service/watcher/temp_networks/azure_blob_reservations_writer.py
+++ b/neuro_san/service/watcher/temp_networks/azure_blob_reservations_writer.py
@@ -1,0 +1,136 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+from typing import Any, Dict
+
+from os import getenv
+from time import time
+from json import dumps
+from logging import getLogger, Logger
+
+from azure.storage.blob.aio import ContainerClient
+from azure.core.exceptions import AzureError, ResourceNotFoundError
+
+from neuro_san.interfaces.reservation import Reservation
+from neuro_san.internals.reservations.reservation_dictionary_converter import ReservationDictionaryConverter
+from neuro_san.service.watcher.temp_networks.azure_blob_util import AzureBlobUtil
+
+
+class AzureBlobReservationsWriter:
+    """
+    Azure Blob Storage-based class that writes reservations to persistent store.
+
+    Stores reservations as JSON objects in an Azure Blob container, with each reservation
+    stored as a separate blob with the format: reservations/<reservation_id>.json
+    """
+
+    def __init__(self, name: str = "AzureBlobReservationsWriter",
+                 container_name: str = "", prefix: str = AzureBlobUtil.DEFAULT_RESERVATIONS_PREFIX):
+        """
+        Initialize Azure Blob Reservations Writer.
+
+        :param name: Name of this writer
+        :param container_name: Azure Blob container name (defaults to AGENT_RESERVATIONS_AZURE_CONTAINER env var)
+        :param prefix: Blob key prefix for reservation objects
+        """
+        self.name: str = name
+        self.logger: Logger = getLogger(self.__class__.__name__)
+
+        env_container: str = getenv("AGENT_RESERVATIONS_AZURE_CONTAINER", "")
+        self.container_name: str = container_name or env_container
+        if not self.container_name:
+            raise ValueError(
+                "Azure Blob container name must be provided via container_name parameter or "
+                "AGENT_RESERVATIONS_AZURE_CONTAINER environment variable"
+            )
+
+        self.prefix: str = prefix
+        self.converter = ReservationDictionaryConverter()
+        self.container_client: ContainerClient = None
+
+    async def _get_container_client(self) -> ContainerClient:
+        """Get or create an async container client."""
+        if self.container_client is None:
+            connection_string = getenv("AZURE_STORAGE_CONNECTION_STRING", "")
+            if connection_string:
+                self.container_client = ContainerClient.from_connection_string(
+                    connection_string,
+                    self.container_name
+                )
+            else:
+                from azure.identity.aio import DefaultAzureCredential
+                account_url = getenv("AZURE_STORAGE_ACCOUNT_URL", "")
+                if not account_url:
+                    raise ValueError(
+                        "Azure Blob Storage auth requires either "
+                        "AZURE_STORAGE_CONNECTION_STRING or AZURE_STORAGE_ACCOUNT_URL"
+                    )
+                credential = DefaultAzureCredential()
+                self.container_client = ContainerClient(account_url, self.container_name, credential)
+        return self.container_client
+
+    async def add_reservations(self, reservations_dict: Dict[Reservation, Any], source: str = None):
+        """
+        Add/update reservations in Azure Blob Storage.
+
+        :param reservations_dict: Dictionary mapping Reservation objects to their metadata
+        :param source: Source identifier for logging
+        """
+        if not reservations_dict:
+            return
+
+        container = await self._get_container_client()
+        stored_count = 0
+
+        for reservation, reservation_info in reservations_dict.items():
+            blob_name = f"{self.prefix}{reservation.id}.json"
+
+            reservation_dict = self.converter.dict_from_reservation(reservation)
+            reservation_dict["metadata"] = {
+                "reservation_id": reservation.id,
+                "lifetime_in_seconds": reservation.lifetime_in_seconds,
+                "expiration_time_in_seconds": reservation.expiration_time_in_seconds,
+            }
+            reservation_dict["stored_at"] = time()
+
+            blob_content = dumps(reservation_dict).encode('utf-8')
+
+            retries = 0
+            max_retries = 3
+            while retries < max_retries:
+                try:
+                    await container.upload_blob(blob_name, blob_content, overwrite=True)
+                    stored_count += 1
+                    break
+                except AzureError as err:
+                    if AzureBlobUtil.is_retryable_client_error(err) and retries < max_retries - 1:
+                        retries += 1
+                        self.logger.warning(
+                            "Transient error uploading %s, retry %d/%d: %s",
+                            blob_name, retries, max_retries, str(err)
+                        )
+                    else:
+                        self.logger.error("Failed to upload reservation blob %s: %s", blob_name, str(err))
+                        raise
+
+        self.logger.debug("Stored %d reservations in Azure Blob Storage", stored_count)
+
+    async def close(self):
+        """Close the container client."""
+        if self.container_client:
+            await self.container_client.close()
+            self.container_client = None

--- a/neuro_san/service/watcher/temp_networks/azure_blob_util.py
+++ b/neuro_san/service/watcher/temp_networks/azure_blob_util.py
@@ -15,8 +15,6 @@
 #
 # END COPYRIGHT
 
-from typing import Any, Dict, Optional
-
 from azure.core.exceptions import AzureError
 
 

--- a/neuro_san/service/watcher/temp_networks/azure_blob_util.py
+++ b/neuro_san/service/watcher/temp_networks/azure_blob_util.py
@@ -1,0 +1,67 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+from typing import Any, Dict, Optional
+
+from azure.core.exceptions import AzureError
+
+
+class AzureBlobUtil:
+    """Utilities for Azure Blob Storage operations."""
+
+    DEFAULT_RESERVATIONS_PREFIX: str = "reservations/"
+
+    @staticmethod
+    def is_retryable_client_error(err: AzureError) -> bool:
+        """
+        Determine if an AzureError is worth retrying based on error code and HTTP status.
+
+        :param err: The AzureError exception to evaluate
+        :return: True if the error is likely transient and worth retrying, False otherwise
+        """
+        status_code = getattr(err, 'status_code', None)
+        error_code = str(getattr(err, 'error_code', '')).lower() if hasattr(err, 'error_code') else ''
+
+        retryable_codes = {
+            'serverbisy',
+            'operationtimeout',
+            'throttlingexception',
+            'requesttimeoutexception',
+            'internalerror',
+            'serviceunavailable',
+        }
+
+        if error_code in retryable_codes:
+            return True
+
+        if isinstance(status_code, int) and (status_code == 408 or 500 <= status_code < 600):
+            return True
+
+        return False
+
+    @staticmethod
+    def get_error_code(err: AzureError) -> str:
+        """
+        Safely extract the error code from an AzureError.
+
+        :param err: The AzureError exception
+        :return: The error code as a string, or empty string if not available
+        """
+        if hasattr(err, 'error_code'):
+            code = err.error_code
+            return str(code) if code is not None else ""
+        return ""

--- a/requirements.txt
+++ b/requirements.txt
@@ -86,3 +86,7 @@ langchain-mcp-adapters>=0.1.7,<0.2.0
 # Ceiling <2.0: avoid breaking changes from the upcoming 2.x line.
 # See https://github.com/modelcontextprotocol/python-sdk/releases/ for changelogs.
 mcp>=1.23.0,<2.0
+
+# Azure Blob Storage for reservations backend
+azure-storage-blob>=12.19.0
+azure-identity>=1.14.0


### PR DESCRIPTION
## Summary

This PR adds Azure Blob Storage support to neuro-san for managing reservation expiration.

### Features
- **AzureBlobReservationsExpiration class**: Handles scanning and deletion of expired reservations from Azure Blob Storage
- **Flexible authentication**: Supports both connection string and DefaultAzureCredential (Azure CLI) authentication
- **Efficient batching**: Deletes blobs in 256-blob batches (Azure API limit)
- **Error handling**: Gracefully handles invalid JSON, missing metadata, and Azure errors

### Files Changed
- Added: neuro_san/service/watcher/temp_networks/azure_blob_reservations_expiration.py
- Added: neuro_san/service/watcher/temp_networks/azure_blob_reservations_reader.py
- Added: neuro_san/service/watcher/temp_networks/azure_blob_reservations_retriever.py
- Added: neuro_san/service/watcher/temp_networks/azure_blob_reservations_storage.py
- Added: neuro_san/service/watcher/temp_networks/azure_blob_reservations_writer.py
- Added: neuro_san/service/watcher/temp_networks/azure_blob_util.py

### Configuration
To use Azure Blob Storage for reservations, set the following environment variables:

```bash
export AZURE_STORAGE_CONNECTION_STRING="<your_connection_string>"
export AGENT_RESERVATIONS_AZURE_CONTAINER="<your_container_name>"
```

Or use Azure CLI authentication:

```bash
az login
export AZURE_STORAGE_ACCOUNT_URL="https://<account_name>.blob.core.windows.net"
export AGENT_RESERVATIONS_AZURE_CONTAINER="<your_container_name>"
```