### PR TITLE
Return tool message content instead of message object from _arun

### DIFF
--- a/neuro_san/internals/run_context/langchain/core/langchain_openai_function_tool.py
+++ b/neuro_san/internals/run_context/langchain/core/langchain_openai_function_tool.py
@@ -209,7 +209,11 @@ It's function_json is described thusly:
         ("a" is for asynchronous).
 
         :return: The content of the BaseMessage that tells us the "answer"
-                 from the tool. Can be None if the tool produced no message.
+                 from the tool - a string today, though langchain also allows
+                 lists of content blocks.
+                 Can be None if the tool produced no message.
+                 On failure, returns the string form of the exception so the
+                 calling LLM can verbally recognize the problem.
         """
         run: LangChainRun = None
         try:

--- a/neuro_san/internals/run_context/langchain/core/langchain_openai_function_tool.py
+++ b/neuro_san/internals/run_context/langchain/core/langchain_openai_function_tool.py
@@ -208,8 +208,8 @@ It's function_json is described thusly:
         calls to another llm/agent instance happen asynchronously.
         ("a" is for asynchronous).
 
-        :return: The result of the tool in the form of the BaseMessage
-                 that tells us the "answer" from the tool.
+        :return: The content of the BaseMessage that tells us the "answer"
+                 from the tool. Can be None if the tool produced no message.
         """
         run: LangChainRun = None
         try:
@@ -246,4 +246,12 @@ It's function_json is described thusly:
 
         # Assume the answer is latest tool message in the Run.
         the_answer: BaseMessage = run.get_tool_message()
-        return the_answer
+        if the_answer is None:
+            return None
+
+        # Return the message's content rather than the message object itself.
+        # Langchain passes str (and content-block list) tool returns through
+        # to the calling LLM's ToolMessage as-is, but falls back to str() for
+        # any other object - which for a BaseMessage is its pydantic repr
+        # ("content='...' additional_kwargs={} ..."), not the answer.
+        return the_answer.content

--- a/tests/neuro_san/internals/run_context/langchain/core/test_langchain_openai_function_tool.py
+++ b/tests/neuro_san/internals/run_context/langchain/core/test_langchain_openai_function_tool.py
@@ -1,0 +1,100 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+
+import pytest
+
+from neuro_san.internals.messages.agent_tool_result_message import AgentToolResultMessage
+from neuro_san.internals.run_context.langchain.core.langchain_openai_function_tool \
+    import LangChainOpenAIFunctionTool
+from neuro_san.internals.run_context.langchain.core.langchain_run import LangChainRun
+
+
+class TestLangChainOpenAIFunctionTool:
+    """
+    Test cases for what _arun() hands back to langchain as the tool output.
+
+    Whatever _arun() returns becomes the ToolMessage content the calling LLM
+    sees: langchain passes str and content-block list returns through as-is,
+    but falls back to str() for any other object.  Returning a BaseMessage
+    would therefore expose its pydantic repr ("content='...'
+    additional_kwargs={} ...") to the calling LLM instead of the answer.
+    """
+
+    @staticmethod
+    def make_tool(run_to_return: LangChainRun = None,
+                  exception: Exception = None) -> LangChainOpenAIFunctionTool:
+        """
+        :param run_to_return: The Run for the mock ToolCaller to hand back
+        :param exception: Optional exception for the mock ToolCaller to raise instead
+        :return: A minimal LangChainOpenAIFunctionTool wired to the mock ToolCaller
+        """
+        tool_caller = MagicMock()
+        if exception is not None:
+            tool_caller.make_tool_function_calls = AsyncMock(side_effect=exception)
+        else:
+            tool_caller.make_tool_function_calls = AsyncMock(return_value=run_to_return)
+
+        return LangChainOpenAIFunctionTool.model_construct(
+            name="test_tool",
+            description="a test tool",
+            tool_caller=tool_caller)
+
+    @pytest.mark.asyncio
+    async def test_arun_returns_message_content_not_message_object(self):
+        """
+        The sub-agent's answer must come back as the message content,
+        not as the AgentToolResultMessage object itself.
+        """
+        the_message = AgentToolResultMessage(content="the answer",
+                                             tool_result_origin=[{"tool": "test_tool",
+                                                                  "instantiation_index": 0}])
+        run = LangChainRun("tool_base", [], tool_message=the_message)
+        tool = self.make_tool(run_to_return=run)
+
+        result = await tool._arun()   # pylint: disable=protected-access
+
+        assert result == "the answer"
+        assert isinstance(result, str)
+
+    @pytest.mark.asyncio
+    async def test_arun_returns_none_when_run_has_no_tool_message(self):
+        """
+        A Run can legitimately carry no tool message (see submit_tool_outputs()
+        when there are no parseable tool outputs). _arun() must not blow up
+        dereferencing content on None.
+        """
+        run = LangChainRun("tool_base", [], tool_message=None)
+        tool = self.make_tool(run_to_return=run)
+
+        result = await tool._arun()   # pylint: disable=protected-access
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_arun_returns_exception_string_on_failure(self):
+        """
+        Exceptions from the tool call are reported back to the calling LLM
+        as their string form so it can verbally recognize the problem.
+        """
+        tool = self.make_tool(exception=ValueError("something broke"))
+
+        result = await tool._arun()   # pylint: disable=protected-access
+
+        assert result == "something broke"


### PR DESCRIPTION
Part of #1222 (PR 6 of the Phase 1 ladder — independent of the others, does not depend on #1216).

## Problem

`LangChainOpenAIFunctionTool._arun()` returns the `AgentToolResultMessage` **object**. Langchain passes `str` (and content-block list) tool returns through to the calling LLM's `ToolMessage` as-is, but falls back to `str()` for any other object — and `str()` of a pydantic message is its repr. So the calling LLM literally sees

```
content='<the actual answer>' additional_kwargs={} response_metadata={} type='agent_tool_result' name=None id=None tool_calls=[] invalid_tool_calls=[] usage_metadata=None tool_result_origin=[{'tool': ...}]
```

as the sub-agent's answer, on **every** sub-agent call: wasted tokens, prompt noise the parent LLM has to unwrap, and internal field names (`tool_result_origin`) leaking into prompts.

## Fix

Return `the_answer.content` (with a `None` guard — a `Run` can legitimately carry no tool message, see `submit_tool_outputs()`). This is deliberately `.content` rather than `.content_blocks` or `.text`: `.content` is the carried payload, so when tool answers later become content-block lists, langchain passes the list through natively and this method needs no further change.

## Behavior change note (for release notes)

The `ToolMessage` text every calling LLM sees changes from the pydantic repr wrapper to the clean answer text. Networks whose prompts were (accidentally) calibrated against the repr format may shift behavior.

## Testing

- New `tests/.../core/test_langchain_openai_function_tool.py`: answer comes back as content (a `str`, not the message object); `None` tool message returns `None` without dereferencing; exception path still returns `str(exception)`.
- `music_nerd_pro_multi_agents`
