### PR TITLE
Sanitize HOCON keys at parse time via leaf-common 1.2.51

### DIFF
--- a/neuro_san/internals/graph/persistence/manifest_key_config_filter.py
+++ b/neuro_san/internals/graph/persistence/manifest_key_config_filter.py
@@ -54,9 +54,10 @@ class ManifestKeyConfigFilter(ConfigFilter):
         for key, value in basis_config.items():
 
             # Key here is an agent name in a form that we choose.
-            # Keys sometimes come with quotes.
-            manifest_key: str = key.replace(r'"', "")
-            manifest_key = manifest_key.strip()
+            # Quotes that pyhocon embeds in keys are already removed by
+            # AbstractAsyncConfigRestorer (sanitize_keys=True), so only
+            # whitespace normalization is left to do here.
+            manifest_key: str = key.strip()
 
             filtered[manifest_key] = value
 

--- a/neuro_san/internals/graph/persistence/manifest_key_config_filter.py
+++ b/neuro_san/internals/graph/persistence/manifest_key_config_filter.py
@@ -54,9 +54,8 @@ class ManifestKeyConfigFilter(ConfigFilter):
         for key, value in basis_config.items():
 
             # Key here is an agent name in a form that we choose.
-            # Quotes that pyhocon embeds in keys are already removed by
-            # AbstractAsyncConfigRestorer (sanitize_keys=True), so only
-            # whitespace normalization is left to do here.
+            # Keys are quote-sanitized at parse time (sanitize_keys=True),
+            # so only whitespace normalization is left to do here.
             manifest_key: str = key.strip()
 
             filtered[manifest_key] = value

--- a/neuro_san/internals/persistence/abstract_async_config_restorer.py
+++ b/neuro_san/internals/persistence/abstract_async_config_restorer.py
@@ -163,7 +163,14 @@ class AbstractAsyncConfigRestorer(Restorer, ConfigFilter):
         if file_path.endswith(".hocon"):
             # Worth noting that includes within hocon files can only be done synchronously
             # The core pyhocon library does not support async includes.
-            serialization = HoconSerializationFormat()
+            #
+            # sanitize_keys=True removes the quotation marks that pyhocon embeds
+            # in keys that had to be quoted in the HOCON source because they
+            # contain characters that are special in HOCON keys (e.g. "." or ":"
+            # in model names like "llama3.1", or in url/file-path keys).
+            # Without it, such keys come back as '"llama3.1"' with the quotes
+            # baked into the string. Applies at all nesting levels.
+            serialization = HoconSerializationFormat(sanitize_keys=True)
             # pyhocon parsing mutates process-global pyparsing state and is not
             # thread-safe. See HoconParseLock.
             parse_lock = HoconParseLock()

--- a/neuro_san/internals/persistence/abstract_async_config_restorer.py
+++ b/neuro_san/internals/persistence/abstract_async_config_restorer.py
@@ -164,12 +164,10 @@ class AbstractAsyncConfigRestorer(Restorer, ConfigFilter):
             # Worth noting that includes within hocon files can only be done synchronously
             # The core pyhocon library does not support async includes.
             #
-            # sanitize_keys=True removes the quotation marks that pyhocon embeds
-            # in keys that had to be quoted in the HOCON source because they
-            # contain characters that are special in HOCON keys (e.g. "." or ":"
-            # in model names like "llama3.1", or in url/file-path keys).
-            # Without it, such keys come back as '"llama3.1"' with the quotes
-            # baked into the string. Applies at all nesting levels.
+            # sanitize_keys=True: without it, keys that had to be quoted in the
+            # HOCON source come back as '"llama3.1"' with the quotes baked into
+            # the string (see the HoconSerializationFormat docstring for details).
+            # Applies at all nesting levels.
             serialization = HoconSerializationFormat(sanitize_keys=True)
             # pyhocon parsing mutates process-global pyparsing state and is not
             # thread-safe. See HoconParseLock.

--- a/neuro_san/internals/run_context/langchain/llms/default_llm_factory.py
+++ b/neuro_san/internals/run_context/langchain/llms/default_llm_factory.py
@@ -127,9 +127,6 @@ class DefaultLlmFactory(ContextTypeLlmFactory, LangChainLlmFactory):
             extra_llm_infos: Dict[str, Any] = restorer.restore(file_reference=self.llm_info_file)
             self.llm_infos = self.overlayer.overlay(self.llm_infos, extra_llm_infos)
 
-        # sanitize the llm_infos keys
-        self.llm_infos = self.sanitize_keys(self.llm_infos)
-
         # Resolve any new llm factories
         extractor = DictionaryExtractor(self.llm_infos)
         llm_factory_classes: List[str] = []
@@ -560,33 +557,6 @@ class DefaultLlmFactory(ContextTypeLlmFactory, LangChainLlmFactory):
             max_prompt_tokens = use_max_tokens
 
         return max_prompt_tokens
-
-    def strip_outer_quotes(self, s: str) -> str:
-        """
-        :param s: The input string to sanitize.
-        :return: The input string without surrounding multiple quotes, if they were present.
-        Otherwise, returns the string unchanged.
-        """
-        if len(s) >= 2 and s[0] in ["'", '"']:
-            quote_char = s[0]
-            unquoted = s[1:-1]
-
-            # Only strip quotes if inner value does not contain the same quote char
-            # and does not start with whitespace
-            if quote_char not in unquoted and not unquoted.startswith(" "):
-                return unquoted
-        return s
-
-    def sanitize_keys(self, d: Dict[str, Any]) -> Dict[str, Any]:
-        """
-        Returns a new dictionary with surrounding double quotes stripped from all keys.
-        This is typically used to clean up configuration dictionaries where key names may
-        be quoted (e.g., '"llama3.1"' instead of "llama3.1") due to parsing artifacts.
-        Only the top-level keys are sanitized; nested keys are left unchanged.
-        :param d: The input dictionary with potentially quoted keys.
-        :return: A new dictionary with the same values, but with sanitized keys.
-        """
-        return {self.strip_outer_quotes(k): v for k, v in d.items()}
 
     # pylint: disable=too-many-branches,too-many-locals,too-many-statements
     def create_llm_with_fallbacks(self, config: Dict[str, Any],

--- a/neuro_san/internals/run_context/langchain/llms/default_llm_factory.py
+++ b/neuro_san/internals/run_context/langchain/llms/default_llm_factory.py
@@ -125,6 +125,13 @@ class DefaultLlmFactory(ContextTypeLlmFactory, LangChainLlmFactory):
         # Mix in user-specified llm info, if available.
         if self.llm_info_file:
             extra_llm_infos: Dict[str, Any] = restorer.restore(file_reference=self.llm_info_file)
+            # Each user entry DEEP-MERGES with any same-named default entry, so a
+            # sparse override like {"gpt-4.1": {"class": "x"}} inherits the default
+            # entry's remaining fields (including a "use_model_name" alias redirect).
+            # This holds for .json user files too now that keys are sanitized at
+            # parse time: their dotted model names ("llama3.1") match the default
+            # keys. Before sanitization, such keys missed the quoted default keys
+            # ('"llama3.1"') and accidentally replaced the default entry wholesale.
             self.llm_infos = self.overlayer.overlay(self.llm_infos, extra_llm_infos)
 
         # Resolve any new llm factories

--- a/neuro_san/internals/run_context/langchain/mcp/mcp_servers_info_restorer.py
+++ b/neuro_san/internals/run_context/langchain/mcp/mcp_servers_info_restorer.py
@@ -49,11 +49,12 @@ class McpServersInfoRestorer(AbstractAsyncConfigRestorer):
         if basis_config is None:
             return None
 
-        # Now, MCP endpoints urls could put in quotes, so strip them out.
+        # Quotes that pyhocon embeds in keys (MCP endpoint urls must be quoted
+        # in HOCON source) are already removed by AbstractAsyncConfigRestorer
+        # (sanitize_keys=True), so only whitespace normalization is left to do here.
         result_dict: Dict[str, Any] = {}
         for key, value in basis_config.items():
-            use_key: str = key.replace(r'"', "")
-            use_key = use_key.strip()
+            use_key: str = key.strip()
             result_dict[use_key] = value
 
         return result_dict

--- a/neuro_san/internals/run_context/langchain/mcp/mcp_servers_info_restorer.py
+++ b/neuro_san/internals/run_context/langchain/mcp/mcp_servers_info_restorer.py
@@ -49,9 +49,9 @@ class McpServersInfoRestorer(AbstractAsyncConfigRestorer):
         if basis_config is None:
             return None
 
-        # Quotes that pyhocon embeds in keys (MCP endpoint urls must be quoted
-        # in HOCON source) are already removed by AbstractAsyncConfigRestorer
-        # (sanitize_keys=True), so only whitespace normalization is left to do here.
+        # Keys (MCP endpoint urls, quoted in HOCON source) are quote-sanitized
+        # at parse time (sanitize_keys=True), so only whitespace normalization
+        # is left to do here.
         result_dict: Dict[str, Any] = {}
         for key, value in basis_config.items():
             use_key: str = key.strip()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,9 @@
 # requirements-build.txt
 
 # In-house dependencies
-leaf-common>=1.2.50
+# Floor 1.2.51: HoconSerializationFormat(sanitize_keys=True) used by
+# AbstractAsyncConfigRestorer to strip pyhocon's embedded quotes from keys.
+leaf-common>=1.2.51
 leaf-server-common>=0.1.25
 
 # Downgraded secondary dependencies for error-free pip installs

--- a/tests/neuro_san/internals/persistence/test_abstract_async_config_restorer.py
+++ b/tests/neuro_san/internals/persistence/test_abstract_async_config_restorer.py
@@ -200,6 +200,35 @@ class TestAbstractAsyncConfigRestorer:
         )
         assert result == VALID_DICT
 
+    def test_deserialize_hocon_sanitizes_quoted_keys(self) -> None:
+        """
+        Keys that must be quoted in HOCON source (containing e.g. "." or ":")
+        come back without pyhocon's embedded quotes, at every nesting level.
+        See cognizant-ai-lab/neuro-san#451 and cognizant-ai-lab/leaf-common#172.
+        """
+        hocon: str = """
+        {
+            "llama3.1": {
+                "class": "ollama",
+                "nested": {
+                    "http://localhost:8080/mcp": true
+                }
+            }
+            plain_key = 1
+        }
+        """
+        r: ConcreteRestorer = self.make_restorer()
+        result: Dict[str, Any] = r.deserialize_file_contents("config.hocon", hocon.encode("utf-8"))
+        assert result == {
+            "llama3.1": {
+                "class": "ollama",
+                "nested": {
+                    "http://localhost:8080/mcp": True
+                }
+            },
+            "plain_key": 1,
+        }
+
     def test_deserialize_raises_value_error_for_unsupported_extension(self) -> None:
         """A ValueError is raised for file extensions other than .json and .hocon."""
         r: ConcreteRestorer = self.make_restorer()


### PR DESCRIPTION
## Summary

Adopts leaf-common 1.2.51's `HoconSerializationFormat(sanitize_keys=True)` (cognizant-ai-lab/leaf-common#172, follow-up to #451) in `AbstractAsyncConfigRestorer`, so keys that had to be quoted in HOCON source (e.g. `"llama3.1"`, `"llama3:8b"`, url/file-path keys) no longer come back with pyhocon's quotation marks baked into the string — at every nesting level, for every `.hocon` restorer.

This makes three downstream workarounds for the same parsing artifact unnecessary:

- `DefaultLlmFactory.sanitize_keys()` / `strip_outer_quotes()` — removed
- `ManifestKeyConfigFilter` quote replacement — reduced to whitespace normalization
- `McpServersInfoRestorer` quote replacement — reduced to whitespace normalization

Also bumps the leaf-common floor to 1.2.51 (the constructor kwarg does not exist earlier) and adds a test pinning the sanitized key shape at all nesting levels.

## Behavior changes worth calling out

- **Sanitization is now deep and universal.** Previously only top-level llm-info/manifest/MCP keys were cleaned; nested keys and agent-network/toolbox hocons retained quoted keys. Any deployment that adapted to the old quoted form (e.g. coded tools looking up `args['"user.name"']`, or clients sending quoted sly_data keys to match `allow` entries) should drop those workarounds when upgrading.
- **User llm-info overrides in `.json` format now deep-merge with default entries** for quoted-key model names, instead of accidentally replacing them wholesale (the old post-overlay sanitize collapsed mismatched quoted/clean keys with last-wins semantics). This matches what `.hocon` user files always did; documented in a comment at the overlay site.
- **Quote-embedded keys in `.json` config files are no longer normalized.** The removed workarounds ran regardless of source format; the parse-time sanitization is HOCON-only. JSON parsing never produces such keys, and no documented case exists — JSON keys are now taken exactly as written.

## Follow-up

- #1205 tracks the one remaining unsanitized HOCON path (`LoggingConfigRestorer` via `EasyHoconPersistence`, which cannot pass `sanitize_keys` in leaf-common 1.2.51).

## Testing

- New test: quoted dotted/url keys in a `.hocon` restore come back clean at all nesting levels.
- Full unit suite green (85 passed; remaining skips are environment-based, same as main).
- Verified end-to-end: `DefaultLlmFactory().load()` yields 115 model keys with no embedded quotes and dotted-name lookups resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)