### PR TITLE
Use latest leaf-common==1.3.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 # requirements-build.txt
 
 # In-house dependencies
-leaf-common>=1.3.0
+leaf-common>=1.3.1
 
 # Downgraded secondary dependencies for error-free pip installs
 pyhocon>=0.3.60

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 # requirements-build.txt
 
 # In-house dependencies
-leaf-common>=1.2.53
+leaf-common>=1.3.0
 
 # Downgraded secondary dependencies for error-free pip installs
 pyhocon>=0.3.60
@@ -24,10 +24,12 @@ ruamel.yaml>=0.18.6
 # Keep all these guys limited for now, as it can be the wild wild west out there
 # We don't want to be on a dependencies treadmill with timing not of our choosing.
 langchain>=1.2.0,<2.0
+
 # Floor 1.4.0: bind() on a chat model must return a chat-model-aware binding
 # (with bind_tools) for the Gemini AFC-disable in gemini_llm_policy.py to activate.
 langchain-core>=1.4.0,<2.0
 bs4>=0.0.2,<0.1
+
 # Python 3.14 note: install pydantic>=2.13 to silence langchain-core's
 # "Core Pydantic V1 functionality isn't compatible with Python 3.14" UserWarning.
 # langchain-core imports pydantic.v1 for backwards compatibility, and


### PR DESCRIPTION
This lighter version of leaf-common also lightens the transient dependency load.
Use leaf-common==1.3.1 which removes the deprecation redirects for Resolver and ResolverUtil - clean break.