### PR TITLE
Swap concurrency for fork check in tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,15 +12,13 @@ on:
     branches:
       - main
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}-${{ github.event.pull_request.head.sha || github.sha }}
-  cancel-in-progress: true
-
 jobs:
   test:
     if: >
       (github.event_name == 'push' && github.ref != 'refs/heads/main') ||
-      (github.event_name == 'pull_request' && github.base_ref == 'main')
+      (github.event_name == 'pull_request' &&
+       github.base_ref == 'main' &&
+       github.event.pull_request.head.repo.full_name != github.repository)
     # 1.0.8
     uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@30321843331e00848309b34e08b839e1f6490ba2
     with:


### PR DESCRIPTION
Removes the `concurrency` block in `.github/workflows/tests.yml` and adds a fork check to the `test` job's `if` condition. Internal PRs are already covered by the `push` event, so the `pull_request` event is skipped for them while still running for fork PRs. This avoids cancelled workflow runs that appear as failures in the PR checks UI. The required `test` check should be satisfied by the `push` run for internal PRs and by the `pull_request` run for forks.

This will bring the major neuro-san* repos in line wrt this trigger. Also, I did look at moving some of this logic down to build-common. There's probably some benefit there, but I won't do so until all consumers are using and happy with this trigger logic.

Link to Devin session: https://app.devin.ai/sessions/635e68f78ccb4fb7b1b94a8dea614de5
Requested by: @donn-leaf
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cognizant-ai-lab/neuro-san/pull/1203" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->