### PR TITLE
Make storage dependencies optional for both S3 and Azure.

### DIFF
--- a/neuro_san/deploy/Dockerfile
+++ b/neuro_san/deploy/Dockerfile
@@ -384,6 +384,7 @@ ENV AGENT_EXTERNAL_SERVER_URL=""
 # When not set, this defaults to a null implementation.
 # A simple default implementation is provided by the class
 # "neuro_san.service.watcher.temp_networks.s3.s3_reservations_storage.S3ReservationsStorage"
+# Note that you will need to install appropriate botocore and aiobotocore packages to use this class.
 ENV AGENT_EXTERNAL_RESERVATIONS_STORAGE=""
 
 # When the AGENT_EXTERNAL_RESERVATIONS_STORAGE (immediately above) is set to the

--- a/neuro_san/service/watcher/temp_networks/azure/azure_blob_reservations_expiration.py
+++ b/neuro_san/service/watcher/temp_networks/azure/azure_blob_reservations_expiration.py
@@ -36,7 +36,7 @@ DefaultAzureCredential: Type[Any] = ResolverUtil.create_type("azure.identity.Def
 ContainerClient: Type[Any] = ResolverUtil.create_type("azure.storage.blob.ContainerClient",
                                                       install_if_missing="azure-storage-blob")
 
-from neuro_san.service.watcher.temp_networks.azure.azure_blob_util import AzureBlobUtil
+from neuro_san.service.watcher.temp_networks.azure.azure_blob_util import AzureBlobUtil     # noqa: E402
 
 
 class AzureBlobReservationsExpiration:

--- a/neuro_san/service/watcher/temp_networks/azure/azure_blob_reservations_expiration.py
+++ b/neuro_san/service/watcher/temp_networks/azure/azure_blob_reservations_expiration.py
@@ -15,7 +15,9 @@
 #
 # END COPYRIGHT
 
+from typing import Any
 from typing import Optional
+from typing import Type
 
 from time import time
 from json import loads
@@ -24,11 +26,16 @@ from logging import getLogger
 from logging import Logger
 from os import getenv
 
-from azure.core.exceptions import AzureError
-from azure.identity import DefaultAzureCredential
-from azure.storage.blob import ContainerClient
+from leaf_common.config.resolver_util import ResolverUtil
 
-# pylint: disable=wrong-import-order
+# Lazily resolve here because this is one of the first places the import happens
+AzureError: Type[Any] = ResolverUtil.create_type("azure.core.exceptions.AzureError",
+                                                 install_if_missing="azure-core")
+DefaultAzureCredential: Type[Any] = ResolverUtil.create_type("azure.identity.DefaultAzureCredential",
+                                                             install_if_missing="azure-identity")
+ContainerClient: Type[Any] = ResolverUtil.create_type("azure.storage.blob.ContainerClient",
+                                                      install_if_missing="azure-storage-blob")
+
 from neuro_san.service.watcher.temp_networks.azure.azure_blob_util import AzureBlobUtil
 
 

--- a/neuro_san/service/watcher/temp_networks/s3/s3_reservations_expiration.py
+++ b/neuro_san/service/watcher/temp_networks/s3/s3_reservations_expiration.py
@@ -35,10 +35,10 @@ from leaf_common.config.resolver_util import ResolverUtil
 BaseClient: Type[Any] = ResolverUtil.create_type("botocore.client.BaseClient", install_if_missing="botocore")
 ClientError: Type[Any] = ResolverUtil.create_type("botocore.exceptions.ClientError", install_if_missing="botocore")
 
-from neuro_san.interfaces.reservationist import Reservationist
-from neuro_san.service.watcher.temp_networks.s3.aws_sync_client_worker import AwsSyncClientWorker
-from neuro_san.service.watcher.temp_networks.s3.s3_reservations_retriever import S3ReservationsRetriever
-from neuro_san.service.watcher.temp_networks.s3.s3_util import S3Util
+from neuro_san.interfaces.reservationist import Reservationist                                              # noqa: E402
+from neuro_san.service.watcher.temp_networks.s3.aws_sync_client_worker import AwsSyncClientWorker           # noqa: E402
+from neuro_san.service.watcher.temp_networks.s3.s3_reservations_retriever import S3ReservationsRetriever    # noqa: E402
+from neuro_san.service.watcher.temp_networks.s3.s3_util import S3Util                                       # noqa: E402
 
 
 class S3ReservationsExpiration:

--- a/neuro_san/service/watcher/temp_networks/s3/s3_reservations_expiration.py
+++ b/neuro_san/service/watcher/temp_networks/s3/s3_reservations_expiration.py
@@ -20,6 +20,7 @@ from typing import Callable
 from typing import Dict
 from typing import Iterable
 from typing import Optional
+from typing import Type
 
 from time import time
 from functools import partial
@@ -28,8 +29,11 @@ from json.decoder import JSONDecodeError
 from logging import getLogger
 from logging import Logger
 
-from botocore.client import BaseClient
-from botocore.exceptions import ClientError
+from leaf_common.config.resolver_util import ResolverUtil
+
+# Lazily resolve here because this is one of the first places the import happens
+BaseClient: Type[Any] = ResolverUtil.create_type("botocore.client.BaseClient", install_if_missing="botocore")
+ClientError: Type[Any] = ResolverUtil.create_type("botocore.exceptions.ClientError", install_if_missing="botocore")
 
 from neuro_san.interfaces.reservationist import Reservationist
 from neuro_san.service.watcher.temp_networks.s3.aws_sync_client_worker import AwsSyncClientWorker

--- a/neuro_san/service/watcher/temp_networks/s3/s3_reservations_writer.py
+++ b/neuro_san/service/watcher/temp_networks/s3/s3_reservations_writer.py
@@ -18,6 +18,7 @@
 from typing import Any
 from typing import Callable
 from typing import Dict
+from typing import Type
 
 from os import getenv
 from time import time
@@ -27,7 +28,11 @@ from json import dumps
 from logging import getLogger
 from logging import Logger
 
-from aiobotocore.client import AioBaseClient
+from leaf_common.config.resolver_util import ResolverUtil
+
+# Lazily resolve here because this is one of the first places the import happens
+AioBaseClient: Type[Any] = ResolverUtil.create_type("aiobotocore.client.AioBaseClient",
+                                                    install_if_missing="aiobotocore")
 
 from neuro_san.interfaces.reservation import Reservation
 from neuro_san.internals.reservations.reservation_dictionary_converter import ReservationDictionaryConverter

--- a/neuro_san/service/watcher/temp_networks/s3/s3_reservations_writer.py
+++ b/neuro_san/service/watcher/temp_networks/s3/s3_reservations_writer.py
@@ -34,10 +34,11 @@ from leaf_common.config.resolver_util import ResolverUtil
 AioBaseClient: Type[Any] = ResolverUtil.create_type("aiobotocore.client.AioBaseClient",
                                                     install_if_missing="aiobotocore")
 
-from neuro_san.interfaces.reservation import Reservation
-from neuro_san.internals.reservations.reservation_dictionary_converter import ReservationDictionaryConverter
-from neuro_san.service.watcher.temp_networks.s3.aws_async_client_worker import AwsAsyncClientWorker
-from neuro_san.service.watcher.temp_networks.s3.s3_util import S3Util
+from neuro_san.interfaces.reservation import Reservation                                                # noqa: E402
+from neuro_san.internals.reservations.reservation_dictionary_converter \
+    import ReservationDictionaryConverter                                                               # noqa: E402
+from neuro_san.service.watcher.temp_networks.s3.aws_async_client_worker import AwsAsyncClientWorker     # noqa: E402
+from neuro_san.service.watcher.temp_networks.s3.s3_util import S3Util                                   # noqa: E402
 
 
 # pylint: disable=too-many-instance-attributes

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -16,6 +16,9 @@ langchain-openrouter>=0.2.3,<1.0
 # ... for S3
 botocore>=1.34.51
 aiobotocore>=3.7.0
+# ... for Azure
+azure-storage-blob>=12.19.0
+azure-identity>=1.14.0
 
 # Optional Authorization
 openfga-sdk

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -12,6 +12,11 @@ langchain-nvidia-ai-endpoints>=1.0.0,<2.0
 langchain-ollama>=1.0.0,<2.0
 langchain-openrouter>=0.2.3,<1.0
 
+# Optional ReservationsStorage
+# ... for S3
+botocore>=1.34.51
+aiobotocore>=3.7.0
+
 # Optional Authorization
 openfga-sdk
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 # requirements-build.txt
 
 # In-house dependencies
-leaf-common>=1.2.49
+leaf-common>=1.2.50
 leaf-server-common>=0.1.25
 
 # Downgraded secondary dependencies for error-free pip installs

--- a/requirements.txt
+++ b/requirements.txt
@@ -84,7 +84,3 @@ langchain-mcp-adapters>=0.1.7,<0.2.0
 # Ceiling <2.0: avoid breaking changes from the upcoming 2.x line.
 # See https://github.com/modelcontextprotocol/python-sdk/releases/ for changelogs.
 mcp>=1.23.0,<2.0
-
-# Azure Blob Storage for reservations backend
-azure-storage-blob>=12.19.0
-azure-identity>=1.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,8 +13,6 @@ leaf-server-common>=0.1.25
 pyhocon>=0.3.60
 pyOpenSSL>=24.0.0
 
-botocore>=1.34.51
-aiobotocore>=3.7.0
 idna>=3.6
 urllib3>=1.26.18
 aiohttp>=3.13.0,<4.0


### PR DESCRIPTION
* Have S3ReservationsStorage and its ilk use ResolverUtil to resolve a couple of types so that the appropriate install_if_missing error comes up if appropriate boto packages are not installed
* Similar deal with AzureBlobReservationsStorage and install_if_missing
* Move botocore aiobotocore azure-storage-blob and azure-identity dependencies to requirements-build.txt from requirements.txt as optional dependencies.
* Use latest leaf-common==1.2.50 whose create_instance() behavior better surfaces missing pip packages in its reporting of failures.