### PR TITLE
Synthesize default parameters for parameterless external front-men

### DIFF
--- a/docs/agent_hocon_reference.md
+++ b/docs/agent_hocon_reference.md
@@ -534,8 +534,17 @@ For a user-facing front-man, what is contained in this description often suffice
 Parameters contains an optional [JSON Schema](https://json-schema.org) dictionary describing what
 specific information the agent needs as input arguments when it is called.
 
-A front-man typically does not need parameters defined, unless the agent network being described
-is anticipated as being called from other agent networks.
+A front-man typically does not need parameters defined when its agent network is only
+ever talked to directly by a user.
+
+When the agent network is anticipated as being called from other agent networks
+(that is, referenced as an external tool), the front-man's parameters are how a
+calling agent passes its request along — the tool-call arguments are the only channel
+through which anything reaches the external network. Declare at least one parameter
+(for example, a single required `inquiry` string) for any network intended to be
+referenced externally. If no parameters are declared, neuro-san synthesizes a default
+required `inquiry` string parameter on the calling side (and logs a warning) so the
+caller's request still gets through.
 
 ##### type
 

--- a/docs/agent_hocon_reference.md
+++ b/docs/agent_hocon_reference.md
@@ -533,6 +533,9 @@ For a user-facing front-man, what is contained in this description often suffice
 
 Parameters contains an optional [JSON Schema](https://json-schema.org) dictionary describing what
 specific information the agent needs as input arguments when it is called.
+Only the `type: object` + `properties` form described below is supported.
+A schema expressed with other JSON Schema constructs (such as `additionalProperties`,
+`anyOf`, or `$ref`) is rejected as invalid when the agent is called as a tool.
 
 A front-man typically does not need parameters defined when its agent network is only
 ever talked to directly by a user.

--- a/docs/agent_hocon_reference.md
+++ b/docs/agent_hocon_reference.md
@@ -534,8 +534,10 @@ For a user-facing front-man, what is contained in this description often suffice
 Parameters contains an optional [JSON Schema](https://json-schema.org) dictionary describing what
 specific information the agent needs as input arguments when it is called.
 Only the `type: object` + `properties` form described below is supported.
-A schema expressed with other JSON Schema constructs (such as `additionalProperties`,
-`anyOf`, or `$ref`) is rejected as invalid when the agent is called as a tool.
+JSON Schema constructs outside this form (such as `additionalProperties`,
+`anyOf`, or `$ref`) are not honored: a schema without a `properties` dictionary
+is rejected as invalid when the agent is called as a tool, and unsupported
+constructs appearing alongside a `properties` dictionary are ignored.
 
 A front-man typically does not need parameters defined when its agent network is only
 ever talked to directly by a user.

--- a/docs/agent_hocon_reference.md
+++ b/docs/agent_hocon_reference.md
@@ -542,8 +542,10 @@ ever talked to directly by a user.
 
 When the agent network is anticipated as being called from other agent networks
 (that is, referenced as an external tool), the front-man's parameters are how a
-calling agent passes its request along — the tool-call arguments are the only channel
-through which anything reaches the external network. Declare at least one parameter
+calling agent passes its request along — the tool-call arguments are the only message
+channel through which a caller's request reaches the external network.
+(Private data can separately flow through the opt-in `sly_data` channel —
+see [to_downstream](#to_downstream).) Declare at least one parameter
 (for example, a single required `inquiry` string) for any network intended to be
 referenced externally. If no parameters are declared, neuro-san synthesizes a default
 required `inquiry` string parameter on the calling side (and logs a warning) so the

--- a/neuro_san/internals/run_context/langchain/core/base_tool_factory.py
+++ b/neuro_san/internals/run_context/langchain/core/base_tool_factory.py
@@ -194,13 +194,27 @@ class BaseToolFactory:
             return function_json
 
         parameters: Dict[str, Any] = function_json.get("parameters") or {}
+        if not isinstance(parameters, Dict):
+            # Not a schema we can reason about.
+            # Let verify_function_json() report it as invalid.
+            return function_json
+
         properties: Dict[str, Any] = parameters.get("properties") or {}
         if properties:
             return function_json
 
+        # A parameters block carrying anything beyond an empty properties
+        # declaration is a declared schema in an unsupported dialect
+        # (e.g. additionalProperties, anyOf, $ref). Let verify_function_json()
+        # report it rather than silently replacing the declared contract
+        # with the synthesized one.
+        if parameters and not {"type", "properties", "required"}.issuperset(parameters.keys()):
+            return function_json
+
         message: str = (
-            f"The front-man of external agent {name} declares no function.parameters, "
-            f"so a single required '{self.DEFAULT_EXTERNAL_PARAMETER_NAME}' string parameter "
+            f"The front-man of external agent {name} declares no parameters "
+            f"in its function definition, so a single required "
+            f"'{self.DEFAULT_EXTERNAL_PARAMETER_NAME}' string parameter "
             "is being synthesized for it to receive the calling agent's request. "
             "To control what this agent network receives, declare at least one parameter "
             "in the function definition of its front-man."

--- a/neuro_san/internals/run_context/langchain/core/base_tool_factory.py
+++ b/neuro_san/internals/run_context/langchain/core/base_tool_factory.py
@@ -20,6 +20,7 @@ from typing import List
 from typing import Set
 from typing import Union
 
+from copy import deepcopy
 from logging import Logger
 from logging import getLogger
 
@@ -45,6 +46,25 @@ class BaseToolFactory:
     """
     Creates langchain BaseTools.
     """
+
+    # The tool-call arguments are the only channel through which a calling
+    # agent passes anything to an external agent network.  A front-man that
+    # declares no function.parameters would be presented to the calling LLM
+    # as a zero-argument tool, which the LLM would then invoke with {} -
+    # the external network would never receive the caller's request.
+    # When that happens we substitute this schema so the request still
+    # gets through.
+    DEFAULT_EXTERNAL_PARAMETER_NAME: str = "inquiry"
+    DEFAULT_EXTERNAL_PARAMETERS: Dict[str, Any] = {
+        "type": "object",
+        "properties": {
+            DEFAULT_EXTERNAL_PARAMETER_NAME: {
+                "type": "string",
+                "description": "The request to send to this agent network."
+            }
+        },
+        "required": [DEFAULT_EXTERNAL_PARAMETER_NAME]
+    }
 
     # pylint: disable=too-many-arguments, too-many-positional-arguments
     def __init__(self,
@@ -113,6 +133,7 @@ class BaseToolFactory:
         adapter = ExternalToolAdapter(session_factory, name)
         try:
             function_json: Dict[str, Any] = await adapter.get_function_json(self.invocation_context)
+            function_json = await self.ensure_external_parameters(function_json, name)
             return self.create_function_tool(function_json, name)
         except ValueError as exception:
             # Could not reach the server for the external agent, so tell about it
@@ -122,6 +143,49 @@ class BaseToolFactory:
             await self.journal.write_message(agent_message)
             self.sensitive_logger.info(message)
             return None
+
+    async def ensure_external_parameters(self, function_json: Dict[str, Any], name: str) -> Dict[str, Any]:
+        """
+        Guarantee that an external agent's function spec declares parameters.
+
+        An external front-man that declares no function.parameters would
+        otherwise be presented to the calling LLM as a zero-argument tool,
+        which the LLM would invoke with an empty {} - and the external network
+        would silently never receive the caller's request (issue #1228).
+
+        Note this is external-tools-only on purpose: internal tools without
+        parameters (e.g. no-argument coded tools) legitimately take no
+        arguments and are left alone.
+
+        :param function_json: The function spec reported by the external agent.
+                    Can be None when the agent was unreachable.
+        :param name: The name of the external agent, for reporting.
+        :return: The function_json as-is when it already declares parameters,
+                    otherwise a copy with DEFAULT_EXTERNAL_PARAMETERS substituted in.
+        """
+        if function_json is None:
+            # Unreachable external agent. create_function_tool() reports this case.
+            return None
+
+        parameters: Dict[str, Any] = function_json.get("parameters") or {}
+        properties: Dict[str, Any] = parameters.get("properties") or {}
+        if properties:
+            return function_json
+
+        message: str = (
+            f"The front-man of external agent {name} declares no function.parameters, "
+            f"so a single required '{self.DEFAULT_EXTERNAL_PARAMETER_NAME}' string parameter "
+            "is being synthesized for it to receive the calling agent's request. "
+            "To control what this agent network receives, declare at least one parameter "
+            "in the function definition of its front-man."
+        )
+        agent_message = AgentMessage(content=message)
+        await self.journal.write_message(agent_message)
+        self.logger.warning(message)
+
+        function_json = dict(function_json)
+        function_json["parameters"] = deepcopy(self.DEFAULT_EXTERNAL_PARAMETERS)
+        return function_json
 
     async def create_internal_tool(self, name: str, agent_spec: Dict[str, Any]) -> BaseTool:
         """

--- a/neuro_san/internals/run_context/langchain/core/base_tool_factory.py
+++ b/neuro_san/internals/run_context/langchain/core/base_tool_factory.py
@@ -199,12 +199,14 @@ class BaseToolFactory:
             # followed by the tool being dropped.
             return function_json
 
-        parameters: Dict[str, Any] = function_json.get("parameters") or {}
-        if not isinstance(parameters, Dict):
-            # Not a schema we can reason about.
+        raw_parameters: Any = function_json.get("parameters")
+        if raw_parameters is not None and not isinstance(raw_parameters, Dict):
+            # Not a schema we can reason about, however truthy or falsy
+            # (e.g. a string, a list, a boolean).
             # Let verify_function_json() report it as invalid.
             return function_json
 
+        parameters: Dict[str, Any] = raw_parameters or {}
         properties: Dict[str, Any] = parameters.get("properties") or {}
         if properties:
             # The network declares its own parameters. Re-arm the synthesis

--- a/neuro_san/internals/run_context/langchain/core/base_tool_factory.py
+++ b/neuro_san/internals/run_context/langchain/core/base_tool_factory.py
@@ -133,16 +133,34 @@ class BaseToolFactory:
         adapter = ExternalToolAdapter(session_factory, name)
         try:
             function_json: Dict[str, Any] = await adapter.get_function_json(self.invocation_context)
-            function_json = await self.ensure_external_parameters(function_json, name)
-            return self.create_function_tool(function_json, name)
         except ValueError as exception:
             # Could not reach the server for the external agent, so tell about it
             message: str = f"Agent/tool {name} was unreachable. Not including it as a tool.\n"
             message += str(exception)
-            agent_message = AgentMessage(content=message)
-            await self.journal.write_message(agent_message)
-            self.sensitive_logger.info(message)
+            await self.report_tool_exclusion(message)
             return None
+
+        try:
+            function_json = await self.ensure_external_parameters(function_json, name)
+            return self.create_function_tool(function_json, name)
+        except ValueError as exception:
+            # The agent was reachable, but what it reported cannot be made into a tool.
+            message: str = f"Agent/tool {name} reported an invalid function definition. " + \
+                           "Not including it as a tool.\n"
+            message += str(exception)
+            await self.report_tool_exclusion(message)
+            return None
+
+    async def report_tool_exclusion(self, message: str):
+        """
+        Report to both the client journal and the server logs that a tool
+        is being left out of the calling agent's tool list.
+
+        :param message: The message describing which tool and why
+        """
+        agent_message = AgentMessage(content=message)
+        await self.journal.write_message(agent_message)
+        self.sensitive_logger.info(message)
 
     async def ensure_external_parameters(self, function_json: Dict[str, Any], name: str) -> Dict[str, Any]:
         """
@@ -166,6 +184,14 @@ class BaseToolFactory:
         if function_json is None:
             # Unreachable external agent. create_function_tool() reports this case.
             return None
+
+        if function_json.get("description") is None:
+            # A spec with no description fails verify_function_json() no matter
+            # what parameters it has. Leave it alone so that validation reports
+            # the real problem, instead of journaling a promise here that a
+            # synthesized parameter will get the request through, immediately
+            # followed by the tool being dropped.
+            return function_json
 
         parameters: Dict[str, Any] = function_json.get("parameters") or {}
         properties: Dict[str, Any] = parameters.get("properties") or {}
@@ -298,9 +324,9 @@ class BaseToolFactory:
         # JSON, which is required.  Use the agent name we are using for look-up for that
         # regardless of intent.
         if function_json is None:
-            # An external agent that couldn't be reached has no function_json.
-            # Raise ValueError so create_external_tool's existing handler turns this
-            # into a user-facing "Agent/tool X was unreachable" message instead of
+            # An external agent that responded without reporting a function has
+            # no function_json. Raise ValueError so create_external_tool's
+            # invalid-function-definition handler reports this instead of
             # the TypeError that the assignment below would otherwise raise.
             message: str = f"Could not create tool to call external agent '{name}'. Its function_json is None."
             raise ValueError(message)

--- a/neuro_san/internals/run_context/langchain/core/base_tool_factory.py
+++ b/neuro_san/internals/run_context/langchain/core/base_tool_factory.py
@@ -47,14 +47,8 @@ class BaseToolFactory:
     Creates langchain BaseTools.
     """
 
-    # The tool-call arguments are the only message channel through which a
-    # calling agent passes its request to an external agent network
-    # (sly_data is a separate, opt-in channel for private data).  A front-man that
-    # declares no function.parameters would be presented to the calling LLM
-    # as a zero-argument tool, which the LLM would then invoke with {} -
-    # the external network would never receive the caller's request.
-    # When that happens we substitute this schema so the request still
-    # gets through.
+    # Parameters substituted for an external agent whose front-man declares
+    # none of its own. See ensure_external_parameters() for the full rationale.
     DEFAULT_EXTERNAL_PARAMETER_NAME: str = "inquiry"
     DEFAULT_EXTERNAL_PARAMETERS: Dict[str, Any] = {
         "type": "object",
@@ -175,8 +169,11 @@ class BaseToolFactory:
         """
         Guarantee that an external agent's function spec declares parameters.
 
+        The tool-call arguments are the only message channel through which a
+        calling agent passes its request to an external agent network
+        (sly_data is a separate, opt-in channel for private data).
         An external front-man that declares no function.parameters would
-        otherwise be presented to the calling LLM as a zero-argument tool,
+        therefore be presented to the calling LLM as a zero-argument tool,
         which the LLM would invoke with an empty {} - and the external network
         would silently never receive the caller's request (issue #1228).
 

--- a/neuro_san/internals/run_context/langchain/core/base_tool_factory.py
+++ b/neuro_san/internals/run_context/langchain/core/base_tool_factory.py
@@ -47,8 +47,9 @@ class BaseToolFactory:
     Creates langchain BaseTools.
     """
 
-    # The tool-call arguments are the only channel through which a calling
-    # agent passes anything to an external agent network.  A front-man that
+    # The tool-call arguments are the only message channel through which a
+    # calling agent passes its request to an external agent network
+    # (sly_data is a separate, opt-in channel for private data).  A front-man that
     # declares no function.parameters would be presented to the calling LLM
     # as a zero-argument tool, which the LLM would then invoke with {} -
     # the external network would never receive the caller's request.

--- a/neuro_san/internals/run_context/langchain/core/base_tool_factory.py
+++ b/neuro_san/internals/run_context/langchain/core/base_tool_factory.py
@@ -66,6 +66,14 @@ class BaseToolFactory:
         "required": [DEFAULT_EXTERNAL_PARAMETER_NAME]
     }
 
+    # Class-level because BaseToolFactory instances are per-request: remembers
+    # which external agents this process has already warned about synthesizing
+    # parameters for, so the warning is not repeated on every request.
+    # An agent later observed with declared parameters is removed again, so a
+    # network that is fixed and then regresses warns anew - hocon files can be
+    # edited and hot-reloaded without a server restart.
+    synthesis_warned: Set[str] = set()
+
     # pylint: disable=too-many-arguments, too-many-positional-arguments
     def __init__(self,
                  tool_caller: ToolCaller,
@@ -201,6 +209,9 @@ class BaseToolFactory:
 
         properties: Dict[str, Any] = parameters.get("properties") or {}
         if properties:
+            # The network declares its own parameters. Re-arm the synthesis
+            # warning in case the network regresses later.
+            BaseToolFactory.synthesis_warned.discard(name)
             return function_json
 
         # A parameters block carrying anything beyond an empty properties
@@ -211,17 +222,19 @@ class BaseToolFactory:
         if parameters and not {"type", "properties", "required"}.issuperset(parameters.keys()):
             return function_json
 
-        message: str = (
-            f"The front-man of external agent {name} declares no parameters "
-            f"in its function definition, so a single required "
-            f"'{self.DEFAULT_EXTERNAL_PARAMETER_NAME}' string parameter "
-            "is being synthesized for it to receive the calling agent's request. "
-            "To control what this agent network receives, declare at least one parameter "
-            "in the function definition of its front-man."
-        )
-        agent_message = AgentMessage(content=message)
-        await self.journal.write_message(agent_message)
-        self.logger.warning(message)
+        if name not in BaseToolFactory.synthesis_warned:
+            BaseToolFactory.synthesis_warned.add(name)
+            message: str = (
+                f"The front-man of external agent {name} declares no parameters "
+                f"in its function definition, so a single required "
+                f"'{self.DEFAULT_EXTERNAL_PARAMETER_NAME}' string parameter "
+                "is being synthesized for it to receive the calling agent's request. "
+                "To control what this agent network receives, declare at least one parameter "
+                "in the function definition of its front-man."
+            )
+            agent_message = AgentMessage(content=message)
+            await self.journal.write_message(agent_message)
+            self.logger.warning(message)
 
         function_json = dict(function_json)
         function_json["parameters"] = deepcopy(self.DEFAULT_EXTERNAL_PARAMETERS)

--- a/neuro_san/internals/run_context/langchain/core/langchain_openai_function_tool.py
+++ b/neuro_san/internals/run_context/langchain/core/langchain_openai_function_tool.py
@@ -101,7 +101,9 @@ class LangChainOpenAIFunctionTool(BaseTool):
             message = f"Function for {name} has no description.\n"
 
         parameters: Dict[str, Any] = function_json.get("parameters")
-        if parameters:
+        if parameters is not None and not isinstance(parameters, Dict):
+            message = f"Function for {name} needs its parameters to be a dictionary.\n"
+        elif parameters:
             if parameters.get("type") is None:
                 message = f"Function for {name} needs to have a parameters.type set to 'object'.\n"
             properties: Dict[str, Any] = parameters.get("properties")

--- a/neuro_san/internals/run_context/utils/external_tool_adapter.py
+++ b/neuro_san/internals/run_context/utils/external_tool_adapter.py
@@ -81,9 +81,11 @@ an agent network by that name. Try these hints:
        which must also have an entry in the manifest.hocon file for the server.
     c. There is one and only one "front man" agent note in each network described
        by a hocon file that receives input on behalf of the network.
-    d. In order to be called by external agents, that front man must have a full
-       "function" definition, which includes a description, and at least one parameter
-       defined.  These are how calling agents know how to interact with the agent network.
+    d. In order to be called by external agents, that front man must have a
+       "function" definition which includes a description. Declaring at least
+       one parameter is recommended, as parameters are how calling agents know
+       what to pass; when none are declared, a single "inquiry" string parameter
+       is synthesized on the calling side so the caller's request still gets through.
 """
                 )
                 raise ValueError(message) from exception

--- a/neuro_san/registries/chat_mock_llm_echo.hocon
+++ b/neuro_san/registries/chat_mock_llm_echo.hocon
@@ -45,8 +45,10 @@
             "name": "echoer",
 
             # Note that there are no parameters defined for this guy's "function" key.
-            # This is the primary way to identify this tool as a front-man,
-            # distinguishing it from the rest of the tools.
+            # This is fine for a front-man that only takes direct user input, but a
+            # network that is to be referenced as an external tool by another network
+            # should declare at least one parameter so the calling agent knows what
+            # to pass. (The front-man is simply the first agent in the "tools" list.)
 
             "function": {
                 # The description acts as an initial prompt. 

--- a/neuro_san/registries/date_time.hocon
+++ b/neuro_san/registries/date_time.hocon
@@ -47,8 +47,10 @@
             "name": "date_time_provider",
 
             # Note that there are no parameters defined for this guy's "function" key.
-            # This is the primary way to identify this tool as a front-man,
-            # distinguishing it from the rest of the tools.
+            # This is fine for a front-man that only takes direct user input, but a
+            # network that is to be referenced as an external tool by another network
+            # should declare at least one parameter so the calling agent knows what
+            # to pass. (The front-man is simply the first agent in the "tools" list.)
 
             "function": {
                 # The description acts as an initial prompt. 

--- a/neuro_san/registries/date_time_timezone.hocon
+++ b/neuro_san/registries/date_time_timezone.hocon
@@ -47,8 +47,10 @@
             "name": "date_time_provider",
 
             # Note that there are no parameters defined for this guy's "function" key.
-            # This is the primary way to identify this tool as a front-man,
-            # distinguishing it from the rest of the tools.
+            # This is fine for a front-man that only takes direct user input, but a
+            # network that is to be referenced as an external tool by another network
+            # should declare at least one parameter so the calling agent knows what
+            # to pass. (The front-man is simply the first agent in the "tools" list.)
 
             "function": {
                 # The description acts as an initial prompt. 

--- a/neuro_san/registries/deep/math_guy_passthrough.hocon
+++ b/neuro_san/registries/deep/math_guy_passthrough.hocon
@@ -43,8 +43,10 @@
             "name": "passthrough",
 
             # Note that there are no parameters defined for this guy's "function" key.
-            # This is the primary way to identify this tool as a front-man,
-            # distinguishing it from the rest of the tools.
+            # This is fine for a front-man that only takes direct user input, but a
+            # network that is to be referenced as an external tool by another network
+            # should declare at least one parameter so the calling agent knows what
+            # to pass. (The front-man is simply the first agent in the "tools" list.)
 
             "function": {
 

--- a/neuro_san/registries/esp_decision_assistant.hocon
+++ b/neuro_san/registries/esp_decision_assistant.hocon
@@ -86,8 +86,10 @@
             "name": "decision_making_assistant",
 
             # Note that there are no parameters defined for this guy's "function" key.
-            # This is the primary way to identify this tool as a front-man,
-            # distinguishing it from the rest of the tools.
+            # This is fine for a front-man that only takes direct user input, but a
+            # network that is to be referenced as an external tool by another network
+            # should declare at least one parameter so the calling agent knows what
+            # to pass. (The front-man is simply the first agent in the "tools" list.)
 
             "function": {
 

--- a/neuro_san/registries/hello_world.hocon
+++ b/neuro_san/registries/hello_world.hocon
@@ -47,8 +47,10 @@
             "name": "announcer",
 
             # Note that there are no parameters defined for this guy's "function" key.
-            # This is the primary way to identify this tool as a front-man,
-            # distinguishing it from the rest of the tools.
+            # This is fine for a front-man that only takes direct user input, but a
+            # network that is to be referenced as an external tool by another network
+            # should declare at least one parameter so the calling agent knows what
+            # to pass. (The front-man is simply the first agent in the "tools" list.)
 
             "function": {
 

--- a/neuro_san/registries/intranet_agents.hocon
+++ b/neuro_san/registries/intranet_agents.hocon
@@ -90,8 +90,10 @@ the inquiry, if any. or if it is being asked to respond to the inquiry.
             "name": "main_search_box",
 
             # Note that there are no parameters defined for this guy's "function" key.
-            # This is the primary way to identify this tool as a front-man,
-            # distinguishing it from the rest of the tools.
+            # This is fine for a front-man that only takes direct user input, but a
+            # network that is to be referenced as an external tool by another network
+            # should declare at least one parameter so the calling agent knows what
+            # to pass. (The front-man is simply the first agent in the "tools" list.)
 
             "function": {
 

--- a/neuro_san/registries/intranet_agents_middleware.hocon
+++ b/neuro_san/registries/intranet_agents_middleware.hocon
@@ -93,8 +93,10 @@ the inquiry, if any. or if it is being asked to respond to the inquiry.
             "name": "main_search_box",
 
             # Note that there are no parameters defined for this guy's "function" key.
-            # This is the primary way to identify this tool as a front-man,
-            # distinguishing it from the rest of the tools.
+            # This is fine for a front-man that only takes direct user input, but a
+            # network that is to be referenced as an external tool by another network
+            # should declare at least one parameter so the calling agent knows what
+            # to pass. (The front-man is simply the first agent in the "tools" list.)
 
             "function": {
 

--- a/neuro_san/registries/math_guy_passthrough.hocon
+++ b/neuro_san/registries/math_guy_passthrough.hocon
@@ -43,8 +43,10 @@
             "name": "passthrough",
 
             # Note that there are no parameters defined for this guy's "function" key.
-            # This is the primary way to identify this tool as a front-man,
-            # distinguishing it from the rest of the tools.
+            # This is fine for a front-man that only takes direct user input, but a
+            # network that is to be referenced as an external tool by another network
+            # should declare at least one parameter so the calling agent knows what
+            # to pass. (The front-man is simply the first agent in the "tools" list.)
 
             "function": {
 

--- a/neuro_san/registries/music_nerd.hocon
+++ b/neuro_san/registries/music_nerd.hocon
@@ -47,8 +47,10 @@
             "name": "MusicNerd",
 
             # Note that there are no parameters defined for this guy's "function" key.
-            # This is the primary way to identify this tool as a front-man,
-            # distinguishing it from the rest of the tools.
+            # This is fine for a front-man that only takes direct user input, but a
+            # network that is to be referenced as an external tool by another network
+            # should declare at least one parameter so the calling agent knows what
+            # to pass. (The front-man is simply the first agent in the "tools" list.)
 
             "function": {
 

--- a/neuro_san/registries/music_nerd_pro.hocon
+++ b/neuro_san/registries/music_nerd_pro.hocon
@@ -47,8 +47,10 @@
             "name": "MusicNerdPro",
 
             # Note that there are no parameters defined for this guy's "function" key.
-            # This is the primary way to identify this tool as a front-man,
-            # distinguishing it from the rest of the tools.
+            # This is fine for a front-man that only takes direct user input, but a
+            # network that is to be referenced as an external tool by another network
+            # should declare at least one parameter so the calling agent knows what
+            # to pass. (The front-man is simply the first agent in the "tools" list.)
 
             "function": {
 

--- a/neuro_san/registries/music_nerd_pro_llm_anthropic.hocon
+++ b/neuro_san/registries/music_nerd_pro_llm_anthropic.hocon
@@ -47,8 +47,10 @@
             "name": "MusicNerdPro",
 
             # Note that there are no parameters defined for this guy's "function" key.
-            # This is the primary way to identify this tool as a front-man,
-            # distinguishing it from the rest of the tools.
+            # This is fine for a front-man that only takes direct user input, but a
+            # network that is to be referenced as an external tool by another network
+            # should declare at least one parameter so the calling agent knows what
+            # to pass. (The front-man is simply the first agent in the "tools" list.)
 
             "function": {
 

--- a/neuro_san/registries/music_nerd_pro_llm_azure.hocon
+++ b/neuro_san/registries/music_nerd_pro_llm_azure.hocon
@@ -48,8 +48,10 @@
             "name": "MusicNerdPro",
 
             # Note that there are no parameters defined for this guy's "function" key.
-            # This is the primary way to identify this tool as a front-man,
-            # distinguishing it from the rest of the tools.
+            # This is fine for a front-man that only takes direct user input, but a
+            # network that is to be referenced as an external tool by another network
+            # should declare at least one parameter so the calling agent knows what
+            # to pass. (The front-man is simply the first agent in the "tools" list.)
 
             "function": {
 

--- a/neuro_san/registries/music_nerd_pro_llm_bedrock_claude.hocon
+++ b/neuro_san/registries/music_nerd_pro_llm_bedrock_claude.hocon
@@ -94,8 +94,10 @@
             "name": "MusicNerdPro",
 
             # Note that there are no parameters defined for this guy's "function" key.
-            # This is the primary way to identify this tool as a front-man,
-            # distinguishing it from the rest of the tools.
+            # This is fine for a front-man that only takes direct user input, but a
+            # network that is to be referenced as an external tool by another network
+            # should declare at least one parameter so the calling agent knows what
+            # to pass. (The front-man is simply the first agent in the "tools" list.)
 
             "function": {
 

--- a/neuro_san/registries/music_nerd_pro_llm_gemini.hocon
+++ b/neuro_san/registries/music_nerd_pro_llm_gemini.hocon
@@ -58,8 +58,10 @@
             "name": "MusicNerdPro",
 
             # Note that there are no parameters defined for this guy's "function" key.
-            # This is the primary way to identify this tool as a front-man,
-            # distinguishing it from the rest of the tools.
+            # This is fine for a front-man that only takes direct user input, but a
+            # network that is to be referenced as an external tool by another network
+            # should declare at least one parameter so the calling agent knows what
+            # to pass. (The front-man is simply the first agent in the "tools" list.)
 
             "function": {
 

--- a/neuro_san/registries/music_nerd_pro_llm_ollama.hocon
+++ b/neuro_san/registries/music_nerd_pro_llm_ollama.hocon
@@ -57,8 +57,10 @@
             "name": "MusicNerdPro",
 
             # Note that there are no parameters defined for this guy's "function" key.
-            # This is the primary way to identify this tool as a front-man,
-            # distinguishing it from the rest of the tools.
+            # This is fine for a front-man that only takes direct user input, but a
+            # network that is to be referenced as an external tool by another network
+            # should declare at least one parameter so the calling agent knows what
+            # to pass. (The front-man is simply the first agent in the "tools" list.)
 
             "function": {
 

--- a/neuro_san/registries/music_nerd_pro_llm_openrouter.hocon
+++ b/neuro_san/registries/music_nerd_pro_llm_openrouter.hocon
@@ -56,8 +56,10 @@
             "name": "MusicNerdPro",
 
             # Note that there are no parameters defined for this guy's "function" key.
-            # This is the primary way to identify this tool as a front-man,
-            # distinguishing it from the rest of the tools.
+            # This is fine for a front-man that only takes direct user input, but a
+            # network that is to be referenced as an external tool by another network
+            # should declare at least one parameter so the calling agent knows what
+            # to pass. (The front-man is simply the first agent in the "tools" list.)
 
             "function": {
 

--- a/neuro_san/registries/music_nerd_pro_multi_agents.hocon
+++ b/neuro_san/registries/music_nerd_pro_multi_agents.hocon
@@ -47,8 +47,10 @@
             "name": "MusicNerdPro",
 
             # Note that there are no parameters defined for this guy's "function" key.
-            # This is the primary way to identify this tool as a front-man,
-            # distinguishing it from the rest of the tools.
+            # This is fine for a front-man that only takes direct user input, but a
+            # network that is to be referenced as an external tool by another network
+            # should declare at least one parameter so the calling agent knows what
+            # to pass. (The front-man is simply the first agent in the "tools" list.)
 
             "function": {
 

--- a/neuro_san/registries/music_nerd_pro_sly.hocon
+++ b/neuro_san/registries/music_nerd_pro_sly.hocon
@@ -42,8 +42,10 @@
             "name": "MusicNerdProSly",
 
             # Note that there are no parameters defined for this guy's "function" key.
-            # This is the primary way to identify this tool as a front-man,
-            # distinguishing it from the rest of the tools.
+            # This is fine for a front-man that only takes direct user input, but a
+            # network that is to be referenced as an external tool by another network
+            # should declare at least one parameter so the calling agent knows what
+            # to pass. (The front-man is simply the first agent in the "tools" list.)
 
             "function": {
 

--- a/neuro_san/registries/music_nerd_pro_sly_api_key.hocon
+++ b/neuro_san/registries/music_nerd_pro_sly_api_key.hocon
@@ -50,8 +50,10 @@
             "name": "MusicNerdProSly",
 
             # Note that there are no parameters defined for this guy's "function" key.
-            # This is the primary way to identify this tool as a front-man,
-            # distinguishing it from the rest of the tools.
+            # This is fine for a front-man that only takes direct user input, but a
+            # network that is to be referenced as an external tool by another network
+            # should declare at least one parameter so the calling agent knows what
+            # to pass. (The front-man is simply the first agent in the "tools" list.)
 
             "function": {
 

--- a/neuro_san/registries/music_nerd_summarize.hocon
+++ b/neuro_san/registries/music_nerd_summarize.hocon
@@ -47,8 +47,10 @@
             "name": "MusicNerd",
 
             # Note that there are no parameters defined for this guy's "function" key.
-            # This is the primary way to identify this tool as a front-man,
-            # distinguishing it from the rest of the tools.
+            # This is fine for a front-man that only takes direct user input, but a
+            # network that is to be referenced as an external tool by another network
+            # should declare at least one parameter so the calling agent knows what
+            # to pass. (The front-man is simply the first agent in the "tools" list.)
 
             "function": {
 

--- a/tests/neuro_san/internals/run_context/langchain/core/test_base_tool_factory.py
+++ b/tests/neuro_san/internals/run_context/langchain/core/test_base_tool_factory.py
@@ -41,6 +41,16 @@ class TestBaseToolFactory:
 
     EXTERNAL_AGENT_NAME: str = "/network_b"
 
+    @pytest.fixture(autouse=True)
+    def clear_synthesis_warned(self):
+        """
+        The synthesis warning is deduplicated per-process via a class-level
+        set. Clear it around each test so tests stay order-independent.
+        """
+        BaseToolFactory.synthesis_warned.clear()
+        yield
+        BaseToolFactory.synthesis_warned.clear()
+
     @staticmethod
     def make_factory(function_json: Dict[str, Any]) -> BaseToolFactory:
         """
@@ -157,6 +167,60 @@ class TestBaseToolFactory:
         assert "synthesized" not in str(reported.content)
         assert "invalid function definition" in str(reported.content)
         assert "unreachable" not in str(reported.content)
+
+    @pytest.mark.asyncio
+    async def test_synthesis_warns_once_per_agent(self):
+        """
+        Tool resources are rebuilt on every request, but the synthesis
+        warning describes a static config condition - it must be reported
+        once per process for a given agent, not once per request.
+        The synthesis itself must still happen every time.
+        """
+        parameterless: Dict[str, Any] = {"description": "Answers music questions."}
+
+        first_factory = self.make_factory(parameterless)
+        first_tool = await first_factory.create_external_tool(self.EXTERNAL_AGENT_NAME)
+        assert first_tool.parameters == BaseToolFactory.DEFAULT_EXTERNAL_PARAMETERS
+        first_factory.journal.write_message.assert_awaited_once()
+
+        second_factory = self.make_factory(parameterless)
+        second_tool = await second_factory.create_external_tool(self.EXTERNAL_AGENT_NAME)
+        assert second_tool.parameters == BaseToolFactory.DEFAULT_EXTERNAL_PARAMETERS
+        second_factory.journal.write_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_synthesis_warning_rearms_when_agent_is_fixed(self):
+        """
+        Hocon files can be edited and hot-reloaded without a server restart.
+        Observing the agent with declared parameters must re-arm the warning,
+        so a later regression back to parameterless warns anew.
+        """
+        parameterless: Dict[str, Any] = {"description": "Answers music questions."}
+        declared: Dict[str, Any] = {
+            "description": "Answers music questions.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "question": {
+                        "type": "string",
+                        "description": "The question to answer."
+                    }
+                },
+                "required": ["question"]
+            }
+        }
+
+        broken_factory = self.make_factory(parameterless)
+        await broken_factory.create_external_tool(self.EXTERNAL_AGENT_NAME)
+        broken_factory.journal.write_message.assert_awaited_once()
+
+        fixed_factory = self.make_factory(declared)
+        await fixed_factory.create_external_tool(self.EXTERNAL_AGENT_NAME)
+        fixed_factory.journal.write_message.assert_not_awaited()
+
+        regressed_factory = self.make_factory(parameterless)
+        await regressed_factory.create_external_tool(self.EXTERNAL_AGENT_NAME)
+        regressed_factory.journal.write_message.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_unsupported_schema_dialect_is_not_replaced(self):

--- a/tests/neuro_san/internals/run_context/langchain/core/test_base_tool_factory.py
+++ b/tests/neuro_san/internals/run_context/langchain/core/test_base_tool_factory.py
@@ -243,15 +243,17 @@ class TestBaseToolFactory:
         assert "synthesized" not in str(reported.content)
 
     @pytest.mark.asyncio
-    async def test_non_dict_parameters_reported_as_invalid(self):
+    @pytest.mark.parametrize("bad_parameters", ["none", [], "", False, 0])
+    async def test_non_dict_parameters_reported_as_invalid(self, bad_parameters):
         """
-        A malformed spec whose "parameters" is not a dictionary must be
-        reported as an invalid function definition, not crash the calling
-        agent's resource setup with an AttributeError.
+        A malformed spec whose "parameters" is not a dictionary - truthy or
+        falsy - must be reported as an invalid function definition: neither
+        crashing the calling agent's resource setup with an AttributeError,
+        nor being silently repaired with the synthesized default.
         """
         factory = self.make_factory({
             "description": "Answers music questions.",
-            "parameters": "none"
+            "parameters": bad_parameters
         })
 
         tool = await factory.create_external_tool(self.EXTERNAL_AGENT_NAME)

--- a/tests/neuro_san/internals/run_context/langchain/core/test_base_tool_factory.py
+++ b/tests/neuro_san/internals/run_context/langchain/core/test_base_tool_factory.py
@@ -159,6 +159,49 @@ class TestBaseToolFactory:
         assert "unreachable" not in str(reported.content)
 
     @pytest.mark.asyncio
+    async def test_unsupported_schema_dialect_is_not_replaced(self):
+        """
+        A declared parameters schema in an unsupported JSON Schema dialect
+        (no properties, but e.g. additionalProperties) is a declared contract,
+        not an absent one. It must be rejected as invalid - never silently
+        replaced with the synthesized default.
+        """
+        factory = self.make_factory({
+            "description": "Answers music questions.",
+            "parameters": {
+                "type": "object",
+                "additionalProperties": {"type": "string"}
+            }
+        })
+
+        tool = await factory.create_external_tool(self.EXTERNAL_AGENT_NAME)
+
+        assert tool is None
+        factory.journal.write_message.assert_awaited_once()
+        reported = factory.journal.write_message.await_args.args[0]
+        assert "invalid function definition" in str(reported.content)
+        assert "synthesized" not in str(reported.content)
+
+    @pytest.mark.asyncio
+    async def test_non_dict_parameters_reported_as_invalid(self):
+        """
+        A malformed spec whose "parameters" is not a dictionary must be
+        reported as an invalid function definition, not crash the calling
+        agent's resource setup with an AttributeError.
+        """
+        factory = self.make_factory({
+            "description": "Answers music questions.",
+            "parameters": "none"
+        })
+
+        tool = await factory.create_external_tool(self.EXTERNAL_AGENT_NAME)
+
+        assert tool is None
+        factory.journal.write_message.assert_awaited_once()
+        reported = factory.journal.write_message.await_args.args[0]
+        assert "invalid function definition" in str(reported.content)
+
+    @pytest.mark.asyncio
     async def test_unreachable_external_tool_reported_as_unreachable(self):
         """
         A transport-level failure fetching the external agent's function spec

--- a/tests/neuro_san/internals/run_context/langchain/core/test_base_tool_factory.py
+++ b/tests/neuro_san/internals/run_context/langchain/core/test_base_tool_factory.py
@@ -135,6 +135,48 @@ class TestBaseToolFactory:
         factory.journal.write_message.assert_awaited_once()
 
     @pytest.mark.asyncio
+    async def test_external_tool_without_description_is_not_synthesized(self):
+        """
+        A front-man spec with no description fails validation no matter what
+        parameters it has (e.g. a hocon with no "function" block at all, for
+        which the server reports {}). No synthesis message may be journaled
+        for it - the client would see a promise that the request will get
+        through, immediately followed by the tool being dropped.
+        """
+        factory = self.make_factory({})
+
+        tool = await factory.create_external_tool(self.EXTERNAL_AGENT_NAME)
+
+        assert tool is None
+
+        # Only the validation-failure report, never the synthesis message,
+        # and under the invalid-definition banner rather than "unreachable" -
+        # the agent did respond.
+        factory.journal.write_message.assert_awaited_once()
+        reported = factory.journal.write_message.await_args.args[0]
+        assert "synthesized" not in str(reported.content)
+        assert "invalid function definition" in str(reported.content)
+        assert "unreachable" not in str(reported.content)
+
+    @pytest.mark.asyncio
+    async def test_unreachable_external_tool_reported_as_unreachable(self):
+        """
+        A transport-level failure fetching the external agent's function spec
+        is a connectivity problem and must keep the "unreachable" banner.
+        """
+        factory = self.make_factory({})
+        session = factory.invocation_context.get_async_session_factory().create_session()
+        session.function = AsyncMock(side_effect=ValueError("connection refused"))
+
+        tool = await factory.create_external_tool(self.EXTERNAL_AGENT_NAME)
+
+        assert tool is None
+        factory.journal.write_message.assert_awaited_once()
+        reported = factory.journal.write_message.await_args.args[0]
+        assert "unreachable" in str(reported.content)
+        assert "invalid function definition" not in str(reported.content)
+
+    @pytest.mark.asyncio
     async def test_ensure_external_parameters_passes_none_through(self):
         """
         An unreachable external agent has no function_json at all.

--- a/tests/neuro_san/internals/run_context/langchain/core/test_base_tool_factory.py
+++ b/tests/neuro_san/internals/run_context/langchain/core/test_base_tool_factory.py
@@ -29,15 +29,10 @@ class TestBaseToolFactory:
     """
     Test cases for BaseToolFactory.
 
-    The cases here currently center on how external agents are presented
-    as tools: the tool-call arguments are the only message channel through
-    which a calling agent passes its request to an external agent network.
-    An external
-    front-man that declares no function.parameters used to be presented to
-    the calling LLM as a zero-argument tool, which the LLM would invoke
-    with {} - the external network silently never received the caller's
-    request (issue #1228).  A default "inquiry" parameter is now
-    synthesized for that case.
+    The cases here currently center on how external agents are presented as
+    tools - in particular the default "inquiry" parameter synthesized for a
+    front-man that declares no parameters of its own (issue #1228).
+    See BaseToolFactory.ensure_external_parameters() for the full rationale.
     """
 
     EXTERNAL_AGENT_NAME: str = "/network_b"

--- a/tests/neuro_san/internals/run_context/langchain/core/test_base_tool_factory.py
+++ b/tests/neuro_san/internals/run_context/langchain/core/test_base_tool_factory.py
@@ -30,8 +30,9 @@ class TestBaseToolFactory:
     Test cases for BaseToolFactory.
 
     The cases here currently center on how external agents are presented
-    as tools: the tool-call arguments are the only channel through which a
-    calling agent passes anything to an external agent network.  An external
+    as tools: the tool-call arguments are the only message channel through
+    which a calling agent passes its request to an external agent network.
+    An external
     front-man that declares no function.parameters used to be presented to
     the calling LLM as a zero-argument tool, which the LLM would invoke
     with {} - the external network silently never received the caller's

--- a/tests/neuro_san/internals/run_context/langchain/core/test_base_tool_factory.py
+++ b/tests/neuro_san/internals/run_context/langchain/core/test_base_tool_factory.py
@@ -1,0 +1,148 @@
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+from typing import Any
+from typing import Dict
+
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+
+import pytest
+
+from neuro_san.internals.run_context.langchain.core.base_tool_factory import BaseToolFactory
+
+
+class TestBaseToolFactory:
+    """
+    Test cases for BaseToolFactory.
+
+    The cases here currently center on how external agents are presented
+    as tools: the tool-call arguments are the only channel through which a
+    calling agent passes anything to an external agent network.  An external
+    front-man that declares no function.parameters used to be presented to
+    the calling LLM as a zero-argument tool, which the LLM would invoke
+    with {} - the external network silently never received the caller's
+    request (issue #1228).  A default "inquiry" parameter is now
+    synthesized for that case.
+    """
+
+    EXTERNAL_AGENT_NAME: str = "/network_b"
+
+    @staticmethod
+    def make_factory(function_json: Dict[str, Any]) -> BaseToolFactory:
+        """
+        :param function_json: The function spec the mocked external agent reports
+        :return: A BaseToolFactory whose external session plumbing is mocked out
+        """
+        session = MagicMock()
+        session.function = AsyncMock(return_value={"function": function_json})
+
+        session_factory = MagicMock()
+        session_factory.create_session = MagicMock(return_value=session)
+
+        invocation_context = MagicMock()
+        invocation_context.get_async_session_factory = MagicMock(return_value=session_factory)
+
+        journal = MagicMock()
+        journal.write_message = AsyncMock()
+
+        tool_caller = MagicMock()
+
+        return BaseToolFactory(tool_caller, invocation_context, journal)
+
+    @pytest.mark.asyncio
+    async def test_external_tool_without_parameters_gets_default_schema(self):
+        """
+        An external front-man with no function.parameters must be presented
+        to the calling LLM with the synthesized required "inquiry" parameter,
+        not as a zero-argument tool.
+        """
+        factory = self.make_factory({"description": "Answers music questions."})
+
+        tool = await factory.create_external_tool(self.EXTERNAL_AGENT_NAME)
+
+        assert tool is not None
+        assert tool.parameters == BaseToolFactory.DEFAULT_EXTERNAL_PARAMETERS
+
+        # The args_schema is what actually reaches the calling LLM.
+        param_name: str = BaseToolFactory.DEFAULT_EXTERNAL_PARAMETER_NAME
+        fields = tool.args_schema.__fields__
+        assert list(fields.keys()) == [param_name]
+        assert fields[param_name].required is True
+
+        # The substitution must not be silent.
+        factory.journal.write_message.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_external_tool_with_parameters_is_untouched(self):
+        """
+        An external front-man that declares its own parameters must be
+        passed through exactly as declared, with no warning.
+        """
+        declared_parameters: Dict[str, Any] = {
+            "type": "object",
+            "properties": {
+                "question": {
+                    "type": "string",
+                    "description": "The question to answer."
+                }
+            },
+            "required": ["question"]
+        }
+        factory = self.make_factory({
+            "description": "Answers music questions.",
+            "parameters": declared_parameters
+        })
+
+        tool = await factory.create_external_tool(self.EXTERNAL_AGENT_NAME)
+
+        assert tool is not None
+        assert tool.parameters == declared_parameters
+        assert list(tool.args_schema.__fields__.keys()) == ["question"]
+        factory.journal.write_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_external_tool_with_empty_properties_gets_default_schema(self):
+        """
+        A parameters block whose properties dictionary is empty is just as
+        uncallable as no parameters at all, so it gets the same substitution.
+        """
+        factory = self.make_factory({
+            "description": "Answers music questions.",
+            "parameters": {
+                "type": "object",
+                "properties": {}
+            }
+        })
+
+        tool = await factory.create_external_tool(self.EXTERNAL_AGENT_NAME)
+
+        assert tool is not None
+        assert tool.parameters == BaseToolFactory.DEFAULT_EXTERNAL_PARAMETERS
+        factory.journal.write_message.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_ensure_external_parameters_passes_none_through(self):
+        """
+        An unreachable external agent has no function_json at all.
+        That case is reported elsewhere and must pass through untouched.
+        """
+        factory = self.make_factory({})
+
+        result = await factory.ensure_external_parameters(None, self.EXTERNAL_AGENT_NAME)
+
+        assert result is None
+        factory.journal.write_message.assert_not_awaited()

--- a/tests/neuro_san/internals/run_context/langchain/core/test_langchain_openai_function_tool.py
+++ b/tests/neuro_san/internals/run_context/langchain/core/test_langchain_openai_function_tool.py
@@ -98,3 +98,20 @@ class TestLangChainOpenAIFunctionTool:
         result = await tool._arun()   # pylint: disable=protected-access
 
         assert result == "something broke"
+
+    def test_from_function_json_without_parameters_builds_empty_args_schema(self):
+        """
+        An internal tool with no "parameters" block must still get an explicit,
+        empty args_schema. Leaving args_schema unset lets langchain auto-derive
+        a schema from _arun(*args, **kwargs), which produces an "args" array
+        property with no "items" field - Gemini rejects that with
+        INVALID_ARGUMENT (see commit 2836c3cf).
+        """
+        function_json = {
+            "name": "date_time",
+            "description": "Returns the current date and time."
+        }
+        tool = LangChainOpenAIFunctionTool.from_function_json(function_json, MagicMock())
+
+        assert tool.args_schema is not None
+        assert len(tool.args_schema.__fields__) == 0


### PR DESCRIPTION
## Summary

Fixes #1228.

When agent network A references network B as an external tool and B's front-man declares no `function.parameters`, B was presented to A's LLM as a zero-argument tool. The LLM invoked it with `{}`, and since the tool-call arguments are the only message channel into an external network, B never received the caller's request — silently producing plausible-looking garbage answers.

Root cause: the calling side builds the external tool directly from the spec that `function()` reports, and an empty parameter schema is faithfully presented as a zero-argument tool. The load-time guard that used to reject parameterless externals was relaxed long ago to support internal no-argument coded tools, which legalized this case by side effect.

## What this does

- **Forward the query.** When an external agent's function spec declares no parameters, `BaseToolFactory` synthesizes a single required `inquiry` string parameter so the calling LLM passes its request through — the same shape as an explicitly declared single-parameter front-man. External agents that declare parameters pass through byte-identical; internal parameterless tools (no-argument coded tools, toolbox tools) are untouched, including the explicit empty args_schema they need for Gemini, now locked in by a regression test.
- **Not silently.** The substitution is reported to the journal and server logs, once per process per agent. Observing the agent healthy re-arms the warning, so a hocon that is fixed via hot-reload and later regresses warns anew.
- **Only when nothing was declared.** A `parameters` block carrying anything beyond an empty `properties` declaration (e.g. `additionalProperties`, `anyOf`, `$ref`) is a declared schema in an unsupported dialect: it is rejected loudly rather than silently replaced. Only the `object` + `properties` form is supported, now stated in the docs.
- **Honest error reporting.** `create_external_tool` now distinguishes a transport failure ("was unreachable") from a spec that cannot be made into a tool ("reported an invalid function definition"), and the synthesis message is never journaled for a spec that will fail validation anyway. A malformed non-dict `parameters` is reported as invalid instead of crashing the calling agent's request with an `AttributeError`.
- **Docs and examples.** `agent_hocon_reference.md` explains the external-parameter contract and the synthesized fallback; the stale "no parameters is the primary way to identify a front-man" comment (front-man detection has been positional for a while) is corrected in all 21 example registries; the unreachable-agent hint no longer claims parameters are mandatory.

## Testing

New unit tests cover: synthesis for absent and empty-properties parameters, pass-through for declared parameters, once-per-process warning with hot-reload re-arm, unsupported-dialect rejection, non-dict parameters, no-description specs, unreachable vs invalid-definition reporting, and the empty-args_schema regression guard for internal tools. Full run_context/graph suites pass; flake8 and pylint clean.

## Related

During review, a pre-existing shared-state bug was found adjacent to this path (same-server external references mutate the referenced network's registry spec via `function_json["name"] = name`). Tracked separately in #1230.