### PR TITLE
NS-1199 Fix macOS Obj-C fork-safety crash in multi-instance mode

### DIFF
--- a/neuro_san/service/main_loop/server_main_loop.py
+++ b/neuro_san/service/main_loop/server_main_loop.py
@@ -109,7 +109,7 @@ class ServerMainLoop:
         preserves the original "-m ... <args>" invocation across the re-exec.
 
         No-op on non-Darwin platforms, and no-op (no re-exec) when the flag is
-        already set -- which is also what stops the re-exec from looping.
+        already set to "YES" -- which is also what stops the re-exec from looping.
         """
         if sys.platform != "darwin":
             return

--- a/neuro_san/service/main_loop/server_main_loop.py
+++ b/neuro_san/service/main_loop/server_main_loop.py
@@ -19,6 +19,7 @@ from typing import Dict
 from typing import List
 
 import os
+import sys
 
 from argparse import ArgumentParser
 
@@ -81,6 +82,41 @@ class ServerMainLoop:
         self.http_server_config = HttpServerConfig()
         self.watcher_config: Dict[str, Any] = {}
         self.logging_config: Dict[str, Any] = {}
+
+    @staticmethod
+    def ensure_macos_fork_safety():
+        """
+        Make Tornado's multi-instance (forking) mode safe on macOS.
+
+        macOS's Objective-C runtime is not fork()-safe. When neuro-san runs more
+        than one HTTP instance (AGENT_HTTP_SERVER_INSTANCES > 1) Tornado forks
+        worker processes via server.start(N); on macOS a forked child aborts with
+            objc[...]: +[NSNumber initialize] may have been in progress in another
+            thread when fork() was called. ... Crashing instead.
+        the first time it touches an Obj-C framework -- which for a worker is
+        typically the first streaming_chat request, whose LLM call reaches
+        through httpx into macOS SystemConfiguration/Security (proxy + trust
+        store). Single-instance mode never forks, so it is unaffected, and Linux
+        (production) has no Obj-C runtime, so it forks safely.
+
+        The documented fix is OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES. The catch:
+        libobjc reads that variable exactly ONCE, at interpreter launch, and
+        forked children inherit that cached decision -- so setting os.environ
+        from inside the already-running process is too late to prevent the abort.
+        To make "just run it from the CLI" work without the caller exporting
+        anything, we therefore set the flag and re-exec this same interpreter so
+        the freshly launched process reads it at libobjc init time. sys.orig_argv
+        preserves the original "-m ... <args>" invocation across the re-exec.
+
+        No-op on non-Darwin platforms, and no-op (no re-exec) when the flag is
+        already set -- which is also what stops the re-exec from looping.
+        """
+        if sys.platform != "darwin":
+            return
+        if os.environ.get("OBJC_DISABLE_INITIALIZE_FORK_SAFETY") == "YES":
+            return
+        os.environ["OBJC_DISABLE_INITIALIZE_FORK_SAFETY"] = "YES"
+        os.execve(sys.executable, sys.orig_argv, os.environ)
 
     def prepare_args(self) -> ArgumentParser:
         """
@@ -304,4 +340,8 @@ class ServerMainLoop:
 
 
 if __name__ == '__main__':
+    # On macOS, ensure the Obj-C runtime won't abort in Tornado's forked
+    # worker processes. Runs before anything is constructed or forked, and may
+    # re-exec this interpreter (see ensure_macos_fork_safety for the why).
+    ServerMainLoop.ensure_macos_fork_safety()
     ServerMainLoop().main_loop()


### PR DESCRIPTION
  Description of the changes

  Running neuro-san with AGENT_HTTP_SERVER_INSTANCES > 1 on macOS aborts a forked worker with objc[...]: +[NSNumber initialize] may have been in progress in another thread when fork() was called 
  ... Crashing instead. The crash surfaces on the first streaming_chat request (the LLM call reaches into macOS SystemConfiguration/Security via httpx), because Tornado's server.start(N) forks
  workers and Apple's Obj-C runtime is not fork()-safe.

  This change sets OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES from the entrypoint on macOS. Because libobjc reads that variable once at interpreter launch, setting it in-process is too late — so the
  guard sets the flag and re-execs the interpreter (preserving the original -m … <args> invocation) so it takes effect. It is a no-op on non-macOS platforms and a no-op when the flag is already
  set (which also prevents any re-exec loop).

  Added to neuro_san/service/main_loop/server_main_loop.py:
  - import sys
  - ServerMainLoop.ensure_macos_fork_safety() static method (with a comment explaining the fork-unsafety and the re-exec rationale)
  - a call to it as the first statement in the __main__ block

  No production/Linux behavior change.

  Testing

  - Verified the re-exec path (launched without the flag): re-execs once, same PID, lands with the flag set, argv preserved, no loop; and the already-set path returns without re-exec.
  - pylint (repo .pylintrc): 10.00/10 on the changed file.

