### PR TITLE
Recover from InvalidToken credential rejections in temp-network S3 access

### DIFF
--- a/neuro_san/service/watcher/temp_networks/s3/aws_async_client_worker.py
+++ b/neuro_san/service/watcher/temp_networks/s3/aws_async_client_worker.py
@@ -95,13 +95,13 @@ class AwsAsyncClientWorker:
                 return retval
 
             except ClientError as err:
-                # S3Util.is_expired_token_error() is used instead of raw
-                # DictionaryExtractor access: the extractor returns a stored
-                # None in preference to its default, and
-                # '"ExpiredToken" not in None' would raise TypeError inside
+                # S3Util.is_credential_rejection_error() is used instead of
+                # raw DictionaryExtractor access: the extractor returns a
+                # stored None in preference to its default, and substring
+                # checks against a None code would raise TypeError inside
                 # this handler, masking the original ClientError
                 # (see S3Util.get_error_code for details).
-                if not S3Util.is_expired_token_error(err):
+                if not S3Util.is_credential_rejection_error(err):
                     raise
 
                 last_err = err
@@ -110,13 +110,17 @@ class AwsAsyncClientWorker:
                 #             profiles have token-based credentials that may expire.
                 #             See: https://docs.aws.amazon.com/boto3/latest/guide/configuration.html
 
-                # Reset the cached credentials as they are likely expired and try again.
+                # Reset the cached credentials - S3 rejected them (expired,
+                # or malformed/mismatched, e.g. captured mid-rotation; see
+                # S3Util.is_credential_rejection_error) - and try again.
                 self.frozen_credentials = None
                 if source is None:
                     source = self.name
-                self.logger.warning("%s (%d): %s credentials seem to have expired. Retrying. "
-                                    "If you believe you have non-expiring %s credentials, be sure they are correct.",
-                                    source, attempt, self.aws_service, self.aws_service)
+                self.logger.warning("%s (%d): %s rejected the request's credentials (%s). Retrying with "
+                                    "re-resolved credentials. If you believe you have valid non-expiring "
+                                    "%s credentials, be sure they are correct.",
+                                    source, attempt, self.aws_service, S3Util.get_error_code(err),
+                                    self.aws_service)
 
         # Exhausted retries
         if last_err is not None:

--- a/neuro_san/service/watcher/temp_networks/s3/aws_sync_client_worker.py
+++ b/neuro_san/service/watcher/temp_networks/s3/aws_sync_client_worker.py
@@ -85,13 +85,13 @@ class AwsSyncClientWorker:
                 return retval
 
             except ClientError as err:
-                # S3Util.is_expired_token_error() is used instead of raw
-                # DictionaryExtractor access: the extractor returns a stored
-                # None in preference to its default, and
-                # '"ExpiredToken" not in None' would raise TypeError inside
+                # S3Util.is_credential_rejection_error() is used instead of
+                # raw DictionaryExtractor access: the extractor returns a
+                # stored None in preference to its default, and substring
+                # checks against a None code would raise TypeError inside
                 # this handler, masking the original ClientError
                 # (see S3Util.get_error_code for details).
-                if not S3Util.is_expired_token_error(err):
+                if not S3Util.is_credential_rejection_error(err):
                     raise
 
                 last_err = err
@@ -100,13 +100,17 @@ class AwsSyncClientWorker:
                 #             profiles have token-based credentials that may expire.
                 #             See: https://docs.aws.amazon.com/boto3/latest/guide/configuration.html
 
-                # Reset the cached credentials as they are likely expired and try again.
+                # Reset the cached credentials - S3 rejected them (expired,
+                # or malformed/mismatched, e.g. captured mid-rotation; see
+                # S3Util.is_credential_rejection_error) - and try again.
                 self.frozen_credentials = None
                 if source is None:
                     source = self.name
-                self.logger.warning("%s (%d): %s credentials seem to have expired. Retrying. "
-                                    "If you believe you have non-expiring %s credentials, be sure they are correct.",
-                                    source, attempt, self.aws_service, self.aws_service)
+                self.logger.warning("%s (%d): %s rejected the request's credentials (%s). Retrying with "
+                                    "re-resolved credentials. If you believe you have valid non-expiring "
+                                    "%s credentials, be sure they are correct.",
+                                    source, attempt, self.aws_service, S3Util.get_error_code(err),
+                                    self.aws_service)
 
         # Exhausted retries
         if last_err is not None:

--- a/neuro_san/service/watcher/temp_networks/s3/s3_reservations_expiration.py
+++ b/neuro_san/service/watcher/temp_networks/s3/s3_reservations_expiration.py
@@ -243,13 +243,14 @@ class S3ReservationsExpiration:
             if error_code in ("NoSuchKey", "404"):
                 self.logger.debug("%s: Reservation %s was already removed by another process", self.name, obj_key)
                 expired = True  # Object is gone, which is the desired outcome for expiration
-            elif S3Util.is_expired_token_error(exception):
-                # Credential expiry must NOT be swallowed here. The client this sweep
+            elif S3Util.is_credential_rejection_error(exception):
+                # Credential rejection (ExpiredToken / InvalidToken /
+                # TokenRefreshRequired) must NOT be swallowed here. The client this sweep
                 # uses was created from frozen credentials (see AwsSyncClientWorker),
                 # which never auto-refresh, and the only code that can refresh them is
                 # retry_with_new_client() wrapping expire_any_reservations() at the top
                 # of the sweep - and it can only react to ClientErrors that actually
-                # reach it. If ExpiredToken were merely logged like the codes below,
+                # reach it. If these errors were merely logged like the codes below,
                 # every remaining key in the sweep would make one doomed S3 call,
                 # nothing would be expired, and the sweep would still report success;
                 # credentials would only refresh when a later sweep's list_objects_v2

--- a/neuro_san/service/watcher/temp_networks/s3/s3_util.py
+++ b/neuro_san/service/watcher/temp_networks/s3/s3_util.py
@@ -98,6 +98,40 @@ class S3Util:
         return "ExpiredToken" in S3Util.get_error_code(err)
 
     @staticmethod
+    def is_credential_rejection_error(err: ClientError) -> bool:
+        """
+        :param err: The ClientError exception to evaluate
+        :return: True if S3 rejected the credentials the request was signed
+                 with, in a way that discarding the cached credential state
+                 and re-resolving it can plausibly fix:
+
+                 * ExpiredToken / ExpiredTokenException - the session token
+                   has expired.
+                 * InvalidToken - "malformed or otherwise invalid", e.g. a
+                   credential state captured mid-rotation or a revoked role
+                   session. Observed in production (neuro-san-studio issue
+                   #1310): a stale cached credential snapshot was rejected
+                   with InvalidToken on every read, and because the retry
+                   gate matched only ExpiredToken, the snapshot was never
+                   invalidated - every S3 read of the affected network
+                   failed (surfacing as a 404 for a network that exists in
+                   S3) until a pod restart. Exact match on purpose; there
+                   is no InvalidTokenException variant for S3, and
+                   near-misses like InvalidClientTokenId belong to other
+                   services.
+                 * TokenRefreshRequired - "the provided token must be
+                   refreshed": the third member of the same temporary-token
+                   rejection family; same remedy.
+
+                 Deliberately NOT matched: InvalidAccessKeyId and
+                 SignatureDoesNotMatch. Those indicate rotated long-lived
+                 key pairs or genuine signing bugs - re-resolution cannot
+                 fix them, and retrying would mask real misconfiguration.
+        """
+        return S3Util.is_expired_token_error(err) \
+            or S3Util.get_error_code(err) in ("InvalidToken", "TokenRefreshRequired")
+
+    @staticmethod
     def extract_reservation_data(agent_spec: Any) -> Optional[Dict[str, Any]]:
         """
         Single, shared policy point for parsing the reservation block out of an

--- a/tests/neuro_san/service/watcher/temp_networks/s3/test_invalid_token_recovery.py
+++ b/tests/neuro_san/service/watcher/temp_networks/s3/test_invalid_token_recovery.py
@@ -1,0 +1,211 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+"""
+Pins recovery from S3 rejecting a request's session token as
+InvalidToken ("The provided token is malformed or otherwise invalid")
+on the reservation READ path.
+
+Motivation - a real production failure (neuro-san-studio issue #1310,
+"AND is sporadically broken"):
+
+    S3ReservationsReader: S3 error processing reservation object <id>
+    during sync: An error occurred (InvalidToken) when calling the
+    GetObject operation: The provided token is malformed or otherwise
+    invalid.
+
+The user-visible symptom was a network that had just been created
+coming back "not found" (404): the reader's ClientError handler logged
+the credential error and reported the reservation as missing, even
+though the object was written to S3 just fine. It looked sporadic
+because the pod that created the network still served it from memory,
+while every other pod had to read S3 and failed.
+
+Root cause: the worker's cached frozen-credential snapshot went stale,
+S3 rejected it with InvalidToken - but the credential-retry gate
+matched only ExpiredToken, so the snapshot was never invalidated and
+every read kept failing until a pod restart.
+
+The widened gate (S3Util.is_credential_rejection_error) treats
+InvalidToken (and TokenRefreshRequired) like ExpiredToken: discard the
+cached snapshot, re-resolve credentials, and retry. Without the
+widening, the recovery test below fails with get_one_reservation()
+returning (None, None) after a single credential resolution - the
+exact #1310 failure mode.
+"""
+import json
+import time
+
+from typing import Any
+from typing import Dict
+
+from unittest import TestCase
+from unittest.mock import patch
+
+from botocore.credentials import Credentials
+from botocore.exceptions import ClientError
+
+from neuro_san.service.watcher.temp_networks.s3.s3_util import S3Util
+from tests.neuro_san.service.watcher.temp_networks.s3.s3_reservations_storage_test_base \
+    import S3ReservationsStorageTestBase
+
+
+def _make_client_error(code: str, operation_name: str = "GetObject") -> ClientError:
+    """
+    Build a ClientError carrying the given S3 error code, shaped the way
+    boto3 surfaces credential rejections (HTTP 400 with a parsed body code).
+    """
+    return ClientError(
+        {
+            "Error": {
+                "Code": code,
+                "Message": f"{code} (test)",
+            },
+            "ResponseMetadata": {"HTTPStatusCode": 400},
+        },
+        operation_name,
+    )
+
+
+class TestCredentialRejectionGate(TestCase):
+    """
+    Pins the boundaries of S3Util.is_credential_rejection_error: which
+    error codes trigger a credential reset + retry, and which are
+    deliberately left to surface.
+    """
+
+    def test_codes_that_trigger_re_resolution(self):
+        """
+        Expired, malformed/mismatched, and refresh-required token codes
+        must trigger a credential reset: each means the cached credential
+        state is bad, and re-resolving it is the only remedy.
+        """
+        for code in ("ExpiredToken", "ExpiredTokenException", "InvalidToken", "TokenRefreshRequired"):
+            with self.subTest(code=code):
+                self.assertTrue(
+                    S3Util.is_credential_rejection_error(_make_client_error(code)),
+                    f"Expected {code} to trigger credential re-resolution.",
+                )
+
+    def test_codes_that_must_surface(self):
+        """
+        Rotated long-lived key pairs and signing problems must NOT be
+        retried: re-resolution cannot fix them, and retrying would mask
+        genuine misconfiguration.
+        """
+        for code in ("InvalidAccessKeyId", "SignatureDoesNotMatch", "AccessDenied", "NoSuchKey"):
+            with self.subTest(code=code):
+                self.assertFalse(
+                    S3Util.is_credential_rejection_error(_make_client_error(code)),
+                    f"Expected {code} NOT to trigger credential re-resolution.",
+                )
+
+
+class TestReaderInvalidTokenRecovery(S3ReservationsStorageTestBase):
+    """
+    Verifies that a read hitting InvalidToken resets the cached frozen
+    credentials, re-resolves, and succeeds - instead of reporting the
+    reservation as not-found until a process restart (the
+    neuro-san-studio #1310 failure mode).
+    """
+
+    def _put_live_reservation(self, reservation_id: str) -> str:
+        """
+        Place a well-formed, unexpired reservation object directly into
+        the fake bucket (matching the writer's on-disk schema, bypassing
+        the writer) so the read path has something real to fetch.
+
+        :return: the reservation id (readers derive the S3 key from it)
+        """
+        spec: Dict[str, Any] = {
+            "name": reservation_id,
+            "llm_config": {"model_name": "gpt-5.2"},
+            "tools": [{"name": reservation_id, "function": {"description": "test frontman"}}],
+            "metadata": {
+                "reservation": {
+                    "id": reservation_id,
+                    "lifetime_in_seconds": 3600.0,
+                    "expiration_time_in_seconds": time.time() + 3600.0,
+                },
+                "stored_at": time.time(),
+            },
+        }
+        self.fake_s3.objects[f"reservations/{reservation_id}.json"] = \
+            json.dumps(spec).encode("utf-8")
+        return reservation_id
+
+    def test_invalid_token_triggers_credential_reset_and_read_succeeds(self):
+        """
+        Scenario: the worker's cached frozen-credential snapshot has gone
+        stale (e.g. captured mid-rotation), so requests signed with it
+        are rejected with InvalidToken; the snapshot re-frozen after the
+        retry's reset is healthy.
+
+        Expected: the widened gate routes InvalidToken through the same
+        reset-and-retry path as ExpiredToken, so the read returns the
+        reservation. If InvalidToken is not gated (the pre-fix behavior),
+        the error propagates to the reader's log-and-continue handler and
+        this test fails with a (None, None) read after a single
+        credential resolution.
+        """
+        reservation_id: str = self._put_live_reservation("copy_cat-invalid-token")
+
+        resolutions = {"count": 0}
+
+        def counting_get_credentials(*_args, **_kwargs) -> Credentials:
+            # Overrides the base class's Session.get_credentials patch
+            # (same target) so the test can observe each re-resolution.
+            resolutions["count"] += 1
+            return Credentials("bogus", "bogus")
+
+        real_get_object = self.fake_s3.get_object
+
+        # pylint: disable=invalid-name
+        def get_object_rejecting_stale_snapshot(Bucket: str, Key: str) -> Dict[str, Any]:
+            if resolutions["count"] < 2:
+                # Requests signed with the first (stale) snapshot are
+                # rejected; the snapshot re-frozen after the retry's
+                # reset works.
+                raise _make_client_error("InvalidToken")
+            return real_get_object(Bucket=Bucket, Key=Key)
+
+        self.fake_s3.get_object = get_object_rejecting_stale_snapshot
+        self.addCleanup(setattr, self.fake_s3, "get_object", real_get_object)
+
+        with patch(
+            "neuro_san.service.watcher.temp_networks.s3.aws_sync_client_worker.Session.get_credentials",
+            new=counting_get_credentials,
+        ):
+            # The worker freezes credentials lazily, so the first
+            # resolution happens inside this read.
+            reservation, agent_network = self.storage.get_one_reservation(reservation_id)
+
+        self.assertIsNotNone(
+            reservation,
+            "Expected the read to recover from InvalidToken by resetting the "
+            "cached frozen credentials. A None reservation means the error was "
+            "logged and swallowed instead - the #1310 failure mode, where the "
+            "stale snapshot persists and every read of the network reports it "
+            "not-found (404) until a pod restart.",
+        )
+        self.assertIsNotNone(agent_network)
+        self.assertGreaterEqual(
+            resolutions["count"], 2,
+            f"Expected at least 2 credential resolutions (the stale snapshot "
+            f"plus the re-resolution after InvalidToken reached the "
+            f"credential-rejection gate); got {resolutions['count']}. A single "
+            f"resolution means the gate never fired.",
+        )


### PR DESCRIPTION
## The problem (production, happening now)

Prod pods sporadically report just-created temp networks as **404 / not found** even though the reservation object is safely in S3 — cognizant-ai-lab/neuro-san-studio#1310. From the Datadog logs:

```
S3ReservationsReader: S3 error processing reservation object <id> during sync:
An error occurred (InvalidToken) when calling the GetObject operation:
The provided token is malformed or otherwise invalid.
```

Mechanism:

1. The S3 workers cache a **frozen credential snapshot** and sign every request with it.
2. When that snapshot goes stale, S3 rejects requests — in prod's case with **`InvalidToken`**, not `ExpiredToken`.
3. The credential-retry gate (`S3Util.is_expired_token_error`) matches **only `ExpiredToken`**, so the stale snapshot is never invalidated.
4. The reader's error handler logs the `ClientError` and returns "not found" — so the API 404s, on every read, until a pod restart.

It looks sporadic because the pod that created the network still serves it from memory (`/function` works), while the other pods must read S3 and fail (`/connectivity` 404s).

## The fix (minimal, recovery-only)

New `S3Util.is_credential_rejection_error()` classifies all three of S3's temporary-token rejection codes as *reset credentials and retry*:

- `ExpiredToken` / `ExpiredTokenException` (what the gate already matched)
- `InvalidToken` — "malformed or otherwise invalid" (what prod is actually getting)
- `TokenRefreshRequired` — "must be refreshed" (the third member of the same family)

Both workers' retry loops and the expiration sweep's re-raise now classify through it. `InvalidAccessKeyId` / `SignatureDoesNotMatch` deliberately still surface — those mean rotated long-lived key pairs or signing bugs, which re-resolution cannot fix and retrying would mask. The retry warning now names the rejection code it is recovering from instead of assuming expiry.

Why this is enough for prod: prod runs on IRSA (`serviceAccount.roleArn`), so the credential chain re-resolves to fresh role credentials whenever the reset fires. The wedge was never that recovery was impossible — it was that the gate never fired for `InvalidToken`.

## What this deliberately does NOT do

This fixes **recovery**, not **prevention**: pods still take the failed call + retry hit whenever the snapshot goes stale, and a rejection that outlasts the retry budget can still surface as a 404. Eliminating the failure mode itself — dropping the frozen-snapshot caching entirely so botocore's credential stack auto-refreshes at request-signing time — is the redesign in #1157, kept separate so this small fix can ship while that design is discussed.

## Tests

- `TestCredentialRejectionGate` — pins the gate's boundary in both directions: the four codes that must reset, the four (`InvalidAccessKeyId`, `SignatureDoesNotMatch`, `AccessDenied`, `NoSuchKey`) that must surface.
- `TestReaderInvalidTokenRecovery` — reproduces the #1310 failure mode end-to-end on the read path: requests signed with the first (stale) credential snapshot are rejected with `InvalidToken`; the test asserts the read *succeeds* after the gate resets and re-resolves. **Verified red against the current gate**: without the widening it fails with a `(None, None)` read after a single credential resolution — logging the exact prod error line above.

Fixes the recovery half of cognizant-ai-lab/neuro-san-studio#1310. Related: #1153, #1157.