### PR TITLE
Add load test framework for agent networks

### DIFF
--- a/tests/load_tests/README.md
+++ b/tests/load_tests/README.md
@@ -157,7 +157,7 @@ then moves to the next. Output labels each batch as `[STAGE N]`.
 | `--stages`                 | 10,30,50,100| Concurrency per stage in ramp mode           |
 | `--num-rounds`             | 1           | Repeat the full sequence N times             |
 | `--max-requests`           | sum(stages) * num_rounds | Hard cap on total requests |
-| `--request-timeout`        | 1200 (20m)  | Hard timeout per request (subprocess mode; see [Abort on timeout](#abort-on-timeout) for `--http-client`). Accepts a bare number (seconds) or an `s`/`m`/`h` suffix (e.g. `90s`, `20m`, `2h`) |
+| `--request-timeout`        | 1200 (20m)  | Hard timeout per request (see [Abort on timeout](#abort-on-timeout) for how `--http-client` differs). Accepts a bare number (seconds) or an `s`/`m`/`h` suffix (e.g. `90s`, `20m`, `2h`) |
 | `--idle-timeout`           | 900 (15m)   | Abort a request that is idle for this long (resets on activity). Accepts seconds or an `s`/`m`/`h` suffix. Subprocess mode: no `agent_cli` output; HTTP mode (`--http-client`): no next stream chunk |
 | `--stage-timeout`          | 1500 (25m)  | Hard timeout for entire stage/round. Accepts seconds or an `s`/`m`/`h` suffix. Kills remaining in-flight requests |
 | `--total-timeout`          | 0 (disabled)| Hard timeout for entire load test. Accepts seconds or an `s`/`m`/`h` suffix. Kills run when exceeded |
@@ -182,10 +182,11 @@ collected so far:
   stream chunk (HTTP mode, `--http-client`).
 - **`--request-timeout`**: A request exceeds its hard time limit →
   abort. Subprocess mode kills the `agent_cli` process at the limit.
-  HTTP mode (`--http-client`) cannot interrupt the in-thread stream,
-  so it marks the request `TIMEOUT` once the stream ends; a slow but
-  still-streaming request is bounded by `--idle-timeout` and
-  `--stage-timeout` instead.
+  HTTP mode (`--http-client`) abandons the request as the response
+  streams, so it stops within one streamed message of the limit
+  rather than exactly at it; that wait is itself bounded by
+  `--idle-timeout`. Interrupting a blocking read exactly would cost
+  a thread per request, which is what HTTP mode exists to avoid.
 - **`--stage-timeout`**: A stage/round exceeds its limit, remaining
   requests killed → abort.
 - **`--total-timeout`**: Overall test elapsed time exceeded → abort

--- a/tests/load_tests/README.md
+++ b/tests/load_tests/README.md
@@ -1,0 +1,579 @@
+# Load Test Framework
+
+Fire concurrent requests at a neuro-san server, monitor resource usage,
+and report results. Fires real LLM calls either via `agent_cli`
+subprocesses (default) or direct HTTP streaming (`--http-client`).
+
+## Contents
+
+- [Quick Start](#quick-start)
+- [Test Levels](#test-levels---level)
+- [Traffic Modes](#traffic-modes)
+- [Flags](#flags)
+- [Environment Variables](#environment-variables)
+- [Pre-Run Summary and Dry-Run Probe](#pre-run-summary-and-dry-run-probe)
+- [Agent Profiles](#agent-profiles)
+- [Output](#output)
+- [Latency Analysis](#latency-analysis)
+- [Exit Codes](#exit-codes)
+- [Code Quality](#code-quality)
+- [Architecture](#architecture)
+- [Cross-Run Comparison](#cross-run-comparison)
+- [Trend History](#trend-history)
+- [Notes](#notes)
+
+## Quick Start
+
+Start the server (from neuro-san-studio):
+
+```bash
+export PYTHONPATH=$(pwd)
+python -m neuro_san.service.main_loop.server_main_loop 2>&1 | tee logs/server.log
+```
+
+Run the load test (from neuro-san):
+
+```bash
+export PYTHONPATH=$(pwd)
+
+# Smoke test — does the server respond? (--client-only runs the
+# lightweight min profile against an already-running server)
+python -m tests.load_tests.load_test_cli --agent hello_world --client-only --no-dry-run
+
+# Standard — with server log (auto-detect from server process)
+python -m tests.load_tests.load_test_cli --agent hello_world --level norm \
+    --server-log --no-dry-run
+
+# Standard — with server log (explicit path)
+python -m tests.load_tests.load_test_cli --agent hello_world --level norm \
+    --server-log /path/to/logs/server.log --no-dry-run
+
+# Standard — without server log (resources + tokens)
+python -m tests.load_tests.load_test_cli --agent hello_world --level norm --no-dry-run
+
+# Full analysis — with server log
+python -m tests.load_tests.load_test_cli --agent hello_world --level adv \
+    --ramp --stages 2,4,8 \
+    --server-log /path/to/logs/server.log --no-dry-run
+
+# Full analysis — without server log (JSON + tokens, no retries)
+python -m tests.load_tests.load_test_cli --agent hello_world --level adv \
+    --ramp --stages 2,4,8 --no-dry-run
+```
+
+## Test Levels (`--level`)
+
+| Feature                              | min | norm | adv |
+|--------------------------------------|-----|------|-----|
+| Fire requests + validate responses   |  Y  |  Y   |  Y  |
+| Server log (retries, disconnections) |     | auto | auto |
+| Resource monitoring (RSS, threads)   |  Y  |  Y   |  Y  |
+| Token accounting (from stdout)       |  Y  |  Y   |  Y  |
+| Pool reuse analysis                  |     |      | opt |
+| JSON export (`raw_results.json`)     |  Y  |  Y   |  Y  |
+
+> **`min` is not selectable for an all-in-one run.** It is the profile
+> used automatically by `--client-only` and `--server-only` (which force
+> `min` and enable resource monitoring). Passing `--level min` without
+> `--client-only`/`--server-only` is rejected — use `norm` or `adv` for a
+> colocated run.
+
+`opt` = available with optional flags; `auto` = on by default when the
+target server is local. `--server-log` enables retry counting,
+server-side validation, disconnection detection, and pool reuse
+analysis. Retry counting covers both neuro-san's own `max_attempts`
+retries (`retrying from <ErrorType>`) and retries the LLM provider SDK
+performs internally (`Retrying request to ... in ... seconds`, reported
+as `Provider SDK retries`); both feed the amplification factor.
+At `norm`/`adv` (all-in-one) a server log is expected: it is
+auto-detected for a local server (no flag needed when colocated). If a
+local log isn't found, the run **prompts** you to continue without it
+(or abort); a **remote** host aborts with a pointer to
+`--client-only`. Use `--no-server-log` to skip the prompt
+and run without log analysis, or `--server-log <path>` for an explicit
+file (`--server-log` alone forces auto-detect and aborts if it fails).
+It stays off by default at `min`.
+Resource monitoring is on automatically at `norm`/`adv` and in the
+`min` profile used by `--client-only`/`--server-only`. Token
+accounting via `agent_cli --tokens` is enabled at all levels by
+default (disable with `--no-tokens`).
+
+**Where LLM/token numbers come from.** Client-side counts arrive in the
+chat stream as a token-accounting message, so they require the default
+(no `--minimal`); `--minimal` filters that message out server-side and
+the `LLM & TOKEN USAGE` section is then omitted for want of data.
+Server-side counts are parsed from the server log instead, so they are
+unaffected by the filter. A `--client-only` run against a remote host
+has no server log to fall back on: with `--minimal` it reports no
+tokens at all.
+
+**`adv` level defaults:** 50 requests, 3 rounds (150 total requests),
+applied automatically unless overridden with `--num-requests`,
+`--max-workers`, or `--num-rounds`.
+
+**`--max-workers` auto-matching:** `--full-concurrency` matches
+`--max-workers` to `--num-requests` so all requests fire at once, at any
+level. Otherwise `--max-workers` stays at its conservative default of 3
+and a warning is shown during the cost confirmation if
+`max-workers < num-requests`. An explicit `--max-workers` always wins,
+and `--ramp` ignores both since its stages set their own concurrency.
+
+At `norm`/`adv`, server-log analysis is expected: it is auto-detected
+for a local server. If a local log isn't found you're prompted to
+continue without it; a remote host aborts (use `--client-only`). Pass
+`--no-server-log` to skip the prompt and
+opt out — server-log-dependent sections then print "not available".
+At `min` (the `--client-only`/`--server-only` profile) server-log
+analysis is always off.
+
+## Traffic Modes
+
+**Flat** (default): `--num-requests 10` — fixed concurrency.
+`--max-workers` defaults to 3; `--full-concurrency` matches it to
+`--num-requests`. Set `--max-workers` explicitly to control concurrency:
+`--num-requests 100 --max-workers 10` fires 100 requests, 10 at a time.
+Flat mode output labels each iteration as a "round" (no stage numbers).
+
+**Ramp-up**: `--ramp --stages 2,4,8,16` — escalating concurrency across
+stages. Each stage fires N concurrent requests, waits for completion,
+then moves to the next. Output labels each batch as `[STAGE N]`.
+
+## Flags
+
+| Flag                       | Default     | Description                                  |
+|----------------------------|-------------|----------------------------------------------|
+| `--agent`                  | hello_world | Agent name as registered in the server       |
+| `--level`                  | norm        | Test depth: norm or adv for an all-in-one run (min is rejected there; min is used automatically by `--client-only`/`--server-only`) |
+| `--server-log [PATH]`      | auto (local, norm/adv) | Server log analysis. Auto-detected for a local server at norm/adv; if not found you're prompted to continue without it (remote host aborts — use `--client-only`). Pass a path for an explicit file, or the flag alone to force auto-detect. |
+| `--no-server-log`          | off         | Skip the missing-log prompt at norm/adv and run without server-log analysis; overrides the local auto-detect |
+| `--no-tokens`              | off         | Disable per-request token accounting         |
+| `--minimal`                | off         | Ask the server for the bare minimum of messages, as `agent_cli --minimal` does: only the final answer, cutting traffic and progress-event work — but it also drops the token-accounting message, so client-side LLM/token reporting is unavailable (tokens then come only from the server log) |
+| `--profile-path`           | auto        | Directory containing profile JSON files (or `LOAD_TEST_PROFILE_PATH` env var) |
+| `--host`                   | localhost   | Neuro-san server host                        |
+| `--port`                   | 8080        | Neuro-san server port                        |
+| `--num-requests`           | 3           | Requests per round in flat mode              |
+| `--max-workers`            | 3             | Concurrent workers in flat mode. See `--full-concurrency` to match `--num-requests` |
+| `--ramp`                   | off         | Enable ramp-up mode                          |
+| `--stages`                 | 10,30,50,100| Concurrency per stage in ramp mode           |
+| `--num-rounds`             | 1           | Repeat the full sequence N times             |
+| `--max-requests`           | sum(stages) * num_rounds | Hard cap on total requests |
+| `--request-timeout`        | 1200 (20m)  | Hard timeout per request (subprocess mode; see [Abort on timeout](#abort-on-timeout) for `--http-client`). Accepts a bare number (seconds) or an `s`/`m`/`h` suffix (e.g. `90s`, `20m`, `2h`) |
+| `--idle-timeout`           | 900 (15m)   | Abort a request that is idle for this long (resets on activity). Accepts seconds or an `s`/`m`/`h` suffix. Subprocess mode: no `agent_cli` output; HTTP mode (`--http-client`): no next stream chunk |
+| `--stage-timeout`          | 1500 (25m)  | Hard timeout for entire stage/round. Accepts seconds or an `s`/`m`/`h` suffix. Kills remaining in-flight requests |
+| `--total-timeout`          | 0 (disabled)| Hard timeout for entire load test. Accepts seconds or an `s`/`m`/`h` suffix. Kills run when exceeded |
+| `--settle-time`            | 15 (15s)    | Wait after each stage for server cleanup. Accepts seconds or an `s`/`m`/`h` suffix |
+| `--same-prompt`            | off         | Use identical prompt for all requests        |
+| `--no-dry-run`             | off         | Skip the dry-run probe + cost confirmation (which run by default at min/norm; adv skips them already) |
+| `--full-concurrency`       | off         | Match `--max-workers` to `--num-requests` so all fire at once |
+| `--scale`                  | 1           | Multiply `--num-requests`, `--max-workers`, `--request-timeout`, `--idle-timeout`, `--stage-timeout`, `--total-timeout` by this factor. `--max-requests` auto-adjusts. |
+| `--skip-reservation-check` | off         | Skip reservation_id validation               |
+| `--output-dir`             | (none)      | Base directory for test output               |
+| `--compare DIR`            | (none)      | Skip load test; scan DIR for previous runs and print a comparison table |
+| `--trend PATH`             | (none)      | Skip load test; print one row per run from the history file, oldest first |
+| `--project-root`           | (none)      | Project root for profile discovery           |
+
+### Abort on timeout
+
+Any timeout aborts the entire test immediately and reports results
+collected so far:
+
+- **`--idle-timeout`**: A request is idle for N seconds → abort.
+  Idle means no `agent_cli` output (subprocess mode) or no next
+  stream chunk (HTTP mode, `--http-client`).
+- **`--request-timeout`**: A request exceeds its hard time limit →
+  abort. Subprocess mode kills the `agent_cli` process at the limit.
+  HTTP mode (`--http-client`) cannot interrupt the in-thread stream,
+  so it marks the request `TIMEOUT` once the stream ends; a slow but
+  still-streaming request is bounded by `--idle-timeout` and
+  `--stage-timeout` instead.
+- **`--stage-timeout`**: A stage/round exceeds its limit, remaining
+  requests killed → abort.
+- **`--total-timeout`**: Overall test elapsed time exceeded → abort
+  before starting the next stage.
+- **Server death**: The heartbeat detects the server process is no
+  longer running (e.g. OOM kill) → abort.
+
+On abort the test still runs the full reporting pipeline (latency
+analysis, completion timeline, summary file, raw JSON) on whatever
+results completed before the timeout.
+
+### Memory monitoring
+
+The heartbeat prints server RSS alongside thread counts on every
+progress tick. The pre-run summary shows total and available system
+RAM. The overall results section reports the peak server RSS observed
+across all stages.
+
+When server RSS exceeds 80% of total system RAM, a warning is printed:
+
+```
+  WARNING: Server RSS 12.8G / 16.0G (80%) — risk of OOM kill
+```
+
+## Environment Variables
+
+| Variable                 | Effect                                     |
+| ------------------------ | ------------------------------------------ |
+| `OPENAI_API_BASE`        | **Aborts the run if set** (see below)      |
+| `LOAD_TEST_PROFILE_PATH` | Default for `--profile-path`               |
+| `PYTHONPATH`             | Repo root, so `tests.load_tests` imports   |
+
+This test requires real LLM calls, so a set `OPENAI_API_BASE` is taken as
+a mock environment and the run aborts before firing anything (a running
+`mock_llm_server` process aborts it too). Unset it, or use
+`load_test_mock_llm_service.py` for mock-based load testing.
+
+## Pre-Run Summary and Dry-Run Probe
+
+Before firing the full test, the load test displays a PRE-RUN SUMMARY.
+
+**min / norm (default):** Fires 1 probe request to measure actual token
+usage, cost, and response time, then shows estimated stage duration,
+numbered warnings (if any), and asks the user to confirm. Pass `--no-dry-run`
+to bypass the probe and confirmation.
+
+**adv (default):** No dry-run probe — adv is treated as an explicit
+stress test, so it shows the summary and runs immediately.
+
+```
+============================================================
+  PRE-RUN SUMMARY
+============================================================
+  Agent:    agent_network_designer
+  Level:    adv
+  Requests: 50 x 3 rounds = 150 total
+  Workers:  3 (concurrent)
+  Timeouts: --request-timeout 1200s (20m) / --idle-timeout 900s (15m) / --stage-timeout 1500s (25m)
+            --total-timeout disabled
+
+  Running 1 dry-run probe to measure actual cost...
+
+  Probe request completed in 30.2s (CREATED)
+  Probe tokens: 500,000 (model: gpt-4o, cost: $0.2500)
+  Estimated stage duration: ~1510s (30.2s x 50 requests)
+
+  WARNINGS (3 found):
+  1. Estimated cost exceeds $1:
+     Probe used ~500,000 tokens ($0.25) x 150 requests = ~75,000,000 tokens (~$37.50)
+     Model: gpt-4o
+  2. --max-workers (3) < --num-requests (50): requests run in batches
+  3. Estimated stage duration ~1510s exceeds --stage-timeout (1500s).
+     Requests may be killed before completing.
+
+  Tip: use --no-dry-run to skip this confirmation.
+============================================================
+
+Proceed with remaining 149 requests? [y/n]:
+```
+
+The probe result counts as request #0 of the first stage (not wasted).
+If the user declines, only 1 request was consumed.
+
+## Agent Profiles
+
+Each agent needs a JSON profile at `tests/load_tests/prompts/profiles/`.
+`--agent hello_world` loads `profiles/hello_world.json`. Prefixed agents
+(e.g., `--agent basic/hello_world`) automatically resolve to the base
+name (`hello_world.json`), so `--profile-path` is not required. Use `--profile-path` to point
+to a custom directory (the filename is always derived from `--agent`).
+
+```json
+{
+    "agent": "hello_world",
+    "prompts": ["Hello, how are you today?", "What can you help me with?"],
+    "estimated_tokens_per_request": 1000,
+    "success_fields": [],
+    "failure_patterns": [
+        "No fully-specified LLM found",
+        "API key to be set as an environment variable"
+    ]
+}
+```
+
+`success_fields`: stdout fields that must be present for success.
+Example: `["reservation_id", "agent_network_name"]` for
+agent_network_designer — the request is marked FAILED if any are missing.
+
+`failure_patterns`: substrings matched against stdout to catch
+server-side errors returned inside a successful HTTP 200 response
+(e.g. missing API key).  When any pattern matches, the request is
+downgraded from CREATED to FAILED.  The load test client does not
+check for API keys itself — it communicates with the server over
+HTTP, so keys are only needed on the server side.
+
+## Output
+
+Results go to `{tempdir}/load_test_{user}/{level}/{timestamp}_{requests}/`
+by default (where `{tempdir}` is the system temp directory, e.g. `/tmp` on
+Linux), or to the path specified by `--output-dir`. The base directory is
+per-user because the temp directory is shared: a fixed `load_test` would
+belong to whoever ran first, and everyone else would get
+`PermissionError`. The request count is appended to the directory name
+for quick identification:
+
+```
+/tmp/load_test_alice/adv/20260622_151428_50/
+/tmp/load_test_alice/adv/20260622_151531_100/
+/tmp/load_test_alice/adv/20260622_151648_150/
+```
+
+At `adv` level this includes:
+
+| File                  | Contents                                         |
+|-----------------------|--------------------------------------------------|
+| `raw_results.json`    | All test data in a single JSON file              |
+| `load_test.log`       | Full terminal output                             |
+| `progress.log`        | All progress ticks and per-request CREATED results |
+| `server_receipts.log` | Per-request server receipt details (with `--server-log`) |
+| `server_tokens.log`   | Per-request token breakdown (when token data available) |
+| `summary.txt`         | Human-readable summary (`adv` level only)        |
+| `requests/`           | Raw stdout/stderr per request                    |
+
+### `raw_results.json`
+
+Single source of truth for all test data. Feed it to an LLM to
+generate Confluence reports, or load it in Python/pandas for custom
+analysis.
+
+Top-level keys:
+
+| Key                       | Description                                          |
+|---------------------------|------------------------------------------------------|
+| `test_metadata`           | Timestamp, versions, platform, verdict, exit code    |
+| `config`                  | All test parameters (agent, level, mode, timeouts)   |
+| `aggregates`              | Totals: requests, tokens, cost, elapsed time         |
+| `stage_summaries`         | Per-round results, retries, server counts, tokens    |
+| `resource_rows`           | Server resource snapshots (before/after per round)   |
+| `client_resource_rows`    | Client resource snapshots (before/peak/settled)      |
+| `_schema`                 | 38 field descriptions for LLM self-service           |
+| `_thresholds`             | 16 health benchmarks (warning/critical levels)       |
+| `_analysis_hints`         | 10 diagnostic patterns to check                      |
+| `_units`                  | 16 unit labels (seconds, MB, USD, etc.)              |
+| `_reporting_instructions` | Tells LLMs to report all checks, even clean ones     |
+
+The `_`-prefixed keys are metadata for LLM-driven analysis. Upload
+the JSON to ChatGPT/Claude/Gemini and say "analyze this" — no prompt
+engineering needed.
+
+Each stage summary contains:
+- Per-request results (status, duration, start/end times, tokens,
+  cost, model, errors)
+- Server log data (retries, disconnections, amplification, server counts)
+- Per-sub-network token breakdowns (`network_tokens`) when
+  `--server-log` is provided — each entry has `network`, `llm_calls`,
+  `total_tokens`, `prompt_tokens`, `completion_tokens`, `duration`,
+  `cost`, and `model`
+
+Resource rows contain server/client snapshots (RSS, threads, FDs, CPU)
+captured before and after each round (flat mode) or stage (ramp mode).
+
+## Latency Analysis
+
+After each test run, a `LATENCY ANALYSIS` section reports LLM bottleneck
+diagnostics:
+
+### Request completion timeline
+
+Shows cumulative request completion milestones per stage — answers
+"how many requests came back after X time":
+
+```
+  Request completion timeline (Stage 1, 50 requests):
+     50% (25 requests) completed by 12.1s
+     60% (30 requests) completed by 14.3s
+     70% (35 requests) completed by 16.8s
+     80% (40 requests) completed by 19.2s
+     90% (45 requests) completed by 22.5s
+     95% (48 requests) completed by 26.1s
+    100% (50 requests) completed by 30.2s
+```
+
+### Round-over-round degradation
+
+Compares average latency at the same concurrency across rounds.
+Increasing latency indicates LLM performance degradation under
+sustained load:
+
+```
+  Latency degradation (round-over-round):
+    50 concurrent: 12.8s -> 14.2s -> 16.1s (+26%)
+```
+
+### Concurrency timeline
+
+Shows actual in-flight request count over time (ASCII chart). Reveals
+whether the LLM serializes concurrent requests:
+
+```
+  Concurrency timeline (stage 1, round 1, 50 planned):
+    Peak in-flight: 50
+      0s |########################################| 50
+     30s |################################        | 40
+     60s |########################                | 30
+```
+
+### Summary file (`--level adv` only)
+
+At `adv` level, a human-readable `summary.txt` is written to the
+output directory. With `--no-dry-run` it is written automatically; without
+`--no-dry-run` the user is prompted.
+
+The summary includes per-request results, completion timeline, and
+(when `--server-log` is provided) a per-request server timing
+breakdown parsed from Start/Finish streaming_chat timestamps:
+
+```
+  request-1 (95.5s total):
+    Client -> Server:     4.5s
+    Server: agent_network_designer      90.8s
+      ├─ agent_network_editor            19.7s
+      ├─ agent_network_instructions_editor  44.4s
+      └─ agent_network_query_generator    8.4s
+    Server -> Client:     0.2s
+```
+
+## Cross-Run Comparison
+
+Use `--compare` to scan a directory of previous runs and print a
+side-by-side comparison table:
+
+```bash
+python -m tests.load_tests.load_test_cli --compare /tmp/load_test_alice/adv/
+```
+
+Output:
+
+```
+============================================================
+  CROSS-RUN COMPARISON
+============================================================
+                    Folder  Requests  Wall Time  Avg/req  TTFR avg  Failed
+-----------------------------------------------------------------------------------
+  20260622_151428_50        50        1200s (20m)    24s      45s       0
+  20260622_151531_100      100        3600s (60m)    36s      90s       2
+  20260622_151648_150      150        6066s (101m)   40s     120s       8
+```
+
+No load test is executed — the command reads `raw_results.json` from
+each subdirectory, extracts key metrics, and sorts by request count.
+
+## Trend History
+
+Use `--trend` to see repeated runs in the order they happened, which is
+how a slowdown between neuro-san versions becomes visible:
+
+```bash
+python -m tests.load_tests.load_test_cli --trend /tmp/load_test_alice/adv/history.jsonl
+```
+
+Output:
+
+```text
+TREND HISTORY (/tmp/load_test_alice/adv/history.jsonl, 3 run(s))
+       timestamp  neuro-san        agent    mode   via  reqs  done  <70s  <300s  ttfr    avg    wall  err  warn
+---------------------------------------------------------------------------------------------------------------
+2026-07-20 14:02     0.5.51  hello_world  client  http   200   200   181    200  2.1s  41.2s  612.0s    0     0
+2026-07-24 09:15     0.5.52  hello_world  client  http   200   200   176    200  2.3s  44.8s  659.1s    0     0
+2026-07-25 18:31     0.5.52  hello_world  client  http   200   188   120    188  3.9s  61.5s  812.7s    7     0
+```
+
+`PATH` may be the history file or a directory containing
+`history.jsonl`, so the path printed at the end of a run works as-is.
+Filter to one agent with `--compare-agent`.
+
+Choose between the two views by the question being asked:
+
+| Question                                          | Use         |
+| ------------------------------------------------- | ----------- |
+| How does the system behave as concurrency rises?  | `--compare` |
+| Did the same load get slower than it used to be?  | `--trend`   |
+
+Only `--trend` shows `neuro_san_version`, which `raw_results.json` does
+not record. Server-only runs appear with `mode=server-only`, and their
+`ttfr` is blank because a server log cannot measure the client's time to
+first response.
+
+## Exit Codes
+
+- `0` — All requests completed successfully
+- `1` — One or more requests failed, timed out, or were killed
+
+## Code Quality
+
+This framework follows three review playbooks:
+
+- **Code_Fink (Dan):** One class per file, `.get()` for dict reads,
+  `.update()` for dict writes, no standalone functions, `%`-formatting
+  for logger calls, specific exception types, named constants for
+  magic numbers.
+
+- **Code_Francon (Olivier):** Silent `except/pass` blocks log via
+  `logger.debug`, `CostEstimator` extracted to its own file, README
+  documents all flags including `--output-dir`.
+
+- **Code_Sargent (Darren):** TypedDicts (`RequestResult`,
+  `StageSummary`, `StatusCounts`, `ServerCounts`, `TokenEntry`,
+  `NetworkTokenEntry`, `ResourceSnapshot`) replace `Dict[str, Any]`
+  at data boundaries. Keyword-only arguments (`*`) eliminate all
+  `too-many-positional-arguments` warnings. Explicit return type
+  annotations on every method.
+
+- **Copilot:** Empty-prompts validation in `AgentProfile`,
+  signed delta formatting (no more `+-3.0M`), Windows compatibility
+  fallbacks (`num_fds`/`select.select`/closed-pipe guards/temp dir),
+  clean error on invalid `--stages`, `ServerCounts` partial TypedDict,
+  auto-resolve profile from agent name, `--full-concurrency` matches
+  `--max-workers` to `--num-requests`, `adv` level defaults (50×3),
+  flat mode hides stage labels and
+  uses round-based output, PRE-RUN SUMMARY with numbered warnings
+  and estimated stage duration.
+
+Lint status: flake8 clean, pylint 10.00/10.
+
+## Architecture
+
+```
+tests/load_tests/
+  load_test_cli.py             LoadTestOrchestrator (main entry point)
+  config.py                    Constants, TypedDicts, compiled patterns
+  confirm.py                   Confirm (strict y/n prompt)
+  cost_estimator.py            CostEstimator (per-model pricing)
+
+  monitoring/
+    heartbeat.py               Heartbeat (progress + peak RSS tracking)
+    resource_monitor.py        ResourceMonitor (psutil snapshots)
+    server_log_monitor.py      ServerLogMonitor (log parsing)
+
+  prompts/
+    agent_profile.py           AgentProfile (prompt/validation config)
+    profiles/                  Per-agent JSON profiles
+
+  reporting/
+    disconnection_reporter.py  DisconnectionReporter
+    json_metadata.py           JsonMetadata (self-documenting JSON)
+    cross_run_comparison.py   CrossRunComparison (--compare output)
+    latency_analyzer.py        LatencyAnalyzer (completion timeline, degradation)
+    summary_file_writer.py     SummaryFileWriter (summary.txt output)
+    pool_analyzer.py           PoolAnalyzer
+    resource_reporter.py       ResourceReporter
+    summary.py                 SummaryReporter
+    system_resources.py        SystemResources (whole-system mem/cpu/threads)
+    table_formatter.py         TableFormatter
+    trend_history.py           TrendHistory (--trend output)
+
+  traffic/
+    cli_builder.py             CliBuilder (agent_cli commands)
+    process_monitor.py         ProcessMonitor (subprocess lifecycle)
+    runner.py                  TrafficRunner (thread pool executor)
+
+  validation/
+    environment_validator.py   EnvironmentValidator (mock LLM, server)
+    input_validator.py         InputValidator (stages, cost probe)
+    output_validator.py        OutputValidator (results, retries)
+```
+
+## Notes
+
+The `monitoring/` modules (`resource_monitor.py`, `server_log_monitor.py`,
+`heartbeat.py`) use `psutil` and server log parsing as interim solutions.
+These may be replaced by neuro-san built-in monitoring when available.

--- a/tests/load_tests/config.py
+++ b/tests/load_tests/config.py
@@ -1,0 +1,345 @@
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+"""Shared constants, regex patterns, and defaults for the load test framework."""
+
+import re
+from typing import Dict
+from typing import List
+from typing import Optional
+
+from typing_extensions import NotRequired
+from typing_extensions import TypedDict
+
+
+class TokenEntry(TypedDict):
+    """Token accounting data parsed from a server log block."""
+
+    request_id: str
+    total_tokens: int
+    prompt_tokens: int
+    completion_tokens: int
+    llm_calls: int
+    model: str
+    reporting_agent: NotRequired[str]
+
+
+class NetworkTokenEntry(TypedDict):
+    """Per-sub-network token data from a server log block."""
+
+    request_id: str
+    network: str
+    total_tokens: int
+    prompt_tokens: int
+    completion_tokens: int
+    llm_calls: int
+    duration: float
+    model: str
+    cost: float
+
+
+class ValidationEvent(TypedDict):
+    """Per-request validation tracking from server log."""
+
+    request_id: str
+    attempts: int
+    fix_cycles: int
+    errors: List[str]
+
+
+class ResourceSnapshot(TypedDict):
+    """Point-in-time resource usage of a process."""
+
+    rss: float
+    fds: int
+    threads: int
+    connections: int
+    children: int
+    cpu: float
+    cpu_seconds: float
+
+
+class ServerCounts(TypedDict, total=False):
+    """Request start/finish counts from the server log.
+
+    All fields are optional because this dict is empty when
+    no server log is available.
+    """
+
+    primary_started: int
+    primary_finished: int
+    total_started: int
+    total_finished: int
+
+
+class _RequestResultRequired(TypedDict):
+    """Required fields in every request result."""
+
+    request_id: str
+    status: str
+    elapsed: float
+    prompt: str
+
+
+class RequestResult(_RequestResultRequired, total=False):
+    """Per-request result from a load test run.
+
+    Required fields are always present.  Optional fields appear when
+    token tracking is enabled or when the request fails.
+    """
+
+    error: Optional[str]
+    ttft: float
+    start_time: float
+    end_time: float
+    total_tokens: int
+    prompt_tokens: int
+    completion_tokens: int
+    llm_calls: int
+    model: str
+    cost_usd: float
+
+
+# Result status constants
+STATUS_CREATED = "CREATED"
+STATUS_FAILED = "FAILED"
+STATUS_TIMEOUT = "TIMEOUT"
+STATUS_KILLED = "KILLED"
+
+
+class StatusCounts(TypedDict):
+    """Per-status request counts from a load test stage."""
+
+    CREATED: int
+    FAILED: int
+    TIMEOUT: int
+    KILLED: int
+
+
+class StageSummary(TypedDict, total=False):
+    """Aggregate data for a single load test stage.
+
+    All fields are optional because resource monitoring and server
+    log parsing are not always enabled.
+    """
+
+    stage: int
+    round: int
+    concurrent: int
+    counts: StatusCounts
+    elapsed: float
+    retries: Dict[str, int]
+    total_retries: int
+    amplification: float
+    results: List[RequestResult]
+    primary_started: Optional[int]
+    primary_finished: Optional[int]
+    total_started: Optional[int]
+    total_finished: Optional[int]
+    disconnections: List[Dict[str, str]]
+    server_errors: List[Dict[str, str]]
+    network_tokens: List[NetworkTokenEntry]
+    validation_events: List[ValidationEvent]
+    has_server_log: bool
+    has_tokens: bool
+    before_threads: Optional[int]
+    after_threads: Optional[int]
+    peak_threads: Optional[int]
+    before_server_rss: Optional[float]
+    after_server_rss: Optional[float]
+    peak_server_rss: Optional[float]
+    before_client_rss: Optional[float]
+    after_client_rss: Optional[float]
+    peak_client_rss: Optional[float]
+    before_sys_mem_pct: Optional[float]
+    after_sys_mem_pct: Optional[float]
+    peak_sys_mem_pct: Optional[float]
+    before_sys_mem_avail_gb: Optional[float]
+    after_sys_mem_avail_gb: Optional[float]
+    peak_sys_mem_avail_gb: Optional[float]
+    before_sys_cpu: Optional[float]
+    after_sys_cpu: Optional[float]
+    peak_sys_cpu: Optional[float]
+    before_sys_threads: Optional[int]
+    after_sys_threads: Optional[int]
+    peak_sys_threads: Optional[int]
+
+
+# Load test levels
+LEVEL_MIN = "min"
+LEVEL_NORM = "norm"
+LEVEL_ADV = "adv"
+
+# Tracked retry error types.  All but ProviderRetry are neuro-san's own
+# max_attempts retries; ProviderRetry counts retries the LLM provider
+# SDK performs internally.
+RETRY_ERROR_TYPES = [
+    "RateLimitError",
+    "APIError",
+    "KeyError",
+    "ValueError",
+    "ProviderRetry",
+]
+# Console labels for retry types whose key alone reads poorly.
+RETRY_LABELS = {
+    "ProviderRetry": "Provider SDK retries",
+}
+
+# Console formatting
+SEPARATOR_WIDTH = 60
+
+# Default configuration
+LOCAL_HOSTS = {"localhost", "127.0.0.1", "::1"}
+DEFAULT_STAGES = [10, 30, 50, 100]
+DEFAULT_TIMEOUT_SECONDS = 1200
+DEFAULT_IDLE_TIMEOUT_SECONDS = 900
+NETWORK_LOOKAHEAD_LINES = 10
+TOKENS_PER_MILLION = 1_000_000
+# Max per-request failure blocks printed to the console before the rest
+# are suppressed (full detail always remains in raw_results.json).
+FAILURE_LOG_LIMIT = 10
+
+# Timeouts for short-lived operations (seconds)
+SOCKET_CHECK_TIMEOUT = 2
+THREAD_JOIN_TIMEOUT = 2
+PROCESS_WAIT_TIMEOUT = 10
+STALE_LOG_THRESHOLD_SECONDS = 300
+
+# Trend history: one append-only JSONL record per client run so
+# throughput can be plotted over time.  The thresholds are fixed (not
+# configurable) so data points stay comparable across every run.
+HISTORY_FILE_NAME = "history.jsonl"
+HISTORY_UNKNOWN_FILE_NAME = "history_unknown.jsonl"
+HISTORY_THRESHOLDS_SECONDS = (70, 300)
+
+
+class SharedRef:
+    """Mutable container for passing a value between threads.
+
+    Replaces the bare-dict pattern (e.g., ``result = {}`` /
+    ``result.update(...)``), making the intent explicit and the
+    expected type visible.
+    """
+
+    __slots__ = ("value",)
+
+    def __init__(self) -> None:
+        self.value = None
+
+
+# Heartbeat and subprocess monitoring
+HEARTBEAT_INTERVAL_SECONDS = 30
+POLL_INTERVAL_SECONDS = 5.0
+READ_BUFFER_SIZE = 4096
+
+# Server log regex patterns
+RETRY_LOG_PATTERN = re.compile(
+    r"retrying from (RateLimit error |)(\w+)"
+)
+# Retries performed inside the LLM provider SDK (e.g. openai's
+# "Retrying request to /chat/completions in 0.45 seconds"), which
+# neuro-san never sees and so never logs as "retrying from ...".
+PROVIDER_RETRY_PATTERN = re.compile(
+    r"Retrying request to (\S+) in "
+)
+REQUEST_START_PATTERN = re.compile(
+    r"Start .*/streaming_chat"
+)
+REQUEST_FINISH_PATTERN = re.compile(
+    r"Finish .*/streaming_chat"
+)
+CLIENT_DISCONNECT_PATTERN = re.compile(
+    r"Request handler stream closed"
+)
+STREAM_CLOSED_REQUEST_PATTERN = re.compile(
+    r'"request_id":\s*"(request-\d+)"'
+)
+TASK_CANCELLED_PATTERN = re.compile(
+    r"Task from ([^:]+):.*was cancelled"
+)
+DONE_STREAMING_PATTERN = re.compile(
+    r'Done with (\S+)\.StreamingChat'
+)
+VALIDATION_ATTEMPT_PATTERN = re.compile(
+    r'Validating toolbox agents'
+)
+VALIDATION_ERROR_PATTERN = re.compile(
+    r'"Validation errors: \[(.+?)\]"'
+)
+VALIDATION_REINVOKE_PATTERN = re.compile(
+    r'Invoking agent network designer to fix the issues'
+)
+VALIDATION_REQUEST_ID_PATTERN = re.compile(
+    r'"request_id":\s*"(request-\d+)"'
+)
+# Server "Errors detected:" event.  Logged as JSON whose "message"
+# value starts with "Errors detected:" and spans literal newlines,
+# ending just before the "user_id" field; matched with re.DOTALL
+# against the joined log window.  Captures (message, request_id).
+SERVER_ERROR_PATTERN = re.compile(
+    r'"message":\s*"(Errors detected:.*?)",\s*"user_id".*?'
+    r'"request_id":\s*"([^"]+)"',
+    re.DOTALL,
+)
+
+# Model pricing (USD per 1M tokens) — update as providers change rates
+# Source: https://openai.com/api/pricing/
+MODEL_PRICING = {
+    "gpt-4o": {"prompt": 2.50, "completion": 10.00},
+    "gpt-4o-mini": {"prompt": 0.15, "completion": 0.60},
+    "gpt-4.1": {"prompt": 2.00, "completion": 8.00},
+    "gpt-4.1-mini": {"prompt": 0.40, "completion": 1.60},
+    "gpt-4.1-nano": {"prompt": 0.10, "completion": 0.40},
+    "gpt-5.2": {"prompt": 2.00, "completion": 8.00},
+    "o4-mini": {"prompt": 1.10, "completion": 4.40},
+}
+# Fallback pricing when model is unknown
+DEFAULT_PRICING = {"prompt": 2.50, "completion": 10.00}
+
+
+class Formatters:
+    """Reporting helpers for human-readable metrics and derived values."""
+
+    @staticmethod
+    def format_rss(rss_mb: float) -> str:
+        """Format RSS in human-readable units."""
+        if rss_mb >= 1024:
+            return f"{rss_mb / 1024:.1f}G"
+        return f"{rss_mb:.0f}M"
+
+    @staticmethod
+    def fmt_duration(seconds: float, *, precision: int = 0) -> str:
+        """Format seconds with minutes suffix when >= 60s.
+
+        Returns e.g. '1870s (31m)' or '45s' for short durations.
+        """
+        base = f"{seconds:.{precision}f}s"
+        if seconds >= 60:
+            mins = int(seconds) // 60
+            return f"{base} ({mins}m)"
+        return base
+
+    @staticmethod
+    def compute_amplification(
+            actual_requests: int, total_retries: int,
+    ) -> float:
+        """Return the retry amplification factor.
+
+        1.0 means no retries; >1.0 means some LLM calls were retried.
+        """
+        if actual_requests <= 0:
+            return 1.0
+        return (actual_requests + total_retries) / actual_requests

--- a/tests/load_tests/confirm.py
+++ b/tests/load_tests/confirm.py
@@ -1,0 +1,51 @@
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+"""Strict interactive yes/no confirmation prompt.
+
+A single reusable helper for every ``[y/n]`` prompt in the load test:
+only ``y`` or ``n`` are accepted (case-insensitive), any other input
+re-prompts, and Ctrl+C / EOF (closed stdin) are treated as ``n``.
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class Confirm:
+    """Strict yes/no prompt: only y or n; Ctrl+C and EOF mean no."""
+
+    @staticmethod
+    def ask(question: str) -> bool:
+        """Prompt until the user answers ``y`` or ``n``.
+
+        Returns True for ``y`` and False for ``n``.  Ctrl+C and EOF
+        (closed stdin) are treated as ``n``.  Anything else is
+        rejected and the question is asked again.
+        """
+        prompt = f"{question} [y/n]: "
+        while True:
+            try:
+                answer = input(prompt).strip().lower()
+            except (EOFError, KeyboardInterrupt):
+                print()
+                return False
+            if answer == "y":
+                return True
+            if answer == "n":
+                return False
+            logger.info("  Please answer 'y' or 'n'.")

--- a/tests/load_tests/cost_estimator.py
+++ b/tests/load_tests/cost_estimator.py
@@ -1,0 +1,54 @@
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+"""Estimate USD cost from LLM token counts and model pricing tables.
+
+Uses per-model pricing for known OpenAI models and falls back to a
+conservative default for unrecognized model strings.  Pricing is
+matched by substring so dated model names (e.g. gpt-5.2-2025-12-11)
+resolve to their base model entry.
+"""
+
+from tests.load_tests.config import DEFAULT_PRICING
+from tests.load_tests.config import MODEL_PRICING
+from tests.load_tests.config import TOKENS_PER_MILLION
+
+
+class CostEstimator:
+    """Estimate USD cost from token counts and model pricing."""
+
+    @staticmethod
+    def estimate(prompt_tokens, completion_tokens, model="unknown") -> float:
+        """Estimate USD cost from token counts and model name.
+
+        Looks up per-model pricing by substring match, then computes
+        cost as (tokens / 1M) * rate for prompt and completion
+        separately.
+        """
+        pricing = DEFAULT_PRICING
+        for key in sorted(MODEL_PRICING, key=len, reverse=True):
+            if key in model:
+                pricing = MODEL_PRICING[key]
+                break
+        prompt_cost = (
+            (prompt_tokens / TOKENS_PER_MILLION)
+            * pricing.get("prompt", 0)
+        )
+        completion_cost = (
+            (completion_tokens / TOKENS_PER_MILLION)
+            * pricing.get("completion", 0)
+        )
+        return prompt_cost + completion_cost

--- a/tests/load_tests/duration.py
+++ b/tests/load_tests/duration.py
@@ -1,0 +1,53 @@
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+"""Parse human-friendly timeout durations into whole seconds."""
+
+import argparse
+
+
+class DurationParser:
+    """Parse human-friendly durations into whole seconds.
+
+    A bare number is seconds (so existing commands are unchanged); an
+    optional ``s``/``m``/``h`` suffix scales it, e.g. ``90s``, ``20m``,
+    ``2h``, ``0.5h``.  Designed to be used as an argparse ``type``.
+    """
+
+    _UNITS = {"s": 1, "m": 60, "h": 3600}
+
+    @staticmethod
+    def parse(value: str) -> int:
+        """Return whole seconds for ``value``; raise on bad input."""
+        text = str(value).strip().lower()
+        if not text:
+            raise argparse.ArgumentTypeError("empty duration")
+        unit = 1
+        if text[-1] in DurationParser._UNITS:
+            unit = DurationParser._UNITS[text[-1]]
+            text = text[:-1]
+        try:
+            seconds = float(text) * unit
+        except ValueError as exc:
+            raise argparse.ArgumentTypeError(
+                f"invalid duration '{value}': use seconds or a s/m/h "
+                "suffix, e.g. 90s, 20m, 2h"
+            ) from exc
+        if seconds < 0:
+            raise argparse.ArgumentTypeError(
+                f"duration must be non-negative: '{value}'"
+            )
+        return int(round(seconds))

--- a/tests/load_tests/load_test_arguments.py
+++ b/tests/load_tests/load_test_arguments.py
@@ -1,0 +1,457 @@
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+"""Command-line interface for the load test.
+
+Holds the argparse definition for every load-test flag, plus the
+detection of which flags the user actually passed, which the
+orchestrator needs in order to leave explicit values alone when it
+applies level-based defaults.
+"""
+
+import argparse
+import os
+from typing import Set
+
+from tests.load_tests.config import DEFAULT_IDLE_TIMEOUT_SECONDS
+from tests.load_tests.config import DEFAULT_TIMEOUT_SECONDS
+from tests.load_tests.config import LEVEL_ADV
+from tests.load_tests.config import LEVEL_MIN
+from tests.load_tests.config import LEVEL_NORM
+from tests.load_tests.duration import DurationParser
+
+
+class LoadTestArguments:
+    """Defines and parses the load test's command-line arguments."""
+
+    @staticmethod
+    def parse_args(epilog) -> argparse.Namespace:
+        """Parse command-line arguments for the load test.
+
+        The epilog is supplied by the caller so that ``--help``
+        still ends with the entrypoint module's usage notes.
+        """
+        parser = argparse.ArgumentParser(
+            description=(
+                "Load-test neuro-san agent networks "
+                "with real LLM calls."
+            ),
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+            epilog=epilog,
+        )
+
+        parser.add_argument(
+            "--agent",
+            type=str,
+            default="hello_world",
+            help="Agent network name to test (default: hello_world). "
+                 "Must be registered in the server's "
+                 "AGENT_REGISTRY_PATH.",
+        )
+        parser.add_argument(
+            "--profile-path",
+            type=str,
+            default=os.environ.get("LOAD_TEST_PROFILE_PATH"),
+            help="Directory containing agent profile JSON files. "
+                 "The filename is derived from --agent "
+                 "(e.g. basic/smart_home → smart_home.json). "
+                 "Without this, searches built-in profiles/. "
+                 "Can also be set via LOAD_TEST_PROFILE_PATH "
+                 "env var.",
+        )
+        parser.add_argument(
+            "--project-root",
+            type=str,
+            default=None,
+            help="Path to the project root where the server is "
+                 "running from (e.g., /path/to/neuro-san-studio). "
+                 "Used to find agent profiles at "
+                 "{project-root}/tests/load_tests/prompts/profiles/. "
+                 "Falls back to PYTHONPATH if not set.",
+        )
+        parser.add_argument(
+            "--num-requests",
+            type=int,
+            default=3,
+            help="Number of requests per round in flat mode "
+                 "(default: 3). Ignored when --ramp is used.",
+        )
+        parser.add_argument(
+            "--max-workers",
+            type=int,
+            default=3,
+            help="Max concurrent workers in flat mode "
+                 "(default: 3). Use --full-concurrency to match "
+                 "--num-requests instead. "
+                 "Ignored when --ramp is used.",
+        )
+        parser.add_argument(
+            "--num-rounds",
+            type=int,
+            default=1,
+            help="Number of rounds in flat mode, or number of "
+                 "times to repeat the full ramp sequence "
+                 "(default: 1).",
+        )
+        parser.add_argument(
+            "--ramp",
+            action="store_true",
+            default=False,
+            help="Enable staged ramp-up mode. Runs escalating "
+                 "concurrency stages instead of flat requests.",
+        )
+        parser.add_argument(
+            "--stages",
+            type=str,
+            default=None,
+            help="Comma-separated concurrency levels for ramp-up "
+                 "mode (default: 10,30,50,100). "
+                 "Only used with --ramp.",
+        )
+        parser.add_argument(
+            "--max-requests",
+            type=int,
+            default=None,
+            help="Hard cap on total requests across all "
+                 "stages/rounds. Cost safeguard for real LLM calls."
+                 " Default: sum(stages) * num_rounds.",
+        )
+        parser.add_argument(
+            "--host",
+            type=str,
+            default="localhost",
+            help="Neuro-san server host (default: localhost)",
+        )
+        parser.add_argument(
+            "--port",
+            type=int,
+            default=8080,
+            help="Neuro-san server port (default: 8080 for "
+                 "http, 443 for https unless overridden)",
+        )
+        parser.add_argument(
+            "--https",
+            action="store_true",
+            default=False,
+            help="Use HTTPS/TLS to reach the server. "
+                 "Default is plain HTTP. When set and --port "
+                 "is not given, the port defaults to 443.",
+        )
+        parser.add_argument(
+            "--request-timeout",
+            type=DurationParser.parse,
+            metavar="DURATION",
+            default=DEFAULT_TIMEOUT_SECONDS,
+            help="Hard timeout per request. Bare number = seconds, "
+                 "or suffix s/m/h (e.g. 90s, 20m, 2h). "
+                 "Default: 1200 (20m). Safety net to prevent "
+                 "requests from running forever.",
+        )
+        parser.add_argument(
+            "--idle-timeout",
+            type=DurationParser.parse,
+            metavar="DURATION",
+            default=DEFAULT_IDLE_TIMEOUT_SECONDS,
+            help="Kill a request if no output for this long. Bare "
+                 "number = seconds, or suffix s/m/h (e.g. 90s, 15m). "
+                 "Default: 900 (15m). Detects hanging requests.",
+        )
+        parser.add_argument(
+            "--stage-timeout",
+            type=DurationParser.parse,
+            metavar="DURATION",
+            default=1500,
+            help="Hard timeout for an entire stage/round. Bare "
+                 "number = seconds, or suffix s/m/h (e.g. 25m, 1h). "
+                 "Default: 1500 (25m). Kills remaining in-flight "
+                 "requests when hit.",
+        )
+        parser.add_argument(
+            "--total-timeout",
+            type=DurationParser.parse,
+            metavar="DURATION",
+            default=0,
+            help="Hard timeout for the entire load test. Bare "
+                 "number = seconds, or suffix s/m/h (e.g. 30m, 2h). "
+                 "Default: 0 (disabled). Kills the test run when "
+                 "exceeded.",
+        )
+        parser.add_argument(
+            "--settle-time",
+            type=DurationParser.parse,
+            metavar="DURATION",
+            default=15,
+            help="Wait this long after each stage for cleanup. Bare "
+                 "number = seconds, or suffix s/m/h (e.g. 15s, 1m). "
+                 "Default: 15 (15s).",
+        )
+        parser.add_argument(
+            "--same-prompt",
+            action="store_true",
+            default=False,
+            help="Use the same prompt for all requests "
+                 "(collision stress test). Default is varied "
+                 "prompts from the agent's prompt pool.",
+        )
+        parser.add_argument(
+            "--no-dry-run",
+            action="store_true",
+            default=False,
+            help="Skip the dry-run probe, which otherwise fires one "
+                 "real request first and asks you to confirm the "
+                 "estimated cost (it runs by default at min/norm; adv "
+                 "skips it already).",
+        )
+        parser.add_argument(
+            "--full-concurrency",
+            action="store_true",
+            default=False,
+            help="Fire every request at once by matching "
+                 "--max-workers to --num-requests, instead of the "
+                 "conservative default of 3 workers. An explicit "
+                 "--max-workers wins, and --ramp ignores this since "
+                 "its stages set their own concurrency.",
+        )
+        parser.add_argument(
+            "--server-log",
+            nargs="?",
+            const="auto",
+            default=None,
+            help="Server log analysis.  Auto-detected by default "
+                 "for a local server at norm/adv levels.  Pass a "
+                 "path to use a specific file, or --server-log "
+                 "with no path to force auto-detect.  Disable with "
+                 "--no-server-log.",
+        )
+        parser.add_argument(
+            "--no-server-log",
+            action="store_true",
+            default=False,
+            help="Disable server log analysis (overrides the "
+                 "default local auto-detect).",
+        )
+        parser.add_argument(
+            "--archive-server-log",
+            action="store_true",
+            default=False,
+            help="Gzip and copy the server log into the "
+                 "output directory after the test completes. "
+                 "Requires --server-log.",
+        )
+        parser.add_argument(
+            "--client-only",
+            action="store_true",
+            default=False,
+            help="Client-only mode for split-machine testing. "
+                 "Fires requests and monitors client RSS and "
+                 "system memory. Skips server process "
+                 "detection and server log analysis. "
+                 "Mutually exclusive with --server-only.",
+        )
+        parser.add_argument(
+            "--http-client",
+            action="store_true",
+            default=False,
+            help="Use direct HTTP requests instead of "
+                 "spawning agent_cli subprocesses. "
+                 "Drastically reduces client memory "
+                 "(~1 MB vs ~96 MB per concurrent request). "
+                 "Implies --client-only.",
+        )
+        parser.add_argument(
+            "--server-only",
+            action="store_true",
+            default=False,
+            help="Server-only mode for split-machine testing. "
+                 "Monitors the server process and reads the "
+                 "server log while a remote client fires "
+                 "requests. Does not fire requests itself. "
+                 "Mutually exclusive with --client-only.",
+        )
+        parser.add_argument(
+            "--level",
+            type=str,
+            choices=[LEVEL_MIN, LEVEL_NORM, LEVEL_ADV],
+            default=LEVEL_NORM,
+            help="Test depth level (default: norm). "
+                 "min: traffic + validation only "
+                 "(only with --client-only/--server-only; "
+                 "not valid for an all-in-one run). "
+                 "norm: adds resource monitoring and "
+                 "server log analysis (if --server-log given). "
+                 "adv: adds pool analysis "
+                 "(defaults to 50 requests, 50 workers, "
+                 "3 rounds unless overridden).",
+        )
+        parser.add_argument(
+            "--no-tokens",
+            action="store_true",
+            default=False,
+            help="Disable per-request token accounting. By default "
+                 "the load test passes --tokens to agent_cli at "
+                 "all levels.",
+        )
+        parser.add_argument(
+            "--minimal",
+            dest="chat_filter",
+            action="store_const",
+            const="minimal",
+            default="maximal",
+            help="Ask the server for the bare minimum of messages, "
+                 "as agent_cli's --minimal does (both subprocess and "
+                 "--http-client modes). Streams only the final answer "
+                 "instead of all messages including AGENT_PROGRESS, "
+                 "which reduces server-to-client traffic and the "
+                 "server-side work of producing progress events, but "
+                 "also drops the token-accounting message and so "
+                 "disables client-side LLM/token reporting (tokens "
+                 "then come only from the server log).",
+        )
+        parser.add_argument(
+            "--skip-reservation-check",
+            action="store_true",
+            default=False,
+            help="Skip reservation_id validation. A request is "
+                 "marked CREATED if other success fields are "
+                 "present, even without a reservation_id.",
+        )
+        parser.add_argument(
+            "--scale",
+            type=int,
+            default=1,
+            help="Multiplier for load parameters. Scales "
+                 "--num-requests, --max-workers, "
+                 "--request-timeout, --idle-timeout, "
+                 "--stage-timeout, and --total-timeout "
+                 "by this factor. "
+                 "--max-requests auto-adjusts. "
+                 "Integer only (default: 1).",
+        )
+        parser.add_argument(
+            "--output-dir",
+            type=str,
+            default=None,
+            help="Base directory for test output. Defaults to "
+                 "/tmp/load_test_{user}/{level}/{timestamp}, which is "
+                 "per-user so a shared temp directory cannot be owned "
+                 "by whoever ran first.",
+        )
+        parser.add_argument(
+            "--history-file",
+            type=str,
+            default=None,
+            help="Append-only JSONL file recording one trend record "
+                 "per client run (completion counts under fixed time "
+                 "thresholds + neuro-san version) for plotting over "
+                 "time. Defaults to <output-base>/history.jsonl.",
+        )
+        parser.add_argument(
+            "--compare",
+            type=str,
+            default=None,
+            metavar="DIR",
+            help="Skip load test; scan DIR for previous "
+                 "raw_results.json files and print a "
+                 "cross-run comparison table.",
+        )
+        parser.add_argument(
+            "--trend",
+            type=str,
+            default=None,
+            metavar="PATH",
+            help="Skip load test; print one row per recorded run "
+                 "from the --history-file JSONL, oldest first, so "
+                 "throughput can be compared across neuro-san "
+                 "versions. PATH is the history file or a directory "
+                 "containing history.jsonl. Filtered by "
+                 "--compare-agent.",
+        )
+        parser.add_argument(
+            "--compare-agent",
+            type=str,
+            default=None,
+            metavar="NAME",
+            help="When used with --compare, show only runs "
+                 "for this agent (e.g. hello_world). "
+                 "Comma-separated for multiple agents. "
+                 "Without this, tables are grouped by agent.",
+        )
+        parser.add_argument(
+            "--compare-baseline",
+            type=int,
+            default=0,
+            metavar="N",
+            help="When used with --compare, only show runs "
+                 "with at least N requests. The smallest "
+                 "remaining run becomes the baseline for "
+                 "percentage deltas.",
+        )
+        parser.add_argument(
+            "--compare-runs",
+            type=str,
+            default=None,
+            metavar="FOLDERS",
+            help="When used with --compare, show only "
+                 "these specific run folders. "
+                 "Comma-separated folder names.",
+        )
+        parser.add_argument(
+            "--rebuild",
+            type=str,
+            default=None,
+            metavar="DIR",
+            help="Reconstruct raw_results.json from the "
+                 "request output files in DIR. Useful for "
+                 "runs interrupted by Ctrl+C.",
+        )
+        parser.add_argument(
+            "--rebuild-all",
+            action="store_true",
+            default=False,
+            help="When used with --rebuild on a parent "
+                 "directory, rebuild ALL runs including "
+                 "those that already have raw_results.json.",
+        )
+        args = parser.parse_args()
+        # Track which args the user explicitly provided so
+        # level-based defaults do not override them.
+        explicit = LoadTestArguments._explicit_args(parser, args)
+        args.explicit_args = explicit
+        # When targeting https and no explicit port was given,
+        # default to the standard TLS port.
+        if args.https and "port" not in explicit:
+            args.port = 443
+        return args
+
+    @staticmethod
+    def _explicit_args(parser, args) -> Set[str]:
+        """Return the dest names the user actually passed.
+
+        Re-parses the command line with every default replaced by a
+        sentinel, so anything still holding the sentinel was not
+        supplied.  This recognizes "--port=8080" as well as
+        "--port 8080", and still counts a value that happens to equal
+        the default.
+        """
+        sentinel = object()
+        parser.set_defaults(
+            **{name: sentinel for name in vars(args)}
+        )
+        return {
+            name
+            for name, value in vars(parser.parse_args()).items()
+            if value is not sentinel
+        }

--- a/tests/load_tests/load_test_cli.py
+++ b/tests/load_tests/load_test_cli.py
@@ -1,0 +1,2933 @@
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+# pylint: disable=too-many-lines
+"""Generic load-test orchestrator for neuro-san agent networks.
+
+See tests/load_tests/README.md for prerequisites, test levels, and
+usage examples.
+"""
+
+import getpass
+import gzip
+import importlib.metadata as _pkg_meta
+import json
+import logging
+import os
+import platform
+import re
+import shutil
+import signal
+import socket
+import sys
+import tempfile
+import threading
+import time
+import urllib.error
+import urllib.request
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Tuple
+
+import psutil
+
+from tests.load_tests.config import NetworkTokenEntry
+from tests.load_tests.config import ValidationEvent
+from tests.load_tests.config import ResourceSnapshot
+from tests.load_tests.config import ServerCounts
+from tests.load_tests.config import StageSummary
+from tests.load_tests.config import Formatters
+from tests.load_tests.config import LEVEL_ADV
+from tests.load_tests.config import LEVEL_MIN
+from tests.load_tests.config import LOCAL_HOSTS
+from tests.load_tests.config import SOCKET_CHECK_TIMEOUT
+from tests.load_tests.config import STALE_LOG_THRESHOLD_SECONDS
+from tests.load_tests.config import STATUS_CREATED
+from tests.load_tests.config import STATUS_FAILED
+from tests.load_tests.config import STATUS_KILLED
+from tests.load_tests.config import STATUS_TIMEOUT
+from tests.load_tests.config import HEARTBEAT_INTERVAL_SECONDS
+from tests.load_tests.config import HISTORY_FILE_NAME
+from tests.load_tests.config import HISTORY_UNKNOWN_FILE_NAME
+from tests.load_tests.config import HISTORY_THRESHOLDS_SECONDS
+from tests.load_tests.config import THREAD_JOIN_TIMEOUT
+from tests.load_tests.confirm import Confirm
+from tests.load_tests.cost_estimator import CostEstimator
+from tests.load_tests.load_test_arguments import LoadTestArguments
+from tests.load_tests.monitoring.heartbeat import Heartbeat
+from tests.load_tests.monitoring.resource_monitor import ResourceMonitor
+from tests.load_tests.monitoring.server_log_monitor import ServerLogMonitor
+from tests.load_tests.prompts.agent_profile import AgentProfile
+from tests.load_tests.reporting.cross_run_comparison import CrossRunComparison
+from tests.load_tests.reporting.rebuild_results import ResultsRebuilder
+from tests.load_tests.reporting.disconnection_reporter import DisconnectionReporter
+from tests.load_tests.reporting.json_metadata import JsonMetadata
+from tests.load_tests.reporting.latency_analyzer import LatencyAnalyzer
+from tests.load_tests.reporting.latency_analyzer import COMPLETION_MILESTONES
+from tests.load_tests.reporting.pool_analyzer import PoolAnalyzer
+from tests.load_tests.reporting.resource_reporter import ResourceReporter
+from tests.load_tests.reporting.summary import SummaryReporter
+from tests.load_tests.reporting.system_resources import SystemResources
+from tests.load_tests.reporting.summary_file_writer import SummaryFileWriter
+from tests.load_tests.reporting.trend_history import TrendHistory
+from tests.load_tests.traffic.runner import TrafficRunner
+from tests.load_tests.validation.environment_validator import EnvironmentValidator
+from tests.load_tests.validation.input_validator import InputValidator
+from tests.load_tests.validation.output_validator import OutputValidator
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+logger = logging.getLogger(__name__)
+
+
+class LoadTestOrchestrator:  # pylint: disable=too-many-instance-attributes
+    """Orchestrates the full load test workflow."""
+
+    @staticmethod
+    def _token_sort_key(rid) -> int:
+        """Extract numeric suffix from a request_id for sorting."""
+        match = re.search(r"(\d+)$", rid)
+        return int(match.group(1)) if match else 0
+
+    @staticmethod
+    def _enrich_failure_reasons(results, validation_events):
+        """Append validation fix cycle info to failure reasons."""
+        if not validation_events:
+            return
+        by_rid = {
+            e.get("request_id"): e
+            for e in validation_events
+        }
+        for result in results:
+            rid = result.get("request_id", "")
+            event = by_rid.get(rid)
+            if event is None:
+                continue
+            fix_cycles = event.get("fix_cycles", 0)
+            if fix_cycles <= 0:
+                continue
+            existing = result.get("failure_reason") or ""
+            suffix = (
+                f" ({fix_cycles} validation fix"
+                f" cycle(s))"
+            )
+            result["failure_reason"] = existing + suffix
+
+    @staticmethod
+    def _attach_token_data(results, token_data) -> None:
+        """Attach token accounting data to request results.
+
+        The server assigns its own request_id numbering (e.g. request-3,
+        request-4) which differs from the client's (request-1, request-2).
+        Match by order: sort server entries by request_id number, then
+        attach to client results in submission order.
+        """
+        if not token_data:
+            return
+
+        key_fn = LoadTestOrchestrator._token_sort_key
+        sorted_entries = sorted(
+            token_data.values(),
+            key=lambda e: key_fn(e.get("request_id", "")),
+        )
+        sorted_results = sorted(
+            results,
+            key=lambda r: key_fn(r.get("request_id", "")),
+        )
+
+        for result, entry in zip(sorted_results, sorted_entries):
+            result.update({
+                "total_tokens": entry.get("total_tokens"),
+                "prompt_tokens": entry.get("prompt_tokens"),
+                "completion_tokens": entry.get("completion_tokens"),
+                "llm_calls": entry.get("llm_calls"),
+                "model": entry.get("model"),
+                "reporting_agent": entry.get("reporting_agent"),
+                "server_request_id": entry.get("request_id"),
+                "cost_usd": CostEstimator.estimate(
+                    entry.get("prompt_tokens", 0),
+                    entry.get("completion_tokens", 0),
+                    entry.get("model", "unknown"),
+                ),
+            })
+
+    def __init__(self, args) -> None:
+        """Initialize the orchestrator with parsed arguments."""
+        self.args = args
+        self.profile = AgentProfile.load(
+            args.agent, args.profile_path, args.project_root,
+        )
+        self.server_proc = None
+        self.server_log = args.server_log
+        self.log_monitor = (
+            ServerLogMonitor(self.server_log)
+            if self.server_log else None
+        )
+        self.runner = TrafficRunner(args, self.profile)
+        self.input_validator = InputValidator(args)
+        self.resource_reporter = ResourceReporter()
+        self.probe_result = None
+        self._output_dir = None
+        self._test_log_path = None
+        self._test_log_handler = None
+        self._aborted = False
+        self._interrupted = False
+        self._cancel_event = threading.Event()
+        self._server_ns_version = None
+
+    # pylint: disable=too-many-locals
+    def _run_all_stages(self, stages, total_cap) -> List[StageSummary]:
+        """Execute all stages of the load test, collecting data per stage."""
+        monitor_resources = (
+            self.args.level != LEVEL_MIN
+            or self.args.client_only
+            or self.args.server_only
+        )
+        has_server_log = self.server_log is not None
+        probe_result = self.probe_result
+        only_stage = (
+            len(stages) == 1 and self.args.num_rounds == 1
+        )
+
+        stage_summaries: List[StageSummary] = []
+        global_offset = 0
+        total_sent = 0
+        test_start = time.time()
+
+        for round_num in range(1, self.args.num_rounds + 1):
+            if self.args.num_rounds > 1:
+                logger.info("\n%s", "#" * 60)
+                logger.info("  ROUND %s of %s", round_num, self.args.num_rounds)
+                logger.info("#" * 60)
+
+            for stage_idx, num_concurrent in enumerate(stages):
+                if total_sent >= total_cap:
+                    total_planned = sum(stages) * self.args.num_rounds
+                    logger.warning(
+                        "\nWARNING: Reached --max-requests cap (%s). "
+                        "Only %s of %s total planned requests completed.\n"
+                        "         Use --max-requests %s to run all "
+                        "planned requests.",
+                        total_cap, total_sent, total_planned,
+                        total_planned,
+                    )
+                    return stage_summaries
+
+                if self._total_timeout_reached(test_start):
+                    self._aborted = True
+                    return stage_summaries
+
+                remaining = total_cap - total_sent
+                actual_requests = min(num_concurrent, remaining)
+
+                summary, probe_used, should_abort = (
+                    self._run_single_stage(
+                        actual_requests=actual_requests,
+                        num_concurrent=num_concurrent,
+                        stage_num=stage_idx + 1,
+                        round_num=round_num,
+                        global_offset=global_offset,
+                        monitor_resources=monitor_resources,
+                        has_server_log=has_server_log,
+                        probe_result=probe_result,
+                        only_stage=only_stage,
+                    )
+                )
+
+                global_offset += actual_requests
+                total_sent += actual_requests
+                if probe_used:
+                    probe_result = None
+                stage_summaries.append(summary)
+                if should_abort:
+                    self._aborted = True
+                    return stage_summaries
+
+        return stage_summaries
+
+    def _total_timeout_reached(self, test_start) -> bool:
+        """Check if total-timeout has been exceeded.
+
+        Returns True and logs a warning when the elapsed time since
+        test_start exceeds --total-timeout (0 means disabled).
+        """
+        limit = self.args.total_timeout
+        if limit <= 0:
+            return False
+        elapsed = time.time() - test_start
+        if elapsed < limit:
+            return False
+        logger.warning(
+            "\n  ABORT: --total-timeout (%ss) reached after %.0fs.\n"
+            "  Stopping test and reporting available results.",
+            limit, elapsed,
+        )
+        return True
+
+    # pylint: disable=too-many-locals,too-many-statements,too-many-branches
+    # pylint: disable=too-many-arguments
+    def _run_single_stage(
+            self, *, actual_requests, num_concurrent,
+            stage_num, round_num, global_offset,
+            monitor_resources, has_server_log,
+            probe_result, only_stage=False,
+    ) -> Tuple[StageSummary, bool, bool]:
+        """Execute one stage of the load test.
+
+        Returns (stage_summary, probe_was_used, should_abort).
+        """
+        stage_workers = (
+            self.args.max_workers
+            if not self.args.ramp
+            else actual_requests
+        )
+
+        logger.info("\n%s", "=" * 60)
+        if self.args.ramp:
+            stage_label = (
+                f"[STAGE {stage_num}] "
+                f"{actual_requests} requests "
+                f"(max {stage_workers} workers)"
+            )
+            if self.args.num_rounds > 1:
+                stage_label += f" (round {round_num})"
+        else:
+            stage_label = (
+                f"{actual_requests} requests "
+                f"(max {stage_workers} workers)"
+            )
+            if self.args.num_rounds > 1:
+                stage_label += f" (round {round_num})"
+        logger.info("  %s", stage_label)
+        logger.info("=" * 60)
+
+        if actual_requests < num_concurrent:
+            logger.info(
+                "  (Capped from %s to %s by --max-requests)",
+                num_concurrent, actual_requests,
+            )
+
+        log_pos = (
+            self.log_monitor.read_position()
+            if has_server_log else None
+        )
+
+        before_server, before_client, client_proc = (
+            self._capture_before_snapshots(monitor_resources)
+        )
+
+        self._log_fire_info(
+            actual_requests, monitor_resources,
+            probe_result=probe_result,
+        )
+
+        # If a dry-run probe ran, inject it into stage 1.  The probe
+        # fired before log_pos was captured, so only stage_requests of
+        # them appear in the server log from here on.
+        stage_requests = actual_requests
+        probe_used = probe_result is not None
+        if probe_used:
+            stage_requests = max(actual_requests - 1, 0)
+
+        stop_event = None
+        monitor = None
+        if has_server_log:
+            stop_event, monitor, _peak = (
+                self.log_monitor.start_log_monitor(
+                    log_pos,
+                    stage_requests, time.time(),
+                    client_proc=client_proc,
+                    primary_start_pattern=(
+                        self.profile.primary_start_pattern
+                    ),
+                    output_dir=self._output_dir,
+                )
+            )
+
+        sys_before = SystemResources.snapshot()
+        before_sys_mem_pct = sys_before["mem_pct"]
+
+        (elapsed, results, peak_threads, peak_client_rss,
+         peak_server_rss, peak_sys_mem_pct, peak_sys_cpu,
+         peak_sys_threads,
+         server_died, interrupted) = (
+            self.runner.run_stage(
+                stage_requests, stage_workers,
+                global_offset + (1 if probe_used else 0),
+                server_proc=self.server_proc,
+                client_proc=client_proc,
+                output_dir=self._output_dir,
+                stage_timeout=self.args.stage_timeout,
+                cancel_event=self._cancel_event,
+                log_monitor=self.log_monitor,
+                primary_start_pattern=(
+                    self.profile.primary_start_pattern
+                ),
+            )
+        )
+        if interrupted:
+            self._interrupted = True
+
+        if probe_used:
+            results.insert(0, probe_result)
+            elapsed += probe_result.get("elapsed", 0.0)
+
+        if stop_event:
+            stop_event.set()
+        if monitor:
+            monitor.join(timeout=THREAD_JOIN_TIMEOUT)
+
+        peak_client = None
+        settled_client = None
+        if monitor_resources:
+            peak_rss = peak_client_rss.value
+            if peak_rss is not None:
+                peak_client = {"rss": peak_rss}
+            settled_client = ResourceMonitor.snapshot(
+                client_proc,
+            )
+
+        counts = OutputValidator.count_results(results)
+
+        retries: Dict[str, int] = {}
+        total_retries = 0
+        amplification = 1.0
+        if has_server_log:
+            retries = self.log_monitor.count_retries_since(
+                log_pos,
+            )
+            total_retries = sum(retries.values())
+            amplification = Formatters.compute_amplification(
+                stage_requests, total_retries,
+            )
+
+        OutputValidator.log_stage_results(
+            actual_requests, counts, elapsed,
+            timeout=self.args.request_timeout,
+            idle_timeout=self.args.idle_timeout,
+            skip_reservation_check=(
+                self.args.skip_reservation_check
+            ),
+            show_counts=not only_stage,
+        )
+        should_abort = server_died or interrupted
+        if not should_abort:
+            should_abort = OutputValidator.check_permission_failures(
+                results, self.args.agent,
+            )
+        if not should_abort:
+            should_abort = OutputValidator.check_timeout_abort(counts)
+        if should_abort:
+            sys_after = SystemResources.snapshot()
+            after_sys_mem_pct = sys_after["mem_pct"]
+            summary_entry = self._build_stage_summary(
+                stage_num=stage_num,
+                round_num=round_num,
+                actual_requests=actual_requests,
+                counts=counts,
+                elapsed=elapsed,
+                retries=retries,
+                total_retries=total_retries,
+                amplification=amplification,
+                results=results,
+                server_counts={},
+                disconnections=[],
+                server_errors=[],
+                tool_warnings=[],
+                network_tokens=[],
+                validation_events=[],
+                has_server_log=has_server_log,
+                has_tokens=self.args.include_tokens,
+                monitor_resources=monitor_resources,
+                before_server=before_server,
+                after_server=None,
+                peak_threads=peak_threads,
+                peak_server_rss=peak_server_rss,
+                before_client=before_client,
+                peak_client=peak_client,
+                settled_client=settled_client,
+                before_sys_mem_pct=before_sys_mem_pct,
+                after_sys_mem_pct=after_sys_mem_pct,
+                peak_sys_mem_pct=peak_sys_mem_pct,
+                peak_sys_cpu=peak_sys_cpu,
+                before_sys=sys_before,
+                after_sys=sys_after,
+                peak_sys_threads=peak_sys_threads,
+            )
+            return summary_entry, probe_used, True
+
+        if has_server_log and stage_requests > 0:
+            OutputValidator.log_retry_activity(
+                retries, total_retries, stage_requests,
+            )
+
+        server_counts, disconnections, server_errors, \
+            tool_warnings, network_tokens, validation_events, \
+            after_server = (
+                self._collect_post_stage_data(
+                    actual_requests, monitor_resources,
+                    has_server_log,
+                    log_pos, results,
+                    before_server=before_server,
+                    before_client=before_client,
+                    peak_client=peak_client,
+                    settled_client=settled_client,
+                    server_log_requests=stage_requests,
+                )
+            )
+
+        sys_after = SystemResources.snapshot()
+        after_sys_mem_pct = sys_after["mem_pct"]
+
+        summary_entry = self._build_stage_summary(
+            stage_num=stage_num,
+            round_num=round_num,
+            actual_requests=actual_requests,
+            counts=counts,
+            elapsed=elapsed,
+            retries=retries,
+            total_retries=total_retries,
+            amplification=amplification,
+            results=results,
+            server_counts=server_counts,
+            disconnections=disconnections,
+            server_errors=server_errors,
+            tool_warnings=tool_warnings,
+            network_tokens=network_tokens,
+            validation_events=validation_events,
+            has_server_log=has_server_log,
+            has_tokens=self.args.include_tokens,
+            monitor_resources=monitor_resources,
+            before_server=before_server,
+            after_server=after_server,
+            peak_threads=peak_threads,
+            peak_server_rss=peak_server_rss,
+            before_client=before_client,
+            peak_client=peak_client,
+            settled_client=settled_client,
+            before_sys_mem_pct=before_sys_mem_pct,
+            after_sys_mem_pct=after_sys_mem_pct,
+            peak_sys_mem_pct=peak_sys_mem_pct,
+            peak_sys_cpu=peak_sys_cpu,
+            before_sys=sys_before,
+            after_sys=sys_after,
+            peak_sys_threads=peak_sys_threads,
+        )
+        return summary_entry, probe_used, False
+
+    def _capture_before_snapshots(self, monitor_resources):
+        """Capture server and client resource snapshots before a stage."""
+        before_server = None
+        before_client = None
+        client_proc = None
+        if monitor_resources:
+            before_server = (
+                ResourceMonitor.snapshot(self.server_proc)
+                if self.server_proc else None
+            )
+            if before_server:
+                ResourceMonitor.log_snapshot(
+                    "Server BEFORE", before_server,
+                )
+            elif not self.args.client_only:
+                logger.info(
+                    "  Server BEFORE: not available"
+                    " (server not running)",
+                )
+
+            client_proc = psutil.Process()
+            before_client = ResourceMonitor.snapshot(
+                client_proc,
+            )
+            if before_client:
+                logger.info(
+                    "  Client BEFORE: RSS %.1fM, CPU %.1f%%",
+                    before_client.get("rss"),
+                    before_client.get("cpu"),
+                )
+
+            mem = psutil.virtual_memory()
+            used_mb = (mem.total - mem.available) / (1024 ** 2)
+            avail_gb = mem.available / (1024 ** 3)
+            total_gb = mem.total / (1024 ** 3)
+            logger.info(
+                "  System BEFORE: %.0f%% used"
+                " (%.0fM used / %.1fG free / %.1fG total)",
+                mem.percent, used_mb, avail_gb, total_gb,
+            )
+        return before_server, before_client, client_proc
+
+    def _log_fire_info(self, actual_requests,
+                       monitor_resources, *, probe_result):
+        """Log the 'Firing N requests' line with thread count."""
+        fire_ts = time.strftime(
+            "%H:%M:%S", time.localtime(time.time()),
+        )
+        fire_threads = ""
+        if monitor_resources and self.server_proc:
+            try:
+                fire_threads = (
+                    f"  threads: {self.server_proc.num_threads()}"
+                )
+            except (psutil.NoSuchProcess, psutil.AccessDenied) as exc:
+                logger.debug("Thread count unavailable: %s", exc)
+        fire_label = actual_requests
+        if probe_result is not None:
+            fire_label = (
+                f"{actual_requests} "
+                f"({actual_requests - 1} + 1 probe)"
+            )
+        logger.info(
+            "\nFiring %s %s requests... [%s]%s",
+            fire_label, self.args.agent, fire_ts, fire_threads,
+        )
+
+    # pylint: disable=too-many-arguments,too-many-positional-arguments
+    def _collect_post_stage_data(
+            self, actual_requests, monitor_resources,
+            has_server_log,
+            log_pos, results, *,
+            before_server, before_client,
+            peak_client, settled_client,
+            server_log_requests=None,
+    ) -> Tuple[
+        ServerCounts, List[Dict[str, str]],
+        List[NetworkTokenEntry], Optional[ResourceSnapshot],
+    ]:
+        """Settle, snapshot, and analyze server log after a stage.
+
+        Returns (server_counts, disconnections, network_tokens,
+        after_server_snapshot).
+        """
+        server_counts: ServerCounts = {}
+        disconnections: List[Dict[str, str]] = []
+        server_errors: List[Dict[str, str]] = []
+        tool_warnings: List[Dict[str, str]] = []
+        network_tokens: List[NetworkTokenEntry] = []
+        after_server = None
+
+        if monitor_resources or has_server_log:
+            time.sleep(self.args.settle_time)
+            settle_end = time.strftime(
+                "%H:%M:%S", time.localtime(time.time()),
+            )
+            logger.info(
+                "\n  Settle: waited %ss for server cleanup [%s]",
+                self.args.settle_time, settle_end,
+            )
+
+            after_server = (
+                ResourceMonitor.snapshot(self.server_proc)
+                if self.server_proc else None
+            )
+            if after_server:
+                ResourceMonitor.log_snapshot(
+                    "Server AFTER", after_server,
+                )
+            elif not self.args.client_only:
+                logger.info(
+                    "  Server AFTER: not available"
+                    " (server not running)",
+                )
+
+        server_counts, disconnections, server_errors, \
+            tool_warnings, network_tokens, validation_events = (
+                self._analyze_server_log(
+                    has_server_log,
+                    log_pos,
+                    results=results,
+                    actual_requests=(
+                        server_log_requests
+                        if server_log_requests is not None
+                        else actual_requests
+                    ),
+                )
+            )
+
+        if before_server and after_server:
+            self.resource_reporter.add_resource_row(
+                f"{actual_requests}",
+                before_server, after_server,
+            )
+
+        if before_client and settled_client:
+            self.resource_reporter.add_client_row(
+                f"{actual_requests}",
+                before_client,
+                peak_client,
+                settled_client,
+            )
+
+        return (
+            server_counts, disconnections, server_errors,
+            tool_warnings, network_tokens, validation_events,
+            after_server,
+        )
+
+    @staticmethod
+    # pylint: disable=too-many-arguments
+    def _build_stage_summary(
+            *, stage_num, round_num, actual_requests,
+            counts, elapsed, retries, total_retries,
+            amplification, results, server_counts,
+            disconnections, server_errors, tool_warnings,
+            network_tokens, validation_events,
+            has_server_log, has_tokens,
+            monitor_resources, before_server,
+            after_server, peak_threads,
+            peak_server_rss,
+            before_client=None,
+            peak_client=None,
+            settled_client=None,
+            before_sys_mem_pct=None,
+            after_sys_mem_pct=None,
+            peak_sys_mem_pct=None,
+            peak_sys_cpu=None,
+            before_sys=None,
+            after_sys=None,
+            peak_sys_threads=None,
+    ) -> StageSummary:
+        """Assemble the stage summary dict."""
+        summary_entry: StageSummary = {
+            "stage": stage_num,
+            "round": round_num,
+            "concurrent": actual_requests,
+            "counts": counts,
+            "elapsed": elapsed,
+            "retries": retries,
+            "total_retries": total_retries,
+            "amplification": amplification,
+            "results": results,
+            "primary_started": server_counts.get("primary_started"),
+            "primary_finished": server_counts.get("primary_finished"),
+            "total_started": server_counts.get("total_started"),
+            "total_finished": server_counts.get("total_finished"),
+            "disconnections": disconnections,
+            "server_errors": server_errors,
+            "tool_warnings": tool_warnings,
+            "network_tokens": network_tokens,
+            "validation_events": validation_events,
+            "has_server_log": has_server_log,
+            "has_tokens": has_tokens,
+        }
+        if monitor_resources:
+            if before_server:
+                summary_entry["before_threads"] = (
+                    before_server.get("threads")
+                )
+                summary_entry["before_server_rss"] = (
+                    before_server.get("rss")
+                )
+            if after_server:
+                summary_entry["after_threads"] = (
+                    after_server.get("threads")
+                )
+                summary_entry["after_server_rss"] = (
+                    after_server.get("rss")
+                )
+        if peak_threads.value is not None:
+            summary_entry["peak_threads"] = (
+                peak_threads.value
+            )
+        if peak_server_rss.value is not None:
+            summary_entry["peak_server_rss"] = (
+                peak_server_rss.value
+            )
+        if before_client:
+            summary_entry["before_client_rss"] = (
+                before_client.get("rss")
+            )
+        if settled_client:
+            summary_entry["after_client_rss"] = (
+                settled_client.get("rss")
+            )
+        if peak_client:
+            summary_entry["peak_client_rss"] = (
+                peak_client.get("rss")
+            )
+        if before_sys_mem_pct is not None:
+            summary_entry["before_sys_mem_pct"] = (
+                before_sys_mem_pct
+            )
+        if after_sys_mem_pct is not None:
+            summary_entry["after_sys_mem_pct"] = (
+                after_sys_mem_pct
+            )
+        if (peak_sys_mem_pct is not None
+                and peak_sys_mem_pct.value is not None):
+            peak_data = peak_sys_mem_pct.value
+            summary_entry["peak_sys_mem_pct"] = (
+                peak_data["pct"]
+            )
+            summary_entry["peak_sys_mem_avail_gb"] = (
+                peak_data["avail_gb"]
+            )
+        if (peak_sys_cpu is not None
+                and peak_sys_cpu.value is not None):
+            summary_entry["peak_sys_cpu"] = peak_sys_cpu.value
+        if before_sys:
+            summary_entry["before_sys_mem_avail_gb"] = (
+                before_sys.get("mem_avail_gb")
+            )
+            summary_entry["before_sys_cpu"] = before_sys.get("cpu_pct")
+            summary_entry["before_sys_threads"] = (
+                before_sys.get("threads")
+            )
+        if after_sys:
+            summary_entry["after_sys_mem_avail_gb"] = (
+                after_sys.get("mem_avail_gb")
+            )
+            summary_entry["after_sys_cpu"] = after_sys.get("cpu_pct")
+            summary_entry["after_sys_threads"] = (
+                after_sys.get("threads")
+            )
+        if (peak_sys_threads is not None
+                and peak_sys_threads.value is not None):
+            summary_entry["peak_sys_threads"] = peak_sys_threads.value
+        return summary_entry
+
+    # pylint: disable=too-many-arguments
+    def _analyze_server_log(
+            self, has_server_log,
+            log_pos, *, results, actual_requests,
+    ) -> Tuple[
+        ServerCounts, List[Dict[str, str]], List[Dict[str, str]],
+        List[Dict[str, str]],
+        List[NetworkTokenEntry], List[ValidationEvent],
+    ]:
+        """Analyze server log or report unavailability.
+
+        Returns (server_counts, disconnections, server_errors,
+        tool_warnings, network_tokens, validation_events).
+        """
+        server_counts: ServerCounts = {}
+        disconnections: List[Dict[str, str]] = []
+        server_errors: List[Dict[str, str]] = []
+        tool_warnings: List[Dict[str, str]] = []
+        network_tokens: List[NetworkTokenEntry] = []
+        validation_events: List[ValidationEvent] = []
+        if has_server_log:
+            server_counts = (
+                self.log_monitor.count_requests_since(
+                    log_pos,
+                    self.profile.primary_start_pattern,
+                    self.profile.primary_finish_pattern,
+                )
+            )
+            disconnections = (
+                self.log_monitor.scan_disconnections_since(
+                    log_pos,
+                    primary_start_pattern=(
+                        self.profile.primary_start_pattern
+                    ),
+                )
+            )
+            token_data = (
+                self.log_monitor.parse_token_accounting_since(
+                    log_pos,
+                )
+            )
+            stage_results = [
+                r for r in results
+                if r.get("request_id") != "request-0"
+            ]
+            if token_data:
+                for result in stage_results:
+                    result["client_total_tokens"] = (
+                        result.get("total_tokens", 0)
+                    )
+                    result["client_prompt_tokens"] = (
+                        result.get("prompt_tokens", 0)
+                    )
+                    result["client_completion_tokens"] = (
+                        result.get("completion_tokens", 0)
+                    )
+                    result["client_llm_calls"] = (
+                        result.get("llm_calls", 0)
+                    )
+            LoadTestOrchestrator._attach_token_data(
+                stage_results, token_data,
+            )
+            network_tokens = (
+                self.log_monitor.parse_per_network_tokens_since(
+                    log_pos,
+                )
+            )
+            validation_events = (
+                self.log_monitor.parse_validation_events_since(
+                    log_pos,
+                )
+            )
+            LoadTestOrchestrator._enrich_failure_reasons(
+                results, validation_events,
+            )
+            if token_data:
+                logger.info(
+                    "\n  Token usage (from server log):",
+                )
+                TrafficRunner.log_token_summary(
+                    results, output_dir=self._output_dir,
+                    network_tokens=network_tokens,
+                    validation_events=validation_events,
+                )
+            OutputValidator.log_disconnections(disconnections)
+            server_errors = (
+                self.log_monitor.scan_server_errors_since(log_pos)
+            )
+            OutputValidator.log_server_errors(server_errors)
+            tool_warnings = (
+                self.log_monitor.scan_tool_warnings_since(log_pos)
+            )
+            OutputValidator.log_tool_warnings(tool_warnings)
+            OutputValidator.log_server_validation(
+                server_counts, actual_requests,
+                self.args.agent,
+            )
+        else:
+            has_token_data = any(
+                r.get("total_tokens") for r in results
+            )
+            if has_token_data:
+                token_source = (
+                    "HTTP token_accounting"
+                    if getattr(self.args, "http_client", False)
+                    else "agent_cli --tokens"
+                )
+                logger.info(
+                    "\n  Token usage (from %s):", token_source,
+                )
+                TrafficRunner.log_token_summary(
+                    results, output_dir=self._output_dir,
+                )
+            if self.args.level != LEVEL_MIN:
+                logger.info(
+                    "\n  Server-side validation: "
+                    "not available (no --server-log)",
+                )
+        return (
+            server_counts, disconnections, server_errors,
+            tool_warnings, network_tokens, validation_events,
+        )
+
+    def _output_base(self) -> str:
+        """Return the base output directory.
+
+        The default is per-user because the temp directory is shared:
+        whoever ran first would otherwise own ``load_test`` and lock
+        everyone else out of it.
+        """
+        if self.args.output_dir:
+            return self.args.output_dir
+        try:
+            user = getpass.getuser()
+        except (KeyError, OSError):
+            # No passwd entry for this uid (some containers).
+            user = str(os.getuid())
+        user = re.sub(r"[^A-Za-z0-9._-]", "_", user)
+        return os.path.join(
+            tempfile.gettempdir(), f"load_test_{user}",
+        )
+
+    def _setup_test_log(self) -> None:
+        """Create output directory and add a file handler for logging."""
+        timestamp = time.strftime("%Y%m%d_%H%M%S")
+        base = self._output_base()
+        folder_name = self._run_folder_name(
+            timestamp, self.args.num_requests,
+        )
+        self._output_dir = os.path.join(
+            base, self.args.level, folder_name,
+        )
+        os.makedirs(self._output_dir, exist_ok=True)
+        self._test_log_path = os.path.join(self._output_dir, "stdout.log")
+        self._test_log_handler = logging.FileHandler(
+            self._test_log_path, encoding="utf-8",
+        )
+        self._test_log_handler.setLevel(logging.INFO)
+        self._test_log_handler.setFormatter(logging.Formatter("%(message)s"))
+        logging.getLogger().addHandler(self._test_log_handler)
+
+    def _preflight_server_check(self) -> None:
+        """Abort before firing if the target server is unreachable.
+
+        A quick TCP connect to --host:--port catches "server not
+        found" (connection refused / DNS failure / host down) so a
+        whole run's worth of requests is not fired at nothing.
+        """
+        host = self.args.host
+        port = self.args.port
+        if EnvironmentValidator.is_port_open(host, port):
+            logger.info(
+                "  Preflight: server %s:%s reachable.", host, port,
+            )
+            self._server_ns_version = self._fetch_server_version()
+            if self._server_ns_version:
+                logger.info(
+                    "  Preflight: server neuro-san version %s.",
+                    self._server_ns_version,
+                )
+            else:
+                logger.info(
+                    "  Preflight: server version unavailable "
+                    "(no /healthz response).",
+                )
+            return
+        scheme = (
+            "https" if getattr(self.args, "https", False) else "http"
+        )
+        logger.error(
+            "ABORT: server %s:%s (%s) is unreachable — "
+            "not firing any requests.\n"
+            "  Check --host/--port/--https, or start the server.",
+            host, port, scheme,
+        )
+        raise SystemExit(1)
+
+    def _fetch_server_version(self) -> Optional[str]:
+        """Return the server's neuro-san version via its /healthz API.
+
+        Queries ``<scheme>://<host>:<port>/healthz`` (the same HTTP
+        endpoint the client already reaches, so it works remotely
+        without any access to the server machine) and reads
+        ``versions['neuro-san']``.  Returns None if the endpoint is
+        unreachable or unparseable (e.g. an older/gRPC-only server).
+        """
+        scheme = (
+            "https" if getattr(self.args, "https", False) else "http"
+        )
+        url = f"{scheme}://{self.args.host}:{self.args.port}/healthz"
+        try:
+            with urllib.request.urlopen(
+                url, timeout=SOCKET_CHECK_TIMEOUT,
+            ) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+            return payload.get("versions", {}).get("neuro-san")
+        except (urllib.error.URLError, OSError, ValueError) as exc:
+            logger.debug(
+                "Could not fetch server version from %s: %s", url, exc,
+            )
+            return None
+
+    def _finalize_test_log(self, stage_summaries) -> None:
+        """Report the output directory and close the log handler."""
+        if self._output_dir is None:
+            if self._test_log_handler is not None:
+                logging.getLogger().removeHandler(
+                    self._test_log_handler,
+                )
+                self._test_log_handler.close()
+            return
+        self._archive_server_log()
+        has_failures = any(
+            summary.get("counts", {}).get(STATUS_FAILED, 0) > 0
+            or summary.get("counts", {}).get(STATUS_TIMEOUT, 0) > 0
+            or summary.get("counts", {}).get(STATUS_KILLED, 0) > 0
+            for summary in stage_summaries
+        )
+        label = (
+            "OUTPUT FILES (with failures)"
+            if has_failures else "OUTPUT FILES"
+        )
+        logger.info("\n%s", "=" * 60)
+        logger.info("  %s", label)
+        logger.info("=" * 60)
+        logger.info("  Directory:   %s", self._output_dir)
+        json_path = os.path.join(
+            self._output_dir, "raw_results.json",
+        )
+        if os.path.isfile(json_path):
+            logger.info("  Raw results: %s", json_path)
+        requests_dir = os.path.join(self._output_dir, "requests")
+        if os.path.isdir(requests_dir):
+            logger.info("  Requests:    %s", requests_dir)
+        gz_path = os.path.join(
+            self._output_dir, "server.log.gz",
+        )
+        if os.path.isfile(gz_path):
+            size_mb = os.path.getsize(gz_path) / (1024 * 1024)
+            logger.info(
+                "  Server log:  %s (%.1fM)",
+                gz_path, size_mb,
+            )
+        if self._test_log_path is not None:
+            logger.info(
+                "  Stdout log:  %s", self._test_log_path,
+            )
+        for history_path in (
+            self._history_path(),
+            self._history_path(successful=False),
+        ):
+            if os.path.isfile(history_path):
+                logger.info("  History:     %s", history_path)
+        # Close handler last so OUTPUT FILES is captured
+        if self._test_log_handler is not None:
+            logging.getLogger().removeHandler(
+                self._test_log_handler,
+            )
+            self._test_log_handler.close()
+
+    def _archive_server_log(self) -> None:
+        """Gzip the server log into the output directory."""
+        if not self.args.archive_server_log:
+            return
+        if not self.server_log or not os.path.isfile(
+            self.server_log,
+        ):
+            logger.warning(
+                "  --archive-server-log: no server log to"
+                " archive (missing --server-log or file"
+                " not found)",
+            )
+            return
+        gz_path = os.path.join(
+            self._output_dir, "server.log.gz",
+        )
+        with open(self.server_log, "rb") as f_in, \
+                gzip.open(gz_path, "wb") as f_out:
+            shutil.copyfileobj(f_in, f_out)
+
+    def _validate_server_log(self) -> Optional[int]:
+        """Validate --server-log path when provided.
+
+        Skips validation when --server-log is used without a path
+        (auto-detect mode, value is ``"auto"``).  At norm/adv levels
+        without --server-log, logs a warning listing which features
+        will be unavailable.
+
+        Returns the stale log age in minutes, or None if not stale.
+        """
+        level = self.args.level
+        server_log = self.args.server_log
+
+        if server_log == "auto":
+            return None
+
+        if level == LEVEL_MIN and not server_log:
+            return None
+
+        if not server_log:
+            logger.warning(
+                "No --server-log provided at %s level.\n"
+                "  The following will be unavailable:\n"
+                "    - Retry counts and amplification factor\n"
+                "    - Server-side request validation\n"
+                "    - Client disconnection detection\n"
+                "    - Per-agent-network token breakdown "
+                "(server log only)\n"
+                "  Resource monitoring (psutil) and aggregated "
+                "token accounting (--tokens) still work.\n"
+                "  To enable full analysis, add:\n"
+                "    --server-log  (auto-detect)\n"
+                "    --server-log logs/server.log",
+                level,
+            )
+            return None
+
+        if not os.path.isfile(server_log):
+            logger.error(
+                "Server log not found: %s", server_log,
+            )
+            sys.exit(1)
+
+        mtime = os.path.getmtime(server_log)
+        age_seconds = time.time() - mtime
+        if age_seconds > STALE_LOG_THRESHOLD_SECONDS:
+            return int(age_seconds // 60)
+        return None
+
+    def _confirm_no_server_log(self, level) -> None:
+        """Prompt to continue when a local server.log isn't found.
+
+        norm/adv expect a server log; if auto-detect fails, offer to
+        run without it or abort. --no-server-log skips this prompt;
+        --no-dry-run does not (it only bypasses the cost confirmation).
+        """
+        logger.warning(
+            "Server log not found for --level %s. Without it: "
+            "no retry, disconnection, or pool analysis.\n"
+            "  Set it with --server-log <path>, or use "
+            "--no-server-log to skip this prompt.",
+            level,
+        )
+        if not Confirm.ask("Continue without server-log analysis?"):
+            logger.info("Aborted by user.")
+            sys.exit(0)
+        logger.info("  Continuing without server-log analysis.")
+
+    @staticmethod
+    def _apply_level_defaults(args, explicit_args) -> None:
+        """Override argparse defaults with level-specific values.
+
+        Only applies when the user did not explicitly set the flag.
+        adv: 50 requests, 3 rounds (stress test).
+
+        --full-concurrency matches workers to num-requests so every
+        request fires at once.  Otherwise workers stay at the
+        conservative default of 3 and a warning is shown if
+        max-workers < num-requests.
+        """
+        if args.level == LEVEL_ADV:
+            if "num_requests" not in explicit_args:
+                args.num_requests = 50
+            if "num_rounds" not in explicit_args:
+                args.num_rounds = 3
+
+        if ("max_workers" not in explicit_args
+                and args.full_concurrency):
+            args.max_workers = args.num_requests
+
+    @staticmethod
+    def _apply_scale(args) -> None:
+        """Multiply load parameters by --scale factor.
+
+        Applied after level defaults so that both explicit
+        values and level defaults are scaled uniformly.
+        """
+        factor = args.scale
+        if factor <= 1:
+            return
+        args.num_requests *= factor
+        args.max_workers *= factor
+        args.request_timeout *= factor
+        args.idle_timeout *= factor
+        args.stage_timeout *= factor
+        if args.total_timeout > 0:
+            args.total_timeout *= factor
+
+    # pylint: disable=too-many-arguments,too-many-positional-arguments
+    def _server_only_primary_pairs(
+            self, log_pos, pri_start_re,
+    ) -> List[Dict]:
+        """Primary-agent streaming_chat Start/Finish pairs since log_pos.
+
+        Returns the subset of parsed pairs whose agent matches the
+        primary (front-man) agent, each with ``start_ts``,
+        ``finish_ts``, and ``duration``.  Empty on read error or when
+        no primary request has completed yet.
+        """
+        if self.log_monitor is None:
+            return []
+        try:
+            pairs = (
+                self.log_monitor
+                .parse_streaming_chat_timing_since(log_pos)
+            )
+        except (OSError, ValueError):
+            return []
+        primary = []
+        for pair in pairs:
+            agent = pair.get("agent", "")
+            start_line = f"Start {agent}/streaming_chat"
+            if pri_start_re.search(start_line):
+                primary.append(pair)
+        return primary
+
+    def _server_only_dur_stats(
+            self, log_pos, pri_start_re,
+    ) -> str:
+        """Cumulative server-side min/avg/max for the primary agent.
+
+        Parses primary streaming_chat Start/Finish pairs seen since
+        the round's log position and formats them.  Returns "n/a"
+        until at least one request has completed.
+        """
+        durations = [
+            float(p["duration"])
+            for p in self._server_only_primary_pairs(
+                log_pos, pri_start_re,
+            )
+            if isinstance(p.get("duration"), (int, float))
+            and p["duration"] > 0
+        ]
+        return Heartbeat.format_dur_stats(durations)
+
+    def _log_server_only_token_usage(self, log_pos) -> None:
+        """Log the LLM & TOKEN USAGE section for a server-only round.
+
+        There is no client side in server-only, so the client line
+        reads "not available" and the numbers come solely from
+        server.log token accounting.
+        """
+        token_data = (
+            self.log_monitor.parse_token_accounting_since(log_pos)
+        )
+        server_stats = SummaryReporter.aggregate_token_entries(
+            token_data.values(),
+        )
+        printed = SummaryReporter.render_token_usage(
+            None, server_stats,
+            client_source="agent_cli --tokens",
+        )
+        if not printed:
+            return
+        model_counts: Dict[str, int] = {}
+        for entry in token_data.values():
+            model = entry.get("model")
+            if model and model != "unknown":
+                model_counts[model] = model_counts.get(model, 0) + 1
+        if model_counts:
+            logger.info(
+                "  LLM models: %s",
+                ", ".join(
+                    f"{m} ({c})" for m, c in sorted(
+                        model_counts.items(),
+                        key=lambda kv: kv[1], reverse=True,
+                    )
+                ),
+            )
+
+    # pylint: disable=too-many-arguments,too-many-positional-arguments
+    def _server_only_heartbeat(
+            self, received, expected, completed,
+            elapsed, now, snap, cur_mem,
+            dur_stats="n/a",
+            cur_sys_cpu=None, peak_sys_cpu=None,
+    ) -> None:
+        """Log a periodic heartbeat during server-only monitoring."""
+        cur_used_mb = (
+            (cur_mem.total - cur_mem.available)
+            / (1024 ** 2)
+        )
+        cur_avail_gb = cur_mem.available / (1024 ** 3)
+        rss_str = ""
+        threads_str = ""
+        if snap:
+            rss_str = (
+                f"  RSS: {snap.get('rss', 0):.0f}M"
+            )
+            threads_str = (
+                f"  threads: "
+                f"{snap.get('threads', 0)}"
+            )
+        ts = time.strftime(
+            "%H:%M:%S", time.localtime(now),
+        )
+        if elapsed < 60:
+            fmt_elapsed = f"{elapsed:.0f}s"
+        else:
+            mins = int(elapsed) // 60
+            fmt_elapsed = f"{elapsed:.0f}s ({mins}m)"
+        in_flight = max(0, received - completed)
+        if received >= expected:
+            progress_str = (
+                f" {expected} recv"
+                f"  {completed}/{expected} done"
+                f"  {in_flight} in-flight"
+            )
+        else:
+            progress_str = (
+                f" {received}/{expected} recv"
+                f"  {completed} done"
+                f"  {in_flight} in-flight"
+            )
+        sys_cpu_str = ""
+        if cur_sys_cpu is not None:
+            peak_val = (
+                peak_sys_cpu
+                if peak_sys_cpu is not None
+                else cur_sys_cpu
+            )
+            sys_cpu_str = (
+                f"  syscpu: {cur_sys_cpu:.0f}%"
+                f" (peak {peak_val:.0f}%)"
+            )
+        logger.info(
+            "  [heartbeat] %s [%s]%s  dur/server: %s%s%s"
+            "  sysmem: %.0f%% (%.0fM used"
+            " / %.1fG free)%s",
+            fmt_elapsed, ts,
+            progress_str,
+            dur_stats,
+            threads_str, rss_str,
+            cur_mem.percent, cur_used_mb,
+            cur_avail_gb,
+            sys_cpu_str,
+        )
+
+    def _run_server_only_monitor(self) -> int:
+        """Interactive server-only monitoring loop.
+
+        Prompts the user for the expected request count, then
+        monitors the server log until all requests arrive (or
+        timeout / Ctrl-C).  After each round, reports results,
+        writes raw_results.json, archives the server log, and
+        loops back for another round.  Only exits on Ctrl-C
+        at the prompt.
+        """
+        primary_start_pattern = (
+            self.profile.primary_start_pattern
+        )
+        pri_start_re = re.compile(primary_start_pattern)
+        primary_finish_pattern = (
+            self.profile.primary_finish_pattern
+        )
+        pri_finish_re = re.compile(
+            primary_finish_pattern,
+        )
+        round_num = 0
+
+        while True:
+            try:
+                answer = input(
+                    "\nHow many requests will the"
+                    " client send? ",
+                )
+            except (KeyboardInterrupt, EOFError):
+                logger.info(
+                    "\n  Exiting server-only monitor.",
+                )
+                return 0
+
+            answer = answer.strip()
+            if not answer:
+                continue
+            try:
+                expected = int(answer)
+            except ValueError:
+                logger.error(
+                    "  Invalid number: %s", answer,
+                )
+                continue
+            if expected <= 0:
+                logger.error(
+                    "  Number must be positive.",
+                )
+                continue
+
+            round_num += 1
+            self._run_server_only_round(
+                expected, round_num,
+                pri_start_re, pri_finish_re,
+            )
+
+    def _setup_round_output_dir(
+            self, expected,
+    ) -> str:
+        """Create an output directory for a server-only round."""
+        timestamp = time.strftime("%Y%m%d_%H%M%S")
+        base = self._output_base()
+        folder_name = self._run_folder_name(timestamp, expected)
+        round_dir = os.path.join(
+            base, "server_only", folder_name,
+        )
+        os.makedirs(round_dir, exist_ok=True)
+        return round_dir
+
+    def _run_server_only_round(
+            self, expected, round_num,
+            pri_start_re, pri_finish_re,
+    ) -> None:
+        """Execute one round of server-only monitoring.
+
+        Wraps the round body with a per-round ``stdout.log`` file
+        handler so each server-only round captures its own console
+        output (heartbeats + summary) in its output directory.
+        """
+        round_dir = self._setup_round_output_dir(expected)
+        log_pos = self.log_monitor.read_position()
+        round_log_path = os.path.join(round_dir, "stdout.log")
+        round_handler = logging.FileHandler(
+            round_log_path, encoding="utf-8",
+        )
+        round_handler.setLevel(logging.INFO)
+        round_handler.setFormatter(
+            logging.Formatter("%(message)s"),
+        )
+        root_logger = logging.getLogger()
+        root_logger.addHandler(round_handler)
+        try:
+            self._server_only_round_body(
+                expected, round_num,
+                pri_start_re, pri_finish_re,
+                round_dir, log_pos, round_log_path,
+            )
+        finally:
+            root_logger.removeHandler(round_handler)
+            round_handler.close()
+
+    # pylint: disable=too-many-locals,too-many-arguments
+    # pylint: disable=too-many-positional-arguments
+    def _server_only_round_body(
+            self, expected, round_num,
+            pri_start_re, pri_finish_re,
+            round_dir, log_pos, round_log_path,
+    ) -> None:
+        """Execute one round of server-only monitoring."""
+        logger.info(
+            "\n%s", "=" * 60,
+        )
+        logger.info(
+            "  Round %d: expecting %d request(s)",
+            round_num, expected,
+        )
+        logger.info("=" * 60)
+        logger.info(
+            "  neuro-san version: %s",
+            self._resolve_ns_version() or "unknown",
+        )
+
+        before_server = (
+            ResourceMonitor.snapshot(self.server_proc)
+            if self.server_proc else None
+        )
+        if before_server:
+            ResourceMonitor.log_snapshot(
+                "Server BEFORE", before_server,
+            )
+        mem = psutil.virtual_memory()
+        before_used_mb = (
+            (mem.total - mem.available) / (1024 ** 2)
+        )
+        avail_gb = mem.available / (1024 ** 3)
+        total_gb = mem.total / (1024 ** 3)
+        logger.info(
+            "  System BEFORE: %.0f%% used"
+            " (%.0fM used / %.1fG free / %.1fG total)",
+            mem.percent, before_used_mb,
+            avail_gb, total_gb,
+        )
+        ncores = psutil.cpu_count() or 1
+        before_sys_cpu = psutil.cpu_percent(interval=0.1)
+        logger.info(
+            "  System CPU: %d cores (%.0f%% in use)",
+            ncores, before_sys_cpu,
+        )
+        before_sys_threads = SystemResources.total_threads()
+        user_limit, sys_max = SystemResources.thread_limits()
+        logger.info(
+            "  System threads: %s in use / limit %s"
+            " per-user (%s max)",
+            f"{before_sys_threads:,}", user_limit, sys_max,
+        )
+        before_sys_mem_pct = mem.percent
+        sys_before = {
+            "mem_pct": mem.percent,
+            "mem_avail_gb": avail_gb,
+            "cpu_pct": before_sys_cpu,
+            "threads": before_sys_threads,
+        }
+
+        logger.info(
+            "\nWaiting for %d request(s) in server"
+            " log...\n"
+            "  Start the client on the remote"
+            " machine now.",
+            expected,
+        )
+
+        count, completed, peak_server, \
+            peak_threads, \
+            peak_sys_mem_pct, elapsed, interrupted, \
+            peak_sys_cpu, avg_sys_cpu, peak_sys_threads = (
+                self._tail_server_log(
+                    expected, log_pos,
+                    pri_start_re, pri_finish_re,
+                    before_server, before_sys_mem_pct,
+                )
+            )
+
+        logger.info(
+            "\n  Monitoring complete: %d/%d received,"
+            " %d/%d processed in %.1fs",
+            count, expected, completed,
+            count, elapsed,
+        )
+
+        after_server = (
+            ResourceMonitor.snapshot(self.server_proc)
+            if self.server_proc else None
+        )
+        after_kernel = self._read_kernel_memory()
+        mem = psutil.virtual_memory()
+        total_gb = mem.total / (1024 ** 3)
+        after_avail_gb = mem.available / (1024 ** 3)
+        after_sys_cpu = psutil.cpu_percent(interval=0.1)
+        after_sys_threads = SystemResources.total_threads()
+        peak_avail_gb = (
+            total_gb - peak_sys_mem_pct / 100.0 * total_gb
+        )
+        SystemResources.log_section(
+            sys_before,
+            {
+                "mem_pct": peak_sys_mem_pct,
+                "mem_avail_gb": peak_avail_gb,
+                "cpu_pct": peak_sys_cpu,
+                "threads": peak_sys_threads,
+            },
+            {
+                "mem_pct": mem.percent,
+                "mem_avail_gb": after_avail_gb,
+                "cpu_pct": after_sys_cpu,
+                "threads": after_sys_threads,
+            },
+        )
+
+        primary_pairs = self._server_only_primary_pairs(
+            log_pos, pri_start_re,
+        )
+        self._log_server_completion_percentiles(primary_pairs)
+
+        server_errors = (
+            self.log_monitor.scan_server_errors_since(log_pos)
+        )
+        OutputValidator.log_server_errors(server_errors)
+        tool_warnings = (
+            self.log_monitor.scan_tool_warnings_since(log_pos)
+        )
+        OutputValidator.log_tool_warnings(tool_warnings)
+
+        self._log_server_only_token_usage(log_pos)
+
+        peak_rss_for_breakdown = 0.0
+        if peak_server:
+            peak_rss_for_breakdown = (
+                peak_server.get("rss", 0)
+            )
+        elif after_server:
+            peak_rss_for_breakdown = (
+                after_server.get("rss", 0)
+            )
+        kernel_breakdown = self._log_kernel_breakdown(
+            after_kernel,
+            peak_rss_for_breakdown,
+            log=False,
+        )
+
+        self._export_server_only_json(
+            round_dir, expected, count, elapsed,
+            before_server, after_server, peak_server,
+            peak_threads,
+            before_sys_mem_pct, peak_sys_mem_pct,
+            mem.percent, interrupted,
+            kernel_breakdown,
+            avg_sys_cpu=avg_sys_cpu,
+            peak_sys_cpu=peak_sys_cpu,
+            server_errors=server_errors,
+            tool_warnings=tool_warnings,
+        )
+
+        self._append_server_history_record(
+            expected, count, elapsed, peak_server, peak_sys_cpu,
+            primary_pairs,
+            server_errors=server_errors,
+            tool_warnings=tool_warnings,
+        )
+
+        self._archive_server_log_to(round_dir)
+
+        logger.info("\n%s", "=" * 60)
+        logger.info("  OUTPUT FILES")
+        logger.info("=" * 60)
+        logger.info("  Directory:   %s", round_dir)
+        json_path = os.path.join(
+            round_dir, "raw_results.json",
+        )
+        if os.path.isfile(json_path):
+            logger.info(
+                "  Raw results: %s", json_path,
+            )
+        gz_path = os.path.join(
+            round_dir, "server.log.gz",
+        )
+        if os.path.isfile(gz_path):
+            size_mb = (
+                os.path.getsize(gz_path) / (1024 * 1024)
+            )
+            logger.info(
+                "  Server log:  %s (%.1fM)",
+                gz_path, size_mb,
+            )
+        logger.info(
+            "  Stdout log:  %s", round_log_path,
+        )
+        for history_path in (
+            self._history_path(),
+            self._history_path(successful=False),
+        ):
+            if os.path.isfile(history_path):
+                logger.info("  History:     %s", history_path)
+
+        logger.info(
+            "\n%s", "\u2500" * 45,
+        )
+        logger.info(
+            "  Round %d complete. Ready for next"
+            " round.", round_num,
+        )
+        logger.info("%s", "\u2500" * 45)
+
+    # pylint: disable=too-many-arguments,too-many-positional-arguments
+    def _tail_server_log(
+            self, expected, log_pos,
+            pri_start_re, pri_finish_re,
+            before_server, before_sys_mem_pct,
+    ):
+        """Tail the server log in two phases.
+
+        Phase 1: count Start patterns until all requests
+        received.  Phase 2: count Finish patterns until all
+        requests processed.
+
+        Returns (count, completed, peak_server,
+        peak_threads, peak_sys_mem_pct, elapsed,
+        interrupted, peak_sys_cpu, avg_sys_cpu,
+        peak_sys_threads).
+        """
+        start_time = time.time()
+        count = 0
+        completed = 0
+        last_heartbeat = start_time
+        heartbeat_interval = HEARTBEAT_INTERVAL_SECONDS
+        peak_server = before_server
+        peak_threads = 0
+        peak_sys_mem_pct = before_sys_mem_pct
+        peak_sys_cpu = 0.0
+        peak_sys_threads = 0
+        sys_cpu_sum = 0.0
+        sys_cpu_n = 0
+        interrupted = False
+        warned_missing_starts = False
+        phase = 1
+        log_limit = 5
+        # Prime the non-blocking system CPU counter.
+        psutil.cpu_percent(interval=None)
+
+        try:
+            with open(
+                    self.server_log, "r",
+                    encoding="utf-8",
+            ) as log_fh:
+                log_fh.seek(log_pos)
+                last_monitor = start_time
+                monitor_interval = 1.0
+                while True:
+                    if phase == 1 and count >= expected:
+                        now = time.time()
+                        elapsed = now - start_time
+                        logger.info(
+                            "\n  All %d request(s)"
+                            " received (%.1fs)."
+                            " Monitoring until"
+                            " processing completes"
+                            "...",
+                            expected, elapsed,
+                        )
+                        phase = 2
+                    if (phase == 2
+                            and completed >= count):
+                        break
+                    # Guard: completions arriving without
+                    # matching starts means the monitor was
+                    # started after the client fired, so the
+                    # Start lines predate our read position and
+                    # were skipped. Warn and finish gracefully
+                    # instead of hanging with negative in-flight.
+                    if completed > count:
+                        if not warned_missing_starts:
+                            logger.warning(
+                                "\n  %d completion(s) seen with"
+                                " only %d start(s). The"
+                                " server-only monitor was"
+                                " likely started after the"
+                                " client; Start lines predate"
+                                " its read position and were"
+                                " missed. Received counts are"
+                                " unreliable -- start the"
+                                " monitor before the client.",
+                                completed, count,
+                            )
+                            warned_missing_starts = True
+                        if completed >= expected:
+                            break
+
+                    line = log_fh.readline()
+                    if line:
+                        if (phase == 1
+                                and pri_start_re.search(
+                                    line)):
+                            count += 1
+                            now = time.time()
+                            ts = time.strftime(
+                                "%H:%M:%S",
+                                time.localtime(now),
+                            )
+                            elapsed = (
+                                now - start_time
+                            )
+                            if (count <= log_limit
+                                    or count == expected):
+                                logger.info(
+                                    "  [server] request"
+                                    " %d/%d received"
+                                    " [%s] (+%.1fs)",
+                                    count, expected,
+                                    ts, elapsed,
+                                )
+                        if pri_finish_re.search(line):
+                            completed += 1
+                            now = time.time()
+                            ts = time.strftime(
+                                "%H:%M:%S",
+                                time.localtime(now),
+                            )
+                            elapsed = (
+                                now - start_time
+                            )
+                            total = (
+                                count if phase == 2
+                                else expected
+                            )
+                            if (completed <= log_limit
+                                    or completed
+                                    == total):
+                                logger.info(
+                                    "  [server] request"
+                                    " %d/%d completed"
+                                    " [%s] (+%.1fs)",
+                                    completed, total,
+                                    ts, elapsed,
+                                )
+                        continue
+                    pos = log_fh.tell()
+                    log_fh.seek(pos)
+                    time.sleep(0.5)
+
+                    now = time.time()
+                    elapsed = now - start_time
+
+                    if (now - last_monitor
+                            >= monitor_interval):
+                        snap = ResourceMonitor.snapshot(
+                            self.server_proc,
+                        )
+                        if snap:
+                            if (peak_server is None
+                                    or snap.get(
+                                        "rss", 0,
+                                    ) > peak_server.get(
+                                        "rss", 0)):
+                                peak_server = snap
+                            cur_threads = snap.get(
+                                "threads", 0,
+                            )
+                            peak_threads = max(
+                                peak_threads, cur_threads,
+                            )
+                        cur_mem = (
+                            psutil.virtual_memory()
+                        )
+                        peak_sys_mem_pct = max(
+                            peak_sys_mem_pct, cur_mem.percent,
+                        )
+                        cur_sys_cpu = psutil.cpu_percent(
+                            interval=None,
+                        )
+                        sys_cpu_sum += cur_sys_cpu
+                        sys_cpu_n += 1
+                        peak_sys_cpu = max(
+                            peak_sys_cpu, cur_sys_cpu,
+                        )
+                        peak_sys_threads = max(
+                            peak_sys_threads,
+                            SystemResources.total_threads(),
+                        )
+                        last_monitor = now
+
+                        if (now - last_heartbeat
+                                >= heartbeat_interval):
+                            dur_stats = (
+                                self._server_only_dur_stats(
+                                    log_pos, pri_start_re,
+                                )
+                            )
+                            self._server_only_heartbeat(
+                                count, expected,
+                                completed,
+                                elapsed, now,
+                                snap, cur_mem,
+                                dur_stats,
+                                cur_sys_cpu, peak_sys_cpu,
+                            )
+                            last_heartbeat = now
+
+                    if (elapsed
+                            > self.args.stage_timeout):
+                        if phase == 1:
+                            logger.warning(
+                                "  Stage timeout"
+                                " (%.0fs) reached"
+                                " with %d/%d"
+                                " requests"
+                                " received.",
+                                self.args.stage_timeout,
+                                count, expected,
+                            )
+                        else:
+                            logger.warning(
+                                "  Stage timeout"
+                                " (%.0fs) reached"
+                                " with %d/%d"
+                                " requests"
+                                " processed.",
+                                self.args.stage_timeout,
+                                completed, count,
+                            )
+                        break
+        except KeyboardInterrupt:
+            interrupted = True
+            logger.info(
+                "\n  Interrupted \u2014 reporting"
+                " partial results...",
+            )
+
+        elapsed = time.time() - start_time
+        avg_sys_cpu = (
+            sys_cpu_sum / sys_cpu_n if sys_cpu_n else 0.0
+        )
+        return (
+            count, completed, peak_server,
+            peak_threads,
+            peak_sys_mem_pct, elapsed, interrupted,
+            peak_sys_cpu, avg_sys_cpu, peak_sys_threads,
+        )
+
+    # pylint: disable=too-many-arguments,too-many-positional-arguments
+    def _export_server_only_json(
+            self, round_dir, expected, count,
+            elapsed, before_server, after_server,
+            peak_server, peak_threads,
+            before_sys_pct, peak_sys_pct,
+            after_sys_pct, interrupted,
+            kernel_breakdown=None,
+            avg_sys_cpu=None, peak_sys_cpu=None,
+            server_errors=None, tool_warnings=None,
+    ) -> None:
+        """Write raw_results.json for a server-only round."""
+        server_cpu_seconds = None
+        if before_server and after_server:
+            cpu_before = before_server.get("cpu_seconds")
+            cpu_after = after_server.get("cpu_seconds")
+            if (cpu_before is not None
+                    and cpu_after is not None):
+                server_cpu_seconds = cpu_after - cpu_before
+        raw_data = {
+            "test_metadata": {
+                "timestamp": time.strftime(
+                    "%Y-%m-%dT%H:%M:%S%z",
+                ),
+                "hostname": socket.gethostname(),
+                "python_version": (
+                    platform.python_version()
+                ),
+                "platform": platform.platform(),
+                "mode": "server-only",
+                "agent": self.args.agent,
+            },
+            "round": {
+                "expected_requests": expected,
+                "received_requests": count,
+                "elapsed_seconds": round(elapsed, 2),
+                "interrupted": interrupted,
+            },
+            "server_resources": {
+                "before": before_server,
+                "after": after_server,
+                "peak": peak_server,
+                "peak_threads": peak_threads,
+            },
+            "system_memory": {
+                "before_pct": before_sys_pct,
+                "peak_pct": peak_sys_pct,
+                "after_pct": after_sys_pct,
+            },
+            "system_cpu": {
+                "avg_pct": avg_sys_cpu,
+                "peak_pct": peak_sys_cpu,
+                "server_cpu_seconds_total": server_cpu_seconds,
+                "server_cpu_seconds_per_request": (
+                    server_cpu_seconds / count
+                    if (server_cpu_seconds is not None
+                        and count > 0)
+                    else None
+                ),
+            },
+        }
+        raw_data["server_errors"] = server_errors or []
+        raw_data["tool_warnings"] = tool_warnings or []
+        if kernel_breakdown:
+            raw_data["kernel_memory_breakdown"] = (
+                kernel_breakdown
+            )
+        json_path = os.path.join(
+            round_dir, "raw_results.json",
+        )
+        with open(
+                json_path, "w", encoding="utf-8",
+        ) as fh:
+            json.dump(raw_data, fh, indent=2)
+
+    @staticmethod
+    def _read_kernel_memory() -> Optional[Dict[str, float]]:
+        """Read kernel memory breakdown from /proc/meminfo.
+
+        Returns a dict with values in MB, or None if not on
+        Linux.
+        """
+        if not os.path.isfile("/proc/meminfo"):
+            return None
+        result = {}
+        try:
+            with open(
+                    "/proc/meminfo", "r", encoding="utf-8",
+            ) as fh:
+                for line in fh:
+                    parts = line.split()
+                    if len(parts) < 2:
+                        continue
+                    key = parts[0].rstrip(":")
+                    val_kb = int(parts[1])
+                    result[key] = val_kb / 1024.0
+        except (OSError, ValueError):
+            return None
+
+        tcp_mem_mb = 0.0
+        try:
+            with open(
+                    "/proc/net/sockstat", "r",
+                    encoding="utf-8",
+            ) as fh:
+                for line in fh:
+                    if line.startswith("TCP:"):
+                        parts = line.split()
+                        idx = parts.index("mem")
+                        pages = int(parts[idx + 1])
+                        tcp_mem_mb = (pages * 4) / 1024.0
+                        break
+        except (OSError, ValueError, IndexError):
+            pass
+        result["TcpMem"] = tcp_mem_mb
+        return result
+
+    @staticmethod
+    def _log_kernel_breakdown(
+            after_kernel, server_rss_peak,
+            *, log=True,
+    ) -> Dict[str, float]:
+        """Compute the kernel memory breakdown.
+
+        When ``log`` is False the values are still returned for JSON
+        export but nothing is printed to the console.
+        """
+        if not after_kernel:
+            return {}
+
+        rss_mb = server_rss_peak or 0.0
+        kern_stacks = after_kernel.get(
+            "KernelStack", 0,
+        )
+        page_tables = after_kernel.get(
+            "PageTables", 0,
+        )
+        slab = after_kernel.get("Slab", 0)
+        cached = (
+            after_kernel.get("Cached", 0)
+            + after_kernel.get("Buffers", 0)
+        )
+        tcp_mem = after_kernel.get("TcpMem", 0)
+        mem_total = after_kernel.get("MemTotal", 0)
+        mem_free = after_kernel.get("MemFree", 0)
+        sys_used = mem_total - mem_free
+
+        accounted = (
+            rss_mb + kern_stacks + page_tables
+            + slab + cached + tcp_mem
+        )
+        unaccounted = max(0, sys_used - accounted)
+
+        if log:
+            logger.info(
+                "\n  Kernel memory breakdown:",
+            )
+            logger.info(
+                "    Server RSS:       %.0fM", rss_mb,
+            )
+            logger.info(
+                "    Kernel stacks:    %.0fM", kern_stacks,
+            )
+            logger.info(
+                "    Page tables:      %.0fM", page_tables,
+            )
+            logger.info(
+                "    Slab cache:       %.0fM", slab,
+            )
+            logger.info(
+                "    Page cache:       %.0fM", cached,
+            )
+            logger.info(
+                "    TCP buffers:      %.0fM", tcp_mem,
+            )
+            logger.info(
+                "    %s", "\u2500" * 30,
+            )
+            logger.info(
+                "    Accounted:        %.0fM", accounted,
+            )
+            logger.info(
+                "    Unaccounted:      %.0fM", unaccounted,
+            )
+            logger.info(
+                "    System total:     %.0fM"
+                " (used + cache)",
+                sys_used,
+            )
+
+        return {
+            "server_rss_mb": rss_mb,
+            "kernel_stacks_mb": kern_stacks,
+            "page_tables_mb": page_tables,
+            "slab_mb": slab,
+            "page_cache_mb": cached,
+            "tcp_buffers_mb": tcp_mem,
+            "accounted_mb": accounted,
+            "unaccounted_mb": unaccounted,
+            "system_total_mb": sys_used,
+        }
+
+    def _archive_server_log_to(
+            self, target_dir,
+    ) -> None:
+        """Gzip the server log into the given directory."""
+        if not self.server_log or not os.path.isfile(
+            self.server_log,
+        ):
+            return
+        gz_path = os.path.join(
+            target_dir, "server.log.gz",
+        )
+        with open(self.server_log, "rb") as f_in, \
+                gzip.open(gz_path, "wb") as f_out:
+            shutil.copyfileobj(f_in, f_out)
+
+    def run(self) -> int:
+        """Execute the full load test workflow."""
+        level = self.args.level
+        self.args.include_tokens = not self.args.no_tokens
+        split_mode = (
+            self.args.client_only or self.args.server_only
+        )
+        if split_mode:
+            level = LEVEL_MIN
+            self.args.level = LEVEL_MIN
+        elif level == LEVEL_MIN:
+            logger.error(
+                "--level min requires --client-only or "
+                "--server-only. For an all-in-one run use "
+                "--level norm or --level adv.",
+            )
+            raise SystemExit(1)
+        if (self.args.client_only
+                and self.args.server_only):
+            logger.error(
+                "--client-only and --server-only are "
+                "mutually exclusive.",
+            )
+            raise SystemExit(1)
+        if (self.args.client_only
+                and self.args.server_log is not None):
+            logger.error(
+                "--client-only cannot be used with "
+                "--server-log (server log is remote).",
+            )
+            raise SystemExit(1)
+        if (self.args.server_only
+                and self.args.server_log is None):
+            self.args.server_log = "auto"
+        if self.args.no_server_log and not self.args.server_only:
+            self.args.server_log = None
+        elif (self.args.server_log is None
+                and not self.args.client_only
+                and not self.args.server_only
+                and self.args.host in LOCAL_HOSTS
+                and level != LEVEL_MIN):
+            self.args.server_log = (
+                EnvironmentValidator.try_auto_detect_server_log(
+                    self.args,
+                )
+            )
+        if (level != LEVEL_MIN
+                and not self.args.client_only
+                and not self.args.server_only
+                and not self.args.no_server_log
+                and self.args.server_log is None):
+            if self.args.host not in LOCAL_HOSTS:
+                logger.error(
+                    "--level %s needs a local server to read "
+                    "server.log. Use --client-only for a remote "
+                    "server, or pass --server-log <path>.",
+                    level,
+                )
+                raise SystemExit(1)
+            self._confirm_no_server_log(level)
+        self._apply_level_defaults(self.args, self.args.explicit_args)
+        self._apply_scale(self.args)
+        self.input_validator.validate_agent_name()
+        EnvironmentValidator.validate_environment()
+        stale_log_age = self._validate_server_log()
+
+        stages = self.input_validator.resolve_stages()
+        total_cap = self.input_validator.resolve_max_requests(
+            stages,
+        )
+
+        self._setup_test_log()
+        if not self.args.server_only:
+            self._preflight_server_check()
+            self.probe_result = (
+                self.input_validator.confirm_cost(
+                    stages, total_cap,
+                    runner=self.runner,
+                    output_dir=self._output_dir,
+                    stale_log_age=stale_log_age,
+                )
+            )
+
+        is_local = self.args.host in LOCAL_HOSTS
+        monitor_resources = (
+            level != LEVEL_MIN or split_mode
+        )
+
+        if self.args.client_only:
+            if self.args.http_client:
+                logger.info(
+                    "Client-only mode (HTTP threads): "
+                    "skipping server process detection.",
+                )
+            else:
+                logger.info(
+                    "Client-only mode: skipping server "
+                    "process detection.",
+                )
+        elif self.args.server_only:
+            self.server_proc = (
+                EnvironmentValidator.find_local_server(
+                    self.args,
+                )
+            )
+        elif is_local:
+            self.server_proc = (
+                EnvironmentValidator.find_local_server(
+                    self.args,
+                )
+            )
+
+        if self.args.server_log == "auto":
+            self.args.server_log = (
+                EnvironmentValidator.auto_detect_server_log(
+                    self.server_proc,
+                )
+            )
+
+        self.server_log = self.args.server_log
+        if self.server_log:
+            self.log_monitor = ServerLogMonitor(self.server_log)
+
+        if self.args.server_only:
+            logger.info(
+                "\nConfig: agent=%s, mode=server-only, "
+                "num_requests=%s, host=%s, port=%s, "
+                "stage_timeout=%ss",
+                self.args.agent, self.args.num_requests,
+                self.args.host, self.args.port,
+                self.args.stage_timeout,
+            )
+            if self.server_log:
+                logger.info(
+                    "  server_log=%s", self.server_log,
+                )
+            return self._run_server_only_monitor()
+
+        if not is_local:
+            logger.info(
+                "Remote mode: targeting %s:%s",
+                self.args.host, self.args.port,
+            )
+            logger.info(
+                "  Process monitoring disabled "
+                "(server is not local)",
+            )
+
+        prompt_mode = "same" if self.args.same_prompt else "varied"
+        mode = "ramp" if self.args.ramp else "flat"
+        logger.info(
+            "\nConfig: agent=%s, mode=%s, level=%s, "
+            "stages=%s, rounds=%s, max_requests=%s, host=%s, port=%s, "
+            "timeout=%ss, idle_timeout=%ss, "
+            "stage_timeout=%ss, prompt_mode=%s",
+            self.args.agent, mode, level, stages,
+            self.args.num_rounds, total_cap,
+            self.args.host, self.args.port, self.args.request_timeout,
+            self.args.idle_timeout, self.args.stage_timeout,
+            prompt_mode,
+        )
+        if monitor_resources:
+            logger.info("  settle_time=%ss", self.args.settle_time)
+        if self.server_log:
+            logger.info("  server_log=%s", self.server_log)
+        else:
+            logger.info("  server_log=none")
+        if self.probe_result and self.probe_result.get("total_tokens"):
+            logger.info(
+                "  tokens_per_request=%s (measured by probe)",
+                f"{self.probe_result.get('total_tokens'):,}",
+            )
+        elif self.profile.estimated_tokens_per_request:
+            logger.info(
+                "  estimated_tokens_per_request=%s",
+                f"{self.profile.estimated_tokens_per_request:,}",
+            )
+
+        stage_summaries: List[StageSummary] = []
+        exit_code = 1
+        pre_test_log_pos = (
+            self.log_monitor.read_position()
+            if self.server_log else None
+        )
+        prev_sigint_handler = self._install_interrupt_handler()
+        try:
+            stage_summaries = self._run_all_stages(
+                stages, total_cap,
+            )
+
+            if self._aborted:
+                exit_code = 1
+            if self._interrupted:
+                logger.warning(
+                    "\n  Test interrupted (Ctrl-C) — the results "
+                    "below cover only the requests that completed "
+                    "before the interrupt.",
+                )
+
+            summary_reporter = SummaryReporter(
+                stage_summaries,
+                neuro_san_version=self._resolve_ns_version(),
+                client_token_source=(
+                    "HTTP token_accounting"
+                    if getattr(self.args, "http_client", False)
+                    else "agent_cli --tokens"
+                ),
+            )
+            if len(stage_summaries) > 1:
+                summary_reporter.log_ramp_summary(
+                    is_ramp=self.args.ramp,
+                )
+
+            summary_reporter.log_overall_results()
+
+            latency_analyzer = LatencyAnalyzer(stage_summaries)
+            latency_analyzer.log_latency_analysis(
+                is_ramp=self.args.ramp,
+            )
+            latency_analyzer.log_degradation(
+                is_ramp=self.args.ramp,
+            )
+
+            server_chat_timing = []
+            if self.server_log and pre_test_log_pos is not None:
+                server_chat_timing = (
+                    self.log_monitor
+                    .parse_streaming_chat_timing_since(
+                        pre_test_log_pos,
+                    )
+                )
+
+            if monitor_resources:
+                total_client_reqs = sum(
+                    s.get("concurrent", 0) for s in stage_summaries
+                )
+                total_server_calls = sum(
+                    s.get("total_started") or 0 for s in stage_summaries
+                )
+
+                self.resource_reporter.log_combined_analysis(
+                    total_client_reqs,
+                    total_server_calls,
+                )
+                disc_reporter = DisconnectionReporter(
+                    stage_summaries,
+                )
+                disc_reporter.log_disconnection_summary()
+
+            if level == LEVEL_ADV:
+                has_server_log = self.server_log is not None
+                if has_server_log:
+                    pool_analyzer = PoolAnalyzer(stage_summaries)
+                    pool_analyzer.log_pool_reuse_analysis()
+                else:
+                    logger.info(
+                        "\n  Pool reuse analysis: "
+                        "not available (no --server-log)",
+                    )
+
+            if self._interrupted:
+                exit_code = 2
+            elif not self._aborted:
+                exit_code = self._check_results(stage_summaries)
+            self._export_raw_json(
+                stage_summaries, exit_code=exit_code,
+            )
+            self._maybe_write_summary(
+                stage_summaries, server_chat_timing,
+            )
+            if self._interrupted:
+                self._rename_interrupted()
+        except KeyboardInterrupt:
+            logger.info(
+                "\n  Interrupted — saving partial results...",
+            )
+            self._export_raw_json(
+                stage_summaries, exit_code=2,
+            )
+            self._rename_interrupted()
+            exit_code = 2
+        finally:
+            if prev_sigint_handler is not None:
+                signal.signal(signal.SIGINT, prev_sigint_handler)
+            self._append_history_record(stage_summaries)
+            self._finalize_test_log(stage_summaries)
+
+        return exit_code
+
+    def was_interrupted(self) -> bool:
+        """Return True if the run was stopped early by Ctrl-C."""
+        return self._interrupted
+
+    def _install_interrupt_handler(self):
+        """Install a SIGINT handler that requests a graceful stop.
+
+        The first Ctrl-C sets a cancel event so in-flight requests are
+        killed and the completed ones are still summarized.  A second
+        Ctrl-C restores the previous handler so the interpreter exits
+        immediately.  Returns the previous handler (or None if it could
+        not be installed, e.g. not on the main thread).
+        """
+        def _handle_sigint(_signum, _frame):
+            # Nested to close over self and prev_handler, which the
+            # signal callback needs to toggle graceful vs. forced stop;
+            # signal.signal() takes a bare callable, not a bound method.
+            if not self._cancel_event.is_set():
+                self._cancel_event.set()
+                self._interrupted = True
+                logger.warning(
+                    "\n  Ctrl-C received — stopping and gathering "
+                    "results for completed requests (press Ctrl-C "
+                    "again to force-quit)...",
+                )
+            elif prev_handler is not None:
+                signal.signal(signal.SIGINT, prev_handler)
+
+        try:
+            prev_handler = signal.getsignal(signal.SIGINT)
+            signal.signal(signal.SIGINT, _handle_sigint)
+            return prev_handler
+        except (ValueError, OSError):
+            return None
+
+    def _history_path(self, *, successful: bool = True) -> str:
+        """Return the append-only trend-history JSONL path.
+
+        Successful runs go to ``history.jsonl`` so the trend file stays
+        clean for plotting; runs that could not determine the server
+        version or completed no requests go to ``history_unknown.jsonl``
+        so they are kept for debugging without polluting the trend data.
+
+        Honours ``--history-file`` (the unknown records are written to a
+        sibling ``*_unknown`` file) and otherwise defaults to
+        ``<output-base>/history[_unknown].jsonl`` so records accumulate
+        outside the per-run output directories.
+        """
+        if self.args.history_file:
+            if successful:
+                return self.args.history_file
+            root, ext = os.path.splitext(self.args.history_file)
+            return f"{root}_unknown{ext or '.jsonl'}"
+        base = self._output_base()
+        name = (
+            HISTORY_FILE_NAME if successful
+            else HISTORY_UNKNOWN_FILE_NAME
+        )
+        return os.path.join(base, name)
+
+    def _append_history_record(self, stage_summaries) -> None:
+        """Append one trend record per client run for plotting later.
+
+        Records how many requests completed under each fixed time
+        threshold, plus the neuro-san version, so throughput can be
+        tracked over time.  Best-effort: any write failure is logged
+        and swallowed so it never fails the test.
+        """
+        results = []
+        for summary in stage_summaries:
+            results.extend(summary.get("results", []))
+        if not results:
+            return
+
+        durations = [
+            r.get("elapsed", 0.0) for r in results
+            if r.get("status") == STATUS_CREATED
+        ]
+        completed = len(durations)
+        avg_duration = (
+            round(sum(durations) / completed, 2) if completed else 0.0
+        )
+        ttfts = [
+            r.get("ttft", 0.0) for r in results
+            if r.get("status") == STATUS_CREATED
+            and r.get("ttft", 0.0) > 0
+        ]
+        avg_first_response = (
+            round(sum(ttfts) / len(ttfts), 2) if ttfts else 0.0
+        )
+        server_errors: List[Dict[str, str]] = []
+        tool_warnings: List[Dict[str, str]] = []
+        for summary in stage_summaries:
+            server_errors.extend(summary.get("server_errors", []))
+            tool_warnings.extend(summary.get("tool_warnings", []))
+        record = {
+            "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+            "neuro_san_version": self._server_ns_version or "unknown",
+            "host": self.args.host,
+            "agent": self.args.agent,
+            "transport": (
+                "http" if getattr(self.args, "http_client", False)
+                else "subprocess"
+            ),
+            "total_requests": len(results),
+            "completed": completed,
+            "avg_first_response_s": avg_first_response,
+            "avg_duration_s": avg_duration,
+            "wall_time_s": round(
+                sum(s.get("elapsed", 0.0) for s in stage_summaries), 2,
+            ),
+            "server_error_count": len(server_errors),
+            "tool_warning_count": len(tool_warnings),
+            "server_errors": server_errors,
+            "tool_warnings": tool_warnings,
+        }
+        for threshold in HISTORY_THRESHOLDS_SECONDS:
+            record[f"completed_within_{int(threshold)}s"] = sum(
+                1 for d in durations if d <= threshold
+            )
+        successful = (
+            completed > 0
+            and record.get("neuro_san_version") != "unknown"
+        )
+        self._write_history_record(record, successful=successful)
+
+    @staticmethod
+    def _log_server_completion_percentiles(primary_pairs) -> None:
+        """Log server-side completion-duration percentiles on one line.
+
+        Durations are server-side processing times (Start->Finish from
+        the primary agent's log pairs), so they run slightly shorter
+        than the client's end-to-end per-request duration.  Reuses
+        ``LatencyAnalyzer._percentile`` and ``COMPLETION_MILESTONES`` so
+        the math and labels match the client's percentile line.
+        """
+        durations = sorted(
+            float(p["duration"]) for p in primary_pairs
+            if isinstance(p.get("duration"), (int, float))
+            and p["duration"] > 0
+        )
+        if not durations:
+            return
+        milestones = [
+            (
+                pct,
+                Formatters.fmt_duration(
+                    # pylint: disable=protected-access
+                    LatencyAnalyzer._percentile(durations, pct),
+                    precision=1,
+                ),
+            )
+            for pct in COMPLETION_MILESTONES
+        ]
+        parts = " / ".join(
+            f"p{pct} {value}" for pct, value in milestones
+        )
+        logger.info(
+            "\n  Server-side completion percentiles"
+            " (%d requests): %s",
+            len(durations), parts,
+        )
+
+    # pylint: disable=too-many-arguments,too-many-positional-arguments
+    def _append_server_history_record(
+            self, expected, received, elapsed,
+            peak_server, peak_sys_cpu, primary_pairs=None,
+            server_errors=None, tool_warnings=None,
+    ) -> None:
+        """Append one server-only trend record for plotting later.
+
+        Records the server's resource peaks (CPU cores, RSS in GB),
+        its neuro-san version, and — derived from the primary agent's
+        Start/Finish log pairs — server-side processing durations.
+        Keyed with ``mode="server-only"`` so it is distinguishable
+        from client records in the same file.
+
+        ``time_to_first_completed_s`` is the server-side time from the
+        first request's Start to the first request's Finish; it is not
+        the client's per-request time-to-first-response (TTFR), which
+        the server log has no way to measure.
+        """
+        primary_pairs = primary_pairs or []
+        durations = [
+            float(p["duration"]) for p in primary_pairs
+            if isinstance(p.get("duration"), (int, float))
+            and p["duration"] > 0
+        ]
+        avg_duration = (
+            round(sum(durations) / len(durations), 2)
+            if durations else 0.0
+        )
+        record = {
+            "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+            "neuro_san_version": self._server_ns_version or "unknown",
+            "host": self.args.host,
+            "agent": self.args.agent,
+            "mode": "server-only",
+            "expected_requests": expected,
+            "received_requests": received,
+            "peak_cpu_cores": round(
+                (peak_sys_cpu or 0.0) / 100
+                * (psutil.cpu_count() or 1), 2,
+            ),
+            "peak_memory_gb": (
+                round(peak_server.get("rss", 0.0) / 1024, 2)
+                if peak_server else None
+            ),
+            "time_to_first_completed_s": self._time_to_first_completed(
+                primary_pairs,
+            ),
+            "avg_duration_s": avg_duration,
+            "wall_time_s": round(elapsed, 2),
+            "server_error_count": len(server_errors or []),
+            "tool_warning_count": len(tool_warnings or []),
+            "server_errors": server_errors or [],
+            "tool_warnings": tool_warnings or [],
+        }
+        for threshold in HISTORY_THRESHOLDS_SECONDS:
+            record[f"completed_within_{int(threshold)}s"] = sum(
+                1 for d in durations if d <= threshold
+            )
+        successful = (
+            received > 0
+            and record.get("neuro_san_version") != "unknown"
+        )
+        self._write_history_record(record, successful=successful)
+
+    @staticmethod
+    def _time_to_first_completed(primary_pairs) -> float:
+        """Seconds from the first request's Start to the first Finish.
+
+        Returns 0.0 when no primary request completed.
+        """
+        starts = [
+            p["start_ts"] for p in primary_pairs
+            if isinstance(p.get("start_ts"), (int, float))
+        ]
+        finishes = [
+            p["finish_ts"] for p in primary_pairs
+            if isinstance(p.get("finish_ts"), (int, float))
+        ]
+        if not starts or not finishes:
+            return 0.0
+        return round(min(finishes) - min(starts), 2)
+
+    def _write_history_record(
+            self, record, *, successful: bool = True,
+    ) -> None:
+        """Append one JSON record to the trend-history file.
+
+        ``successful`` selects the destination: clean trend file for
+        good runs, ``history_unknown.jsonl`` otherwise.  Best-effort:
+        any write failure is logged and swallowed so it never fails the
+        run.
+        """
+        path = self._history_path(successful=successful)
+        try:
+            os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+            with open(path, "a", encoding="utf-8") as handle:
+                handle.write(json.dumps(record) + "\n")
+            logger.info("  Trend history appended: %s", path)
+        except OSError as exc:
+            logger.warning(
+                "  Could not write trend history to %s: %s",
+                path, exc,
+            )
+
+    def _export_raw_json(self, stage_summaries, *,
+                         exit_code) -> None:
+        """Save all test data as a single raw_results.json file."""
+        all_results = []
+        for s in stage_summaries:
+            all_results.extend(s.get("results", []))
+
+        total_tokens = sum(
+            r.get("total_tokens", 0) for r in all_results
+        )
+        total_cost = sum(
+            r.get("cost_usd", 0.0) for r in all_results
+        )
+        total_elapsed = sum(
+            s.get("elapsed", 0) for s in stage_summaries
+        )
+        total_requests = len(all_results)
+        passed = sum(
+            1 for r in all_results
+            if r.get("status") == STATUS_CREATED
+        )
+        avg_latency = sum(
+            r.get("elapsed", 0) for r in all_results
+        ) / total_requests if total_requests else 0
+
+        raw_data = {
+            "test_metadata": {
+                "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+                "hostname": socket.gethostname(),
+                "python_version": platform.python_version(),
+                "platform": platform.platform(),
+                "neuro_san_version": self._resolve_ns_version(),
+                "neuro_san_studio_version": self._get_package_version(
+                    "neuro_san_studio",
+                ),
+                "verdict": "PASSED" if exit_code == 0 else "FAILED",
+                "exit_code": exit_code,
+            },
+            "config": {
+                "agent": self.args.agent,
+                "profile_path": self.args.profile_path,
+                "level": self.args.level,
+                "mode": "ramp" if self.args.ramp else "flat",
+                "host": self.args.host,
+                "port": self.args.port,
+                "request_timeout": self.args.request_timeout,
+                "idle_timeout": self.args.idle_timeout,
+                "stage_timeout": self.args.stage_timeout,
+                "total_timeout": self.args.total_timeout,
+                "settle_time": self.args.settle_time,
+                "max_workers": self.args.max_workers,
+                "num_rounds": self.args.num_rounds,
+                "num_requests": self.args.num_requests,
+                "same_prompt": self.args.same_prompt,
+                "chat_filter": self.args.chat_filter,
+                "server_log": self.server_log,
+                "estimated_tokens_per_request": (
+                    self.profile.estimated_tokens_per_request
+                ),
+            },
+            "aggregates": {
+                "total_requests": total_requests,
+                "passed": passed,
+                "failed": total_requests - passed,
+                "total_elapsed_seconds": round(total_elapsed, 2),
+                "avg_latency_seconds": round(avg_latency, 2),
+                "total_tokens": total_tokens,
+                "total_cost_usd": round(total_cost, 6),
+            },
+            "stage_summaries": stage_summaries,
+            "resource_rows": [
+                {"before": row[1], "after": row[2]}
+                for row in self.resource_reporter.resource_rows
+            ],
+            "client_resource_rows": [
+                {
+                    "before": row[1],
+                    "peak": row[2],
+                    "settled": row[3],
+                }
+                for row in self.resource_reporter.client_rows
+            ],
+        }
+        raw_data.update(JsonMetadata.build())
+        json_path = os.path.join(self._output_dir, "raw_results.json")
+        with open(json_path, "w", encoding="utf-8") as fh:
+            json.dump(raw_data, fh, indent=2, default=str)
+
+    def _rename_interrupted(self) -> None:
+        """Append _interrupted to the output directory name."""
+        if self._output_dir is None:
+            return
+        new_path = self._output_dir + "_interrupted"
+        try:
+            os.rename(self._output_dir, new_path)
+            self._output_dir = new_path
+            logger.info(
+                "  Renamed output to: %s", new_path,
+            )
+        except OSError as exc:
+            logger.warning(
+                "  Could not rename output dir: %s", exc,
+            )
+
+    def _maybe_write_summary(
+            self, stage_summaries, server_chat_timing,
+    ) -> None:
+        """Write summary.txt for adv level only.
+
+        With --no-dry-run: auto-write.  Otherwise prompt the user.
+        """
+        if self.args.level != LEVEL_ADV:
+            return
+        if not self.args.no_dry_run:
+            if not Confirm.ask("\nSave summary.txt?"):
+                return
+        writer = SummaryFileWriter(
+            stage_summaries, self.args,
+            server_chat_timing=server_chat_timing,
+        )
+        writer.write(self._output_dir)
+
+    def _check_results(self, stage_summaries) -> int:
+        """Log pass/fail verdict and return appropriate exit code."""
+        all_results = []
+        for s in stage_summaries:
+            all_results.extend(s.get("results", []))
+        total = len(all_results)
+        passed = sum(
+            1 for r in all_results
+            if r.get("status") == STATUS_CREATED
+        )
+        failed = total - passed
+
+        if failed > 0:
+            logger.info(
+                "\nLOAD TEST FAILED: %s/%s requests failed",
+                failed, total,
+            )
+            return 1
+
+        logger.info(
+            "\nLOAD TEST PASSED: all %s requests completed successfully",
+            total,
+        )
+        return 0
+
+    @staticmethod
+    def _get_package_version(package_name) -> Optional[str]:
+        """Return the installed version of a package, or None."""
+        try:
+            return _pkg_meta.version(package_name)
+        except _pkg_meta.PackageNotFoundError:
+            return None
+
+    def _host_tag(self) -> str:
+        """Return the ``--host`` value as a folder-name segment."""
+        return re.sub(r"[^0-9A-Za-z.+-]", "-", str(self.args.host))
+
+    def _resolve_ns_version(self) -> Optional[str]:
+        """Return the neuro-san version to tag this run with.
+
+        Prefers the *server's* version (via ``/healthz``) so the tag
+        reflects what is actually being exercised, even when the client
+        runs from a different checkout/venv or a remote machine.  The
+        result is cached in ``_server_ns_version``.  Falls back to the
+        locally installed package version when the server is
+        unreachable or does not report one.
+        """
+        if not self._server_ns_version:
+            self._server_ns_version = self._fetch_server_version()
+        return (
+            self._server_ns_version
+            or self._get_package_version("neuro-san")
+        )
+
+    def _version_tag(self) -> str:
+        """Return a folder-name segment for the neuro-san version.
+
+        E.g. ``ns0.6.81`` from the server's ``/healthz`` version, or
+        ``""`` when the version can't be determined.
+        """
+        version = self._resolve_ns_version()
+        if not version:
+            return ""
+        safe = re.sub(r"[^0-9A-Za-z.+-]", "-", version)
+        return f"ns{safe}"
+
+    def _run_folder_name(self, timestamp, count) -> str:
+        """Build ``<timestamp>_<host>[_ns<version>]_<count>``."""
+        parts = [timestamp, self._host_tag()]
+        vtag = self._version_tag()
+        if vtag:
+            parts.append(vtag)
+        parts.append(str(count))
+        return "_".join(parts)
+
+    @staticmethod
+    def _agent_filter(args) -> Optional[List[str]]:
+        """Split --compare-agent into a list of agent names."""
+        if not args.compare_agent:
+            return None
+        return [
+            name.strip()
+            for name in args.compare_agent.split(",")
+        ]
+
+    @staticmethod
+    def main() -> None:
+        """Entry point for the load test script."""
+        args = LoadTestArguments.parse_args(__doc__)
+        if args.rebuild:
+            ResultsRebuilder(
+                args.rebuild,
+                force=args.rebuild_all,
+            ).run()
+            return
+        if args.trend:
+            TrendHistory(
+                args.trend,
+                agent_filter=LoadTestOrchestrator._agent_filter(args),
+            ).run()
+            return
+        if args.compare:
+            agent_filter = LoadTestOrchestrator._agent_filter(args)
+            run_filter = None
+            if args.compare_runs:
+                run_filter = [
+                    r.strip()
+                    for r in args.compare_runs.split(",")
+                ]
+            CrossRunComparison(
+                args.compare,
+                agent_filter=agent_filter,
+                baseline_requests=args.compare_baseline,
+                run_filter=run_filter,
+            ).run()
+            return
+        orchestrator = LoadTestOrchestrator(args)
+        exit_code = orchestrator.run()
+        if orchestrator.was_interrupted():
+            # After Ctrl-C some worker threads (e.g. un-killable
+            # in-thread HTTP requests) may still be blocked.  Results
+            # are already printed and saved, so exit hard rather than
+            # hang joining those threads at interpreter shutdown.
+            sys.stdout.flush()
+            sys.stderr.flush()
+            os._exit(exit_code)  # pylint: disable=protected-access
+        sys.exit(exit_code)
+
+
+if __name__ == "__main__":
+    LoadTestOrchestrator.main()

--- a/tests/load_tests/load_test_mock_llm_service.py
+++ b/tests/load_tests/load_test_mock_llm_service.py
@@ -1,4 +1,20 @@
 #!/usr/bin/env python
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
 """
 Load-test script for neuro-san server using the mock LLM service.
 
@@ -48,16 +64,19 @@ import subprocess
 import sys
 import time
 from concurrent.futures import ThreadPoolExecutor
-from typing import Any
-from typing import Dict
 from typing import List
-from typing import Optional
 from typing import Tuple
 
 import psutil
 
+from tests.load_tests.monitoring.resource_monitor import ResourceMonitor
+
 logging.basicConfig(level=logging.INFO, format="%(message)s")
 logger = logging.getLogger(__name__)
+
+
+MOCK_REQUEST_TIMEOUT = 120
+PROCESS_WAIT_TIMEOUT = 10
 
 
 class MockLlmLoadTest:  # pylint: disable=too-many-instance-attributes
@@ -183,46 +202,6 @@ class MockLlmLoadTest:  # pylint: disable=too-many-instance-attributes
         )
         return parser.parse_args()
 
-    @staticmethod
-    def _find_process(keyword):
-        """Find a running process whose command line contains the given keyword."""
-        for proc in psutil.process_iter(["pid", "cmdline"]):
-            try:
-                cmdline = " ".join(proc.info.get("cmdline") or [])
-                if keyword in cmdline:
-                    return psutil.Process(proc.info.get("pid"))
-            except (psutil.NoSuchProcess, psutil.AccessDenied):
-                continue
-        return None
-
-    @staticmethod
-    def _snapshot(proc) -> Optional[Dict[str, Any]]:
-        """Capture a point-in-time resource snapshot of a process."""
-        try:
-            mem = proc.memory_info()
-            return {
-                "rss": mem.rss / 1024 / 1024,
-                "fds": proc.num_fds(),
-                "threads": proc.num_threads(),
-                "connections": len(proc.net_connections()),
-                "children": len(proc.children()),
-                "cpu": proc.cpu_percent(interval=0.1),
-            }
-        except (psutil.NoSuchProcess, psutil.AccessDenied):
-            return None
-
-    @staticmethod
-    def _log_snapshot(label, snap):
-        """Log a single resource snapshot."""
-        if snap is None:
-            logger.info("  %s: process not found", label)
-            return
-        logger.info(
-            "  %s: RSS=%.1f MB, FDs=%s, Threads=%s, Conns=%s, CPU=%.1f%%, Children=%s",
-            label, snap.get("rss"), snap.get("fds"), snap.get("threads"),
-            snap.get("connections"), snap.get("cpu"), snap.get("children"),
-        )
-
     def _build_cli_command(self):
         """
         Build the agent_cli subprocess command list from instance arguments.
@@ -250,7 +229,7 @@ class MockLlmLoadTest:  # pylint: disable=too-many-instance-attributes
             cmd,
             capture_output=True,
             text=True,
-            timeout=120,
+            timeout=MOCK_REQUEST_TIMEOUT,
             check=False,
         )
         elapsed = time.time() - start
@@ -330,8 +309,8 @@ class MockLlmLoadTest:  # pylint: disable=too-many-instance-attributes
             for i, arg in enumerate(cmdline):
                 if arg == "--port" and i + 1 < len(cmdline):
                     return cmdline[i + 1]
-        except (psutil.NoSuchProcess, psutil.AccessDenied):
-            pass
+        except (psutil.NoSuchProcess, psutil.AccessDenied) as exc:
+            logger.debug("Could not read mock process cmdline: %s", exc)
         return "8888"
 
     @staticmethod
@@ -346,7 +325,7 @@ class MockLlmLoadTest:  # pylint: disable=too-many-instance-attributes
         try:
             server_env = server_proc.environ()
         except (psutil.NoSuchProcess, psutil.AccessDenied) as exc:
-            logger.warning("Could not read server environment: %s", exc)
+            logger.info("Could not read server environment: %s", exc)
             return None
 
         api_base = server_env.get("OPENAI_API_BASE")
@@ -381,8 +360,8 @@ class MockLlmLoadTest:  # pylint: disable=too-many-instance-attributes
         Exits with an error if either is not found.
         Also validates the server's OPENAI_API_BASE matches the mock port.
         """
-        self.server_proc = self._find_process("server_main_loop")
-        self.mock_proc = self._find_process("mock_llm_server")
+        self.server_proc = ResourceMonitor.find_process("server_main_loop")
+        self.mock_proc = ResourceMonitor.find_process("mock_llm_server")
 
         if self.server_proc is None:
             logger.error(
@@ -471,14 +450,14 @@ class MockLlmLoadTest:  # pylint: disable=too-many-instance-attributes
                 self._auto_server_popen.pid,
             )
             self._auto_server_popen.terminate()
-            self._auto_server_popen.wait(timeout=10)
+            self._auto_server_popen.wait(timeout=PROCESS_WAIT_TIMEOUT)
         if self._auto_mock_popen is not None:
             logger.info(
                 "Stopping mock LLM server (PID %s)...",
                 self._auto_mock_popen.pid,
             )
             self._auto_mock_popen.terminate()
-            self._auto_mock_popen.wait(timeout=10)
+            self._auto_mock_popen.wait(timeout=PROCESS_WAIT_TIMEOUT)
         if self._server_log_fh is not None:
             self._server_log_fh.close()
         if self._mock_log_fh is not None:
@@ -522,27 +501,29 @@ class MockLlmLoadTest:  # pylint: disable=too-many-instance-attributes
             )
             logger.info("=" * 60)
 
-            before_server = self._snapshot(self.server_proc) if self.server_proc else None
-            before_mock = self._snapshot(self.mock_proc) if self.mock_proc else None
+            before_server = ResourceMonitor.snapshot(self.server_proc)
+            before_mock = ResourceMonitor.snapshot(self.mock_proc)
             if before_server:
-                self._log_snapshot("Server BEFORE", before_server)
+                ResourceMonitor.log_snapshot("Server BEFORE", before_server)
 
             logger.info(
                 "\nFiring %s concurrent requests with %s workers...",
                 self.args.num_requests, self.args.max_workers,
             )
             passed, failed, elapsed = self._run_round()
-            totals["passed"] = totals.get("passed", 0) + passed
-            totals["failed"] = totals.get("failed", 0) + failed
-            totals["time"] = totals.get("time", 0.0) + elapsed
+            totals.update({
+                "passed": totals.get("passed", 0) + passed,
+                "failed": totals.get("failed", 0) + failed,
+                "time": totals.get("time", 0.0) + elapsed,
+            })
 
             logger.info("\nWaiting %ss for server cleanup...", self.args.settle_time)
             time.sleep(self.args.settle_time)
 
-            after_server = self._snapshot(self.server_proc) if self.server_proc else None
-            after_mock = self._snapshot(self.mock_proc) if self.mock_proc else None
+            after_server = ResourceMonitor.snapshot(self.server_proc)
+            after_mock = ResourceMonitor.snapshot(self.mock_proc)
             if after_server:
-                self._log_snapshot("Server SETTLED", after_server)
+                ResourceMonitor.log_snapshot("Server AFTER", after_server)
 
             if before_server and after_server:
                 server_rows.append(

--- a/tests/load_tests/monitoring/__init__.py
+++ b/tests/load_tests/monitoring/__init__.py
@@ -1,0 +1,15 @@
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT

--- a/tests/load_tests/monitoring/heartbeat.py
+++ b/tests/load_tests/monitoring/heartbeat.py
@@ -1,0 +1,485 @@
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+"""Progress heartbeat — periodic logging while requests are in-flight.
+
+Interim implementation. May be replaced by neuro-san built-in
+monitoring and telemetry when those features become available.
+"""
+
+import concurrent.futures
+import logging
+import os
+import re
+import sys
+import threading
+import time
+from typing import List
+from typing import Optional
+
+import psutil
+
+from tests.load_tests.config import Formatters
+from tests.load_tests.config import HEARTBEAT_INTERVAL_SECONDS
+from tests.load_tests.config import SharedRef
+from tests.load_tests.reporting.system_resources import SystemResources
+
+logger = logging.getLogger(__name__)
+
+CONSOLE_TICK_INTERVAL = 1
+OOM_WARNING_THRESHOLD = 0.80
+
+
+class Heartbeat:  # pylint: disable=too-many-instance-attributes
+    """Logs periodic progress while requests are in-flight.
+
+    Holds the server process handle so the heartbeat thread can
+    read thread counts without the caller passing it each time.
+    """
+
+    # pylint: disable=too-many-arguments,too-many-positional-arguments
+    def __init__(
+            self, server_proc: Optional[psutil.Process],
+            client_proc: Optional[psutil.Process] = None,
+            output_dir: Optional[str] = None,
+            log_monitor=None,
+            log_start_pos=None,
+            primary_start_pattern: Optional[str] = None,
+    ) -> None:
+        self._server_proc = server_proc
+        self._client_proc = client_proc
+        self._output_dir = output_dir
+        self._total_system_ram = psutil.virtual_memory().total
+        self._oom_warned = False
+        self._swap_warned = False
+        self._peak_sys_cpu = 0.0
+        self._console_started = False
+        # Prime the non-blocking system CPU counter so the first real
+        # sample reflects usage since the heartbeat started rather
+        # than returning 0.0.
+        psutil.cpu_percent(interval=None)
+        # Optional server-log source for per-request server-side
+        # timing.  When set, the heartbeat parses primary
+        # streaming_chat Start/Finish pairs to report cumulative
+        # server-side min/avg/max durations.
+        self._log_monitor = log_monitor
+        self._log_start_pos = log_start_pos
+        self._primary_start_re = (
+            re.compile(primary_start_pattern)
+            if primary_start_pattern else None
+        )
+
+    def _sample_client_rss(self, peak_rss, peak_ref) -> float:
+        """Sample client RSS and update peak if higher.
+
+        Returns the current peak value.
+        """
+        if self._client_proc is None:
+            return peak_rss
+        try:
+            rss = (
+                self._client_proc.memory_info().rss / (1024 * 1024)
+            )
+            if rss > peak_rss:
+                peak_rss = rss
+                peak_ref.value = rss
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            pass
+        return peak_rss
+
+    def _sample_server_memory(self):
+        """Sample server RSS and swap in MB.
+
+        Returns (rss_mb, swap_mb) or (None, None) if unavailable.
+        """
+        if self._server_proc is None:
+            return None, None
+        try:
+            info = self._server_proc.memory_full_info()
+            rss_mb = info.rss / (1024 * 1024)
+            swap_mb = info.swap / (1024 * 1024)
+            return rss_mb, swap_mb
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            return None, None
+
+    def _check_server_alive(self) -> bool:
+        """Return True if the server process is still running."""
+        if self._server_proc is None:
+            return True
+        try:
+            return self._server_proc.is_running()
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            return False
+
+    def _check_memory_warnings(
+            self, swap_mb, progress_file,
+    ) -> None:
+        """Warn if system memory or swap exceeds thresholds."""
+        self._check_system_memory_warning(progress_file)
+        if not self._swap_warned and swap_mb > 0:
+            self._swap_warned = True
+            warning = (
+                f"  WARNING: Server has"
+                f" {Formatters.format_rss(swap_mb)} swapped to disk"
+                " — severe performance impact"
+            )
+            logger.warning("%s", warning)
+            self._write_to_file(progress_file, warning)
+
+    def _check_system_memory_warning(
+            self, progress_file,
+    ) -> None:
+        """Warn when total system memory usage exceeds threshold."""
+        if self._oom_warned:
+            return
+        mem = psutil.virtual_memory()
+        used_pct = mem.percent / 100.0
+        if used_pct >= OOM_WARNING_THRESHOLD:
+            self._oom_warned = True
+            total_gb = mem.total / (1024 ** 3)
+            avail_gb = mem.available / (1024 ** 3)
+            warning = (
+                f"  WARNING: System memory at"
+                f" {mem.percent:.0f}%"
+                f" ({avail_gb:.1f}G free"
+                f" / {total_gb:.1f}G total)"
+                " — risk of OOM kill"
+            )
+            logger.warning("%s", warning)
+            self._write_to_file(progress_file, warning)
+            swap = psutil.swap_memory()
+            if swap.total > 0 and swap.used > 0:
+                swap_gb = swap.used / (1024 ** 3)
+                swap_warning = (
+                    f"  WARNING: System swap in use:"
+                    f" {swap_gb:.1f}G"
+                    " — severe performance impact"
+                )
+                logger.warning("%s", swap_warning)
+                self._write_to_file(
+                    progress_file, swap_warning,
+                )
+
+    # pylint: disable=too-many-locals,too-many-arguments
+    # pylint: disable=too-many-statements
+    def progress_heartbeat(self, futures, total, start_time,
+                           stop_event, *,
+                           ready_event: threading.Event,
+                           fires_done_event: threading.Event,
+                           peak_threads_ref: SharedRef,
+                           peak_client_rss_ref: SharedRef,
+                           peak_server_rss_ref: SharedRef,
+                           peak_sys_mem_pct_ref: SharedRef,
+                           peak_sys_cpu_ref: SharedRef,
+                           peak_sys_threads_ref: SharedRef,
+                           failed_ref: SharedRef,
+                           server_dead_event: threading.Event,
+                           ) -> None:
+        """Log periodic progress while requests are in-flight.
+
+        Signals ready_event after the initial RSS sample so the
+        caller can wait for the heartbeat to be ready before
+        firing requests.  Waits for fires_done_event before
+        printing progress so ticks do not overlap receipt dots.
+        """
+        last_done = 0
+        last_change = start_time
+        peak_threads = 0
+        peak_server_rss = 0.0
+        peak_sys_mem_pct = 0.0
+        peak_sys_threads = 0
+        tick_count = 0
+        peak_rss = self._sample_client_rss(0.0, peak_client_rss_ref)
+        ready_event.set()
+        fires_done_event.wait()
+        progress_file = self._open_progress_file()
+        try:
+            while True:
+                stopped = stop_event.wait(
+                    timeout=HEARTBEAT_INTERVAL_SECONDS,
+                )
+                if not stopped and not self._check_server_alive():
+                    logger.error(
+                        "\n  ABORT: Server process is no longer"
+                        " running. Possible OOM kill.",
+                    )
+                    server_dead_event.set()
+                    break
+                peak_rss = self._sample_client_rss(
+                    peak_rss, peak_client_rss_ref,
+                )
+                done = sum(1 for f in futures if f.done())
+                elapsed = int(time.time() - start_time)
+                ts = time.strftime("%H:%M:%S", time.localtime())
+                pct = done * 100 // total if total > 0 else 0
+                suffix = ""
+                in_flight = total - done
+                if done == last_done and done < total:
+                    stall = int(time.time() - last_change)
+                    suffix = (
+                        f"  !! {in_flight} request(s) stalled for "
+                        f"{Heartbeat._fmt_elapsed(stall)}"
+                    )
+                if done > last_done:
+                    last_change = time.time()
+                    last_done = done
+                thread_info, server_rss_info = (
+                    self._sample_server_metrics(
+                        peak_threads, peak_threads_ref,
+                        peak_server_rss, peak_server_rss_ref,
+                        progress_file,
+                    )
+                )
+                peak_threads = peak_threads_ref.value or 0
+                if peak_server_rss_ref.value is not None:
+                    peak_server_rss = peak_server_rss_ref.value
+                tick_count += 1
+                failed = failed_ref.value or 0
+                fail_info = ""
+                if failed > 0:
+                    fail_pct = failed * 100 // done if done else 0
+                    fail_info = (
+                        f", {failed} failed {fail_pct}%"
+                    )
+                sys_mem_info, cur_pct, cur_avail = (
+                    self._format_system_memory()
+                )
+                if cur_pct > peak_sys_mem_pct:
+                    peak_sys_mem_pct = cur_pct
+                    peak_sys_mem_pct_ref.value = {
+                        "pct": cur_pct,
+                        "avail_gb": cur_avail,
+                    }
+                dur_info = (
+                    "  dur/client: "
+                    + Heartbeat.format_dur_stats(
+                        Heartbeat._client_durations(futures),
+                    )
+                )
+                server_durs = self._server_durations()
+                if server_durs is not None:
+                    dur_info += (
+                        "  dur/server: "
+                        + Heartbeat.format_dur_stats(server_durs)
+                    )
+                sys_cpu_info = self._format_system_cpu()
+                peak_sys_cpu_ref.value = self._peak_sys_cpu
+                cur_sys_threads = SystemResources.total_threads()
+                if cur_sys_threads > peak_sys_threads:
+                    peak_sys_threads = cur_sys_threads
+                    peak_sys_threads_ref.value = cur_sys_threads
+                line = (
+                    f"  [progress] {done} of {total} completed"
+                    f" ({pct}%{fail_info}) --"
+                    f" {Heartbeat._fmt_elapsed(elapsed)}"
+                    f" elapsed [{ts}]{suffix}  {dur_info.strip()}"
+                    f"{thread_info}"
+                    f"{server_rss_info}{sys_mem_info}{sys_cpu_info}"
+                )
+                self._write_to_file(progress_file, line)
+                self._write_to_console(
+                    tick_count, line, force=stopped,
+                )
+                if stopped:
+                    break
+        finally:
+            if progress_file is not None:
+                progress_file.close()
+
+    @staticmethod
+    def _format_system_memory():
+        """Format total system memory usage for the progress line.
+
+        Returns (formatted_string, current_percent,
+        available_gb).
+        """
+        mem = psutil.virtual_memory()
+        used_mb = (mem.total - mem.available) / (1024 ** 2)
+        avail_gb = mem.available / (1024 ** 3)
+        return (
+            f"  sysmem: {mem.percent:.0f}%"
+            f" ({used_mb:.0f}M used / {avail_gb:.1f}G free)",
+            mem.percent,
+            avail_gb,
+        )
+
+    def _format_system_cpu(self) -> str:
+        """Format whole-box CPU utilization with peak-so-far.
+
+        Uses non-blocking ``cpu_percent`` (usage since the previous
+        sample) and tracks the peak across the run.  0-100% across
+        all cores.
+        """
+        cur = psutil.cpu_percent(interval=None)
+        self._peak_sys_cpu = max(self._peak_sys_cpu, cur)
+        return f"  syscpu: {cur:.0f}% (peak {self._peak_sys_cpu:.0f}%)"
+
+    @staticmethod
+    def _fmt_elapsed(seconds) -> str:
+        """Format seconds with minutes when >= 60."""
+        if seconds >= 60:
+            return f"{seconds}s ({seconds // 60}m)"
+        return f"{seconds}s"
+
+    @staticmethod
+    def format_dur_stats(durations: List[float]) -> str:
+        """Format cumulative min/avg/max over durations (seconds).
+
+        Returns "n/a" when there are no durations yet.
+        """
+        if not durations:
+            return "n/a"
+        lo = int(min(durations))
+        hi = int(max(durations))
+        avg = int(sum(durations) / len(durations))
+        return (
+            f"{Heartbeat._fmt_elapsed(lo)} min /"
+            f" {Heartbeat._fmt_elapsed(avg)} avg /"
+            f" {Heartbeat._fmt_elapsed(hi)} max"
+        )
+
+    @staticmethod
+    def _client_durations(futures) -> List[float]:
+        """Collect per-request wall-time for completed futures.
+
+        Reads only already-done futures (non-blocking) and skips
+        cancelled ones or ones that raised, so a failed request
+        can never break the heartbeat line.
+        """
+        durations: List[float] = []
+        for fut in futures:
+            if not fut.done() or fut.cancelled():
+                continue
+            try:
+                if fut.exception() is not None:
+                    continue
+                result = fut.result()
+            except (
+                concurrent.futures.CancelledError,
+                concurrent.futures.TimeoutError,
+            ):
+                continue
+            dur = result.get("elapsed", result.get("duration"))
+            if isinstance(dur, (int, float)) and dur > 0:
+                durations.append(float(dur))
+        return durations
+
+    def _server_durations(self) -> Optional[List[float]]:
+        """Collect cumulative server-side per-request durations.
+
+        Parses primary streaming_chat Start/Finish pairs from the
+        server log since the stage start position.  Returns None
+        when no server log is available (so the caller can render
+        ``n/a`` and distinguish "no data source" from "no requests
+        yet").
+        """
+        if self._log_monitor is None or self._log_start_pos is None:
+            return None
+        try:
+            pairs = self._log_monitor.parse_streaming_chat_timing_since(
+                self._log_start_pos,
+            )
+        except (OSError, ValueError):
+            return []
+        durations: List[float] = []
+        for pair in pairs:
+            if self._primary_start_re is not None:
+                agent = pair.get("agent", "")
+                start_line = f"Start {agent}/streaming_chat"
+                if not self._primary_start_re.search(start_line):
+                    continue
+            dur = pair.get("duration")
+            if isinstance(dur, (int, float)) and dur > 0:
+                durations.append(float(dur))
+        return durations
+
+    # pylint: disable=too-many-positional-arguments
+    def _sample_server_metrics(
+            self, peak_threads, peak_threads_ref,
+            peak_server_rss, peak_server_rss_ref,
+            progress_file,
+    ):
+        """Sample server thread count and RSS.
+
+        Returns (thread_info, server_rss_info) strings.
+        """
+        thread_info = ""
+        server_rss_info = ""
+        if self._server_proc is None:
+            return thread_info, server_rss_info
+        try:
+            threads = self._server_proc.num_threads()
+            if threads > peak_threads:
+                peak_threads_ref.value = threads
+                thread_info = (
+                    f"  threads: {threads} (peak)"
+                )
+            else:
+                thread_info = f"  threads: {threads}"
+        except (
+            psutil.NoSuchProcess, psutil.AccessDenied,
+        ) as exc:
+            logger.debug(
+                "Heartbeat thread count unavailable: %s",
+                exc,
+            )
+        rss_mb, swap_mb = self._sample_server_memory()
+        if rss_mb is not None:
+            swap_info = ""
+            if swap_mb > 0:
+                swap_info = f" swap: {Formatters.format_rss(swap_mb)}"
+            server_rss_info = (
+                f"  RSS: {Formatters.format_rss(rss_mb)}{swap_info}"
+            )
+            if rss_mb > peak_server_rss:
+                peak_server_rss_ref.value = rss_mb
+            self._check_memory_warnings(
+                swap_mb, progress_file,
+            )
+        return thread_info, server_rss_info
+
+    def _open_progress_file(self):
+        """Open progress.log for writing if output_dir is set."""
+        if not self._output_dir:
+            return None
+        path = os.path.join(self._output_dir, "progress.log")
+        # pylint: disable=consider-using-with
+        return open(path, "w", encoding="utf-8")
+
+    @staticmethod
+    def _write_to_file(progress_file, line) -> None:
+        """Write a progress line to the file."""
+        if progress_file is None:
+            return
+        progress_file.write(line + "\n")
+        progress_file.flush()
+
+    def _write_to_console(self, tick_count, line, force=False) -> None:
+        """Write progress to console.
+
+        Prints the full line on tick 1, then every
+        ``CONSOLE_TICK_INTERVAL`` ticks (currently every tick), and
+        always when ``force`` is set (e.g. the final line once all
+        requests are done).  A single blank separator is emitted only
+        before the first console line so the heartbeats are
+        single-spaced thereafter.
+        """
+        if (force or tick_count == 1
+                or tick_count % CONSOLE_TICK_INTERVAL == 0):
+            if not self._console_started:
+                sys.stdout.write("\n")
+                self._console_started = True
+            logger.info("%s", line)

--- a/tests/load_tests/monitoring/resource_monitor.py
+++ b/tests/load_tests/monitoring/resource_monitor.py
@@ -1,0 +1,94 @@
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+"""Resource monitoring — psutil-based process snapshots.
+
+Interim implementation. May be replaced by neuro-san built-in
+monitoring and telemetry when those features become available.
+"""
+
+import logging
+from typing import Optional
+
+import psutil
+
+from tests.load_tests.config import ResourceSnapshot
+
+logger = logging.getLogger(__name__)
+
+
+class ResourceMonitor:
+    """Captures and logs psutil-based process resource snapshots."""
+
+    @staticmethod
+    def find_process(keyword) -> Optional[psutil.Process]:
+        """Find a running process whose command line contains the given keyword."""
+        for proc in psutil.process_iter(["pid", "cmdline"]):
+            try:
+                cmdline = " ".join(proc.info.get("cmdline") or [])
+                if keyword in cmdline:
+                    return psutil.Process(proc.info.get("pid"))
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                continue
+        return None
+
+    @staticmethod
+    def find_process_by_port(port) -> Optional[psutil.Process]:
+        """Find a process listening on the given port."""
+        for proc in psutil.process_iter(["pid"]):
+            try:
+                for conn in proc.net_connections():
+                    if conn.status == "LISTEN" and conn.laddr.port == port:
+                        return psutil.Process(proc.info.get("pid"))
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                continue
+        return None
+
+    @staticmethod
+    def snapshot(proc) -> Optional[ResourceSnapshot]:
+        """Capture a point-in-time resource snapshot of a process."""
+        if proc is None:
+            return None
+        try:
+            mem = proc.memory_info()
+            try:
+                fds = proc.num_fds()
+            except AttributeError:
+                fds = proc.num_handles()
+            cpu_times = proc.cpu_times()
+            return {
+                "rss": mem.rss / 1024 / 1024,
+                "fds": fds,
+                "threads": proc.num_threads(),
+                "connections": len(proc.net_connections()),
+                "children": len(proc.children()),
+                "cpu": proc.cpu_percent(interval=0.1),
+                "cpu_seconds": cpu_times.user + cpu_times.system,
+            }
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            return None
+
+    @staticmethod
+    def log_snapshot(label, snap) -> None:
+        """Log a single resource snapshot."""
+        if snap is None:
+            logger.info("  %s: process not found", label)
+            return
+        logger.info(
+            "  %s: RSS=%.1f MB, FDs=%s, Threads=%s, Conns=%s, CPU=%.1f%%, Children=%s",
+            label, snap.get("rss"), snap.get("fds"), snap.get("threads"),
+            snap.get("connections"), snap.get("cpu"), snap.get("children"),
+        )

--- a/tests/load_tests/monitoring/server_log_monitor.py
+++ b/tests/load_tests/monitoring/server_log_monitor.py
@@ -1,0 +1,743 @@
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+"""Server log monitoring — retry counting, request tracking, and disconnection scanning.
+
+Interim implementation. May be replaced by neuro-san built-in
+monitoring and telemetry when those features become available.
+"""
+
+import json
+import logging
+import os
+import re
+import sys
+import threading
+import time
+
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Tuple
+
+import psutil
+
+from tests.load_tests.config import CLIENT_DISCONNECT_PATTERN
+from tests.load_tests.config import DONE_STREAMING_PATTERN
+from tests.load_tests.config import NETWORK_LOOKAHEAD_LINES
+from tests.load_tests.config import NetworkTokenEntry
+from tests.load_tests.config import PROVIDER_RETRY_PATTERN
+from tests.load_tests.config import REQUEST_FINISH_PATTERN
+from tests.load_tests.config import REQUEST_START_PATTERN
+from tests.load_tests.config import RETRY_LOG_PATTERN
+from tests.load_tests.config import SERVER_ERROR_PATTERN
+from tests.load_tests.config import STREAM_CLOSED_REQUEST_PATTERN
+from tests.load_tests.config import SharedRef
+from tests.load_tests.config import TASK_CANCELLED_PATTERN
+from tests.load_tests.config import TokenEntry
+from tests.load_tests.config import VALIDATION_ATTEMPT_PATTERN
+from tests.load_tests.config import VALIDATION_ERROR_PATTERN
+from tests.load_tests.config import ValidationEvent
+from tests.load_tests.config import VALIDATION_REINVOKE_PATTERN
+from tests.load_tests.config import VALIDATION_REQUEST_ID_PATTERN
+from tests.load_tests.monitoring.resource_monitor import ResourceMonitor
+
+logger = logging.getLogger(__name__)
+
+# Console progress ticks for arrivals: single-line dots written via
+# logging (not print()).  An empty terminator keeps the dots on one
+# line, and propagate=False stops the root logger from prefixing each
+# dot with a timestamp or duplicating it.
+_progress_logger = logging.getLogger(__name__ + ".progress")
+_progress_logger.propagate = False
+if not _progress_logger.handlers:
+    _progress_handler = logging.StreamHandler(sys.stdout)
+    _progress_handler.terminator = ""
+    _progress_handler.setFormatter(logging.Formatter("%(message)s"))
+    _progress_logger.addHandler(_progress_handler)
+    _progress_logger.setLevel(logging.INFO)
+
+
+class _NullFile:
+    """No-op context manager used when no receipt file is needed."""
+
+    def __enter__(self):
+        return None
+
+    def __exit__(self, *args):
+        pass
+
+
+class ServerLogMonitor:
+    """Parses a neuro-san server log for retries, tokens, and disconnections.
+
+    Holds the server log path so that callers do not need to pass it
+    to every method.
+    """
+
+    def __init__(self, server_log: Optional[str]) -> None:
+        self._server_log = server_log
+
+    def read_position(self) -> Optional[int]:
+        """Return the current end position of the server log file."""
+        if self._server_log is None:
+            return None
+        try:
+            with open(self._server_log, "r", encoding="utf-8") as log_fh:
+                log_fh.seek(0, 2)
+                return log_fh.tell()
+        except OSError:
+            return None
+
+    def _read_lines_since(self, position, label) -> List[str]:
+        """Read all lines from server_log starting at the given position.
+
+        Returns an empty list on read failure.  The label is used in
+        the log message when an OSError occurs.
+        """
+        try:
+            with open(self._server_log, "r", encoding="utf-8") as log_fh:
+                log_fh.seek(position)
+                return log_fh.readlines()
+        except OSError as exc:
+            logger.info(
+                "Could not read server log for %s: %s", label, exc,
+            )
+            return []
+
+    def count_retries_since(self, position) -> Dict[str, int]:
+        """Count retry log entries since the given position.
+
+        Covers both neuro-san's own max_attempts retries ("retrying
+        from <ErrorType>") and retries the LLM provider SDK performs
+        internally ("Retrying request to ... in ... seconds"), counted
+        under the "ProviderRetry" key.  The latter are invisible to
+        neuro-san but are still extra LLM attempts, so they belong in
+        the amplification factor.
+
+        Returns a dict of error_type -> count for each tracked type.
+        """
+        if self._server_log is None or position is None:
+            return {}
+        lines = self._read_lines_since(position, "retries")
+        retry_counts: Dict[str, int] = {}
+        for line in lines:
+            match = RETRY_LOG_PATTERN.search(line)
+            if match:
+                error_type = match.group(2)
+                retry_counts[error_type] = (
+                    retry_counts.get(error_type, 0) + 1
+                )
+            elif PROVIDER_RETRY_PATTERN.search(line):
+                retry_counts["ProviderRetry"] = (
+                    retry_counts.get("ProviderRetry", 0) + 1
+                )
+        return retry_counts
+
+    def scan_server_errors_since(self, position) -> List[Dict[str, str]]:
+        """Scan for server "Errors detected:" events since position.
+
+        These are logged as JSON with a "message" value that starts
+        with "Errors detected:" and spans literal newlines, so the log
+        window is joined and matched with a DOTALL pattern.  Returns a
+        list of {request_id, message} dicts with the message flattened
+        to a single line.
+        """
+        if self._server_log is None or position is None:
+            return []
+        lines = self._read_lines_since(position, "errors")
+        if not lines:
+            return []
+        text = "".join(lines)
+        errors: List[Dict[str, str]] = []
+        for match in SERVER_ERROR_PATTERN.finditer(text):
+            message = " ".join(match.group(1).split())
+            errors.append({
+                "request_id": match.group(2),
+                "message": message,
+            })
+        return errors
+
+    def scan_tool_warnings_since(self, position) -> List[Dict[str, str]]:
+        """Scan for "Failed to create Agent/tool" warnings since position.
+
+        These are logged as one-line JSON with message_type "Warning"
+        and mean a requested tool (e.g. web_search) was unavailable to
+        an agent.  They do not affect the created network, but a high
+        count under load may point to tool-creation failures.  Returns
+        a list of {request_id, message} dicts.
+        """
+        if self._server_log is None or position is None:
+            return []
+        lines = self._read_lines_since(position, "tool warnings")
+        warnings: List[Dict[str, str]] = []
+        for line in lines:
+            stripped = line.strip()
+            if "Failed to create Agent/tool" not in stripped:
+                continue
+            try:
+                entry = json.loads(stripped)
+            except (json.JSONDecodeError, ValueError):
+                continue
+            if not isinstance(entry, dict):
+                continue
+            message = entry.get("message", "")
+            if not message.startswith("Failed to create Agent/tool"):
+                continue
+            warnings.append({
+                "request_id": entry.get("request_id", "unknown"),
+                "message": " ".join(message.split()),
+            })
+        return warnings
+
+    def count_requests_since(self, position,
+                             primary_start_pattern,
+                             primary_finish_pattern
+                             ) -> Dict[str, Optional[int]]:
+        """Count request Start/Finish entries since the given position.
+
+        Uses agent-specific patterns for primary requests.
+        """
+        none_result = {
+            "primary_started": None, "primary_finished": None,
+            "total_started": None, "total_finished": None,
+        }
+        if self._server_log is None or position is None:
+            return none_result
+        lines = self._read_lines_since(position, "counts")
+        if not lines:
+            return none_result
+        primary_started = 0
+        primary_finished = 0
+        total_started = 0
+        total_finished = 0
+        pri_start_re = re.compile(primary_start_pattern)
+        pri_finish_re = re.compile(primary_finish_pattern)
+        for line in lines:
+            if REQUEST_START_PATTERN.search(line):
+                total_started += 1
+            if REQUEST_FINISH_PATTERN.search(line):
+                total_finished += 1
+            if pri_start_re.search(line):
+                primary_started += 1
+            if pri_finish_re.search(line):
+                primary_finished += 1
+        return {
+            "primary_started": primary_started,
+            "primary_finished": primary_finished,
+            "total_started": total_started,
+            "total_finished": total_finished,
+        }
+
+    def parse_token_accounting_since(
+            self, position,
+    ) -> Dict[str, TokenEntry]:
+        """Parse Request reporting entries for token accounting data.
+
+        Returns a dict of request_id -> token data, where each entry has:
+            total_tokens, prompt_tokens, completion_tokens,
+            successful_requests, model, reporting_agent
+        """
+        if self._server_log is None or position is None:
+            return {}
+        lines = self._read_lines_since(position, "tokens")
+        if not lines:
+            return {}
+        results: Dict[str, TokenEntry] = {}
+        for block in self._collect_reporting_blocks(lines):
+            entry = self._extract_token_entry(
+                block.get("text", ""),
+            )
+            if entry:
+                rid = entry.get("request_id")
+                if rid is not None:
+                    agent = self._find_network_after(
+                        lines, block.get("end_idx", 0),
+                    )
+                    if agent:
+                        entry["reporting_agent"] = agent
+                    results[rid] = entry
+        return results
+
+    @staticmethod
+    def _extract_token_entry(block: str) -> Optional[TokenEntry]:
+        """Extract token accounting fields from a Request reporting log block."""
+        rid_match = re.search(r'"request_id": "([^"]+)"', block)
+        if not rid_match:
+            return None
+        total = re.search(r'"total_tokens": (\d+)', block)
+        prompt = re.search(r'"prompt_tokens": (\d+)', block)
+        completion = re.search(r'"completion_tokens": (\d+)', block)
+        llm_calls = re.search(r'"successful_requests": (\d+)', block)
+        model_names = re.findall(
+            r'"(gpt[^"]+|claude[^"]+|gemini[^"]+|o\d[^"]*)"', block,
+        )
+        return {
+            "request_id": rid_match.group(1),
+            "total_tokens": int(total.group(1)) if total else 0,
+            "prompt_tokens": int(prompt.group(1)) if prompt else 0,
+            "completion_tokens": int(completion.group(1)) if completion else 0,
+            "llm_calls": int(llm_calls.group(1)) if llm_calls else 0,
+            "model": model_names[0] if model_names else "unknown",
+        }
+
+    def parse_per_network_tokens_since(
+            self, position,
+    ) -> List[NetworkTokenEntry]:
+        """Parse per-sub-network token data from Request reporting blocks.
+
+        For multi-agent networks (e.g. AND), each sub-network produces
+        its own Request reporting block followed by a
+        "Done with <network>.StreamingChat" log line.  This method
+        collects all such blocks and returns one entry per sub-network
+        per request.
+        """
+        if self._server_log is None or position is None:
+            return []
+        lines = self._read_lines_since(position, "network tokens")
+        if not lines:
+            return []
+        blocks = self._collect_reporting_blocks(lines)
+        return self._resolve_network_names(blocks, lines)
+
+    @staticmethod
+    def _collect_reporting_blocks(lines) -> List[Dict[str, object]]:
+        """Collect Request reporting blocks with their line positions."""
+        blocks = []
+        in_block = False
+        block_lines: List[str] = []
+        for idx, line in enumerate(lines):
+            if "Request reporting" in line and not in_block:
+                in_block = True
+                block_lines = [line]
+            elif in_block:
+                block_lines.append(line)
+                if '"request_id"' in line:
+                    blocks.append({
+                        "text": "".join(block_lines),
+                        "end_idx": idx,
+                    })
+                    in_block = False
+                    block_lines = []
+        return blocks
+
+    @staticmethod
+    def _resolve_network_names(blocks, lines) -> List[NetworkTokenEntry]:
+        """Match each block to its network via Done-with log lines."""
+        results: List[NetworkTokenEntry] = []
+        for block in blocks:
+            block_text = block.get("text", "")
+            entry = ServerLogMonitor._extract_token_entry(
+                block_text,
+            )
+            if not entry:
+                continue
+            network = ServerLogMonitor._find_network_after(
+                lines, block.get("end_idx", 0),
+            )
+            if not network:
+                continue
+            duration = re.search(
+                r'"time_taken_in_seconds": ([\d.]+)',
+                block_text,
+            )
+            total_cost = re.search(
+                r'"total_cost": ([\d.]+)',
+                block_text,
+            )
+            results.append({
+                "request_id": entry.get("request_id", ""),
+                "network": network,
+                "total_tokens": entry.get("total_tokens", 0),
+                "prompt_tokens": entry.get("prompt_tokens", 0),
+                "completion_tokens": entry.get(
+                    "completion_tokens", 0,
+                ),
+                "llm_calls": entry.get("llm_calls", 0),
+                "duration": (
+                    float(duration.group(1)) if duration else 0.0
+                ),
+                "model": entry.get("model", "unknown"),
+                "cost": (
+                    float(total_cost.group(1)) if total_cost else 0.0
+                ),
+            })
+        return results
+
+    @staticmethod
+    def _find_network_after(lines, end_idx,
+                            lookahead=NETWORK_LOOKAHEAD_LINES
+                            ) -> Optional[str]:
+        """Find the network name from Done-with lines after a block."""
+        limit = min(end_idx + lookahead, len(lines))
+        for idx in range(end_idx + 1, limit):
+            match = DONE_STREAMING_PATTERN.search(lines[idx])
+            if match:
+                return match.group(1)
+        return None
+
+    def parse_validation_events_since(
+            self, position,
+    ) -> List[ValidationEvent]:
+        """Parse validation attempts and fix cycles per request.
+
+        Scans for 'Validating toolbox agents' (attempt),
+        'Validation errors' (error detail), and
+        'Invoking agent network designer to fix' (fix cycle).
+        Groups by request_id.
+        """
+        if self._server_log is None or position is None:
+            return []
+        lines = self._read_lines_since(
+            position, "validation events",
+        )
+        if not lines:
+            return []
+        return self._collect_validation_events(lines)
+
+    @staticmethod
+    def _collect_validation_events(lines) -> List[ValidationEvent]:
+        """Group validation log lines by request_id."""
+        by_request: Dict[str, Dict[str, object]] = {}
+        for line in lines:
+            rid_match = VALIDATION_REQUEST_ID_PATTERN.search(line)
+            if not rid_match:
+                continue
+            rid = rid_match.group(1)
+            if rid not in by_request:
+                by_request[rid] = {
+                    "attempts": 0,
+                    "fix_cycles": 0,
+                    "errors": [],
+                }
+            entry = by_request[rid]
+            if VALIDATION_ATTEMPT_PATTERN.search(line):
+                entry["attempts"] += 1
+            if VALIDATION_REINVOKE_PATTERN.search(line):
+                entry["fix_cycles"] += 1
+            err_match = VALIDATION_ERROR_PATTERN.search(line)
+            if err_match:
+                raw = err_match.group(1)
+                for err in re.findall(r'"([^"]+)"', raw):
+                    entry["errors"].append(err)
+        results: List[ValidationEvent] = []
+        for rid, data in sorted(by_request.items()):
+            if data.get("fix_cycles", 0) > 0:
+                results.append({
+                    "request_id": rid,
+                    "attempts": data.get("attempts", 0),
+                    "fix_cycles": data.get("fix_cycles", 0),
+                    "errors": data.get("errors", []),
+                })
+        return results
+
+    def parse_streaming_chat_timing_since(
+            self, position,
+    ) -> List[Dict[str, object]]:
+        """Parse Start/Finish streaming_chat entries for timing.
+
+        Returns a list of dicts with agent, start_ts, finish_ts,
+        duration, and request_id for each streaming_chat pair.
+        """
+        if self._server_log is None or position is None:
+            return []
+        lines = self._read_lines_since(
+            position, "streaming_chat timing",
+        )
+        if not lines:
+            return []
+        return self._match_streaming_chat_pairs(lines)
+
+    @staticmethod
+    def _match_streaming_chat_pairs(
+            lines,
+    ) -> List[Dict[str, object]]:
+        """Match Start/Finish pairs from server log lines."""
+        from datetime import datetime  # pylint: disable=import-outside-toplevel
+
+        starts: Dict[Tuple[str, str], float] = {}
+        results: List[Dict[str, object]] = []
+        for line in lines:
+            try:
+                entry = json.loads(line.strip())
+            except (json.JSONDecodeError, ValueError):
+                continue
+            if not isinstance(entry, dict):
+                continue
+            msg = entry.get("message", "")
+            ts_str = entry.get("Timestamp", "")
+            req_id = entry.get("request_id", "")
+            if not msg or not ts_str:
+                continue
+            try:
+                ts = datetime.fromisoformat(
+                    ts_str,
+                ).timestamp()
+            except (ValueError, TypeError):
+                continue
+            if msg.startswith("Start ") and "/streaming_chat" in msg:
+                agent = msg.replace(
+                    "Start ", "",
+                ).replace("/streaming_chat", "")
+                starts[(agent, req_id)] = ts
+            elif msg.startswith("Finish ") and "/streaming_chat" in msg:
+                agent = msg.replace(
+                    "Finish ", "",
+                ).replace("/streaming_chat", "")
+                start_ts = starts.pop(
+                    (agent, req_id), None,
+                )
+                if start_ts is not None:
+                    results.append({
+                        "agent": agent,
+                        "start_ts": start_ts,
+                        "finish_ts": ts,
+                        "duration": ts - start_ts,
+                        "request_id": req_id,
+                    })
+        return results
+
+    def scan_disconnections_since(
+            self, position, primary_start_pattern=None,
+    ) -> List[Dict[str, str]]:
+        """Scan server log for client disconnections since the given position.
+
+        Returns a list of dicts with request_id, agent, and
+        client_request (the originating client request ordinal).
+        """
+        if self._server_log is None or position is None:
+            return []
+        lines = self._read_lines_since(position, "disconnections")
+        if not lines:
+            return []
+
+        pri_re = (
+            re.compile(primary_start_pattern)
+            if primary_start_pattern else None
+        )
+        primary_request_ids = []
+        disconnections = {}
+        context_request_id = None
+
+        for line in lines:
+            req_match = STREAM_CLOSED_REQUEST_PATTERN.search(line)
+            if req_match:
+                context_request_id = req_match.group(1)
+            if pri_re and pri_re.search(line) and context_request_id:
+                if context_request_id not in primary_request_ids:
+                    primary_request_ids.append(
+                        context_request_id,
+                    )
+            if CLIENT_DISCONNECT_PATTERN.search(line):
+                req_id = context_request_id or "unknown"
+                if req_id not in disconnections:
+                    disconnections[req_id] = {
+                        "request_id": req_id,
+                        "agent": "unknown",
+                    }
+            cancel_match = TASK_CANCELLED_PATTERN.search(line)
+            if cancel_match and context_request_id:
+                agent = cancel_match.group(1)
+                disc = disconnections.get(context_request_id)
+                if disc is not None:
+                    disc.update({"agent": agent})
+
+        self._map_to_client_requests(
+            disconnections, primary_request_ids,
+        )
+        return list(disconnections.values())
+
+    @staticmethod
+    def _map_to_client_requests(disconnections, primary_request_ids):
+        """Map each disconnected sub-request to its parent client request.
+
+        Uses sequential server request_id ordering: a sub-request
+        belongs to the nearest preceding primary request.
+        """
+        if not primary_request_ids:
+            return
+
+        def _extract_num(rid):
+            # Nested: tiny parse helper used only to order request_ids
+            # within this method; not needed elsewhere.
+            match = re.search(r"(\d+)$", rid)
+            return int(match.group(1)) if match else -1
+
+        primary_nums = [
+            _extract_num(rid) for rid in primary_request_ids
+        ]
+
+        for disc in disconnections.values():
+            rid = disc.get("request_id", "")
+            rid_num = _extract_num(rid)
+            parent_idx = None
+            for idx, pnum in enumerate(primary_nums):
+                if pnum <= rid_num:
+                    parent_idx = idx
+                else:
+                    break
+            if parent_idx is not None:
+                disc["client_request"] = (
+                    f"request-{parent_idx + 1}"
+                )
+
+    # pylint: disable=too-many-arguments
+    def start_log_monitor(self, position,
+                          expected_count, fire_time, *,
+                          client_proc, primary_start_pattern,
+                          output_dir=None,
+                          ) -> Tuple[
+        Optional[threading.Event],
+        Optional[threading.Thread],
+        Optional[SharedRef],
+    ]:
+        """Start a background thread to monitor server log for request arrivals.
+
+        Returns (stop_event, thread, peak_client_ref).
+        Returns (None, None, None) if monitoring is not available.
+        """
+        if self._server_log is None or position is None:
+            return None, None, None
+        stop_event = threading.Event()
+        peak_client_ref = SharedRef()
+        monitor = threading.Thread(
+            target=ServerLogMonitor._log_monitor_worker,
+            args=(self._server_log, position, expected_count,
+                  stop_event, fire_time),
+            kwargs={
+                "client_proc": client_proc,
+                "peak_client_ref": peak_client_ref,
+                "primary_start_pattern": primary_start_pattern,
+                "output_dir": output_dir,
+            },
+            daemon=True,
+        )
+        monitor.start()
+        return stop_event, monitor, peak_client_ref
+
+    # pylint: disable=too-many-arguments,too-many-locals
+    @staticmethod
+    def _log_monitor_worker(server_log, position,
+                            expected_count, stop_event,
+                            fire_time, *, client_proc,
+                            peak_client_ref,
+                            primary_start_pattern,
+                            output_dir=None) -> None:
+        """Background worker that tails server log and reports arrivals."""
+        pri_start_re = re.compile(primary_start_pattern)
+        agent_label = primary_start_pattern.split("/")[0].split(" ")[-1]
+        receipt_path = (
+            os.path.join(output_dir, "server_receipts.log")
+            if output_dir else None
+        )
+        try:
+            with ServerLogMonitor._open_receipt_log(
+                    receipt_path,
+            ) as receipt_fh:
+                with open(
+                        server_log, "r", encoding="utf-8",
+                ) as log_fh:
+                    log_fh.seek(position)
+                    ServerLogMonitor._tail_arrivals(
+                        log_fh, stop_event, pri_start_re,
+                        expected_count, fire_time,
+                        agent_label=agent_label,
+                        receipt_fh=receipt_fh,
+                        client_proc=client_proc,
+                        peak_client_ref=peak_client_ref,
+                    )
+        except OSError as exc:
+            logger.debug("Log monitor stopped: %s", exc)
+
+    @staticmethod
+    def _open_receipt_log(path):
+        """Open the receipt log file or return a no-op context."""
+        if path:
+            return open(path, "w", encoding="utf-8")
+        return _NullFile()
+
+    # pylint: disable=too-many-arguments
+    @staticmethod
+    def _tail_arrivals(
+            log_fh, stop_event, pri_start_re,
+            expected_count, fire_time, *,
+            agent_label, receipt_fh,
+            client_proc, peak_client_ref,
+    ) -> None:
+        """Tail log for arrivals, printing dots or full lines."""
+        count = 0
+        use_dots = receipt_fh is not None
+        while not stop_event.is_set() and count < expected_count:
+            line = log_fh.readline()
+            if not line:
+                stop_event.wait(0.5)
+                continue
+            if not pri_start_re.search(line):
+                continue
+            count += 1
+            now = time.time()
+            ts = time.strftime(
+                "%H:%M:%S", time.localtime(now),
+            )
+            delta = now - fire_time
+            detail = (
+                f"  [server] {agent_label} request"
+                f" {count}/{expected_count}"
+                f" received [{ts}] (+{delta:.1f}s)"
+            )
+            if use_dots:
+                receipt_fh.write(detail + "\n")
+                receipt_fh.flush()
+                _progress_logger.info(".")
+            else:
+                logger.info("%s", detail)
+            if count >= expected_count:
+                ServerLogMonitor._log_all_received(
+                    use_dots, count, expected_count,
+                    now - fire_time,
+                    client_proc=client_proc,
+                    peak_client_ref=peak_client_ref,
+                )
+
+    @staticmethod
+    def _log_all_received(
+            use_dots, count, expected_count,
+            elapsed, *, client_proc, peak_client_ref,
+    ) -> None:
+        """Log the final receipt summary and client snapshot."""
+        if use_dots:
+            _progress_logger.info("\n")
+            logger.info(
+                "  All %s/%s requests received by "
+                "server (%.1fs)",
+                count, expected_count, elapsed,
+            )
+        snap = ResourceMonitor.snapshot(client_proc)
+        if snap:
+            logger.info(
+                "  Client AFTER: RSS %.1fM, CPU %.1f%%",
+                snap.get("rss"), snap.get("cpu"),
+            )
+            peak_client_ref.value = snap
+        mem = psutil.virtual_memory()
+        used_mb = (mem.total - mem.available) / (1024 ** 2)
+        avail_gb = mem.available / (1024 ** 3)
+        total_gb = mem.total / (1024 ** 3)
+        logger.info(
+            "  System RECEIVED: %.0f%% used"
+            " (%.0fM used / %.1fG free / %.1fG total)",
+            mem.percent, used_mb, avail_gb, total_gb,
+        )

--- a/tests/load_tests/prompts/__init__.py
+++ b/tests/load_tests/prompts/__init__.py
@@ -1,0 +1,15 @@
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT

--- a/tests/load_tests/prompts/agent_profile.py
+++ b/tests/load_tests/prompts/agent_profile.py
@@ -1,0 +1,200 @@
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+"""Agent profile loader — reads agent-specific prompts and configuration."""
+
+import json
+import logging
+import os
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+class AgentProfile:
+    """Configuration profile for a specific agent under test."""
+
+    def __init__(self, agent_name, profile_data) -> None:
+        """Initialize the profile from a loaded profile dict."""
+        self.agent_name = agent_name
+        self._data = profile_data
+
+    @property
+    def prompts(self) -> List[str]:
+        """Return the list of prompts for this agent."""
+        return self._data.get("prompts", [])
+
+    @property
+    def estimated_tokens_per_request(self) -> Optional[int]:
+        """Return the estimated token usage per request, or None if unknown."""
+        return self._data.get("estimated_tokens_per_request")
+
+    @property
+    def primary_start_pattern(self) -> str:
+        """Return regex pattern to identify primary request starts in server log."""
+        default = f"Start {self.agent_name}/streaming_chat"
+        return self._data.get("primary_start_pattern", default)
+
+    @property
+    def primary_finish_pattern(self) -> str:
+        """Return regex pattern to identify primary request completions in server log."""
+        default = f"Finish {self.agent_name}/streaming_chat"
+        return self._data.get("primary_finish_pattern", default)
+
+    @property
+    def success_fields(self) -> List[str]:
+        """Return list of stdout fields that must be present for success.
+
+        For agent_network_designer: ["reservation_id", "agent_network_name"]
+        For generic agents: [] (just check exit code)
+        """
+        return self._data.get("success_fields", [])
+
+    @property
+    def failure_patterns(self) -> List[str]:
+        """Return substrings that indicate a failed response.
+
+        When any pattern is found in stdout, a request that would
+        otherwise be marked CREATED is downgraded to FAILED.  This
+        catches cases where the server returns an error message
+        inside a successful HTTP 200 response (e.g. missing API key).
+        """
+        return self._data.get("failure_patterns", [])
+
+    def get_prompt(self, request_id, same_prompt=False) -> str:
+        """Return the prompt for a given request.
+
+        In same_prompt mode, always returns the first prompt.
+        In varied mode, cycles through the pool and appends the request_id.
+        """
+        prompts = self.prompts
+        if not prompts:
+            logger.error(
+                "Agent profile '%s' has an empty prompts list.\n"
+                "  Add at least one prompt to the profile JSON.\n"
+                "  Aborting.",
+                self.agent_name,
+            )
+            raise SystemExit(1)
+        if same_prompt:
+            return prompts[0]
+        base_prompt = prompts[request_id % len(prompts)]
+        return f"{base_prompt} (request {request_id})"
+
+    @classmethod
+    def load(cls, agent_name, profile_path=None, project_root=None) -> "AgentProfile":
+        """Load an agent profile from a JSON file.
+
+        Search order:
+        1. --profile-path directory: look for {base}.json there
+        2. ./profiles/{agent_name}.json then ./profiles/{base}.json
+        3. {project_root}/tests/load_tests/prompts/profiles/{name}.json
+           where project_root comes from --project-root or PYTHONPATH
+        4. Not found → abort
+
+        When agent_name includes a prefix (e.g. basic/hello_world),
+        the base name (hello_world) is tried as a fallback so
+        --profile-path is not required for prefixed agents.
+        """
+        agent_base = agent_name.rsplit("/", 1)[-1]
+
+        if profile_path:
+            if os.path.isfile(profile_path):
+                logger.error(
+                    "--profile-path should be a directory, not a "
+                    "file.\n"
+                    "  Got: %s\n"
+                    "  Try: --profile-path %s",
+                    profile_path, os.path.dirname(profile_path),
+                )
+                raise SystemExit(1)
+            candidate = os.path.join(profile_path, f"{agent_base}.json")
+            if not os.path.isfile(candidate):
+                logger.error(
+                    "Profile not found: %s\n"
+                    "  --profile-path directory: %s\n"
+                    "  Expected file: %s.json\n"
+                    "  Aborting.",
+                    candidate, profile_path, agent_base,
+                )
+                raise SystemExit(1)
+            return cls._load_from_file(agent_name, candidate)
+
+        searched = []
+
+        # Search in the built-in profiles directory next to this module
+        profiles_dir = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)), "profiles",
+        )
+        for name in (agent_name, agent_base):
+            candidate = os.path.join(profiles_dir, f"{name}.json")
+            searched.append(candidate)
+            if os.path.isfile(candidate):
+                return cls._load_from_file(agent_name, candidate)
+
+        # Resolve project root: --project-root flag → PYTHONPATH fallback
+        resolved_root = cls._resolve_project_root(project_root)
+        if resolved_root:
+            for name in (agent_name, agent_base):
+                candidate = os.path.normpath(os.path.join(
+                    resolved_root, "tests", "load_tests",
+                    "prompts", "profiles", f"{name}.json",
+                ))
+                searched.append(candidate)
+                if os.path.isfile(candidate):
+                    return cls._load_from_file(agent_name, candidate)
+
+        logger.error(
+            "No profile found for agent '%s'.\n"
+            "Searched:\n%s\n"
+            "Create a profile JSON or use --profile-path to specify one.\n"
+            "Aborting.",
+            agent_name,
+            "".join(f"  - {p}\n" for p in searched),
+        )
+        raise SystemExit(1)
+
+    @classmethod
+    def _resolve_project_root(cls, project_root=None) -> Optional[str]:
+        """Resolve the project root directory.
+
+        Priority: explicit --project-root → first entry in PYTHONPATH.
+        """
+        if project_root:
+            return os.path.abspath(project_root)
+
+        python_path = os.environ.get("PYTHONPATH")
+        if python_path:
+            first_entry = python_path.split(os.pathsep)[0]
+            if os.path.isdir(first_entry):
+                return os.path.abspath(first_entry)
+
+        return None
+
+    @classmethod
+    def _load_from_file(cls, agent_name, path) -> "AgentProfile":
+        """Load profile data from a JSON file."""
+        try:
+            with open(path, "r", encoding="utf-8") as fh:
+                data: Dict[str, Any] = json.load(fh)
+            logger.info("Loaded agent profile: %s", path)
+            return cls(agent_name, data)
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.error("Failed to load profile %s: %s\nAborting.", path, exc)
+            raise SystemExit(1) from exc

--- a/tests/load_tests/prompts/profiles/agent_network_designer.json
+++ b/tests/load_tests/prompts/profiles/agent_network_designer.json
@@ -1,0 +1,31 @@
+{
+    "agent": "agent_network_designer",
+    "prompts": [
+        "Create an agent network for a pet grooming salon",
+        "Design a multi-agent system for a university admissions office",
+        "Build an agent network for a food truck fleet management company",
+        "Create an agent network for a veterinary clinic",
+        "Design a multi-agent system for a public library",
+        "Build an agent network for a car rental agency",
+        "Create an agent network for a music festival organizer",
+        "Design a multi-agent system for a real estate property manager",
+        "Build an agent network for a dental office",
+        "Create an agent network for a local farmers market",
+        "Design a multi-agent system for a fitness gym",
+        "Build an agent network for a travel agency",
+        "Create an agent network for a daycare center",
+        "Design a multi-agent system for a home renovation contractor",
+        "Build an agent network for a catering company",
+        "Create an agent network for a dog walking service",
+        "Design a multi-agent system for a photography studio",
+        "Build an agent network for a landscaping business",
+        "Create an agent network for an auto repair shop",
+        "Design a multi-agent system for a wedding planning company"
+    ],
+    "estimated_tokens_per_request": 500000,
+    "success_fields": ["reservation_id", "agent_network_name"],
+    "failure_patterns": [
+        "No fully-specified LLM found",
+        "API key to be set as an environment variable"
+    ]
+}

--- a/tests/load_tests/prompts/profiles/coffee_finder_advanced.json
+++ b/tests/load_tests/prompts/profiles/coffee_finder_advanced.json
@@ -1,0 +1,15 @@
+{
+    "agent": "basic/coffee_finder_advanced",
+    "prompts": [
+        "Find me a good coffee shop nearby",
+        "I need a late night coffee, what's open?",
+        "Where can I get coffee at 3am?",
+        "What are my coffee options right now?",
+        "I want to order a latte, where should I go?"
+    ],
+    "estimated_tokens_per_request": 10000,
+    "failure_patterns": [
+        "No fully-specified LLM found",
+        "API key to be set as an environment variable"
+    ]
+}

--- a/tests/load_tests/prompts/profiles/hello_world.json
+++ b/tests/load_tests/prompts/profiles/hello_world.json
@@ -1,0 +1,16 @@
+{
+    "agent": "hello_world",
+    "prompts": [
+        "Hello, how are you today?",
+        "What can you help me with?",
+        "Tell me something interesting about yourself",
+        "What is the meaning of hello world in programming?",
+        "Can you greet me in different languages?"
+    ],
+    "estimated_tokens_per_request": 1000,
+    "success_fields": [],
+    "failure_patterns": [
+        "No fully-specified LLM found",
+        "API key to be set as an environment variable"
+    ]
+}

--- a/tests/load_tests/prompts/profiles/intranet_agents_with_tools.json
+++ b/tests/load_tests/prompts/profiles/intranet_agents_with_tools.json
@@ -1,0 +1,31 @@
+{
+    "agent": "industry/intranet_agents_with_tools",
+    "prompts": [
+        "I'm getting married in the morning! What do I need to do in the corporate system?",
+        "I just had a baby. What benefits and leave do I need to set up in the corporate system?",
+        "I'm relocating to a new city for work. What do I need to update in the corporate system?",
+        "I want to change my 401k contribution. How do I do that in the corporate system?",
+        "I'm going on parental leave next month. What steps do I take in the corporate system?",
+        "How do I submit an expense report for my recent business trip?",
+        "I need to request two weeks of vacation in July. How do I do that?",
+        "My direct deposit bank account changed. How do I update it in the corporate system?",
+        "I want to enroll in the health insurance plan during open enrollment. What do I do?",
+        "How do I book a conference room for a team meeting next Tuesday?",
+        "I lost my badge. How do I request a replacement in the corporate system?",
+        "I'm starting a new role internally. What onboarding steps do I need to complete?",
+        "How do I nominate a coworker for an employee recognition award?",
+        "I need to file for tuition reimbursement for a course I'm taking. What's the process?",
+        "How do I set up my out-of-office and delegate approvals while I'm away?",
+        "I want to update my emergency contact information. Where do I do that?",
+        "How do I request new equipment like a laptop or monitor for my home office?",
+        "I'm retiring at the end of the year. What do I need to do in the corporate system?",
+        "How do I report a workplace safety concern through the corporate system?",
+        "I need to complete my annual compliance training. Where do I find it?"
+    ],
+    "estimated_tokens_per_request": 50000,
+    "success_fields": [],
+    "failure_patterns": [
+        "No fully-specified LLM found",
+        "API key to be set as an environment variable"
+    ]
+}

--- a/tests/load_tests/prompts/profiles/music_nerd_pro.json
+++ b/tests/load_tests/prompts/profiles/music_nerd_pro.json
@@ -1,0 +1,16 @@
+{
+    "agent": "music_nerd_pro",
+    "prompts": [
+        "Tell me about the history of jazz music",
+        "Who are the greatest rock guitarists of all time?",
+        "What makes classical music different from baroque?",
+        "Recommend some albums for someone who likes blues",
+        "What is the connection between hip hop and jazz?"
+    ],
+    "estimated_tokens_per_request": 5000,
+    "success_fields": [],
+    "failure_patterns": [
+        "No fully-specified LLM found",
+        "API key to be set as an environment variable"
+    ]
+}

--- a/tests/load_tests/prompts/profiles/smart_home.json
+++ b/tests/load_tests/prompts/profiles/smart_home.json
@@ -1,0 +1,15 @@
+{
+    "agent": "basic/smart_home",
+    "prompts": [
+        "Turn on the living room lights",
+        "Turn off the kitchen lights",
+        "Can you turn on the TV?",
+        "Please turn off all the lights",
+        "Switch on the radio"
+    ],
+    "estimated_tokens_per_request": 5000,
+    "failure_patterns": [
+        "No fully-specified LLM found",
+        "API key to be set as an environment variable"
+    ]
+}

--- a/tests/load_tests/reporting/__init__.py
+++ b/tests/load_tests/reporting/__init__.py
@@ -1,0 +1,15 @@
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT

--- a/tests/load_tests/reporting/cross_run_comparison.py
+++ b/tests/load_tests/reporting/cross_run_comparison.py
@@ -1,0 +1,442 @@
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+"""Cross-run comparison — scan output directories and compare metrics."""
+
+import json
+import logging
+import os
+import re
+
+from tests.load_tests.config import Formatters
+from tests.load_tests.config import SEPARATOR_WIDTH
+from tests.load_tests.config import STATUS_CREATED
+from tests.load_tests.cost_estimator import CostEstimator
+from tests.load_tests.reporting.table_formatter import TableFormatter
+
+_NORMAL_LLM_CALLS = 4
+_LOOP_THRESHOLD = 10
+_SERVER_TOKEN_RE = re.compile(
+    r"(request-\d+):\s*([\d,]+)\s*tokens"
+    r"\s*\(([\d,]+)\s*prompt\s*\+\s*([\d,]+)\s*completion\),"
+    r"\s*(\d+)\s*LLM call\(s\),"
+    r"\s*model=([^\s]+)",
+)
+
+logger = logging.getLogger(__name__)
+
+
+class CrossRunComparison:
+    """Scans a base directory for raw_results.json files and logs
+    a comparison table across runs."""
+
+    def __init__(
+        self, base_dir, *,
+        agent_filter=None,
+        baseline_requests=0,
+        run_filter=None,
+    ) -> None:
+        self._base_dir = base_dir
+        self._agent_filter: set = (
+            set(agent_filter) if agent_filter else set()
+        )
+        self._baseline_requests = baseline_requests
+        self._run_filter: set = (
+            set(run_filter) if run_filter else set()
+        )
+
+    def run(self) -> None:
+        """Scan for runs and log comparison tables by agent."""
+        all_runs = self._collect_runs()
+        if not all_runs:
+            logger.info(
+                "No raw_results.json files found in %s",
+                self._base_dir,
+            )
+            return
+        groups = self._group_by_agent(all_runs)
+        for agent_name in sorted(groups):
+            runs = (
+                groups[agent_name]
+                if self._run_filter
+                else self._deduplicate(groups[agent_name])
+            )
+            if self._baseline_requests > 0:
+                runs = [
+                    r for r in runs
+                    if r.get("num_requests", 0)
+                    >= self._baseline_requests
+                ]
+            runs.sort(
+                key=lambda r: r.get("num_requests", 0),
+            )
+            if not runs:
+                continue
+            self._log_table(runs, agent_name)
+            self._log_validation_loops(runs)
+
+    def _collect_runs(self):
+        """Walk subdirectories for raw_results.json and extract metrics."""
+        runs = []
+        for entry in os.listdir(self._base_dir):
+            if (self._run_filter
+                    and entry not in self._run_filter):
+                continue
+            json_path = os.path.join(
+                self._base_dir, entry, "raw_results.json",
+            )
+            if not os.path.isfile(json_path):
+                continue
+            metrics = self._extract_metrics(json_path, entry)
+            if metrics is not None:
+                runs.append(metrics)
+        return runs
+
+    @staticmethod
+    def _deduplicate(runs):
+        """Keep only the latest run per request count."""
+        by_count = {}
+        for run in runs:
+            count = run.get("num_requests", 0)
+            existing = by_count.get(count)
+            if (existing is None
+                    or run.get("folder", "")
+                    > existing.get("folder", "")):
+                by_count[count] = run
+        return list(by_count.values())
+
+    @staticmethod
+    def _extract_metrics(json_path, folder_name):
+        """Parse a raw_results.json and return key metrics."""
+        try:
+            with open(json_path, "r", encoding="utf-8") as fh:
+                data = json.load(fh)
+        except (json.JSONDecodeError, OSError):
+            return None
+
+        aggregates = data.get("aggregates", {})
+        stages = data.get("stage_summaries", [])
+        all_results = []
+        for stage in stages:
+            all_results.extend(stage.get("results", []))
+
+        agent = data.get("config", {}).get(
+            "agent", "unknown",
+        )
+
+        return {
+            "agent": agent,
+            "folder": folder_name,
+            "num_requests": data.get("config", {}).get(
+                "num_requests",
+                aggregates.get("total_requests", 0),
+            ),
+            "wall_time": aggregates.get(
+                "total_elapsed_seconds", 0,
+            ),
+            "avg_success": CrossRunComparison._avg(
+                [
+                    r for r in all_results
+                    if r.get("status") == STATUS_CREATED
+                ],
+                "elapsed",
+            ),
+            "ttfr_avg": CrossRunComparison._avg(
+                [
+                    r for r in all_results
+                    if r.get("status") == STATUS_CREATED
+                ],
+                "ttft",
+            ),
+            "peak_rss": max(
+                (s.get("peak_server_rss", 0) or 0
+                 for s in stages),
+                default=0,
+            ),
+            "succeeded": aggregates.get("passed", 0),
+            "failed": aggregates.get("failed", 0),
+            "fail_breakdown": CrossRunComparison._classify_failures(
+                all_results,
+            ),
+        }
+
+    @staticmethod
+    def _classify_failures(all_results):
+        """Categorize failed requests by failure reason."""
+        counts = {
+            "empty_llm": 0,
+            "validation": 0,
+            "incomplete": 0,
+            "no_token_data": 0,
+        }
+        for result in all_results:
+            if result.get("status") == STATUS_CREATED:
+                continue
+            reason = result.get("failure_reason", "") or ""
+            if "empty LLM response" in reason:
+                counts["empty_llm"] += 1
+            elif "validation fix cycle" in reason:
+                counts["validation"] += 1
+            elif "incomplete response" in reason:
+                counts["incomplete"] += 1
+            elif "no token data" in reason:
+                counts["no_token_data"] += 1
+            else:
+                counts.setdefault("other", 0)
+                counts["other"] += 1
+        return counts
+
+    @staticmethod
+    def _avg(results, key):
+        """Compute average of a result field, ignoring zeros."""
+        values = [
+            r.get(key, 0) for r in results
+            if r.get(key, 0) > 0
+        ]
+        if not values:
+            return 0
+        return sum(values) / len(values)
+
+    def _group_by_agent(self, runs):
+        """Group runs by agent name, applying filter if set."""
+        groups = {}
+        for run in runs:
+            agent = run.get("agent", "unknown")
+            if (self._agent_filter
+                    and agent not in self._agent_filter):
+                continue
+            groups.setdefault(agent, []).append(run)
+        return groups
+
+    @staticmethod
+    def _log_table(runs, agent_name):
+        """Log the comparison table with pct change from baseline."""
+        logger.info("\n%s", "=" * SEPARATOR_WIDTH)
+        logger.info("  CROSS-RUN COMPARISON: %s", agent_name)
+        logger.info("=" * SEPARATOR_WIDTH)
+
+        header = [
+            "Folder", "Requests", "Succeeded",
+            "Wall Time",
+            "Avg success (duration)",
+            "TTFR avg", "Peak RSS",
+            "Failed requests",
+        ]
+        rows = []
+        metric_keys = [
+            "num_requests", "wall_time",
+            "avg_success",
+            "ttfr_avg", "peak_rss",
+            "failed",
+        ]
+        baseline = runs[0] if runs else None
+        for run in runs:
+            ref = baseline if run is not baseline else None
+            deltas = CrossRunComparison._compute_deltas(
+                ref, run, metric_keys,
+            )
+            rows.append((
+                run.get("folder", ""),
+                CrossRunComparison._val_with_delta(
+                    str(run.get("num_requests", 0)),
+                    deltas.get("num_requests"),
+                ),
+                str(run.get("succeeded", 0)),
+                CrossRunComparison._val_with_delta(
+                    Formatters.fmt_duration(run.get("wall_time", 0)),
+                    deltas.get("wall_time"),
+                ),
+                CrossRunComparison._fmt_optional(
+                    run.get("avg_success", 0),
+                    deltas.get("avg_success"),
+                ),
+                CrossRunComparison._fmt_ttfr(
+                    run.get("ttfr_avg", 0),
+                    deltas.get("ttfr_avg"),
+                ),
+                CrossRunComparison._fmt_rss(
+                    run.get("peak_rss", 0),
+                    deltas.get("peak_rss"),
+                ),
+                CrossRunComparison._fmt_failed(
+                    run.get("failed", 0),
+                    run.get("num_requests", 0),
+                    run.get("fail_breakdown", {}),
+                ),
+            ))
+        TableFormatter.log_table(header, rows)
+
+    def _log_validation_loops(self, runs):
+        """Log validation loop summary for runs that have them."""
+        for run in runs:
+            folder = run.get("folder", "")
+            log_path = os.path.join(
+                self._base_dir, folder, "server_tokens.log",
+            )
+            loops = self._parse_validation_loops(log_path)
+            if not loops:
+                continue
+            self._print_loop_summary(folder, loops)
+
+    @staticmethod
+    def _parse_validation_loops(log_path):
+        """Parse server_tokens.log for validation loop requests."""
+        if not os.path.isfile(log_path):
+            return []
+        loops = []
+        with open(log_path, "r", encoding="utf-8") as fh:
+            for line in fh:
+                match = _SERVER_TOKEN_RE.search(line)
+                if not match:
+                    continue
+                llm_calls = int(match.group(5))
+                if llm_calls < _LOOP_THRESHOLD:
+                    continue
+                prompt = int(
+                    match.group(3).replace(",", ""),
+                )
+                completion = int(
+                    match.group(4).replace(",", ""),
+                )
+                model = match.group(6)
+                retries = llm_calls - _NORMAL_LLM_CALLS
+                cost = CostEstimator.estimate(
+                    prompt, completion, model,
+                )
+                loops.append({
+                    "request_id": match.group(1),
+                    "llm_calls": llm_calls,
+                    "retries": retries,
+                    "prompt_tokens": prompt,
+                    "completion_tokens": completion,
+                    "total_tokens": prompt + completion,
+                    "model": model,
+                    "cost_usd": cost,
+                })
+        return loops
+
+    @staticmethod
+    def _print_loop_summary(folder, loops):
+        """Print aggregated validation loop stats."""
+        total_retries = sum(
+            lp.get("retries", 0) for lp in loops
+        )
+        total_tokens = sum(
+            lp.get("total_tokens", 0) for lp in loops
+        )
+        total_cost = sum(
+            lp.get("cost_usd", 0.0) for lp in loops
+        )
+        logger.info("")
+        logger.info(
+            "  Validation loops in %s "
+            "(%s request(s)):",
+            folder, len(loops),
+        )
+        logger.info(
+            "    Total: %s retries, %s tokens, "
+            "$%.2f",
+            total_retries,
+            f"{total_tokens:,}",
+            total_cost,
+        )
+        for lp in sorted(
+            loops, key=lambda x: x.get("retries", 0),
+            reverse=True,
+        ):
+            logger.info(
+                "    %s: %s retries, %s tokens "
+                "($%.2f)",
+                lp.get("request_id", ""),
+                lp.get("retries", 0),
+                f"{lp.get('total_tokens', 0):,}",
+                lp.get("cost_usd", 0.0),
+            )
+
+    @staticmethod
+    def _compute_deltas(prev, current, keys):
+        """Compute percentage change from prev to current for each key."""
+        if prev is None:
+            return {}
+        deltas = {}
+        for key in keys:
+            prev_val = prev.get(key, 0)
+            curr_val = current.get(key, 0)
+            if prev_val > 0:
+                deltas[key] = (
+                    (curr_val - prev_val) / prev_val * 100
+                )
+        return deltas
+
+    @staticmethod
+    def _val_with_delta(formatted_val, delta_pct):
+        """Append percentage change suffix if available."""
+        if delta_pct is None:
+            return formatted_val
+        sign = "+" if delta_pct >= 0 else ""
+        return f"{formatted_val} ({sign}{delta_pct:.0f}%)"
+
+    @staticmethod
+    def _fmt_optional(value, delta_pct):
+        """Format a duration, showing a dash when data is missing."""
+        if value <= 0:
+            return "\u2014"
+        return CrossRunComparison._val_with_delta(
+            Formatters.fmt_duration(value), delta_pct,
+        )
+
+    @staticmethod
+    def _fmt_ttfr(value, delta_pct):
+        """Format TTFR, showing a dash when data is missing."""
+        if value <= 0:
+            return "\u2014"
+        return CrossRunComparison._val_with_delta(
+            Formatters.fmt_duration(value), delta_pct,
+        )
+
+    @staticmethod
+    def _fmt_rss(value, delta_pct):
+        """Format peak RSS, showing a dash when data is missing."""
+        if value <= 0:
+            return "\u2014"
+        return CrossRunComparison._val_with_delta(
+            Formatters.format_rss(value), delta_pct,
+        )
+
+    @staticmethod
+    def _fmt_failed(count, total, breakdown):
+        """Format failed count with optional breakdown."""
+        if count == 0:
+            return "0"
+        pct = (count * 100 // total) if total else 0
+        base = f"{count} ({pct}%)"
+        if not breakdown:
+            return base
+        labels = (
+            ("empty_llm", "empty LLM"),
+            ("validation", "validation"),
+            ("incomplete", "incomplete"),
+            ("no_token_data", "no token data"),
+            ("other", "other"),
+        )
+        parts = []
+        for key, label in labels:
+            val = breakdown.get(key, 0)
+            if val:
+                parts.append(f"{val} {label}")
+        if not parts:
+            return base
+        return f"{base}: {', '.join(parts)}"

--- a/tests/load_tests/reporting/disconnection_reporter.py
+++ b/tests/load_tests/reporting/disconnection_reporter.py
@@ -1,0 +1,63 @@
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+"""Aggregates and logs client disconnection analysis."""
+
+import logging
+
+from tests.load_tests.config import SEPARATOR_WIDTH
+
+logger = logging.getLogger(__name__)
+
+
+class DisconnectionReporter:
+    """Aggregates and logs client disconnection analysis.
+
+    Holds the collected stage summaries for analysis.
+    """
+
+    def __init__(self, stage_summaries) -> None:
+        self._summaries = stage_summaries
+
+    def log_disconnection_summary(self) -> None:
+        """Log aggregate client disconnection report."""
+        all_disconnections = []
+        for idx, stage in enumerate(self._summaries):
+            for disc in stage.get("disconnections") or []:
+                disc_copy = dict(disc)
+                disc_copy.update({"batch": idx + 1})
+                all_disconnections.append(disc_copy)
+        if not all_disconnections:
+            return
+        logger.info("\n%s", "=" * SEPARATOR_WIDTH)
+        logger.info(
+            "  CLIENT DISCONNECTIONS (%s detected in server log)",
+            len(all_disconnections),
+        )
+        logger.info("=" * SEPARATOR_WIDTH)
+        for disc in all_disconnections:
+            logger.info(
+                "  Batch %s: %s — %s still processing at disconnect",
+                disc.get("batch", "?"),
+                disc.get("request_id", "unknown"),
+                disc.get("agent", "unknown"),
+            )
+        logger.info(
+            "\n  These requests had their client disconnect"
+            "\n  before the server finished. The server detected the"
+            "\n  disconnection and cancelled in-flight tasks."
+            "\n  If unexpected, consider increasing --idle-timeout.",
+        )

--- a/tests/load_tests/reporting/json_metadata.py
+++ b/tests/load_tests/reporting/json_metadata.py
@@ -1,0 +1,269 @@
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+"""Self-documenting metadata for raw_results.json.
+
+Provides field descriptions, health thresholds, analysis hints, and
+unit labels so that any LLM can interpret the JSON without external
+documentation.
+"""
+
+from typing import Dict
+from typing import List
+
+
+class JsonMetadata:
+    """Builds the _schema, _thresholds, _analysis_hints, and _units
+    sections embedded in raw_results.json."""
+
+    @staticmethod
+    def schema() -> Dict[str, str]:
+        """Return field descriptions for every non-obvious JSON field."""
+        return {
+            "test_metadata.timestamp":
+                "ISO 8601 test start time with timezone.",
+            "test_metadata.neuro_san_version":
+                "Installed neuro-san package version, or null.",
+            "test_metadata.neuro_san_studio_version":
+                "Installed neuro-san-studio package version, or null.",
+            "test_metadata.verdict":
+                "PASSED if all requests succeeded, FAILED otherwise.",
+            "config.level":
+                "Test depth: min (traffic only), norm (+resources), "
+                "adv (+tokens, JSON, pool analysis).",
+            "config.mode":
+                "flat = same concurrency every stage; "
+                "ramp = increasing concurrency per stage.",
+            "config.same_prompt":
+                "If true, all requests use the same prompt "
+                "(collision stress test).",
+            "aggregates.total_elapsed_seconds":
+                "Sum of wall-clock time across all stages.",
+            "aggregates.avg_latency_seconds":
+                "Mean per-request duration. Requests overlap, so this "
+                "is not total elapsed / total requests.",
+            "stage_summaries[].counts":
+                "Per-status request counts: "
+                "CREATED=success, FAILED=error/crash, "
+                "TIMEOUT=hit hard timeout cap, "
+                "KILLED=no output for idle_timeout.",
+            "stage_summaries[].retries":
+                "Server-side retries by type: neuro-san max_attempts "
+                "retries (e.g. RateLimitError, APIError) plus "
+                "ProviderRetry for retries the LLM provider SDK "
+                "performed internally. "
+                "Empty dict means zero retries.",
+            "stage_summaries[].amplification":
+                "Ratio of total server LLM attempts to client "
+                "requests. 1.0 = no retries. "
+                ">1.0 means some requests were retried.",
+            "stage_summaries[].disconnections":
+                "Client disconnections: list of "
+                "{request_id, agent} for requests where the "
+                "client disconnected before the server finished.",
+            "stage_summaries[].primary_started":
+                "Server-side count of requests received for the "
+                "target agent network.",
+            "stage_summaries[].primary_finished":
+                "Server-side count of requests completed for the "
+                "target agent network.",
+            "stage_summaries[].total_started":
+                "Total server calls started (includes sub-network "
+                "calls for multi-agent networks).",
+            "stage_summaries[].total_finished":
+                "Total server calls completed.",
+            "stage_summaries[].before_threads":
+                "Server thread count before stage execution.",
+            "stage_summaries[].after_threads":
+                "Server thread count after settle period.",
+            "stage_summaries[].peak_threads":
+                "Peak server thread count during stage execution "
+                "(only present when heartbeat captured it).",
+            "results[].status":
+                "CREATED=success, FAILED=error/crash, "
+                "TIMEOUT=exceeded request timeout, "
+                "KILLED=no output for idle_timeout.",
+            "results[].error":
+                "Error message string when status != CREATED, "
+                "null on success.",
+            "results[].total_tokens":
+                "Total LLM tokens (prompt + completion) for "
+                "this request.",
+            "results[].cost_usd":
+                "Estimated OpenAI API cost for this request.",
+            "network_tokens[].network":
+                "Sub-agent network name. For multi-agent systems "
+                "(e.g. AND), each sub-network appears separately.",
+            "network_tokens[].duration":
+                "Server-side LLM processing time for this "
+                "sub-network (excludes client overhead).",
+            "network_tokens[].cost":
+                "Server-side cost for this sub-network.",
+            "resource_rows[].before":
+                "Server process snapshot before stage execution.",
+            "resource_rows[].after":
+                "Server process snapshot after settle period.",
+            "resource_rows[].*.rss":
+                "Resident Set Size in megabytes.",
+            "resource_rows[].*.fds":
+                "Open file descriptor count.",
+            "resource_rows[].*.threads":
+                "OS thread count for the server process.",
+            "resource_rows[].*.connections":
+                "Active network connections.",
+            "resource_rows[].*.children":
+                "Child process count.",
+            "resource_rows[].*.cpu":
+                "CPU usage percentage.",
+            "client_resource_rows[].before":
+                "Client process snapshot before stage.",
+            "client_resource_rows[].peak":
+                "Client process peak snapshot during stage.",
+            "client_resource_rows[].settled":
+                "Client process snapshot after all subprocesses "
+                "completed.",
+            "config.request_timeout":
+                "Hard timeout per request in seconds. "
+                "Kills the request if it exceeds this limit.",
+            "config.idle_timeout":
+                "Per-request idle timeout in seconds. "
+                "Kills a request if agent_cli produces no "
+                "stdout/stderr output for this duration. "
+                "Resets on every output activity.",
+            "config.stage_timeout":
+                "Hard timeout for an entire stage/round in "
+                "seconds. Kills all remaining in-flight "
+                "requests when the stage exceeds this limit.",
+            "config.total_timeout":
+                "Hard timeout for the entire load test in "
+                "seconds. 0 means disabled.",
+            "config.settle_time":
+                "Seconds to wait after each stage for server "
+                "cleanup before taking the post-stage resource "
+                "snapshot.",
+            "results[].start_time":
+                "Unix timestamp when the request started.",
+            "results[].end_time":
+                "Unix timestamp when the request completed.",
+        }
+
+    @staticmethod
+    def thresholds() -> Dict[str, object]:
+        """Return health thresholds for automated analysis."""
+        return {
+            "amplification_warning": 1.2,
+            "amplification_critical": 1.5,
+            "failure_pct_warning": 1.0,
+            "failure_pct_critical": 5.0,
+            "timeout_pct_warning": 1.0,
+            "timeout_pct_critical": 5.0,
+            "retry_pct_warning": 5.0,
+            "retry_pct_critical": 20.0,
+            "thread_growth_per_round_warning": 10,
+            "thread_growth_per_round_critical": 50,
+            "rss_growth_per_round_mb_warning": 50,
+            "rss_growth_per_round_mb_critical": 200,
+            "pool_reuse_pct_healthy": 80,
+            "pool_reuse_pct_warning": 50,
+            "duration_degradation_pct_warning": 15,
+            "cost_outlier_multiplier": 2.0,
+        }
+
+    @staticmethod
+    def analysis_hints() -> List[str]:
+        """Return diagnostic patterns to check."""
+        return [
+            "Compare thread counts across rounds — growth "
+            "without reclaiming suggests a thread leak.",
+            "Compare RSS across rounds — growth without "
+            "reclaiming suggests a memory leak.",
+            "Compare pool reuse % vs pool available — low "
+            "reuse with high availability suggests executor "
+            "pool lock contention.",
+            "Check if avg duration increases across rounds "
+            "at the same concurrency — indicates resource "
+            "pressure or degradation.",
+            "Check completion_tokens variance across "
+            "requests — high variance means LLM behavior "
+            "is unpredictable and cost estimates unreliable.",
+            "Compare primary_started/finished vs expected "
+            "request count — mismatch suggests server-side "
+            "request routing issues.",
+            "Check amplification factor — values above 1.0 "
+            "mean the server retried LLM calls, increasing "
+            "cost and latency.",
+            "Check for TIMEOUT or KILLED requests — these "
+            "indicate the server or LLM is too slow for the "
+            "configured timeout thresholds.",
+            "Compare client-side elapsed vs server-side "
+            "network_tokens duration — large gaps indicate "
+            "client overhead (subprocess, gRPC, CLI parsing).",
+            "Check FD growth across rounds — unclosed file "
+            "descriptors indicate resource leaks.",
+        ]
+
+    @staticmethod
+    def units() -> Dict[str, str]:
+        """Return unit labels for numeric fields."""
+        return {
+            "elapsed": "seconds",
+            "duration": "seconds",
+            "total_elapsed_seconds": "seconds",
+            "avg_latency_seconds": "seconds",
+            "request_timeout": "seconds",
+            "idle_timeout": "seconds",
+            "stage_timeout": "seconds",
+            "total_timeout": "seconds",
+            "settle_time": "seconds",
+            "start_time": "unix_timestamp",
+            "end_time": "unix_timestamp",
+            "rss": "megabytes",
+            "cpu": "percent",
+            "cost_usd": "USD",
+            "cost": "USD",
+            "total_cost_usd": "USD",
+            "total_tokens": "tokens",
+            "prompt_tokens": "tokens",
+            "completion_tokens": "tokens",
+            "estimated_tokens_per_request": "tokens",
+        }
+
+    @staticmethod
+    def reporting_instructions() -> str:
+        """Return instructions for LLM-based analysis."""
+        return (
+            "Report ALL checks explicitly, including clean "
+            "results (e.g. '0 errors found', '0 retries', "
+            "'no thread growth'). Do not skip checks with "
+            "zero or normal values — explicitly confirming "
+            "that something is healthy is as important as "
+            "flagging issues. For each check in "
+            "_analysis_hints, state the finding and rate it "
+            "as OK, WARNING, or CRITICAL using _thresholds."
+        )
+
+    @staticmethod
+    def build() -> Dict[str, object]:
+        """Return the complete metadata block for raw_results.json."""
+        return {
+            "_schema": JsonMetadata.schema(),
+            "_thresholds": JsonMetadata.thresholds(),
+            "_analysis_hints": JsonMetadata.analysis_hints(),
+            "_units": JsonMetadata.units(),
+            "_reporting_instructions": (
+                JsonMetadata.reporting_instructions()
+            ),
+        }

--- a/tests/load_tests/reporting/latency_analyzer.py
+++ b/tests/load_tests/reporting/latency_analyzer.py
@@ -1,0 +1,281 @@
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+"""Latency analysis — completion timeline, degradation, concurrency
+timeline, and server-side timing for diagnosing LLM bottlenecks.
+"""
+
+import logging
+import math
+from typing import Dict
+from typing import List
+from typing import Tuple
+
+from tests.load_tests.config import Formatters
+
+from tests.load_tests.config import SEPARATOR_WIDTH
+
+logger = logging.getLogger(__name__)
+
+# Completion latency percentiles (percent)
+COMPLETION_MILESTONES = [0, 50, 90, 95, 100]
+
+# Step size for count-based milestones (e.g. 50, 100, 150...)
+COUNT_MILESTONE_STEP = 50
+
+
+class LatencyAnalyzer:
+    """Analyse per-request latency data across stages."""
+
+    def __init__(self, stage_summaries) -> None:
+        self._summaries = stage_summaries
+
+    @staticmethod
+    def _percentile(sorted_values, pct):
+        """Compute the pct-th percentile from pre-sorted values."""
+        if not sorted_values:
+            return 0.0
+        idx = (pct / 100.0) * (len(sorted_values) - 1)
+        lower = int(math.floor(idx))
+        upper = min(lower + 1, len(sorted_values) - 1)
+        frac = idx - lower
+        return sorted_values[lower] + frac * (
+            sorted_values[upper] - sorted_values[lower]
+        )
+
+    # ----------------------------------------------------------
+    # 1. Cumulative completion timeline per stage
+    # ----------------------------------------------------------
+
+    def log_latency_analysis(self, *, is_ramp=True) -> None:
+        """Log completion timeline for each stage."""
+        logger.info("\n%s", "=" * SEPARATOR_WIDTH)
+        logger.info("  LATENCY ANALYSIS")
+        logger.info("=" * SEPARATOR_WIDTH)
+
+        self._log_completion_timeline(is_ramp=is_ramp)
+
+    def _log_completion_timeline(self, *, is_ramp) -> None:
+        """Log completion latency percentiles per stage on one line."""
+        for summary in self._summaries:
+            latencies = self._extract_latencies(summary)
+            if not latencies:
+                continue
+            latencies.sort()
+            total = len(latencies)
+            stage = summary.get("stage", "?")
+            rnd = summary.get("round", "?")
+            if is_ramp:
+                label = f"Stage {stage}"
+                if rnd != "?":
+                    label += f", round {rnd}"
+            else:
+                label = f"Round {rnd}"
+            parts_list = []
+            for pct in COMPLETION_MILESTONES:
+                dur = Formatters.fmt_duration(
+                    self._percentile(latencies, pct),
+                    precision=1,
+                )
+                parts_list.append(f"p{pct} {dur}")
+            parts = " / ".join(parts_list)
+            logger.info(
+                "\n  Completion percentiles "
+                "(%s, %s requests): %s",
+                label, total, parts,
+            )
+            self._log_count_milestones(latencies)
+
+    @staticmethod
+    def _log_count_milestones(sorted_latencies) -> None:
+        """Log completion times at round-number request counts."""
+        total = len(sorted_latencies)
+        if total <= COUNT_MILESTONE_STEP:
+            return
+        milestones = list(
+            range(
+                COUNT_MILESTONE_STEP, total,
+                COUNT_MILESTONE_STEP,
+            ),
+        )
+        if not milestones or milestones[-1] != total:
+            milestones.append(total)
+        logger.info("\n  Completion by count:")
+        for count in milestones:
+            duration = sorted_latencies[count - 1]
+            logger.info(
+                "    %4d requests completed by %s",
+                count,
+                Formatters.fmt_duration(duration, precision=1),
+            )
+
+    # ----------------------------------------------------------
+    # 2. Round-over-round degradation
+    # ----------------------------------------------------------
+
+    def log_degradation(  # pylint: disable=unused-argument
+            self, *, is_ramp=True,
+    ) -> None:
+        """Compare avg latency across rounds/stages at same concurrency."""
+        if len(self._summaries) < 2:
+            return
+
+        groups = self._group_by_concurrency()
+        has_degradation = False
+        for concurrency, summaries in sorted(groups.items()):
+            if len(summaries) < 2:
+                continue
+            avgs = []
+            for s in summaries:
+                latencies = self._extract_latencies(s)
+                if latencies:
+                    avgs.append(
+                        sum(latencies) / len(latencies),
+                    )
+            if len(avgs) < 2:
+                continue
+            if not has_degradation:
+                logger.info(
+                    "\n  Latency degradation "
+                    "(round-over-round):",
+                )
+                has_degradation = True
+            parts = " -> ".join(
+                f"{a:.1f}s" for a in avgs
+            )
+            change = (
+                (avgs[-1] - avgs[0]) / avgs[0] * 100
+                if avgs[0] > 0 else 0
+            )
+            sign = "+" if change >= 0 else ""
+            logger.info(
+                "    %s concurrent: %s (%s%.0f%%)",
+                concurrency, parts, sign, change,
+            )
+
+    # ----------------------------------------------------------
+    # 3. Concurrent request timeline
+    # ----------------------------------------------------------
+
+    def log_concurrency_timeline(self) -> None:
+        """Log actual in-flight request counts over time per stage."""
+        for summary in self._summaries:
+            results = summary.get("results", [])
+            timeline = self._build_timeline(results)
+            if not timeline:
+                continue
+            stage = summary.get("stage", "?")
+            rnd = summary.get("round", "?")
+            concurrent = summary.get("concurrent", "?")
+            peak = max(c for _, c in timeline)
+            logger.info(
+                "\n  Concurrency timeline "
+                "(stage %s, round %s, %s planned):",
+                stage, rnd, concurrent,
+            )
+            logger.info(
+                "    Peak in-flight: %s", peak,
+            )
+            self._log_timeline_chart(timeline)
+
+    # ----------------------------------------------------------
+    # Helpers
+    # ----------------------------------------------------------
+
+    @staticmethod
+    def _extract_latencies(
+            summary,
+    ) -> List[float]:
+        """Extract elapsed times from stage results."""
+        results = summary.get("results", [])
+        return [
+            r.get("elapsed", 0)
+            for r in results
+            if r.get("elapsed", 0) > 0
+        ]
+
+    def _group_by_concurrency(
+            self,
+    ) -> Dict[int, list]:
+        """Group stage summaries by their concurrency level."""
+        groups: Dict[int, list] = {}
+        for s in self._summaries:
+            conc = s.get("concurrent", 0)
+            groups.setdefault(conc, []).append(s)
+        return groups
+
+    @staticmethod
+    def _build_timeline(
+            results,
+    ) -> List[Tuple[float, int]]:
+        """Build a concurrency-over-time timeline from results.
+
+        Returns list of (relative_seconds, in_flight_count) tuples.
+        """
+        events: List[Tuple[float, int]] = []
+        for r in results:
+            start_t = r.get("start_time", 0)
+            end_t = r.get("end_time", 0)
+            if start_t and end_t:
+                events.append((start_t, 1))
+                events.append((end_t, -1))
+        if not events:
+            return []
+        events.sort()
+        base = events[0][0]
+        timeline: List[Tuple[float, int]] = []
+        in_flight = 0
+        for ts, delta in events:
+            in_flight += delta
+            timeline.append((ts - base, in_flight))
+        return timeline
+
+    @staticmethod
+    def _log_timeline_chart(
+            timeline,
+    ) -> None:
+        """Log a simple ASCII chart of concurrency over time."""
+        if not timeline:
+            return
+        max_conc = max(c for _, c in timeline)
+        total_duration = timeline[-1][0]
+        if total_duration <= 0 or max_conc <= 0:
+            return
+        num_buckets = min(20, int(total_duration) + 1)
+        bucket_size = total_duration / num_buckets
+        bucket_peaks = [0] * num_buckets
+        # Carry forward the in-flight count so buckets
+        # without events reflect the actual state.
+        current = 0
+        event_idx = 0
+        for i in range(num_buckets):
+            bucket_end = (i + 1) * bucket_size
+            bucket_peaks[i] = current
+            while (event_idx < len(timeline)
+                   and timeline[event_idx][0] < bucket_end):
+                current = timeline[event_idx][1]
+                bucket_peaks[i] = max(
+                    bucket_peaks[i], current,
+                )
+                event_idx += 1
+        for i, peak in enumerate(bucket_peaks):
+            t_start = i * bucket_size
+            chart = "#" * (peak * 40 // max_conc) if max_conc else ""
+            label = Formatters.fmt_duration(t_start)
+            logger.info(
+                "    %8s |%-40s| %d",
+                label, chart, peak,
+            )

--- a/tests/load_tests/reporting/pool_analyzer.py
+++ b/tests/load_tests/reporting/pool_analyzer.py
@@ -1,0 +1,140 @@
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+"""Analyzes executor thread pool reuse across load test stages."""
+
+import logging
+from typing import List
+
+from tests.load_tests.config import SEPARATOR_WIDTH
+from tests.load_tests.reporting.table_formatter import TableFormatter
+
+logger = logging.getLogger(__name__)
+
+
+class PoolAnalyzer:
+    """Analyzes executor thread pool reuse across load test stages.
+
+    Holds the collected stage summaries for analysis.
+    """
+
+    def __init__(self, stage_summaries) -> None:
+        self._summaries = stage_summaries
+
+    # pylint: disable=too-many-locals
+    def log_pool_reuse_analysis(self) -> None:
+        """Log executor pool reuse analysis across stages."""
+        stages_with_data = [
+            s for s in self._summaries
+            if s.get("before_threads") is not None
+            and s.get("after_threads") is not None
+            and s.get("total_started") is not None
+            and s.get("total_started") > 0
+        ]
+        if not stages_with_data:
+            return
+
+        base_threads = stages_with_data[0].get("before_threads")
+
+        logger.info("\n%s", "=" * SEPARATOR_WIDTH)
+        logger.info("  EXECUTOR POOL REUSE ANALYSIS")
+        logger.info("=" * SEPARATOR_WIDTH)
+
+        header = [
+            "Batch", "Server Calls", "New Threads",
+            "Peak Threads", "Reused", "Reuse%",
+            "Pool Avail", "Exec/Req",
+        ]
+        rows: List[tuple] = []
+        total_new_threads = 0
+        reuse_pcts: List[float] = []
+
+        for idx, stage in enumerate(stages_with_data):
+            batch_num = idx + 1
+            server_calls = stage.get("total_started")
+            before_threads = stage.get("before_threads")
+            after_threads = stage.get("after_threads")
+            new_threads = max(after_threads - before_threads, 0)
+            total_new_threads += new_threads
+            reused = max(server_calls - new_threads, 0)
+            reuse_pct = (
+                (reused / server_calls * 100.0)
+                if server_calls > 0 else 0.0
+            )
+            reuse_pcts.append(reuse_pct)
+            pool_avail = max(before_threads - base_threads, 0)
+
+            primary = (
+                stage.get("primary_started")
+                or stage.get("concurrent")
+            )
+            exec_per_req = (
+                server_calls / primary if primary > 0 else 0.0
+            )
+
+            peak_t = stage.get("peak_threads")
+            peak_str = str(peak_t) if peak_t is not None else "-"
+
+            rows.append((
+                str(batch_num),
+                str(server_calls),
+                f"+{new_threads}",
+                peak_str,
+                str(reused),
+                f"{reuse_pct:.1f}%",
+                str(pool_avail),
+                f"{exec_per_req:.1f}",
+            ))
+
+        TableFormatter.log_table(header, rows)
+
+        first_demand = max(
+            stages_with_data[0].get("after_threads")
+            - stages_with_data[0].get("before_threads"), 0,
+        )
+        self._log_pool_diagnostics(
+            reuse_pcts, total_new_threads,
+            first_demand=first_demand,
+        )
+
+    @staticmethod
+    def _log_pool_diagnostics(
+            reuse_pcts, total_new_threads, *,
+            first_demand,
+    ) -> None:
+        """Log summary diagnostics for pool reuse."""
+        if len(reuse_pcts) < 2:
+            return
+        logger.info(
+            "\n  Pool reuse: %.1f%% (batch 1) -> %.1f%% (batch %d)",
+            reuse_pcts[0], reuse_pcts[-1], len(reuse_pcts),
+        )
+        if total_new_threads > first_demand > 0:
+            excess = total_new_threads - first_demand
+            logger.info(
+                "  WARNING: %d new threads created across all "
+                "batches, but batch 1 demand was only %d.",
+                total_new_threads, first_demand,
+            )
+            logger.info(
+                "           %d excess threads indicate pool lock "
+                "contention in return_executor().",
+                excess,
+            )
+            logger.info(
+                "           cancel_current_tasks() holds the pool "
+                "lock for up to 5s, blocking reuse.",
+            )

--- a/tests/load_tests/reporting/rebuild_results.py
+++ b/tests/load_tests/reporting/rebuild_results.py
@@ -1,0 +1,420 @@
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+"""Rebuild raw_results.json from individual request output files.
+
+Useful for runs that were interrupted (Ctrl+C) before the normal
+export ran.  Scans the requests/ subdirectory and log files to
+reconstruct per-request results.
+"""
+
+import json
+import logging
+import os
+import re
+
+from tests.load_tests.config import STATUS_CREATED
+from tests.load_tests.config import STATUS_FAILED
+from tests.load_tests.config import STATUS_KILLED
+from tests.load_tests.config import STATUS_TIMEOUT
+from tests.load_tests.reporting.json_metadata import JsonMetadata
+from tests.load_tests.traffic.cli_builder import CliBuilder
+
+logger = logging.getLogger(__name__)
+
+_TIMING_RE = re.compile(
+    r"Request\s+(\d+):\s+(\w+)\s+\(([0-9.]+)s",
+)
+
+_CONFIG_AGENT_RE = re.compile(
+    r"Config:.*agent=([^,]+)",
+)
+
+_CONFIG_NUM_REQ_RE = re.compile(
+    r"Requests:\s*(\d+)",
+)
+
+
+class ResultsRebuilder:
+    """Reconstructs raw_results.json from per-request files."""
+
+    def __init__(self, output_dir, *, force=False) -> None:
+        self._output_dir = output_dir
+        self._force = force
+
+    def run(self) -> None:
+        """Rebuild raw_results.json for one or many run directories.
+
+        If the path contains a requests/ subdirectory, rebuild that
+        single run.  Otherwise treat it as a parent directory and
+        rebuild every subdirectory that has requests/ but is missing
+        raw_results.json.
+        """
+        requests_dir = os.path.join(self._output_dir, "requests")
+        json_path = os.path.join(
+            self._output_dir, "raw_results.json",
+        )
+        if os.path.isdir(requests_dir):
+            if os.path.isfile(json_path) and self._force:
+                self._reclassify(json_path, requests_dir)
+            else:
+                self._rebuild_single()
+            return
+        self._rebuild_all()
+
+    def _rebuild_all(self) -> None:
+        """Scan subdirectories and rebuild or reclassify."""
+        rebuilt = 0
+        reclassified = 0
+        skipped = 0
+        for entry in sorted(os.listdir(self._output_dir)):
+            sub_dir = os.path.join(self._output_dir, entry)
+            if not os.path.isdir(sub_dir):
+                continue
+            requests_dir = os.path.join(sub_dir, "requests")
+            json_path = os.path.join(sub_dir, "raw_results.json")
+            if not os.path.isdir(requests_dir):
+                continue
+            if os.path.isfile(json_path):
+                if self._force:
+                    logger.info("Reclassifying: %s", entry)
+                    ResultsRebuilder(
+                        sub_dir, force=True,
+                    ).run()
+                    reclassified += 1
+                else:
+                    skipped += 1
+                continue
+            logger.info("Rebuilding: %s", entry)
+            ResultsRebuilder(sub_dir).run()
+            rebuilt += 1
+        logger.info(
+            "Done: %s rebuilt, %s reclassified, "
+            "%s skipped",
+            rebuilt, reclassified, skipped,
+        )
+
+    def _rebuild_single(self) -> None:
+        """Rebuild raw_results.json for a single run directory."""
+        requests_dir = os.path.join(self._output_dir, "requests")
+        if not os.path.isdir(requests_dir):
+            logger.error(
+                "No requests/ directory in %s", self._output_dir,
+            )
+            return
+
+        timing = self._parse_timing()
+        agent, num_requests = self._parse_config()
+        results = self._scan_requests(requests_dir, timing)
+
+        if not results:
+            logger.error("No request files found to rebuild.")
+            return
+
+        passed = sum(
+            1 for r in results
+            if r.get("status") == STATUS_CREATED
+        )
+        total = len(results)
+        # The slowest request stands in for the run's wall-clock time,
+        # which is not recoverable from per-request files alone.
+        total_elapsed = max(
+            r.get("elapsed", 0) for r in results
+        )
+        avg_latency = sum(
+            r.get("elapsed", 0) for r in results
+        ) / total if total > 0 else 0
+        total_tokens = sum(
+            r.get("total_tokens", 0) for r in results
+        )
+        total_cost = sum(
+            r.get("cost_usd", 0.0) for r in results
+        )
+
+        raw_data = {
+            "test_metadata": {
+                "verdict": "REBUILT",
+                "exit_code": 2,
+                "note": "Reconstructed from request files",
+            },
+            "config": {
+                "agent": agent,
+                "num_requests": num_requests or total,
+            },
+            "aggregates": {
+                "total_requests": total,
+                "passed": passed,
+                "failed": total - passed,
+                "total_elapsed_seconds": round(
+                    total_elapsed, 2,
+                ),
+                "avg_latency_seconds": round(avg_latency, 2),
+                "total_tokens": total_tokens,
+                "total_cost_usd": round(total_cost, 6),
+            },
+            "stage_summaries": [{
+                "concurrent": total,
+                "results": results,
+                "elapsed": total_elapsed,
+            }],
+        }
+        raw_data.update(JsonMetadata.build())
+
+        json_path = os.path.join(
+            self._output_dir, "raw_results.json",
+        )
+        with open(json_path, "w", encoding="utf-8") as fh:
+            json.dump(raw_data, fh, indent=2, default=str)
+
+        logger.info(
+            "Rebuilt raw_results.json: %s requests "
+            "(%s passed, %s failed)",
+            total, passed, total - passed,
+        )
+        logger.info("  Saved to: %s", json_path)
+
+    def _parse_timing(self):
+        """Extract request timing from log files."""
+        timing = {}
+        for filename in ("load_test.log", "progress.log"):
+            path = os.path.join(self._output_dir, filename)
+            if not os.path.isfile(path):
+                continue
+            with open(path, "r", encoding="utf-8") as fh:
+                for line in fh:
+                    match = _TIMING_RE.search(line)
+                    if match:
+                        req_id = int(match.group(1))
+                        status = match.group(2)
+                        elapsed = float(match.group(3))
+                        timing[req_id] = {
+                            "status": status,
+                            "elapsed": elapsed,
+                        }
+        return timing
+
+    def _parse_config(self):
+        """Extract agent name and num_requests from log."""
+        agent = "unknown"
+        num_requests = 0
+        log_path = os.path.join(
+            self._output_dir, "load_test.log",
+        )
+        if not os.path.isfile(log_path):
+            return agent, num_requests
+        with open(log_path, "r", encoding="utf-8") as fh:
+            for line in fh:
+                match = _CONFIG_AGENT_RE.search(line)
+                if match:
+                    agent = match.group(1).strip()
+                match = _CONFIG_NUM_REQ_RE.search(line)
+                if match:
+                    num_requests = int(match.group(1))
+        return agent, num_requests
+
+    def _scan_requests(self, requests_dir, timing):
+        """Parse each request stdout file into a result dict."""
+        results = []
+        for filename in sorted(os.listdir(requests_dir)):
+            if not filename.endswith("_stdout.txt"):
+                continue
+            match = re.search(r"request_(\d+)_stdout", filename)
+            if not match:
+                continue
+            req_id = int(match.group(1))
+            stdout_path = os.path.join(
+                requests_dir, filename,
+            )
+            with open(
+                stdout_path, "r", encoding="utf-8",
+            ) as fh:
+                stdout = fh.read()
+
+            result = self._build_result(
+                req_id, stdout, timing,
+            )
+            results.append(result)
+        return results
+
+    @staticmethod
+    def _build_result(req_id, stdout, timing):
+        """Build a single result dict from stdout and timing."""
+        parsed_fields = {
+            "reservation_id": CliBuilder.parse_stdout_field(
+                stdout, "reservation_id",
+            ),
+            "agent_network_name": CliBuilder.parse_stdout_field(
+                stdout, "agent_network_name",
+            ),
+        }
+
+        timing_info = timing.get(req_id, {})
+        elapsed = timing_info.get("elapsed", 0)
+        status = ResultsRebuilder._resolve_status(timing_info)
+
+        result = {
+            "request_id": f"request-{req_id}",
+            "status": status,
+            "elapsed": elapsed,
+            "ttft": 0,
+            "failure_reason": ResultsRebuilder._diagnose(
+                status, stdout, parsed_fields,
+            ),
+        }
+        result.update(parsed_fields)
+        ResultsRebuilder._attach_tokens(result, stdout)
+        return result
+
+    @staticmethod
+    def _attach_tokens(result, stdout):
+        """Add token accounting fields to a result dict."""
+        token_data = CliBuilder.parse_token_accounting(stdout)
+        if token_data:
+            result.update({
+                "total_tokens": token_data.get(
+                    "total_tokens", 0,
+                ),
+                "prompt_tokens": token_data.get(
+                    "prompt_tokens", 0,
+                ),
+                "completion_tokens": token_data.get(
+                    "completion_tokens", 0,
+                ),
+                "llm_calls": token_data.get(
+                    "successful_requests", 0,
+                ),
+            })
+
+    @staticmethod
+    def _load_stdout_cache(requests_dir):
+        """Load all request stdout files into a dict keyed by id."""
+        cache = {}
+        for filename in os.listdir(requests_dir):
+            if not filename.endswith("_stdout.txt"):
+                continue
+            match = re.search(
+                r"request_(\d+)_stdout", filename,
+            )
+            if not match:
+                continue
+            req_id = int(match.group(1))
+            path = os.path.join(requests_dir, filename)
+            with open(
+                path, "r", encoding="utf-8",
+            ) as fh:
+                cache[req_id] = fh.read()
+        return cache
+
+    def _reclassify(self, json_path, requests_dir):
+        """Update failure_reason and config in existing JSON."""
+        with open(json_path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+
+        self._fix_config(data)
+
+        stdout_cache = ResultsRebuilder._load_stdout_cache(
+            requests_dir,
+        )
+
+        updated = 0
+        for stage in data.get("stage_summaries", []):
+            for result in stage.get("results", []):
+                if result.get("status") == STATUS_CREATED:
+                    continue
+                rid = result.get("request_id", "")
+                match = re.search(r"(\d+)$", rid)
+                if not match:
+                    continue
+                stdout = stdout_cache.get(
+                    int(match.group(1)), "",
+                )
+                parsed = {
+                    "reservation_id": result.get(
+                        "reservation_id",
+                    ),
+                    "agent_network_name": result.get(
+                        "agent_network_name",
+                    ),
+                }
+                reason = ResultsRebuilder._diagnose(
+                    result.get("status"), stdout, parsed,
+                )
+                if reason != result.get("failure_reason"):
+                    result["failure_reason"] = reason
+                    updated += 1
+
+        with open(json_path, "w", encoding="utf-8") as fh:
+            json.dump(data, fh, indent=2, default=str)
+        logger.info(
+            "  Updated %s failure reason(s)", updated,
+        )
+
+    def _fix_config(self, data):
+        """Repair config.num_requests from log if needed."""
+        _agent, num_requests = self._parse_config()
+        if num_requests <= 0:
+            return
+        config = data.get("config", {})
+        old_val = config.get("num_requests", 0)
+        if old_val != num_requests:
+            config["num_requests"] = num_requests
+            logger.info(
+                "  Fixed num_requests: %s -> %s",
+                old_val, num_requests,
+            )
+
+    @staticmethod
+    def _resolve_status(timing_info):
+        """Determine request status from the log line for the request.
+
+        Every status the runner reports is preserved, including TIMEOUT
+        and KILLED: a rebuild that collapsed those into CREATED or
+        FAILED would misstate what happened.  A request with no log
+        line was never observed to finish -- failures past
+        FAILURE_LOG_LIMIT are never printed -- so it counts as failed
+        rather than being guessed at from its partial output.
+        """
+        log_status = timing_info.get("status", "")
+        if log_status in (
+            STATUS_CREATED, STATUS_FAILED, STATUS_TIMEOUT, STATUS_KILLED,
+        ):
+            return log_status
+        return STATUS_FAILED
+
+    @staticmethod
+    def _diagnose(status, stdout, parsed_fields):
+        """Build a failure reason string for failed requests."""
+        if status == STATUS_CREATED:
+            return None
+        reasons = []
+        for field in ("reservation_id", "agent_network_name"):
+            if not parsed_fields.get(field):
+                reasons.append(f"missing {field}")
+        tokens = CliBuilder.parse_token_accounting(stdout)
+        if not tokens:
+            reasons.append("no token data")
+        else:
+            empty = tokens.get("empty_responses", 0)
+            completion = tokens.get("completion_tokens", 0)
+            if empty > 0:
+                reasons.append(
+                    f"empty LLM response "
+                    f"({completion} completion tokens, "
+                    f"{empty} empty response(s))"
+                )
+            else:
+                reasons.append("incomplete response")
+        return "; ".join(reasons) if reasons else None

--- a/tests/load_tests/reporting/resource_reporter.py
+++ b/tests/load_tests/reporting/resource_reporter.py
@@ -1,0 +1,228 @@
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+"""Builds and logs server and client resource delta tables."""
+
+import logging
+from typing import List
+from typing import Tuple
+
+from tests.load_tests.config import ResourceSnapshot
+from tests.load_tests.config import SEPARATOR_WIDTH
+from tests.load_tests.reporting.table_formatter import TableFormatter
+
+# (display_row, before_snapshot, after_snapshot)
+ServerResourceRow = Tuple[tuple, ResourceSnapshot, ResourceSnapshot]
+
+# (display_row, before_snapshot, peak_snapshot, settled_snapshot)
+ClientResourceRow = Tuple[
+    tuple, ResourceSnapshot, ResourceSnapshot, ResourceSnapshot,
+]
+
+logger = logging.getLogger(__name__)
+
+
+class ResourceReporter:
+    """Builds and logs server and client resource delta tables.
+
+    Accumulates resource rows during the test run, then logs
+    the complete analysis tables at the end.
+    """
+
+    def __init__(self) -> None:
+        self._resource_rows: List[ServerResourceRow] = []
+        self._client_rows: List[ClientResourceRow] = []
+
+    @property
+    def resource_rows(self) -> List[ServerResourceRow]:
+        """Return the accumulated server resource rows."""
+        return list(self._resource_rows)
+
+    @property
+    def client_rows(self) -> List[ClientResourceRow]:
+        """Return the accumulated client resource rows."""
+        return list(self._client_rows)
+
+    def add_resource_row(
+            self, stage_label, before, after,
+    ) -> ServerResourceRow:
+        """Build and store a server resource row from before/after snapshots.
+
+        Returns (display_row, before_snapshot, after_snapshot) so that
+        delta calculations can use raw numeric values instead of
+        reverse-parsing formatted strings.
+        """
+        rss_delta = after.get("rss") - before.get("rss")
+        thread_delta = after.get("threads") - before.get("threads")
+        display = (
+            str(stage_label),
+            f"{before.get('rss'):.1f}M",
+            f"{after.get('rss'):.1f}M",
+            f"{rss_delta:+.1f}M",
+            str(after.get("fds")),
+            f"{before.get('threads')} -> {after.get('threads')}",
+            f"{thread_delta:+d}",
+            str(after.get("connections")),
+            f"{after.get('cpu'):.1f}%",
+            str(after.get("children")),
+        )
+        row = (display, before, after)
+        self._resource_rows.append(row)
+        return row
+
+    def add_client_row(
+            self, stage_label, before, peak, settled,
+    ) -> ClientResourceRow:
+        """Build and store a client resource row from before/peak/settled.
+
+        Returns (display_row, before_snapshot, peak_snapshot,
+        settled_snapshot) so that delta calculations and JSON export
+        can use raw numeric values.
+        """
+        rss_delta = settled.get("rss") - before.get("rss")
+        peak_rss = f"{peak.get('rss'):.1f}M" if peak else "-"
+        display = (
+            str(stage_label),
+            f"{before.get('rss'):.1f}M",
+            peak_rss,
+            f"{settled.get('rss'):.1f}M",
+            f"{rss_delta:+.1f}M",
+            f"{settled.get('cpu'):.1f}%",
+            str(settled.get("fds")),
+            str(settled.get("threads")),
+        )
+        row = (display, before, peak or {}, settled)
+        self._client_rows.append(row)
+        return row
+
+    # Placeholder row (Component + 11 metric columns) shown when a
+    # component produced no data at all.
+    _NA_METRICS = ("na",) * 11
+
+    def log_combined_analysis(
+            self, total_client_reqs, total_server_calls,
+    ) -> None:
+        """Log one combined server-app + client-app resource table.
+
+        Server-app and client-app rows share a single table.  Columns
+        that don't apply to a component — or a component that produced
+        no data (no local server, or the server-only mode's absent
+        client) — show ``na``.
+        """
+        if not self._resource_rows and not self._client_rows:
+            return
+        header = [
+            "Component", "Concurrent", "Before RSS", "Peak RSS",
+            "Settled RSS", "RSS Delta", "CPU%", "FDs",
+            "Threads", "Thread Delta", "Conns", "Children",
+        ]
+        rows = self._combined_server_rows() + self._combined_client_rows()
+        logger.info("\n%s", "=" * SEPARATOR_WIDTH)
+        if total_server_calls > 0:
+            logger.info(
+                "  RESOURCE ANALYSIS"
+                " (%s client requests, %s server calls)",
+                total_client_reqs, total_server_calls,
+            )
+        else:
+            logger.info(
+                "  RESOURCE ANALYSIS (%s total requests)",
+                total_client_reqs,
+            )
+        logger.info("=" * SEPARATOR_WIDTH)
+        TableFormatter.log_table(header, rows)
+        self._log_resource_deltas()
+        self._log_client_deltas()
+
+    def _combined_server_rows(self) -> List[tuple]:
+        """Server-app rows for the combined table (na when absent)."""
+        if not self._resource_rows:
+            return [("Server app",) + self._NA_METRICS]
+        rows = []
+        for display, _before, _after in self._resource_rows:
+            # display: (concurrent, before_rss, settled_rss, rss_delta,
+            #   fds, threads, thread_delta, conns, cpu, children)
+            rows.append((
+                "Server app", display[0], display[1], "na",
+                display[2], display[3], display[8], display[4],
+                display[5], display[6], display[7], display[9],
+            ))
+        return rows
+
+    def _combined_client_rows(self) -> List[tuple]:
+        """Client-app rows for the combined table (na when absent)."""
+        if not self._client_rows:
+            return [("Client app",) + self._NA_METRICS]
+        rows = []
+        for row in self._client_rows:
+            display = row[0]
+            # display: (concurrent, before_rss, peak_rss, settled_rss,
+            #   rss_delta, cpu, fds, threads)
+            rows.append((
+                "Client app", display[0], display[1], display[2],
+                display[3], display[4], display[5], display[6],
+                display[7], "na", "na", "na",
+            ))
+        return rows
+
+    def _log_resource_deltas(self) -> None:
+        """Log overall resource deltas if enough data points."""
+        if len(self._resource_rows) < 2:
+            return
+        first_before = self._resource_rows[0][1]
+        last_after = self._resource_rows[-1][2]
+        self._log_snapshot_deltas(
+            "Server", first_before, last_after,
+            fields=[
+                ("RSS", "rss", "%.1f MB"),
+                ("FDs", "fds", "%s"),
+                ("Threads", "threads", "%s"),
+                ("Connections", "connections", "%s"),
+                ("Children", "children", "%s"),
+            ],
+        )
+
+    def _log_client_deltas(self) -> None:
+        """Log overall client resource deltas if enough data points."""
+        if len(self._client_rows) < 2:
+            return
+        first_before = self._client_rows[0][1]
+        last_settled = self._client_rows[-1][3]
+        self._log_snapshot_deltas(
+            "Client", first_before, last_settled,
+            fields=[
+                ("RSS", "rss", "%.1f MB"),
+                ("FDs", "fds", "%s"),
+                ("Threads", "threads", "%s"),
+            ],
+        )
+
+    @staticmethod
+    def _log_snapshot_deltas(label, before, after, *, fields):
+        """Log deltas between two ResourceSnapshots."""
+        max_name = max(len(name) for name, _, _ in fields)
+        logger.info(
+            "\n  %s overall deltas (first stage vs last stage):",
+            label,
+        )
+        for name, key, fmt in fields:
+            delta = after.get(key) - before.get(key)
+            padded = f"{name}:".ljust(max_name + 1)
+            formatted = fmt % abs(delta)
+            sign = "+" if delta >= 0 else "-"
+            logger.info(
+                "    %s %s%s", padded, sign, formatted,
+            )

--- a/tests/load_tests/reporting/summary.py
+++ b/tests/load_tests/reporting/summary.py
@@ -1,0 +1,519 @@
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+"""Summary reporting — ramp-up and overall results."""
+
+import logging
+
+from collections import Counter
+
+from tests.load_tests.config import Formatters
+from tests.load_tests.config import SEPARATOR_WIDTH
+from tests.load_tests.config import STATUS_CREATED
+from tests.load_tests.config import STATUS_FAILED
+from tests.load_tests.config import STATUS_KILLED
+from tests.load_tests.config import STATUS_TIMEOUT
+from tests.load_tests.reporting.system_resources import SystemResources
+from tests.load_tests.reporting.table_formatter import TableFormatter
+
+logger = logging.getLogger(__name__)
+
+
+class SummaryReporter:
+    """Logs ramp-up and overall results across all stages.
+
+    Holds the collected stage summaries so that multiple
+    reporting methods can access them without re-passing.
+    """
+
+    def __init__(self, stage_summaries, neuro_san_version=None,
+                 client_token_source="agent_cli --tokens") -> None:
+        self._summaries = stage_summaries
+        self._neuro_san_version = neuro_san_version
+        self._client_token_source = client_token_source
+
+    def log_ramp_summary(self, *, is_ramp=True) -> None:
+        """Log the ramp-up summary table across all stages."""
+        logger.info("\n%s", "=" * SEPARATOR_WIDTH)
+        title = "RAMP-UP SUMMARY" if is_ramp else "ROUND SUMMARY"
+        logger.info("  %s", title)
+        logger.info("=" * SEPARATOR_WIDTH)
+
+        has_server_counts = any(
+            summary.get("primary_started") is not None
+            for summary in self._summaries
+        )
+        first_col = "Stage" if is_ramp else "Round"
+        header = [
+            first_col, "Concurrent", "Created", "Failed",
+            "Timeout", "Killed", "Retries", "Amplification",
+            "Duration",
+        ]
+        if has_server_counts:
+            header.extend(["Recv", "Done", "Internal"])
+        rows = []
+        for summary in self._summaries:
+            counts = summary.get("counts", {})
+            row = (
+                str(summary.get("stage") if is_ramp
+                    else summary.get("round", summary.get("stage"))),
+                str(summary.get("concurrent")),
+                str(counts.get(STATUS_CREATED, 0)),
+                str(counts.get(STATUS_FAILED, 0)),
+                str(counts.get(STATUS_TIMEOUT, 0)),
+                str(counts.get(STATUS_KILLED, 0)),
+                str(summary.get("total_retries", 0)),
+                f"{summary.get('amplification', 1.0):.2f}x",
+                f"{summary.get('elapsed', 0):.1f}s",
+            )
+            if has_server_counts:
+                pri_started = summary.get("primary_started")
+                pri_finished = summary.get("primary_finished")
+                total_started = summary.get("total_started")
+                internal = (
+                    str(total_started - pri_started)
+                    if pri_started is not None
+                    and total_started is not None
+                    else "-"
+                )
+                row += (
+                    str(pri_started)
+                    if pri_started is not None else "-",
+                    str(pri_finished)
+                    if pri_finished is not None else "-",
+                    internal,
+                )
+            rows.append(row)
+        TableFormatter.log_table(header, rows)
+
+    def log_overall_results(self) -> None:
+        """Log overall results across all stages."""
+        total_created = 0
+        total_failed = 0
+        total_timeout = 0
+        total_killed = 0
+        total_time = 0.0
+        total_retries = 0
+
+        for summary in self._summaries:
+            counts = summary.get("counts", {})
+            total_created += counts.get(STATUS_CREATED, 0)
+            total_failed += counts.get(STATUS_FAILED, 0)
+            total_timeout += counts.get(STATUS_TIMEOUT, 0)
+            total_killed += counts.get(STATUS_KILLED, 0)
+            total_time += summary.get("elapsed", 0)
+            total_retries += summary.get("total_retries", 0)
+
+        total_sent = (
+            total_created + total_failed + total_timeout + total_killed
+        )
+
+        logger.info("\n%s", "=" * SEPARATOR_WIDTH)
+        logger.info("  OVERALL RESULTS")
+        logger.info("=" * SEPARATOR_WIDTH)
+        if self._neuro_san_version:
+            logger.info(
+                "  neuro-san version: %s", self._neuro_san_version,
+            )
+        logger.info("  Total requests: %s", total_sent)
+        logger.info("    Created:   %s", total_created)
+        logger.info("    Failed:    %s", total_failed)
+        logger.info("    Timed out: %s", total_timeout)
+        logger.info("    Killed:    %s", total_killed)
+        logger.info(
+            "  Total wall time: %s",
+            Formatters.fmt_duration(total_time, precision=2),
+        )
+        self._log_performance_stats()
+
+        if total_retries > 0:
+            total_requests = sum(
+                s.get("concurrent", 0)
+                for s in self._summaries
+            )
+            amplification = (
+                (total_requests + total_retries) / total_requests
+                if total_requests > 0 else 1.0
+            )
+            logger.info("\n  Overall retry totals:")
+            logger.info("    Total retries:   %s", total_retries)
+            logger.info(
+                "    Amplification:   %.2fx", amplification,
+            )
+
+        self._log_llm_token_usage()
+        self._log_system_resources()
+
+    def _log_performance_stats(self) -> None:
+        """Log TTFR and request-duration stats."""
+        ttfr = self._ttfr_stats()
+        if ttfr is not None:
+            logger.info(
+                "  Time to first response: %s min"
+                " / %s avg / %s max",
+                Formatters.fmt_duration(ttfr.get("min", 0)),
+                Formatters.fmt_duration(ttfr.get("avg", 0)),
+                Formatters.fmt_duration(ttfr.get("max", 0)),
+            )
+
+        duration = self._request_duration_stats()
+        if duration is not None:
+            logger.info(
+                "  Request duration: %s min / %s avg"
+                " / %s max",
+                Formatters.fmt_duration(duration.get("min", 0)),
+                Formatters.fmt_duration(duration.get("avg", 0)),
+                Formatters.fmt_duration(duration.get("max", 0)),
+            )
+
+        self._log_validation_summary()
+
+    def _log_llm_token_usage(self) -> None:
+        """Log the LLM & TOKEN USAGE section (client vs server log).
+
+        A uniform block for all modes: the client side comes from
+        agent_cli/HTTP token accounting, the server side from
+        server.log.  Whichever side is unavailable prints "not
+        available".  When both are present (all-in-one) a Match line
+        reports whether they agree.
+        """
+        if self._has_client_token_copy():
+            client = self._token_stats("client_")
+            server = self._token_stats("")
+        else:
+            client = self._token_stats("")
+            server = None
+        printed = SummaryReporter.render_token_usage(
+            client, server,
+            client_source=self._client_token_source,
+        )
+        if printed:
+            self._log_model_distribution()
+
+    @staticmethod
+    def render_token_usage(client, server, *, client_source) -> bool:
+        """Render the LLM & TOKEN USAGE block; return True if printed.
+
+        ``client`` and ``server`` are token-stat dicts (from
+        ``aggregate_token_entries``) or None when that side is
+        unavailable.  Prints nothing when both are None.
+        """
+        if client is None and server is None:
+            return False
+        logger.info("\n%s", "=" * SEPARATOR_WIDTH)
+        logger.info("  LLM & TOKEN USAGE")
+        logger.info("=" * SEPARATOR_WIDTH)
+        SummaryReporter._log_token_source(
+            f"Client ({client_source})", client,
+        )
+        SummaryReporter._log_token_source("Server log", server)
+        if client is not None and server is not None:
+            SummaryReporter._log_token_match(client, server)
+        return True
+
+    @staticmethod
+    def _log_token_source(label, stats) -> None:
+        """Log one source's LLM/token lines, or 'not available'."""
+        if stats is None:
+            logger.info("  %s: not available", label)
+            return
+        logger.info("  %s:", label)
+        logger.info(
+            "    LLM calls: %s total  (%s / %s / %s min/avg/max)",
+            stats["calls_total"], stats["calls_min"],
+            stats["calls_avg"], stats["calls_max"],
+        )
+        logger.info(
+            "    Tokens:    %s total  (%s / %s / %s min/avg/max),"
+            "  %s prompt + %s completion",
+            f"{stats['tok_total']:,}", f"{stats['tok_min']:,}",
+            f"{stats['tok_avg']:,}", f"{stats['tok_max']:,}",
+            f"{stats['prompt_total']:,}", f"{stats['comp_total']:,}",
+        )
+
+    @staticmethod
+    def _log_token_match(client, server) -> None:
+        """Log whether client and server-log totals agree."""
+        calls_ok = client["calls_total"] == server["calls_total"]
+        tok_ok = client["tok_total"] == server["tok_total"]
+        if calls_ok and tok_ok:
+            logger.info("  Match: OK")
+            return
+        logger.info(
+            "  Match: MISMATCH — LLM calls %s vs %s, "
+            "tokens %s vs %s",
+            client["calls_total"], server["calls_total"],
+            f"{client['tok_total']:,}", f"{server['tok_total']:,}",
+        )
+
+    @staticmethod
+    def aggregate_token_entries(entries):
+        """Aggregate token dicts into a stats dict, or None if empty.
+
+        Each entry needs total_tokens, prompt_tokens,
+        completion_tokens, and llm_calls.  Entries with zero total
+        tokens are ignored.
+        """
+        calls = []
+        toks = []
+        prompt_total = 0
+        comp_total = 0
+        for entry in entries:
+            tok = entry.get("total_tokens", 0) or 0
+            if not tok:
+                continue
+            toks.append(tok)
+            prompt_total += entry.get("prompt_tokens", 0) or 0
+            comp_total += entry.get("completion_tokens", 0) or 0
+            calls.append(entry.get("llm_calls", 0) or 0)
+        if not toks:
+            return None
+        count = len(toks)
+        return {
+            "calls_min": min(calls),
+            "calls_avg": round(sum(calls) / count),
+            "calls_max": max(calls),
+            "calls_total": sum(calls),
+            "tok_min": min(toks),
+            "tok_avg": round(sum(toks) / count),
+            "tok_max": max(toks),
+            "tok_total": sum(toks),
+            "prompt_total": prompt_total,
+            "comp_total": comp_total,
+        }
+
+    def _has_client_token_copy(self) -> bool:
+        """True if results carry a preserved client-side token copy."""
+        for summary in self._summaries:
+            for result in summary.get("results", []):
+                if "client_total_tokens" in result:
+                    return True
+        return False
+
+    def _token_stats(self, prefix):
+        """Aggregate per-request token fields (optionally prefixed)."""
+        entries = []
+        for summary in self._summaries:
+            for result in summary.get("results", []):
+                entries.append({
+                    "total_tokens": result.get(
+                        prefix + "total_tokens", 0,
+                    ),
+                    "prompt_tokens": result.get(
+                        prefix + "prompt_tokens", 0,
+                    ),
+                    "completion_tokens": result.get(
+                        prefix + "completion_tokens", 0,
+                    ),
+                    "llm_calls": result.get(
+                        prefix + "llm_calls", 0,
+                    ),
+                })
+        return SummaryReporter.aggregate_token_entries(entries)
+
+    def _log_system_resources(self) -> None:
+        """Log the aligned SYSTEM RESOURCES before/peak/after section."""
+        SystemResources.log_section(
+            self._sys_edge_snapshot("before"),
+            self._sys_peak_snapshot(),
+            self._sys_edge_snapshot("after"),
+        )
+
+    def _sys_edge_snapshot(self, edge):
+        """Build the before/after whole-system snapshot across stages.
+
+        ``before`` takes the first stage's start values; ``after``
+        takes the last stage's end values.  Returns None when no
+        system data was collected.
+        """
+        prefix = f"{edge}_sys_"
+        chosen = None
+        for summary in self._summaries:
+            pct = summary.get(prefix + "mem_pct")
+            if pct is None:
+                continue
+            snap = {
+                "mem_pct": pct,
+                "mem_avail_gb": summary.get(prefix + "mem_avail_gb"),
+                "cpu_pct": summary.get(prefix + "cpu"),
+                "threads": summary.get(prefix + "threads"),
+            }
+            if edge == "before":
+                return snap
+            chosen = snap
+        return chosen
+
+    def _sys_peak_snapshot(self):
+        """Build the whole-system peak snapshot (per-metric max)."""
+        peak_pct = None
+        peak_avail = None
+        peak_cpu = None
+        peak_threads = None
+        for summary in self._summaries:
+            pct = summary.get("peak_sys_mem_pct")
+            if pct is not None and (peak_pct is None or pct > peak_pct):
+                peak_pct = pct
+                peak_avail = summary.get("peak_sys_mem_avail_gb")
+            cpu = summary.get("peak_sys_cpu")
+            if cpu is not None and (peak_cpu is None or cpu > peak_cpu):
+                peak_cpu = cpu
+            threads = summary.get("peak_sys_threads")
+            if (threads is not None
+                    and (peak_threads is None or threads > peak_threads)):
+                peak_threads = threads
+        if peak_pct is None and peak_cpu is None and peak_threads is None:
+            return None
+        return {
+            "mem_pct": peak_pct,
+            "mem_avail_gb": peak_avail,
+            "cpu_pct": peak_cpu,
+            "threads": peak_threads,
+        }
+
+    def _request_duration_stats(self):
+        """Compute min/avg/max elapsed time across requests."""
+        durations = []
+        for summary in self._summaries:
+            for result in summary.get("results", []):
+                durations.append(result.get("elapsed", 0))
+        if not durations:
+            return None
+        return {
+            "min": min(durations),
+            "avg": sum(durations) / len(durations),
+            "max": max(durations),
+        }
+
+    def _log_model_distribution(self) -> None:
+        """Log LLM model usage and flag fallback models.
+
+        Collects model names from all results and reports
+        how many requests used each model.  When multiple
+        models appear, highlights the non-primary ones as
+        potential fallbacks.
+        """
+        model_counts: Counter = Counter()
+        fallback_requests = 0
+        for summary in self._summaries:
+            for result in summary.get("results", []):
+                all_models = result.get("all_models", [])
+                model = result.get("model")
+                if all_models:
+                    for m in all_models:
+                        model_counts[m] += 1
+                    if len(all_models) > 1:
+                        fallback_requests += 1
+                elif model and model != "unknown":
+                    model_counts[model] += 1
+        if not model_counts:
+            return
+        logger.info(
+            "  LLM models: %s",
+            ", ".join(
+                f"{m} ({c})" for m, c in
+                model_counts.most_common()
+            ),
+        )
+        if fallback_requests > 0:
+            logger.info(
+                "    Fallback LLM used: %s request(s)",
+                fallback_requests,
+            )
+
+    def _ttfr_stats(self):
+        """Compute min/avg/max time-to-first-response."""
+        values = []
+        for summary in self._summaries:
+            for result in summary.get("results", []):
+                ttfr = result.get("ttft", 0)
+                if ttfr > 0:
+                    values.append(ttfr)
+        if not values:
+            return None
+        return {
+            "min": min(values),
+            "avg": sum(values) / len(values),
+            "max": max(values),
+        }
+
+    def _log_validation_summary(self) -> None:
+        """Log aggregate validation retry info if any."""
+        all_events = self._collect_validation_events()
+        if not all_events:
+            return
+        total_cycles = sum(
+            e.get("fix_cycles", 0) for e in all_events
+        )
+        total_requests = sum(
+            s.get("concurrent", 0) for s in self._summaries
+        )
+        affected = len(all_events)
+        all_errors = []
+        for event in all_events:
+            all_errors.extend(event.get("errors", []))
+        logger.info(
+            "\n  Validation: %s of %s requests needed"
+            " fixes (%s fix cycles total)",
+            affected, total_requests, total_cycles,
+        )
+        self._log_validation_time_impact(all_events)
+        if all_errors:
+            self._log_top_errors(all_errors)
+
+    def _log_validation_time_impact(self, events) -> None:
+        """Log avg duration of requests with/without fixes."""
+        fix_rids = {e.get("request_id") for e in events}
+        with_fixes = []
+        without_fixes = []
+        for summary in self._summaries:
+            for result in summary.get("results", []):
+                rid = result.get("request_id", "")
+                elapsed = result.get("elapsed", 0)
+                if rid in fix_rids:
+                    with_fixes.append(elapsed)
+                else:
+                    without_fixes.append(elapsed)
+        if with_fixes and without_fixes:
+            avg_with = sum(with_fixes) / len(with_fixes)
+            avg_without = sum(without_fixes) / len(without_fixes)
+            logger.info(
+                "    Requests with fixes took %s avg"
+                " vs %s avg without",
+                Formatters.fmt_duration(avg_with),
+                Formatters.fmt_duration(avg_without),
+            )
+
+    @staticmethod
+    def _log_top_errors(all_errors) -> None:
+        """Log the most common validation errors."""
+        counts = Counter(all_errors)
+        top = counts.most_common(3)
+        parts = [
+            f"{err} ({cnt}x)" for err, cnt in top
+        ]
+        logger.info(
+            "    %s errors found: %s",
+            len(all_errors), ", ".join(parts),
+        )
+
+    def _collect_validation_events(self):
+        """Gather all validation events across stages."""
+        events = []
+        for summary in self._summaries:
+            events.extend(
+                summary.get("validation_events", []),
+            )
+        return events

--- a/tests/load_tests/reporting/summary_file_writer.py
+++ b/tests/load_tests/reporting/summary_file_writer.py
@@ -1,0 +1,534 @@
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+"""Write a human-readable summary.txt for load test results."""
+
+import logging
+import os
+import time
+from typing import Dict
+from typing import List
+from typing import Optional
+
+from collections import Counter
+
+import psutil
+
+from tests.load_tests.config import Formatters
+from tests.load_tests.config import STATUS_CREATED
+
+logger = logging.getLogger(__name__)
+
+
+class SummaryFileWriter:
+    """Writes a human-readable summary.txt to the output directory.
+
+    Collects data from stage summaries and optional server timing
+    to produce a single text file for quick review.
+    """
+
+    def __init__(
+            self, stage_summaries, args,
+            server_chat_timing=None,
+    ) -> None:
+        self._summaries = stage_summaries
+        self._args = args
+        self._server_timing = server_chat_timing or []
+
+    def write(self, output_dir) -> Optional[str]:
+        """Write summary.txt and return the file path."""
+        lines = []
+        self._write_header(lines)
+        self._write_request_results(lines)
+        self._write_completion_timeline(lines)
+        self._write_server_timing(lines)
+
+        path = os.path.join(output_dir, "summary.txt")
+        with open(path, "w", encoding="utf-8") as fh:
+            fh.write("\n".join(lines) + "\n")
+        logger.info("  Summary:     %s", path)
+        return path
+
+    def _write_header(self, lines) -> None:
+        """Write the test configuration header."""
+        total_requests = sum(
+            len(s.get("results", []))
+            for s in self._summaries
+        )
+        total_elapsed = sum(
+            s.get("elapsed", 0) for s in self._summaries
+        )
+        agent = self._args.agent
+        date_str = time.strftime("%Y-%m-%d %H:%M")
+        num_req = self._args.num_requests
+        num_rnd = self._args.num_rounds
+        workers = self._args.max_workers
+        lines.append("=" * 60)
+        lines.append("  LOAD TEST SUMMARY")
+        lines.append("=" * 60)
+        lines.append(f"  Agent:       {agent}")
+        lines.append(f"  Date:        {date_str} UTC")
+        lines.append(
+            f"  Requests:    {num_req} x {num_rnd}"
+            f" round(s) = {total_requests} total",
+        )
+        lines.append(f"  Workers:     {workers} (concurrent)")
+        lines.append(
+            f"  Total wall time:"
+            f" {Formatters.fmt_duration(total_elapsed, precision=1)}"
+        )
+        ttfr_values = [
+            r.get("ttft", 0)
+            for s in self._summaries
+            for r in s.get("results", [])
+            if r.get("ttft", 0) > 0
+        ]
+        if ttfr_values:
+            avg_ttfr = sum(ttfr_values) / len(ttfr_values)
+            lines.append(
+                f"  Time to first response:"
+                f" {Formatters.fmt_duration(min(ttfr_values))} min"
+                f" / {Formatters.fmt_duration(avg_ttfr)} avg"
+                f" / {Formatters.fmt_duration(max(ttfr_values))} max"
+            )
+        durations = [
+            r.get("elapsed", 0)
+            for s in self._summaries
+            for r in s.get("results", [])
+        ]
+        if durations:
+            avg_dur = sum(durations) / len(durations)
+            lines.append(
+                f"  Request duration:"
+                f" {Formatters.fmt_duration(min(durations))} min"
+                f" / {Formatters.fmt_duration(avg_dur)} avg"
+                f" / {Formatters.fmt_duration(max(durations))} max"
+            )
+        llm_calls = [
+            r.get("llm_calls", 0)
+            for s in self._summaries
+            for r in s.get("results", [])
+            if r.get("llm_calls", 0) > 0
+        ]
+        if llm_calls:
+            avg_calls = round(sum(llm_calls) / len(llm_calls))
+            lines.append(
+                f"  LLM calls:"
+                f" {min(llm_calls)} min"
+                f" / {avg_calls} avg"
+                f" / {max(llm_calls)} max"
+            )
+        self._write_rss_trajectory(lines)
+        self._write_client_rss_trajectory(lines)
+        self._write_sys_mem_trajectory(lines)
+        self._write_validation_summary(lines)
+        lines.append("")
+
+    def _write_rss_trajectory(self, lines) -> None:
+        """Write server RSS start/peak/end if available."""
+        start_rss = None
+        end_rss = None
+        peak_rss = None
+        for summary in self._summaries:
+            before = summary.get("before_server_rss")
+            after = summary.get("after_server_rss")
+            peak = summary.get("peak_server_rss")
+            if before is not None and start_rss is None:
+                start_rss = before
+            if after is not None:
+                end_rss = after
+            if peak is not None:
+                if peak_rss is None or peak > peak_rss:
+                    peak_rss = peak
+        if peak_rss is None:
+            return
+        lines.append(
+            f"  Server RSS:"
+            f" {Formatters.format_rss(start_rss or 0)} start"
+            f" \u2192 {Formatters.format_rss(peak_rss)} peak"
+            f" \u2192 {Formatters.format_rss(end_rss or 0)} end"
+        )
+
+    def _write_client_rss_trajectory(self, lines) -> None:
+        """Write client RSS start/peak/end if available."""
+        start_rss = None
+        end_rss = None
+        peak_rss = None
+        for summary in self._summaries:
+            before = summary.get("before_client_rss")
+            after = summary.get("after_client_rss")
+            peak = summary.get("peak_client_rss")
+            if before is not None and start_rss is None:
+                start_rss = before
+            if after is not None:
+                end_rss = after
+            if peak is not None:
+                if peak_rss is None or peak > peak_rss:
+                    peak_rss = peak
+        if peak_rss is None:
+            return
+        lines.append(
+            f"  Client RSS:"
+            f" {Formatters.format_rss(start_rss or 0)} start"
+            f" \u2192 {Formatters.format_rss(peak_rss)} peak"
+            f" \u2192 {Formatters.format_rss(end_rss or 0)} end"
+        )
+
+    def _write_sys_mem_trajectory(self, lines) -> None:
+        """Write system memory start/peak/end if available."""
+        start_pct = None
+        end_pct = None
+        peak_pct = None
+        peak_avail_gb = None
+        for summary in self._summaries:
+            before = summary.get("before_sys_mem_pct")
+            after = summary.get("after_sys_mem_pct")
+            peak = summary.get("peak_sys_mem_pct")
+            avail = summary.get("peak_sys_mem_avail_gb")
+            if before is not None and start_pct is None:
+                start_pct = before
+            if after is not None:
+                end_pct = after
+            if peak is not None:
+                if peak_pct is None or peak > peak_pct:
+                    peak_pct = peak
+                    peak_avail_gb = avail
+        if peak_pct is None:
+            return
+        total_gb = (
+            psutil.virtual_memory().total / (1024 ** 3)
+        )
+        peak_detail = (
+            f"{peak_pct:.0f}% peak"
+            f" ({peak_avail_gb or 0:.1f}G free"
+            f" / {total_gb:.1f}G)"
+        )
+        lines.append(
+            f"  System memory:"
+            f" {start_pct or 0:.0f}% start"
+            f" \u2192 {peak_detail}"
+            f" \u2192 {end_pct or 0:.0f}% end"
+        )
+
+    def _write_validation_summary(self, lines) -> None:
+        """Write validation retry summary if any events exist."""
+        all_events = []
+        for summary in self._summaries:
+            all_events.extend(
+                summary.get("validation_events", []),
+            )
+        if not all_events:
+            return
+        total_cycles = sum(
+            e.get("fix_cycles", 0) for e in all_events
+        )
+        total_requests = sum(
+            s.get("concurrent", 0) for s in self._summaries
+        )
+        affected = len(all_events)
+        lines.append(
+            f"  Validation: {affected} of {total_requests}"
+            f" requests needed fixes"
+            f" ({total_cycles} fix cycles total)"
+        )
+        self._write_validation_time_impact(
+            lines, all_events,
+        )
+        all_errors = []
+        for event in all_events:
+            all_errors.extend(event.get("errors", []))
+        if all_errors:
+            counts = Counter(all_errors)
+            top = counts.most_common(3)
+            parts = [
+                f"{err} ({cnt}x)" for err, cnt in top
+            ]
+            lines.append(
+                f"    {len(all_errors)} errors found:"
+                f" {', '.join(parts)}"
+            )
+
+    def _write_validation_time_impact(
+            self, lines, events,
+    ) -> None:
+        """Write avg duration with/without validation fixes."""
+        fix_rids = {e.get("request_id") for e in events}
+        with_fixes = []
+        without_fixes = []
+        for summary in self._summaries:
+            for result in summary.get("results", []):
+                rid = result.get("request_id", "")
+                elapsed = result.get("elapsed", 0)
+                if rid in fix_rids:
+                    with_fixes.append(elapsed)
+                else:
+                    without_fixes.append(elapsed)
+        if with_fixes and without_fixes:
+            avg_with = sum(with_fixes) / len(with_fixes)
+            avg_without = (
+                sum(without_fixes) / len(without_fixes)
+            )
+            lines.append(
+                f"    Requests with fixes took"
+                f" {Formatters.fmt_duration(avg_with)} avg"
+                f" vs {Formatters.fmt_duration(avg_without)} avg"
+                f" without"
+            )
+
+    def _write_request_results(self, lines) -> None:
+        """Write per-request result table."""
+        all_results = []
+        for summary in self._summaries:
+            all_results.extend(summary.get("results", []))
+        if not all_results:
+            return
+
+        lines.append("=" * 60)
+        lines.append("  REQUEST RESULTS")
+        lines.append("=" * 60)
+
+        for result in all_results:
+            self._format_result_line(lines, result)
+
+        self._format_result_totals(lines, all_results)
+
+    def _format_result_line(self, lines, result) -> None:
+        """Format a single request result line."""
+        rid = result.get("request_id", "?")
+        elapsed = result.get("elapsed", 0)
+        status = result.get("status", "?")
+        detail = self._extract_detail(result)
+        if detail:
+            lines.append(
+                f"  {rid:<12s} {elapsed:7.1f}s"
+                f"  {status:<8s}  {detail}",
+            )
+        else:
+            lines.append(
+                f"  {rid:<12s} {elapsed:7.1f}s"
+                f"  {status:<8s}",
+            )
+
+    @staticmethod
+    def _format_result_totals(lines, all_results) -> None:
+        """Format overall totals for request results."""
+        passed = sum(
+            1 for r in all_results
+            if r.get("status") == STATUS_CREATED
+        )
+        total = len(all_results)
+        failed = total - passed
+        latencies = [
+            r.get("elapsed", 0) for r in all_results
+        ]
+        lines.append("")
+        lines.append(
+            f"  Overall: {passed}/{total} CREATED,"
+            f" {failed} failed",
+        )
+        if latencies:
+            avg = sum(latencies) / len(latencies)
+            lines.append(
+                f"  Avg: {avg:.1f}s"
+                f" | Min: {min(latencies):.1f}s"
+                f" | Max: {max(latencies):.1f}s",
+            )
+        lines.append("")
+
+    def _write_completion_timeline(self, lines) -> None:
+        """Write cumulative completion timeline."""
+        all_latencies = []
+        for summary in self._summaries:
+            for result in summary.get("results", []):
+                all_latencies.append(result.get("elapsed", 0))
+        if not all_latencies:
+            return
+
+        all_latencies.sort()
+        total = len(all_latencies)
+        milestones = [50, 60, 70, 80, 90, 95, 100]
+        lines.append("=" * 60)
+        lines.append("  COMPLETION TIMELINE")
+        lines.append("=" * 60)
+
+        prev_count = -1
+        for pct in milestones:
+            idx = min(
+                int(total * pct / 100 + 0.999999) - 1,
+                total - 1,
+            )
+            count = idx + 1
+            val = all_latencies[idx]
+            if count == prev_count:
+                continue
+            prev_count = count
+            lines.append(
+                f"  {pct:4d}% ({count} requests)"
+                f" completed by"
+                f" {Formatters.fmt_duration(val, precision=1)}",
+            )
+        self._write_count_milestones(lines, all_latencies)
+        lines.append("")
+
+    @staticmethod
+    def _write_count_milestones(lines, sorted_latencies):
+        """Write completion times at round-number request counts."""
+        total = len(sorted_latencies)
+        step = 50
+        if total <= step:
+            return
+        milestones = list(range(step, total, step))
+        if not milestones or milestones[-1] != total:
+            milestones.append(total)
+        lines.append("")
+        lines.append("  Completion by count:")
+        for count in milestones:
+            duration = sorted_latencies[count - 1]
+            lines.append(
+                f"  {count:5d} requests completed by"
+                f" {Formatters.fmt_duration(duration, precision=1)}",
+            )
+
+    def _write_server_timing(self, lines) -> None:
+        """Write per-request server timing breakdown."""
+        if not self._server_timing:
+            return
+
+        client_results = self._collect_client_times()
+        by_server_id: Dict[str, list] = {}
+        for entry in self._server_timing:
+            sid = entry.get("request_id", "")
+            by_server_id.setdefault(sid, []).append(entry)
+
+        lines.append("=" * 60)
+        lines.append("  SERVER TIMING BREAKDOWN")
+        lines.append("=" * 60)
+
+        for sid in sorted(by_server_id.keys()):
+            entries = by_server_id[sid]
+            entries.sort(
+                key=lambda e: e.get("start_ts", 0),
+            )
+            if not entries:
+                continue
+            top_start = entries[0].get("start_ts", 0)
+            client = self._match_client(
+                top_start, client_results,
+            )
+            label = client.get("id", sid)
+            self._format_request_timing(
+                lines, label, entries, client,
+            )
+        lines.append("")
+
+    def _collect_client_times(
+            self,
+    ) -> List[Dict[str, float]]:
+        """Collect client start/end times from all results."""
+        results: List[Dict[str, float]] = []
+        for summary in self._summaries:
+            for result in summary.get("results", []):
+                rid = result.get("request_id", "")
+                start = result.get("start_time", 0)
+                end = result.get("end_time", 0)
+                if rid and start and end:
+                    results.append({
+                        "id": rid,
+                        "start": start,
+                        "end": end,
+                    })
+        return results
+
+    @staticmethod
+    def _match_client(
+            server_start_ts, client_results,
+    ) -> Dict[str, float]:
+        """Find the client request whose window contains the ts."""
+        for client in client_results:
+            if (client.get("start", 0)
+                    <= server_start_ts
+                    <= client.get("end", 0)):
+                return client
+        return {}
+
+    @staticmethod
+    def _format_request_timing(
+            lines, rid, entries, client,
+    ) -> None:
+        """Format timing breakdown for a single request."""
+        top = entries[0]
+        top_agent = top.get("agent", "?")
+        c_start = client.get("start", 0)
+        c_end = client.get("end", 0)
+        total = (
+            c_end - c_start if c_start and c_end else 0
+        )
+        s_start = top.get("start_ts", 0)
+        s_finish = top.get("finish_ts", 0)
+        lines.append("")
+        lines.append(f"  {rid} ({total:.1f}s total):")
+        if c_start and s_start and s_start > c_start:
+            lines.append(
+                f"    Client -> Server: "
+                f" {s_start - c_start:6.1f}s",
+            )
+        lines.append(
+            f"    Server: {top_agent:<25s}"
+            f" {top.get('duration', 0):6.1f}s",
+        )
+        SummaryFileWriter._format_sub_agents(
+            lines, entries, top_agent,
+        )
+        if c_end and s_finish and c_end > s_finish:
+            lines.append(
+                f"    Server -> Client: "
+                f" {c_end - s_finish:6.1f}s",
+            )
+
+    @staticmethod
+    def _format_sub_agents(
+            lines, entries, top_agent,
+    ) -> None:
+        """Format sub-agent timing lines."""
+        sub_agents = [
+            e for e in entries
+            if e.get("agent") != top_agent
+        ]
+        for i, sub in enumerate(sub_agents):
+            prefix = (
+                "\u2514\u2500"
+                if i == len(sub_agents) - 1
+                else "\u251c\u2500"
+            )
+            name = sub.get("agent", "?")
+            dur = sub.get("duration", 0)
+            lines.append(
+                f"      {prefix} {name:<23s} {dur:6.1f}s",
+            )
+
+    @staticmethod
+    def _extract_detail(result) -> str:
+        """Extract a human-readable detail from parsed fields."""
+        parts = []
+        for key in ("agent_network_name", "reservation_id"):
+            val = result.get(key, "")
+            if val:
+                parts.append(str(val))
+                break
+        reason = result.get("failure_reason")
+        if reason:
+            parts.append(f"reason: {reason}")
+        return "  ".join(parts)

--- a/tests/load_tests/reporting/system_resources.py
+++ b/tests/load_tests/reporting/system_resources.py
@@ -1,0 +1,186 @@
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+"""Shared whole-system resource snapshots and reporting.
+
+Centralizes the whole-machine (not per-process) memory, CPU, and
+thread readings so the PRE-RUN SUMMARY and the OVERALL SYSTEM
+RESOURCES section render from a single source instead of duplicated
+copies across the input validator, load test, and summary reporter.
+"""
+
+import logging
+from typing import Dict
+from typing import Optional
+from typing import Tuple
+
+try:
+    import resource
+except ImportError:
+    # Unix-only module.  Thread limits report "n/a" without it.
+    resource = None
+
+import psutil
+
+from tests.load_tests.config import SEPARATOR_WIDTH
+
+logger = logging.getLogger(__name__)
+
+# A whole-system snapshot: mem_pct, mem_avail_gb, cpu_pct, threads.
+SysSnapshot = Dict[str, float]
+
+
+class SystemResources:
+    """Whole-system (not per-process) resource readings and reporting."""
+
+    @staticmethod
+    def total_threads() -> int:
+        """Sum thread counts across all processes on the machine."""
+        total = 0
+        for proc in psutil.process_iter(["num_threads"]):
+            try:
+                total += proc.info["num_threads"] or 0
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                continue
+        return total
+
+    @staticmethod
+    def thread_limits() -> Tuple[str, str]:
+        """Return (per-user limit, system max) as display strings."""
+        user_limit = "n/a"
+        if resource is not None:
+            try:
+                soft, _ = resource.getrlimit(resource.RLIMIT_NPROC)
+                user_limit = (
+                    "unlimited"
+                    if soft == resource.RLIM_INFINITY
+                    else f"{soft:,}"
+                )
+            except (ValueError, OSError, AttributeError):
+                user_limit = "n/a"
+        sys_max = "n/a"
+        try:
+            with open(
+                "/proc/sys/kernel/threads-max",
+                encoding="utf-8",
+            ) as handle:
+                sys_max = f"{int(handle.read().strip()):,}"
+        except (OSError, ValueError):
+            pass
+        return user_limit, sys_max
+
+    @classmethod
+    def snapshot(cls, *, cpu_interval: float = 0.1) -> SysSnapshot:
+        """Capture a point-in-time whole-system snapshot."""
+        mem = psutil.virtual_memory()
+        return {
+            "mem_pct": mem.percent,
+            "mem_avail_gb": mem.available / (1024 ** 3),
+            "cpu_pct": psutil.cpu_percent(interval=cpu_interval),
+            "threads": cls.total_threads(),
+        }
+
+    @classmethod
+    def log_prerun(cls) -> None:
+        """Log the PRE-RUN SUMMARY system lines (RAM / CPU / threads)."""
+        mem = psutil.virtual_memory()
+        total_gb = mem.total / (1024 ** 3)
+        avail_gb = mem.available / (1024 ** 3)
+        ncores = psutil.cpu_count() or 1
+        cpu_pct = psutil.cpu_percent(interval=0.1)
+        user_limit, sys_max = cls.thread_limits()
+        logger.info(
+            "  System RAM: %.1fG (%.1fG available, %.0f%% used)",
+            total_gb, avail_gb, mem.percent,
+        )
+        logger.info(
+            "  System CPU: %d cores (%.0f%% in use)",
+            ncores, cpu_pct,
+        )
+        logger.info(
+            "  System threads: %s in use / limit %s per-user (%s max)",
+            f"{cls.total_threads():,}", user_limit, sys_max,
+        )
+
+    @classmethod
+    def log_section(
+            cls,
+            before: Optional[SysSnapshot],
+            peak: Optional[SysSnapshot],
+            after: Optional[SysSnapshot],
+    ) -> None:
+        """Log the aligned SYSTEM RESOURCES before/peak/after section."""
+        rows = (("before", before), ("peak", peak), ("after", after))
+        if all(snap is None for _, snap in rows):
+            return
+        logger.info("\n%s", "=" * SEPARATOR_WIDTH)
+        logger.info("  SYSTEM RESOURCES")
+        logger.info("=" * SEPARATOR_WIDTH)
+        total_gb = psutil.virtual_memory().total / (1024 ** 3)
+        ncores = psutil.cpu_count() or 1
+        user_limit, sys_max = cls.thread_limits()
+        for tag, snap in rows:
+            if snap is not None and snap.get("mem_pct") is not None:
+                cls._log_row(
+                    "System memory", tag, cls._fmt_mem(snap, total_gb),
+                )
+        for tag, snap in rows:
+            if snap is not None and snap.get("cpu_pct") is not None:
+                cls._log_row(
+                    "System CPU", tag, cls._fmt_cpu(snap, ncores),
+                )
+        for tag, snap in rows:
+            if snap is not None and snap.get("threads") is not None:
+                cls._log_row(
+                    "System threads", tag,
+                    cls._fmt_threads(snap, tag, user_limit, sys_max),
+                )
+
+    @staticmethod
+    def _log_row(metric: str, tag: str, value: str) -> None:
+        """Log one aligned metric row so value columns line up."""
+        logger.info("  %-14s %-9s %s", metric, f"({tag}):", value)
+
+    @staticmethod
+    def _fmt_mem(snap: SysSnapshot, total_gb: float) -> str:
+        """Format a memory row: used / free / percent."""
+        pct = snap["mem_pct"]
+        avail_gb = snap.get("mem_avail_gb", 0.0)
+        used_mb = pct / 100.0 * total_gb * 1024.0
+        return (
+            f"{used_mb:.0f}M used / {avail_gb:.1f}G free"
+            f" ({pct:.0f}% used)"
+        )
+
+    @staticmethod
+    def _fmt_cpu(snap: SysSnapshot, ncores: int) -> str:
+        """Format a CPU row: percent and core-equivalents."""
+        pct = snap["cpu_pct"]
+        return f"{pct:.0f}% ({pct / 100.0 * ncores:.2f} of {ncores} cores)"
+
+    @staticmethod
+    def _fmt_threads(
+            snap: SysSnapshot, tag: str,
+            user_limit: str, sys_max: str,
+    ) -> str:
+        """Format a threads row; limits only on the before row."""
+        threads = int(snap["threads"])
+        if tag == "before":
+            return (
+                f"{threads:,} in use / limit {user_limit}"
+                f" per-user ({sys_max} max)"
+            )
+        return f"{threads:,} in use"

--- a/tests/load_tests/reporting/table_formatter.py
+++ b/tests/load_tests/reporting/table_formatter.py
@@ -1,0 +1,40 @@
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+"""Formats and logs aligned console tables."""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class TableFormatter:
+    """Formats and logs aligned tables."""
+
+    @staticmethod
+    def log_table(header, rows) -> None:
+        """Log an aligned table given a header list and rows."""
+        col_widths = [len(h) for h in header]
+        for row in rows:
+            for i, val in enumerate(row):
+                col_widths[i] = max(col_widths[i], len(str(val)))
+        fmt = "  ".join(f"{{:>{w}}}" for w in col_widths)
+        logger.info("%s", fmt.format(*header))
+        logger.info(
+            "%s", "-" * (sum(col_widths) + 2 * (len(header) - 1)),
+        )
+        for row in rows:
+            logger.info("%s", fmt.format(*row))

--- a/tests/load_tests/reporting/trend_history.py
+++ b/tests/load_tests/reporting/trend_history.py
@@ -1,0 +1,210 @@
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+"""Trend history — read the append-only history file and log a table.
+
+Complements the cross-run comparison, which answers a different
+question: that one groups runs by request count to show how the system
+scales, while this one keeps runs in the order they happened so a
+regression between neuro-san versions is visible.
+"""
+
+import json
+import logging
+import os
+
+from typing import Dict
+from typing import List
+from typing import Optional
+
+from tests.load_tests.config import HISTORY_FILE_NAME
+from tests.load_tests.config import HISTORY_THRESHOLDS_SECONDS
+from tests.load_tests.reporting.table_formatter import TableFormatter
+
+logger = logging.getLogger(__name__)
+
+
+class TrendHistory:
+    """Reads history JSONL records and logs them in run order."""
+
+    def __init__(self, path, *, agent_filter=None) -> None:
+        self._path = path
+        self._agent_filter: set = (
+            set(agent_filter) if agent_filter else set()
+        )
+
+    def run(self) -> None:
+        """Read the history file and log one row per recorded run."""
+        history_path = self._resolve_path()
+        if history_path is None:
+            logger.info(
+                "No history file found at %s. Runs append one record "
+                "each, so this file appears after the first run.",
+                self._path,
+            )
+            return
+        records = self._read_records(history_path)
+        if not records:
+            logger.info("No usable records in %s", history_path)
+            return
+        if self._agent_filter:
+            records = [
+                record for record in records
+                if record.get("agent") in self._agent_filter
+            ]
+            if not records:
+                logger.info(
+                    "No records for agent(s) %s in %s",
+                    ", ".join(sorted(self._agent_filter)),
+                    history_path,
+                )
+                return
+        records.sort(key=lambda record: record.get("timestamp", ""))
+        logger.info("")
+        logger.info(
+            "TREND HISTORY (%s, %s run(s))",
+            history_path, len(records),
+        )
+        TableFormatter.log_table(
+            self._header(), [self._row(record) for record in records],
+        )
+        logger.info("")
+
+    def _resolve_path(self) -> Optional[str]:
+        """Return the history file to read, or None when absent.
+
+        Accepts either the file itself or a directory holding the
+        default-named history file, so the path printed at the end of a
+        run and its parent output directory both work.
+        """
+        if os.path.isfile(self._path):
+            return self._path
+        candidate = os.path.join(self._path, HISTORY_FILE_NAME)
+        if os.path.isfile(candidate):
+            return candidate
+        return None
+
+    @staticmethod
+    def _read_records(history_path) -> List[Dict]:
+        """Parse the JSONL file, skipping unreadable lines.
+
+        A partially written final line is expected when a run is
+        interrupted, so a bad line is reported and skipped rather than
+        losing every earlier record.
+        """
+        records: List[Dict] = []
+        skipped = 0
+        try:
+            with open(history_path, "r", encoding="utf-8") as handle:
+                for line in handle:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        record = json.loads(line)
+                    except json.JSONDecodeError:
+                        skipped += 1
+                        continue
+                    if isinstance(record, dict):
+                        records.append(record)
+                    else:
+                        skipped += 1
+        except OSError as exc:
+            logger.warning(
+                "Could not read history file %s: %s", history_path, exc,
+            )
+            return []
+        if skipped:
+            logger.warning(
+                "  Skipped %s unreadable line(s) in %s",
+                skipped, history_path,
+            )
+        return records
+
+    @staticmethod
+    def _header() -> List[str]:
+        """Return the table header, including a column per threshold."""
+        header = [
+            "timestamp", "neuro-san", "agent", "mode", "via",
+            "reqs", "done",
+        ]
+        header.extend(
+            f"<{int(threshold)}s"
+            for threshold in HISTORY_THRESHOLDS_SECONDS
+        )
+        header.extend(["ttfr", "avg", "wall", "err", "warn"])
+        return header
+
+    @staticmethod
+    def _row(record) -> List[str]:
+        """Format one history record as a table row.
+
+        Client and server-only records count requests under different
+        keys, and a server log cannot measure the client's time to
+        first response, so the missing values render as "-".
+
+        The transport is shown because subprocess and HTTP runs are not
+        comparable to each other, and both land in the same file.
+        """
+        mode = record.get("mode", "client")
+        requests = record.get(
+            "total_requests", record.get("expected_requests", 0),
+        )
+        completed = record.get(
+            "completed", record.get("received_requests", 0),
+        )
+        row = [
+            TrendHistory._fmt_timestamp(record.get("timestamp", "")),
+            record.get("neuro_san_version", "unknown"),
+            record.get("agent", "unknown"),
+            mode,
+            record.get("transport", "-"),
+            str(requests),
+            str(completed),
+        ]
+        row.extend(
+            str(record.get(f"completed_within_{int(threshold)}s", "-"))
+            for threshold in HISTORY_THRESHOLDS_SECONDS
+        )
+        row.append(
+            TrendHistory._fmt_seconds(
+                record.get("avg_first_response_s"),
+            ),
+        )
+        row.append(
+            TrendHistory._fmt_seconds(record.get("avg_duration_s")),
+        )
+        row.append(
+            TrendHistory._fmt_seconds(record.get("wall_time_s")),
+        )
+        row.append(str(record.get("server_error_count", "-")))
+        row.append(str(record.get("tool_warning_count", "-")))
+        return row
+
+    @staticmethod
+    def _fmt_timestamp(timestamp) -> str:
+        """Shorten an ISO timestamp to "YYYY-MM-DD HH:MM"."""
+        if not timestamp:
+            return "-"
+        text = str(timestamp).replace("T", " ")
+        return text[:16]
+
+    @staticmethod
+    def _fmt_seconds(value) -> str:
+        """Format a seconds value, rendering absent or zero as "-"."""
+        if not isinstance(value, (int, float)) or value <= 0:
+            return "-"
+        return f"{value:.1f}s"

--- a/tests/load_tests/traffic/__init__.py
+++ b/tests/load_tests/traffic/__init__.py
@@ -1,0 +1,15 @@
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT

--- a/tests/load_tests/traffic/cli_builder.py
+++ b/tests/load_tests/traffic/cli_builder.py
@@ -1,0 +1,126 @@
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+"""Build agent_cli subprocess commands and manage prompt files."""
+
+import json
+import logging
+import os
+import re
+import tempfile
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+class CliBuilder:
+    """Builds agent_cli subprocess commands and manages prompt files."""
+
+    # pylint: disable=too-many-arguments,too-many-positional-arguments
+    @staticmethod
+    def build_cli_command(
+            host, port, agent_name, prompt_file,
+            include_tokens=False, use_https=False,
+            chat_filter_type="MAXIMAL",
+    ) -> List[str]:
+        """Build the agent_cli subprocess command list.
+
+        Uses --no_thinking_file to avoid race conditions under
+        concurrency.  When include_tokens is True, adds --tokens
+        for inline token accounting.  When use_https is True,
+        connects over HTTPS/TLS instead of plain HTTP.  When
+        chat_filter_type is "MINIMAL", adds --minimal so the server
+        streams only the final answer; agent_cli defaults to
+        --maximal otherwise.
+        """
+        cmd = [
+            "python", "-m", "neuro_san.client.agent_cli",
+            "--https" if use_https else "--http",
+            "--host", host,
+            "--port", str(port),
+            "--agent", agent_name,
+            "--first_prompt_file", prompt_file,
+            "--one_shot",
+            "--no_thinking_file",
+        ]
+        if include_tokens:
+            cmd.append("--tokens")
+        if str(chat_filter_type).upper() == "MINIMAL":
+            cmd.append("--minimal")
+        return cmd
+
+    @staticmethod
+    def write_prompt_file(global_request_id, prompt) -> str:
+        """Write prompt text to a temporary file and return its path."""
+        fd, prompt_file = tempfile.mkstemp(
+            prefix=f"load_test_prompt_{global_request_id}_",
+            suffix=".txt",
+        )
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(prompt)
+        return prompt_file
+
+    @staticmethod
+    def cleanup_prompt_file(prompt_file) -> None:
+        """Remove the temporary prompt file."""
+        try:
+            os.remove(prompt_file)
+        except OSError as exc:
+            logger.debug("Could not remove prompt file: %s", exc)
+
+    @staticmethod
+    def parse_stdout_field(stdout, field_name) -> Optional[str]:
+        """Extract a JSON field value from agent_cli stdout (sly_data output)."""
+        match = re.search(rf'"{field_name}"\s*:\s*"([^"]+)"', stdout)
+        if match:
+            return match.group(1)
+        return None
+
+    @staticmethod
+    def parse_token_accounting(stdout) -> Dict[str, Any]:
+        """Extract Token Accounting JSON block from agent_cli stdout."""
+        marker = "Token Accounting:"
+        idx = stdout.find(marker)
+        if idx < 0:
+            return {}
+        json_start = stdout.find("{", idx)
+        if json_start < 0:
+            return {}
+        depth = 0
+        json_end = json_start
+        for i in range(json_start, len(stdout)):
+            if stdout[i] == "{":
+                depth += 1
+            elif stdout[i] == "}":
+                depth -= 1
+                if depth == 0:
+                    json_end = i + 1
+                    break
+        try:
+            return json.loads(stdout[json_start:json_end])
+        except (json.JSONDecodeError, ValueError):
+            return {}
+
+    @staticmethod
+    def last_stderr_line(stderr) -> str:
+        """Extract the last line of stderr for error reporting."""
+        stripped = stderr.strip() if stderr else ""
+        if not stripped:
+            return ""
+        return stripped.rsplit("\n", maxsplit=1)[-1]

--- a/tests/load_tests/traffic/http_client.py
+++ b/tests/load_tests/traffic/http_client.py
@@ -1,0 +1,201 @@
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+"""In-thread HTTP client for load testing without subprocess overhead.
+
+Instead of spawning a separate ``python -m neuro_san.client.agent_cli``
+process per request (~96 MB each), this module instantiates
+``HttpServiceAgentSession`` and ``StreamingInputProcessor`` directly
+in the calling thread.  Memory cost drops from ~96 MB per concurrent
+request to ~1-2 MB per thread.
+"""
+
+import logging
+import time
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Tuple
+
+from neuro_san.client.streaming_input_processor import (
+    StreamingInputProcessor,
+)
+from neuro_san.session.http_service_agent_session import (
+    HttpServiceAgentSession,
+)
+
+from tests.load_tests.config import STATUS_CREATED
+from tests.load_tests.config import STATUS_FAILED
+from tests.load_tests.config import STATUS_TIMEOUT
+
+logger = logging.getLogger(__name__)
+
+# Timeout for the initial TCP connection (seconds).
+_CONNECT_TIMEOUT = 30
+
+
+class _RequestTimeout(Exception):
+    """Raised to abandon a request that outran --request-timeout."""
+
+
+class HttpClient:
+    """Runs agent_cli logic in-thread via HttpServiceAgentSession."""
+
+    @staticmethod
+    def execute_request(
+            host, port, agent, prompt, *,
+            timeout, idle_timeout, use_https=False,
+            chat_filter_type="MAXIMAL",
+    ) -> Tuple[str, Dict[str, str], str, float, Dict]:
+        """Send one streaming_chat request using the agent_cli
+        client stack in-thread.
+
+        Creates an ``HttpServiceAgentSession`` and a
+        ``StreamingInputProcessor`` (the same objects that
+        ``agent_cli`` uses), then calls ``process_once()``
+        to send the request, consume the streaming response,
+        and extract sly_data fields.  When ``use_https`` is True,
+        a ``security_cfg`` is supplied so the session connects
+        over HTTPS/TLS instead of plain HTTP.
+
+        ``timeout`` (from ``--request-timeout``) is enforced while the
+        response streams, so a request that keeps producing messages
+        cannot outlive the cap.  The check happens per streamed
+        message, so a request is abandoned within one message of the
+        cap rather than exactly at it; the wait for that message is
+        itself bounded by ``idle_timeout``.
+
+        Returns (status, parsed_fields, response_text, ttft,
+        token_accounting).
+        """
+        start = time.time()
+
+        security_cfg: Dict[str, Any] = {} if use_https else None
+        session = HttpServiceAgentSession(
+            host=host,
+            port=str(port),
+            agent_name=agent,
+            security_cfg=security_cfg,
+            timeout_in_seconds=_CONNECT_TIMEOUT,
+            streaming_timeout_in_seconds=idle_timeout,
+        )
+
+        # Time-to-first-response: wrap the session's streaming_chat so
+        # the first streamed chat message is timestamped, matching the
+        # subprocess mode's time-to-first-stdout metric. process_once()
+        # iterates this generator internally.
+        first_response: List[float] = []
+        original_streaming_chat = session.streaming_chat
+
+        def timed_streaming_chat(request_dict):
+            # Nested to close over original_streaming_chat, start, and
+            # first_response so the first streamed message is timed
+            # without threading that state through process_once().
+            for chat_response in original_streaming_chat(request_dict):
+                if not first_response:
+                    first_response.append(time.time() - start)
+                if time.time() - start >= timeout:
+                    raise _RequestTimeout()
+                yield chat_response
+
+        session.streaming_chat = timed_streaming_chat
+
+        processor = StreamingInputProcessor(
+            default_input="DEFAULT",
+            thinking_file=None,
+            session=session,
+            thinking_dir=None,
+        )
+
+        state: Dict[str, Any] = {
+            "last_chat_response": None,
+            "num_input": 0,
+            "user_input": prompt,
+            "sly_data": None,
+            "chat_filter": {
+                "chat_filter_type": chat_filter_type,
+            },
+        }
+
+        try:
+            state = processor.process_once(state)
+        except _RequestTimeout:
+            return (STATUS_TIMEOUT, {}, "", 0.0, {})
+        # Broad by design: process_once() drives the third-party
+        # HTTP/streaming stack, whose failure surface (connection,
+        # decode, gRPC/transport errors) is not enumerable here.  This
+        # is a per-request isolation boundary — any single request must
+        # be recorded as FAILED/TIMEOUT without aborting the load test.
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            elapsed = time.time() - start
+            if elapsed >= timeout:
+                return (STATUS_TIMEOUT, {}, "", 0.0, {})
+            logger.debug("HTTP request failed: %s", exc)
+            return (STATUS_FAILED, {}, str(exc), 0.0, {})
+
+        elapsed = time.time() - start
+        if elapsed >= timeout:
+            return (STATUS_TIMEOUT, {}, "", 0.0, {})
+
+        answer_text = state.get("last_chat_response") or ""
+        returned_sly_data = state.get(
+            "returned_sly_data",
+        ) or {}
+        token_accounting = state.get(
+            "token_accounting",
+        ) or {}
+
+        parsed_fields: Dict[str, str] = {}
+        HttpClient._extract_string_fields(
+            returned_sly_data, parsed_fields,
+        )
+
+        status = (
+            STATUS_CREATED if answer_text
+            else STATUS_FAILED
+        )
+        ttft = first_response[0] if first_response else 0.0
+        return (
+            status, parsed_fields, answer_text,
+            ttft, token_accounting,
+        )
+
+    @staticmethod
+    def _extract_string_fields(
+            obj, parsed_fields,
+    ):
+        """Recursively extract string-valued fields.
+
+        The subprocess mode prints sly_data as JSON and then
+        regex-searches the entire stdout.  Fields like
+        ``reservation_id`` may be nested inside lists (e.g.
+        ``sly_data["agent_reservations"][0]["reservation_id"]``).
+        A flat top-level scan misses them, so we recurse.
+        """
+        if isinstance(obj, dict):
+            for key, value in obj.items():
+                if isinstance(value, str):
+                    parsed_fields.setdefault(key, value)
+                elif isinstance(value, (dict, list)):
+                    HttpClient._extract_string_fields(
+                        value, parsed_fields,
+                    )
+        elif isinstance(obj, list):
+            for item in obj:
+                if isinstance(item, (dict, list)):
+                    HttpClient._extract_string_fields(
+                        item, parsed_fields,
+                    )

--- a/tests/load_tests/traffic/process_monitor.py
+++ b/tests/load_tests/traffic/process_monitor.py
@@ -1,0 +1,193 @@
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+"""Subprocess execution with idle-timeout and hard-timeout detection."""
+
+import logging
+import os
+import subprocess
+import sys
+import time
+from typing import List
+from typing import Optional
+from typing import Tuple
+
+from tests.load_tests.config import POLL_INTERVAL_SECONDS
+from tests.load_tests.config import PROCESS_WAIT_TIMEOUT
+from tests.load_tests.config import READ_BUFFER_SIZE
+from tests.load_tests.config import STATUS_FAILED
+from tests.load_tests.config import STATUS_KILLED
+from tests.load_tests.config import STATUS_TIMEOUT
+
+logger = logging.getLogger(__name__)
+
+
+class ProcessMonitor:
+    """Runs subprocesses with idle-timeout and hard-timeout detection."""
+
+    @staticmethod
+    def execute_with_idle_detection(
+            cmd, timeout, idle_timeout, cancel_event=None,
+    ) -> Tuple[str, str, str, int, float]:
+        """Run a subprocess with idle-timeout and hard-timeout detection.
+
+        When ``cancel_event`` is supplied and becomes set (e.g. after a
+        Ctrl-C), the subprocess is killed promptly and reported as
+        KILLED so the caller can salvage completed requests instead of
+        hanging on stalled ones.
+
+        Returns (status, stdout, stderr, returncode, ttft).
+        ttft is time-to-first-token in seconds (0.0 if no stdout).
+        """
+        stdout_chunks: List[bytes] = []
+        stderr_chunks: List[bytes] = []
+        status = STATUS_FAILED
+        ttft_ref: List[float] = []
+
+        try:
+            # pylint: disable=consider-using-with
+            proc = subprocess.Popen(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+        except OSError as exc:
+            return (STATUS_FAILED, "", str(exc), -1, 0.0)
+
+        try:
+            monitor_status = ProcessMonitor._monitor_process(
+                proc, stdout_chunks, stderr_chunks,
+                timeout=timeout, idle_timeout=idle_timeout,
+                ttft_ref=ttft_ref, cancel_event=cancel_event,
+            )
+            if monitor_status is not None:
+                status = monitor_status
+        except (OSError, subprocess.SubprocessError):
+            proc.kill()
+            proc.wait()
+            status = STATUS_FAILED
+
+        if not proc.stdout.closed:
+            remaining_out = proc.stdout.read()
+            if remaining_out:
+                stdout_chunks.append(remaining_out)
+        if not proc.stderr.closed:
+            remaining_err = proc.stderr.read()
+            if remaining_err:
+                stderr_chunks.append(remaining_err)
+        try:
+            proc.wait(timeout=PROCESS_WAIT_TIMEOUT)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
+            if status == STATUS_FAILED:
+                status = STATUS_KILLED
+
+        ttft = ttft_ref[0] if ttft_ref else 0.0
+        return (
+            status,
+            b"".join(stdout_chunks).decode("utf-8", errors="replace"),
+            b"".join(stderr_chunks).decode("utf-8", errors="replace"),
+            proc.returncode,
+            ttft,
+        )
+
+    @staticmethod
+    # pylint: disable=too-many-arguments
+    def _monitor_process(proc, stdout_chunks,
+                         stderr_chunks, *,
+                         timeout, idle_timeout,
+                         ttft_ref, cancel_event=None) -> Optional[str]:
+        """Monitor a running process for output, idle timeout, and hard timeout.
+
+        Returns STATUS_TIMEOUT or STATUS_KILLED for abnormal exits,
+        or None when the process exits normally (caller determines
+        final status from the return code).
+        """
+        if sys.platform == "win32":
+            return ProcessMonitor._monitor_process_win(
+                proc, stdout_chunks, stderr_chunks,
+                timeout=timeout,
+            )
+        return ProcessMonitor._monitor_process_unix(
+            proc, stdout_chunks, stderr_chunks,
+            timeout=timeout, idle_timeout=idle_timeout,
+            ttft_ref=ttft_ref, cancel_event=cancel_event,
+        )
+
+    @staticmethod
+    # pylint: disable=too-many-arguments
+    def _monitor_process_unix(proc, stdout_chunks,
+                              stderr_chunks, *,
+                              timeout, idle_timeout,
+                              ttft_ref, cancel_event=None) -> Optional[str]:
+        """Unix implementation using select() for idle-timeout detection."""
+        import select  # pylint: disable=import-outside-toplevel
+        start = time.time()
+        last_activity = time.time()
+        while proc.poll() is None:
+            elapsed = time.time() - start
+            idle_elapsed = time.time() - last_activity
+
+            if cancel_event is not None and cancel_event.is_set():
+                proc.kill()
+                proc.wait()
+                return STATUS_KILLED
+
+            if elapsed >= timeout:
+                proc.kill()
+                proc.wait()
+                return STATUS_TIMEOUT
+
+            if idle_elapsed >= idle_timeout:
+                proc.kill()
+                proc.wait()
+                return STATUS_KILLED
+
+            readable, _, _ = select.select(
+                [proc.stdout, proc.stderr], [], [],
+                POLL_INTERVAL_SECONDS,
+            )
+            for stream in readable:
+                data = os.read(stream.fileno(), READ_BUFFER_SIZE)
+                if data:
+                    last_activity = time.time()
+                    if stream == proc.stdout:
+                        if not ttft_ref:
+                            ttft_ref.append(
+                                time.time() - start,
+                            )
+                        stdout_chunks.append(data)
+                    else:
+                        stderr_chunks.append(data)
+        return None
+
+    @staticmethod
+    def _monitor_process_win(proc, stdout_chunks,
+                             stderr_chunks, *,
+                             timeout) -> Optional[str]:
+        """Windows fallback using communicate() (hard-timeout only)."""
+        try:
+            out, err = proc.communicate(timeout=timeout)
+            if out:
+                stdout_chunks.append(out)
+            if err:
+                stderr_chunks.append(err)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
+            return STATUS_TIMEOUT
+        return None

--- a/tests/load_tests/traffic/runner.py
+++ b/tests/load_tests/traffic/runner.py
@@ -1,0 +1,914 @@
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+"""Traffic runner — fires concurrent requests via a thread pool."""
+
+import json
+import logging
+import os
+import re
+import sys
+import threading
+import time
+from concurrent.futures import as_completed
+from concurrent.futures import CancelledError
+from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import TimeoutError as FutureTimeoutError
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Tuple
+
+from tests.load_tests.config import FAILURE_LOG_LIMIT
+from tests.load_tests.config import Formatters
+from tests.load_tests.config import RequestResult
+from tests.load_tests.config import SharedRef
+from tests.load_tests.config import STATUS_CREATED
+from tests.load_tests.config import STATUS_FAILED
+from tests.load_tests.config import STATUS_KILLED
+from tests.load_tests.config import STATUS_TIMEOUT
+from tests.load_tests.config import POLL_INTERVAL_SECONDS
+from tests.load_tests.config import THREAD_JOIN_TIMEOUT
+from tests.load_tests.cost_estimator import CostEstimator
+from tests.load_tests.monitoring.heartbeat import Heartbeat
+from tests.load_tests.traffic.cli_builder import CliBuilder
+from tests.load_tests.traffic.http_client import HttpClient
+from tests.load_tests.traffic.process_monitor import ProcessMonitor
+
+logger = logging.getLogger(__name__)
+
+# Grace period after Ctrl-C for in-flight requests to wind down before
+# they are recorded as KILLED.  Sized above the subprocess poll interval
+# so killed subprocess requests have time to resolve.
+INTERRUPT_GRACE_SECONDS = 2 * POLL_INTERVAL_SECONDS + 2.0
+
+
+class TrafficRunner:
+    """Fires concurrent requests via a thread pool and collects results.
+
+    Holds the parsed CLI args and the agent profile so that callers
+    do not need to thread them through every method.
+    """
+
+    def __init__(self, args, profile) -> None:
+        self._args = args
+        self._profile = profile
+        self._failure_log_lock = threading.Lock()
+        self._failures_logged = 0
+
+    # pylint: disable=too-many-arguments,too-many-positional-arguments
+    def _run_one_tracked(self, request_id, global_request_id,
+                         output_dir, failed_ref,
+                         cancel_event=None) -> RequestResult:
+        """Run one request and increment failed_ref on failure."""
+        if getattr(self._args, "http_client", False):
+            result = self.run_one_http(
+                request_id, global_request_id, output_dir,
+            )
+        else:
+            result = self.run_one(
+                request_id, global_request_id, output_dir,
+                cancel_event=cancel_event,
+            )
+        if result.get("status") != STATUS_CREATED:
+            failed_ref.value = (failed_ref.value or 0) + 1
+        return result
+
+    # pylint: disable=too-many-locals
+    def run_one(self, request_id, global_request_id,
+                output_dir=None, cancel_event=None) -> RequestResult:
+        """Execute a single request with idle-timeout detection.
+
+        Returns a result dict with status, elapsed, prompt, and parsed fields.
+        """
+        prompt = self._profile.get_prompt(
+            global_request_id, same_prompt=self._args.same_prompt,
+        )
+        prompt_file = CliBuilder.write_prompt_file(global_request_id, prompt)
+
+        try:
+            start = time.time()
+            status, stdout, stderr, returncode, ttft = (
+                ProcessMonitor.execute_with_idle_detection(
+                    CliBuilder.build_cli_command(
+                        self._args.host, self._args.port,
+                        self._args.agent, prompt_file,
+                        include_tokens=self._args.include_tokens,
+                        use_https=getattr(self._args, "https", False),
+                        chat_filter_type=getattr(
+                            self._args, "chat_filter", "maximal",
+                        ).upper(),
+                    ),
+                    self._args.request_timeout, self._args.idle_timeout,
+                    cancel_event,
+                )
+            )
+            elapsed = time.time() - start
+
+            parsed_fields: Dict[str, str] = {
+                field: CliBuilder.parse_stdout_field(stdout, field)
+                for field in self._profile.success_fields
+            }
+
+            self._save_request_output(
+                output_dir, request_id, stdout, stderr,
+            )
+
+            status, failure_reason = self._validate_result(
+                status, returncode, stdout, parsed_fields,
+            )
+            self._log_request_result(
+                request_id, status, elapsed,
+                parsed_fields=parsed_fields,
+                failure_reason=failure_reason,
+                stderr=stderr,
+                output_dir=output_dir,
+            )
+
+            result = {
+                "request_id": f"request-{request_id}",
+                "status": status,
+                "elapsed": elapsed,
+                "ttft": ttft,
+                "start_time": start,
+                "end_time": start + elapsed,
+                "prompt": prompt,
+                "failure_reason": failure_reason,
+                "error": (
+                    CliBuilder.last_stderr_line(stderr)
+                    if status != STATUS_CREATED else None
+                ),
+            }
+            result.update(parsed_fields)
+            if self._args.include_tokens:
+                self._attach_token_data(result, stdout)
+            return result
+        finally:
+            CliBuilder.cleanup_prompt_file(prompt_file)
+
+    # pylint: disable=too-many-locals
+    def run_one_http(self, request_id, global_request_id,
+                     output_dir=None) -> RequestResult:
+        """Execute a single request via direct HTTP.
+
+        Uses thread-based HTTP POST instead of spawning a
+        subprocess, reducing per-request memory from ~96 MB
+        to ~1-2 MB.
+        """
+        prompt = self._profile.get_prompt(
+            global_request_id,
+            same_prompt=self._args.same_prompt,
+        )
+        start = time.time()
+        status, parsed_fields, response_text, ttft, token_data = (
+            HttpClient.execute_request(
+                self._args.host, self._args.port,
+                self._args.agent, prompt,
+                timeout=self._args.request_timeout,
+                idle_timeout=self._args.idle_timeout,
+                use_https=getattr(self._args, "https", False),
+                chat_filter_type=getattr(
+                    self._args, "chat_filter", "maximal",
+                ).upper(),
+            )
+        )
+        elapsed = time.time() - start
+
+        # Subprocess mode extracts fields via regex over the
+        # entire stdout (answer text + sly_data).  Match that
+        # behaviour: for any success field not already found in
+        # sly_data, search the answer text with the same regex.
+        for field in self._profile.success_fields:
+            if not parsed_fields.get(field) and response_text:
+                match = re.search(
+                    rf'"{field}"\s*:\s*"([^"]+)"',
+                    response_text,
+                )
+                if match:
+                    parsed_fields[field] = match.group(1)
+
+        failure_reason = None
+        if status == STATUS_CREATED:
+            for pattern in self._profile.failure_patterns:
+                if pattern in response_text:
+                    status = STATUS_FAILED
+                    failure_reason = (
+                        "response matched failure pattern: "
+                        + pattern
+                    )
+                    break
+            if status == STATUS_CREATED:
+                if self._args.skip_reservation_check:
+                    required = [
+                        f for f in self._profile.success_fields
+                        if f != "reservation_id"
+                    ]
+                else:
+                    required = self._profile.success_fields
+                missing = [
+                    f for f in required
+                    if not parsed_fields.get(f)
+                ]
+                if missing:
+                    status = STATUS_FAILED
+                    failure_reason = (
+                        "missing " + ", ".join(missing)
+                    )
+        elif status == STATUS_FAILED and not response_text:
+            failure_reason = "empty response from agent"
+
+        self._save_request_output(
+            output_dir, request_id,
+            self._http_saved_stdout(response_text, token_data), "",
+        )
+
+        self._log_request_result(
+            request_id, status, elapsed,
+            parsed_fields=parsed_fields,
+            failure_reason=failure_reason,
+            stderr="",
+            output_dir=output_dir,
+        )
+
+        result = {
+            "request_id": f"request-{request_id}",
+            "status": status,
+            "elapsed": elapsed,
+            "ttft": ttft,
+            "start_time": start,
+            "end_time": start + elapsed,
+            "prompt": prompt,
+            "failure_reason": failure_reason,
+            "error": (
+                failure_reason
+                if status != STATUS_CREATED else None
+            ),
+        }
+        result.update(parsed_fields)
+        if token_data:
+            self._attach_http_token_data(result, token_data)
+        return result
+
+    def _validate_result(self, status, returncode, stdout,
+                         parsed_fields,
+                         ) -> Tuple[str, Optional[str]]:
+        """Determine final status and failure reason for a request."""
+        failure_reason = None
+        if status in (STATUS_TIMEOUT, STATUS_KILLED):
+            return status, failure_reason
+        if self._profile.success_fields:
+            if self._args.skip_reservation_check:
+                required = [
+                    f for f in self._profile.success_fields
+                    if f != "reservation_id"
+                ]
+            else:
+                required = self._profile.success_fields
+            passed = returncode == 0 and all(
+                parsed_fields.get(f) for f in required
+            )
+        else:
+            passed = returncode == 0
+        if passed and not stdout.strip():
+            passed = False
+            failure_reason = "empty response from agent"
+        if passed:
+            matched = self._check_failure_patterns(stdout)
+            if matched is not None:
+                passed = False
+                failure_reason = (
+                    f"response matched failure pattern: {matched}"
+                )
+        status = STATUS_CREATED if passed else STATUS_FAILED
+        if status == STATUS_FAILED and not failure_reason:
+            failure_reason = self._diagnose_failure(
+                returncode, parsed_fields, stdout,
+            )
+        return status, failure_reason
+
+    def _check_failure_patterns(self, stdout) -> Optional[str]:
+        """Check stdout against the profile's failure patterns.
+
+        Returns the first matched pattern, or None if no match.
+        """
+        for pattern in self._profile.failure_patterns:
+            if pattern in stdout:
+                return pattern
+        return None
+
+    @staticmethod
+    def _attach_token_data(result, stdout) -> None:
+        """Parse token accounting from stdout and attach to result."""
+        token_data = CliBuilder.parse_token_accounting(stdout)
+        if not token_data:
+            return
+        models_dict = token_data.get("models", {})
+        model = TrafficRunner._extract_model(models_dict)
+        all_models = TrafficRunner._extract_all_models(
+            models_dict,
+        )
+        prompt_tok = token_data.get("prompt_tokens", 0)
+        completion_tok = token_data.get("completion_tokens", 0)
+        result.update({
+            "total_tokens": token_data.get("total_tokens", 0),
+            "prompt_tokens": prompt_tok,
+            "completion_tokens": completion_tok,
+            "llm_calls": token_data.get("successful_requests", 0),
+            "model": model,
+            "all_models": all_models,
+            "cost_usd": CostEstimator.estimate(
+                prompt_tok, completion_tok, model,
+            ),
+        })
+
+    @staticmethod
+    def _extract_model(models_dict) -> str:
+        """Extract the specific model name from the nested models dict.
+
+        Token Accounting returns: {"openai": {"gpt-4o-mini": {...}}}.
+        This traverses provider -> model to return "gpt-4o-mini".
+        """
+        for provider_models in models_dict.values():
+            if isinstance(provider_models, dict):
+                for model_name in provider_models:
+                    return model_name
+        return "unknown"
+
+    @staticmethod
+    def _extract_all_models(models_dict) -> list:
+        """Extract all model names from the nested models dict.
+
+        Returns a list of all model names across all providers,
+        useful for detecting fallback LLM usage when multiple
+        models responded within a single request.
+        """
+        all_models = []
+        for provider_models in models_dict.values():
+            if isinstance(provider_models, dict):
+                all_models.extend(provider_models.keys())
+        return all_models
+
+    def _http_saved_stdout(self, response_text, token_data) -> str:
+        """Final answer plus Token Accounting JSON (agent_cli parity).
+
+        In HTTP mode the client receives the answer and token
+        accounting on separate channels; join them so the saved
+        per-request file matches subprocess (agent_cli) output.
+        """
+        saved = response_text or ""
+        if self._args.include_tokens and token_data:
+            saved += (
+                "\n\nToken Accounting:\n"
+                + json.dumps(token_data, indent=2)
+                + "\n"
+            )
+        return saved
+
+    @staticmethod
+    def _attach_http_token_data(result, token_data) -> None:
+        """Attach token accounting from HTTP response to result.
+
+        Same logic as _attach_token_data but accepts the
+        token_accounting dict directly instead of parsing from
+        stdout.
+        """
+        if not token_data:
+            return
+        models_dict = token_data.get("models", {})
+        model = TrafficRunner._extract_model(models_dict)
+        all_models = TrafficRunner._extract_all_models(
+            models_dict,
+        )
+        prompt_tok = token_data.get("prompt_tokens", 0)
+        completion_tok = token_data.get("completion_tokens", 0)
+        result.update({
+            "total_tokens": token_data.get("total_tokens", 0),
+            "prompt_tokens": prompt_tok,
+            "completion_tokens": completion_tok,
+            "llm_calls": token_data.get(
+                "successful_requests", 0,
+            ),
+            "model": model,
+            "all_models": all_models,
+            "cost_usd": CostEstimator.estimate(
+                prompt_tok, completion_tok, model,
+            ),
+        })
+
+    # pylint: disable=too-many-locals,too-many-arguments
+    def run_stage(self, num_requests,
+                  max_workers, global_offset, *,
+                  server_proc=None, client_proc=None,
+                  output_dir=None,
+                  stage_timeout=None,
+                  cancel_event=None,
+                  log_monitor=None,
+                  primary_start_pattern=None,
+                  ) -> Tuple[
+        float, List[RequestResult], SharedRef, SharedRef,
+        SharedRef, SharedRef, SharedRef, SharedRef, bool, bool,
+    ]:
+        """Fire num_requests concurrent requests using a thread pool.
+
+        Returns (elapsed, results, peak_threads_ref,
+        peak_client_rss_ref, peak_server_rss_ref,
+        peak_sys_mem_pct_ref, peak_sys_cpu_ref,
+        peak_sys_threads_ref, server_died, interrupted).
+
+        When ``cancel_event`` becomes set (Ctrl-C), in-flight
+        subprocess requests are killed and the stage returns early
+        with whatever completed so far, marking the remainder KILLED.
+        """
+        results_list: List[RequestResult] = []
+        peak_threads_ref = SharedRef()
+        peak_client_rss_ref = SharedRef()
+        peak_server_rss_ref = SharedRef()
+        peak_sys_mem_pct_ref = SharedRef()
+        peak_sys_cpu_ref = SharedRef()
+        peak_sys_threads_ref = SharedRef()
+        failed_ref = SharedRef()
+        failed_ref.value = 0
+        server_dead_event = threading.Event()
+        start = time.time()
+        interrupted = False
+        heartbeat_thread = None
+        heartbeat_stop = threading.Event()
+        # Not using ``with`` so that on Ctrl-C we can shut the pool
+        # down without blocking on stalled worker threads (e.g.
+        # in-thread HTTP requests that cannot be force-killed).
+        pool = ThreadPoolExecutor(max_workers=max_workers)
+        try:
+            heartbeat_ready = threading.Event()
+            fires_done_event = threading.Event()
+            futures_ref: list = []
+            log_start_pos = (
+                log_monitor.read_position()
+                if log_monitor is not None else None
+            )
+            hb = Heartbeat(
+                server_proc, client_proc, output_dir,
+                log_monitor=log_monitor,
+                log_start_pos=log_start_pos,
+                primary_start_pattern=primary_start_pattern,
+            )
+            heartbeat_thread = threading.Thread(
+                target=hb.progress_heartbeat,
+                args=(futures_ref, num_requests, start,
+                      heartbeat_stop),
+                kwargs={
+                    "ready_event": heartbeat_ready,
+                    "fires_done_event": fires_done_event,
+                    "peak_threads_ref": peak_threads_ref,
+                    "peak_client_rss_ref": peak_client_rss_ref,
+                    "peak_server_rss_ref": peak_server_rss_ref,
+                    "peak_sys_mem_pct_ref": peak_sys_mem_pct_ref,
+                    "peak_sys_cpu_ref": peak_sys_cpu_ref,
+                    "peak_sys_threads_ref": peak_sys_threads_ref,
+                    "failed_ref": failed_ref,
+                    "server_dead_event": server_dead_event,
+                },
+                daemon=True,
+            )
+            heartbeat_thread.start()
+            heartbeat_ready.wait()
+            futures_ref.extend(
+                pool.submit(
+                    self._run_one_tracked,
+                    i + 1, global_offset + i,
+                    output_dir, failed_ref, cancel_event,
+                )
+                for i in range(num_requests)
+            )
+            fires_done_event.set()
+            killed_count, interrupted = self._collect_with_timeout(
+                futures_ref, results_list,
+                start=start, stage_timeout=stage_timeout,
+                cancel_event=cancel_event,
+            )
+            if killed_count and not interrupted:
+                logger.warning(
+                    "  Stage timeout (%ss) reached — "
+                    "%s request(s) killed.",
+                    stage_timeout, killed_count,
+                )
+            elif interrupted:
+                logger.warning(
+                    "  Interrupted (Ctrl-C) — %s request(s) still "
+                    "in flight were dropped; reporting completed ones.",
+                    killed_count,
+                )
+        finally:
+            heartbeat_stop.set()
+            if heartbeat_thread is not None:
+                heartbeat_thread.join(timeout=THREAD_JOIN_TIMEOUT)
+            pool.shutdown(wait=not interrupted, cancel_futures=True)
+        total_time = time.time() - start
+        return (
+            total_time, results_list,
+            peak_threads_ref, peak_client_rss_ref,
+            peak_server_rss_ref, peak_sys_mem_pct_ref,
+            peak_sys_cpu_ref, peak_sys_threads_ref,
+            server_dead_event.is_set(), interrupted,
+        )
+
+    @staticmethod
+    # pylint: disable=too-many-branches
+    def _collect_with_timeout(
+            futures, results_list, *,
+            start, stage_timeout, cancel_event=None,
+    ) -> Tuple[int, bool]:
+        """Collect future results, cancelling stragglers on timeout/Ctrl-C.
+
+        Polls in short slices so a set ``cancel_event`` (Ctrl-C) is
+        noticed promptly: the event tells in-flight subprocesses to
+        die, then their futures resolve as KILLED.  Returns
+        (num_killed, interrupted).
+        """
+        pending = set(futures)
+        killed = 0
+        interrupted = False
+        while pending:
+            if cancel_event is not None and cancel_event.is_set():
+                interrupted = True
+                break
+            elapsed = time.time() - start
+            if stage_timeout is not None:
+                remaining = stage_timeout - elapsed
+                if remaining <= 0:
+                    break
+                wait_slice = min(1.0, remaining)
+            else:
+                wait_slice = 1.0
+            try:
+                for fut in as_completed(pending, timeout=wait_slice):
+                    results_list.append(fut.result())
+                    pending.discard(fut)
+            except FutureTimeoutError:
+                pass
+
+        reason = (
+            "Killed by Ctrl-C interrupt" if interrupted
+            else "Killed by --stage-timeout"
+        )
+        for fut in pending:
+            fut.cancel()
+        if interrupted:
+            # Give in-flight requests a short grace to wind down:
+            # subprocess requests are killed via cancel_event and
+            # resolve within a poll interval.  Anything still stuck
+            # after the grace (e.g. an un-killable in-thread HTTP
+            # request) is recorded as KILLED without blocking on it.
+            grace_deadline = time.time() + INTERRUPT_GRACE_SECONDS
+            for fut in list(pending):
+                remaining = max(0.0, grace_deadline - time.time())
+                try:
+                    results_list.append(fut.result(timeout=remaining))
+                    pending.discard(fut)
+                except FutureTimeoutError:
+                    pass
+                except CancelledError:
+                    pending.discard(fut)
+
+        for fut in pending:
+            killed += 1
+            if fut.cancelled() or not fut.done():
+                results_list.append({
+                    "request_id": "unknown",
+                    "status": STATUS_KILLED,
+                    "stdout": "",
+                    "stderr": reason,
+                    "returncode": -1,
+                    "elapsed": time.time() - start,
+                    "ttft": 0.0,
+                    "prompt": "",
+                })
+            else:
+                results_list.append(fut.result())
+        return killed, interrupted
+
+    def _diagnose_failure(self, returncode, parsed_fields,
+                          stdout) -> str:
+        """Return a human-readable reason why a request was marked FAILED."""
+        reasons = []
+        if returncode != 0:
+            reasons.append(f"non-zero exit code ({returncode})")
+        for field in self._profile.success_fields:
+            if field == "reservation_id" and self._args.skip_reservation_check:
+                continue
+            if not parsed_fields.get(field):
+                reasons.append(f"missing {field}")
+        token_hint = self._detect_empty_llm_response(stdout)
+        if token_hint:
+            reasons.append(token_hint)
+        return "; ".join(reasons) if reasons else "unknown"
+
+    @staticmethod
+    def _detect_empty_llm_response(stdout) -> Optional[str]:
+        """Check token accounting for signs of an empty LLM response."""
+        tokens = CliBuilder.parse_token_accounting(stdout)
+        if not tokens:
+            return "no token data"
+        empty = tokens.get("empty_responses", 0)
+        completion = tokens.get("completion_tokens", 0)
+        if empty > 0:
+            return (
+                f"empty LLM response "
+                f"({completion} completion tokens, "
+                f"{empty} empty response(s))"
+            )
+        return "incomplete response"
+
+    def _log_request_result(self, request_id, status, elapsed, *,
+                            parsed_fields, failure_reason,
+                            stderr, output_dir=None) -> None:
+        """Log the result of a single request.
+
+        CREATED results go to progress.log when output_dir is set.
+        FAILED/TIMEOUT/KILLED always print to console.
+        """
+        is_failure = status in (
+            STATUS_FAILED, STATUS_TIMEOUT, STATUS_KILLED,
+        )
+        if output_dir and not is_failure:
+            self._write_result_to_file(
+                output_dir, request_id, status, elapsed,
+                parsed_fields=parsed_fields,
+            )
+            return
+        if is_failure:
+            with self._failure_log_lock:
+                self._failures_logged += 1
+                rank = self._failures_logged
+            if rank > FAILURE_LOG_LIMIT:
+                return
+            if rank == FAILURE_LOG_LIMIT:
+                sys.stdout.write("\n")
+                sys.stdout.flush()
+                logger.info(
+                    "Request %s: %s (%s)",
+                    request_id, status,
+                    Formatters.fmt_duration(elapsed, precision=2),
+                )
+                logger.info(
+                    "  ... further per-request failures suppressed"
+                    " (see totals below and raw_results.json)",
+                )
+                return
+        sys.stdout.write("\n")
+        sys.stdout.flush()
+        logger.info(
+            "Request %s: %s (%s)",
+            request_id, status,
+            Formatters.fmt_duration(elapsed, precision=2),
+        )
+        for field, value in parsed_fields.items():
+            if field == "reservation_id" and self._args.skip_reservation_check:
+                logger.info("  %s: skipped", field)
+            else:
+                logger.info("  %s: %s", field, value or "")
+        if failure_reason:
+            logger.info("  reason: %s", failure_reason)
+        if is_failure:
+            last_err = CliBuilder.last_stderr_line(stderr)
+            if last_err and last_err.strip():
+                logger.info("  stderr: %s", last_err)
+
+    @staticmethod
+    def _write_result_to_file(output_dir, request_id, status,
+                              elapsed, *, parsed_fields) -> None:
+        """Append a successful request result to progress.log."""
+        path = os.path.join(output_dir, "progress.log")
+        fields_str = "  ".join(
+            f"{k}: {v or ''}" for k, v in parsed_fields.items()
+        )
+        line = (
+            f"Request {request_id}: {status}"
+            f" ({Formatters.fmt_duration(elapsed, precision=2)})"
+            f"  {fields_str}\n"
+        )
+        with open(path, "a", encoding="utf-8") as fh:
+            fh.write(line)
+
+    @staticmethod
+    def log_token_summary(
+            results, *, output_dir=None,
+            network_tokens=None,
+            validation_events=None,
+    ) -> None:
+        """Log token usage summary to console, detail to file.
+
+        When output_dir is provided, per-request lines go to
+        server_tokens.log and only totals appear on the console.
+        Without output_dir, per-request lines go to the console.
+        """
+        has_tokens = any(r.get("total_tokens") for r in results)
+        if not has_tokens:
+            return
+        if output_dir:
+            TrafficRunner._write_token_file(
+                results, output_dir,
+                network_tokens=network_tokens,
+                validation_events=validation_events,
+            )
+            TrafficRunner._log_token_totals(results)
+        else:
+            TrafficRunner._log_token_per_request(results)
+
+    @staticmethod
+    def _log_token_per_request(results) -> None:
+        """Log per-request token lines to the console."""
+        for result in results:
+            total = result.get("total_tokens", 0)
+            if not total:
+                continue
+            prompt_tok = result.get("prompt_tokens", 0)
+            comp_tok = result.get("completion_tokens", 0)
+            llm_calls = result.get("llm_calls", 0)
+            model = result.get("model", "unknown")
+            rid = result.get("request_id", "?")
+            logger.info(
+                "  %s: %s tokens (%s prompt + %s completion), "
+                "%s LLM call(s), model=%s",
+                rid, f"{total:,}",
+                f"{prompt_tok:,}",
+                f"{comp_tok:,}",
+                llm_calls, model,
+            )
+
+    @staticmethod
+    def _write_token_file(
+            results, output_dir, *,
+            network_tokens=None,
+            validation_events=None,
+    ) -> None:
+        """Write per-request token detail to server_tokens.log."""
+        by_request = TrafficRunner._group_network_tokens(
+            network_tokens,
+        )
+        by_validation = TrafficRunner._group_validation_events(
+            validation_events,
+        )
+        path = os.path.join(output_dir, "server_tokens.log")
+        with open(path, "w", encoding="utf-8") as fh:
+            for result in results:
+                total = result.get("total_tokens", 0)
+                if not total:
+                    continue
+                TrafficRunner._write_token_request(
+                    fh, result, by_request,
+                    by_validation,
+                )
+        logger.info("  Detail:  %s", path)
+
+    @staticmethod
+    def _group_network_tokens(network_tokens):
+        """Group network token entries by request_id."""
+        by_request = {}
+        for entry in (network_tokens or []):
+            rid = entry.get("request_id", "")
+            by_request.setdefault(rid, []).append(entry)
+        return by_request
+
+    @staticmethod
+    def _group_validation_events(validation_events):
+        """Index validation events by request_id."""
+        by_request = {}
+        for event in (validation_events or []):
+            rid = event.get("request_id", "")
+            by_request[rid] = event
+        return by_request
+
+    @staticmethod
+    def _write_token_request(
+            fh, result, by_request, by_validation,
+    ) -> None:
+        """Write one request's token line with agent breakdown."""
+        rid = result.get("request_id", "?")
+        total = result.get("total_tokens", 0)
+        llm_calls = result.get("llm_calls", 0)
+        model = result.get("model", "unknown")
+        agent = result.get("reporting_agent", "")
+        elapsed = result.get("elapsed", 0)
+        status = result.get("status", "?")
+        agent_suffix = f", agent={agent}" if agent else ""
+        fh.write(
+            f"{rid}: {total:,} tokens, "
+            f"{llm_calls} LLM call(s), "
+            f"model={model}{agent_suffix}"
+            f"  [{elapsed:.1f}s {status}]\n"
+        )
+        TrafficRunner._write_validation_detail(
+            fh, rid, by_validation,
+        )
+        server_rid = result.get("server_request_id", rid)
+        agents = (
+            by_request.get(server_rid)
+            or by_request.get(rid)
+            or []
+        )
+        if not agents and agent:
+            fh.write(
+                f"  {agent}: {llm_calls} call(s)"
+                f"  {total:,} tokens"
+                f" ({result.get('prompt_tokens', 0):,} prompt"
+                f" / {result.get('completion_tokens', 0):,}"
+                f" completion)\n"
+            )
+        elif not agents and not agent:
+            fh.write(
+                "  (agent data not found in server log)\n"
+            )
+        for ag_entry in agents:
+            net = ag_entry.get("network", "?")
+            a_calls = ag_entry.get("llm_calls", 0)
+            a_total = ag_entry.get("total_tokens", 0)
+            a_prompt = ag_entry.get("prompt_tokens", 0)
+            a_comp = ag_entry.get("completion_tokens", 0)
+            fh.write(
+                f"  {net}: {a_calls} call(s)"
+                f"  {a_total:,} tokens"
+                f" ({a_prompt:,} prompt"
+                f" / {a_comp:,} completion)\n"
+            )
+        if agents or agent or rid in by_validation:
+            fh.write("\n")
+
+    @staticmethod
+    def _write_validation_detail(fh, rid, by_validation):
+        """Write per-request validation retry detail."""
+        event = by_validation.get(rid)
+        if not event:
+            return
+        attempts = event.get("attempts", 0)
+        fix_cycles = event.get("fix_cycles", 0)
+        fh.write(
+            f"  Validation: {attempts} attempt(s),"
+            f" {fix_cycles} fix cycle(s)\n"
+        )
+        errors = event.get("errors", [])
+        for err in errors:
+            fh.write(f"    - {err}\n")
+
+    @staticmethod
+    def _log_token_totals(results) -> None:
+        """Log aggregate token totals to the console."""
+        total_tok = 0
+        total_prompt = 0
+        total_comp = 0
+        count = 0
+        for result in results:
+            tok = result.get("total_tokens", 0)
+            if not tok:
+                continue
+            total_tok += tok
+            total_prompt += result.get("prompt_tokens", 0)
+            total_comp += result.get("completion_tokens", 0)
+            count += 1
+        if count == 0:
+            return
+        avg = total_tok // count
+        logger.info(
+            "  Total: %s tokens (%s prompt + %s completion)",
+            f"{total_tok:,}", f"{total_prompt:,}",
+            f"{total_comp:,}",
+        )
+        logger.info(
+            "  %s requests, avg %s tokens/request",
+            count, f"{avg:,}",
+        )
+
+    @staticmethod
+    def _save_request_output(
+            output_dir, request_id, stdout, stderr,
+    ) -> None:
+        """Save raw CLI stdout/stderr for every request."""
+        if not output_dir:
+            return
+        requests_dir = os.path.join(output_dir, "requests")
+        os.makedirs(requests_dir, exist_ok=True)
+        stdout_path = os.path.join(
+            requests_dir,
+            f"request_{request_id}_stdout.txt",
+        )
+        with open(stdout_path, "w", encoding="utf-8") as fh:
+            fh.write(stdout)
+        if stderr and stderr.strip():
+            stderr_path = os.path.join(
+                requests_dir,
+                f"request_{request_id}_stderr.txt",
+            )
+            with open(stderr_path, "w", encoding="utf-8") as fh:
+                fh.write(stderr)

--- a/tests/load_tests/unit/test_cost_estimator.py
+++ b/tests/load_tests/unit/test_cost_estimator.py
@@ -1,0 +1,75 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+from unittest import TestCase
+
+from tests.load_tests.config import DEFAULT_PRICING
+from tests.load_tests.config import MODEL_PRICING
+from tests.load_tests.cost_estimator import CostEstimator
+
+
+class TestCostEstimator(TestCase):
+    """
+    Unit tests for CostEstimator.estimate().
+
+    The estimate is what the dry-run probe shows before a paid run, so
+    a wrong rate means an under-stated bill at exactly the moment the
+    user is deciding whether to spend the money.
+    """
+
+    def test_rate_is_per_million_tokens(self):
+        """Prompt and completion tokens are billed at their own rates."""
+        pricing = MODEL_PRICING["gpt-4o"]
+        expected = pricing["prompt"] + pricing["completion"]
+
+        self.assertAlmostEqual(
+            CostEstimator.estimate(1_000_000, 1_000_000, "gpt-4o"),
+            expected,
+        )
+
+    def test_longest_matching_model_key_wins(self):
+        """A more specific model must not be priced as its base model.
+
+        'gpt-4o' is a substring of 'gpt-4o-mini', so matching in
+        dictionary order would bill mini traffic at ~17x its real
+        prompt rate.  Keys are tried longest-first to prevent that.
+        """
+        mini = CostEstimator.estimate(1_000_000, 0, "gpt-4o-mini")
+
+        self.assertAlmostEqual(mini, MODEL_PRICING["gpt-4o-mini"]["prompt"])
+        self.assertLess(mini, CostEstimator.estimate(1_000_000, 0, "gpt-4o"))
+
+    def test_nano_is_not_priced_as_mini(self):
+        """The same specificity rule holds across a three-way prefix."""
+        nano = CostEstimator.estimate(1_000_000, 0, "gpt-4.1-nano")
+
+        self.assertAlmostEqual(nano, MODEL_PRICING["gpt-4.1-nano"]["prompt"])
+
+    def test_dated_model_names_resolve_to_their_base_model(self):
+        """Server-reported names carry a date suffix and still match."""
+        dated = CostEstimator.estimate(1_000_000, 0, "gpt-5.2-2025-12-11")
+
+        self.assertAlmostEqual(dated, MODEL_PRICING["gpt-5.2"]["prompt"])
+
+    def test_unknown_model_falls_back_to_default_pricing(self):
+        """An unrecognized model is costed, not silently free."""
+        unknown = CostEstimator.estimate(1_000_000, 0, "llama-9")
+
+        self.assertAlmostEqual(unknown, DEFAULT_PRICING["prompt"])
+
+    def test_zero_tokens_cost_nothing(self):
+        """A request with no token data contributes no cost."""
+        self.assertEqual(CostEstimator.estimate(0, 0, "gpt-4o"), 0.0)

--- a/tests/load_tests/unit/test_duration_parser.py
+++ b/tests/load_tests/unit/test_duration_parser.py
@@ -1,0 +1,80 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+from argparse import ArgumentTypeError
+from unittest import TestCase
+
+from tests.load_tests.duration import DurationParser
+
+
+class TestDurationParser(TestCase):
+    """
+    Unit tests for DurationParser.parse().
+
+    Every timeout flag runs through this, so a wrong answer silently
+    changes what a run measures rather than failing visibly.
+    """
+
+    def test_bare_number_is_seconds(self):
+        """Existing numeric commands keep their meaning."""
+        self.assertEqual(DurationParser.parse("1200"), 1200)
+
+    def test_suffixes_scale(self):
+        """s/m/h scale the value."""
+        self.assertEqual(DurationParser.parse("90s"), 90)
+        self.assertEqual(DurationParser.parse("20m"), 1200)
+        self.assertEqual(DurationParser.parse("2h"), 7200)
+
+    def test_fractional_and_uppercase_are_accepted(self):
+        """A fraction with an uppercase suffix still parses."""
+        self.assertEqual(DurationParser.parse("0.5H"), 1800)
+
+    def test_surrounding_whitespace_is_ignored(self):
+        """Values arriving with whitespace parse the same."""
+        self.assertEqual(DurationParser.parse("  20m  "), 1200)
+
+    def test_result_is_whole_seconds(self):
+        """Fractional seconds round rather than truncate."""
+        self.assertEqual(DurationParser.parse("1.5"), 2)
+        self.assertIsInstance(DurationParser.parse("1.5"), int)
+
+    def test_zero_is_allowed(self):
+        """Zero is a legitimate "no timeout" value for these flags."""
+        self.assertEqual(DurationParser.parse("0"), 0)
+
+    def test_empty_value_is_rejected(self):
+        """An empty string is not a duration."""
+        with self.assertRaises(ArgumentTypeError):
+            DurationParser.parse("   ")
+
+    def test_garbage_is_rejected(self):
+        """Unparseable text raises the argparse error, not ValueError."""
+        with self.assertRaises(ArgumentTypeError):
+            DurationParser.parse("soon")
+
+    def test_unknown_suffix_is_rejected(self):
+        """A plausible-looking unit that is not supported is rejected.
+
+        'd' is not in the unit table, so it must not be silently
+        dropped and read as 5 seconds.
+        """
+        with self.assertRaises(ArgumentTypeError):
+            DurationParser.parse("5d")
+
+    def test_negative_is_rejected(self):
+        """A negative timeout would abort every request immediately."""
+        with self.assertRaises(ArgumentTypeError):
+            DurationParser.parse("-5m")

--- a/tests/load_tests/unit/test_http_client_timeout.py
+++ b/tests/load_tests/unit/test_http_client_timeout.py
@@ -1,0 +1,129 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+import time
+from unittest import TestCase
+from unittest.mock import patch
+
+from tests.load_tests.config import STATUS_CREATED
+from tests.load_tests.config import STATUS_TIMEOUT
+from tests.load_tests.traffic.http_client import HttpClient
+
+
+class FakeSession:
+    """Stand-in for HttpServiceAgentSession that streams on a timer."""
+
+    def __init__(self, *, message_count, message_interval, **_kwargs):
+        """Stream ``message_count`` messages, one per interval."""
+        self._message_count = message_count
+        self._message_interval = message_interval
+        self.sent = 0
+
+    def streaming_chat(self, _request_dict):
+        """Yield one message per interval, counting what was consumed."""
+        for _ in range(self._message_count):
+            time.sleep(self._message_interval)
+            self.sent += 1
+            yield {
+                "response": {
+                    "type": "AI",
+                    "text": "answer",
+                },
+            }
+
+
+class FakeProcessor:
+    """Stand-in for StreamingInputProcessor that drains the stream."""
+
+    def __init__(self, *, session, **_kwargs):
+        """Keep the session whose streaming_chat is consumed."""
+        self._session = session
+
+    def process_once(self, state):
+        """Consume every streamed message, as the real processor does."""
+        for _ in self._session.streaming_chat({}):
+            pass
+        updated = dict(state)
+        updated["last_chat_response"] = "answer"
+        updated["returned_sly_data"] = {"reservation_id": "abc-1"}
+        return updated
+
+
+class TestHttpRequestTimeout(TestCase):
+    """
+    Unit tests for --request-timeout in the HTTP transport.
+
+    A streaming request that keeps producing messages must still be
+    abandoned at the cap: without that, one slow request holds a worker
+    for the whole run and the timeout only describes subprocess mode.
+    """
+
+    def _execute(self, *, timeout, message_count, message_interval):
+        """Run one request against a stream with the given timing."""
+        session = FakeSession(
+            message_count=message_count,
+            message_interval=message_interval,
+        )
+        with patch(
+            "tests.load_tests.traffic.http_client."
+            "HttpServiceAgentSession",
+            return_value=session,
+        ), patch(
+            "tests.load_tests.traffic.http_client."
+            "StreamingInputProcessor",
+            FakeProcessor,
+        ):
+            result = HttpClient.execute_request(
+                "localhost", 30011, "music_nerd", "prompt",
+                timeout=timeout, idle_timeout=60,
+            )
+        return result, session
+
+    def test_streaming_past_the_cap_is_a_timeout(self):
+        """A stream that outruns the cap reports TIMEOUT."""
+        (status, _fields, _text, _ttft, _tokens), _session = self._execute(
+            timeout=0.3, message_count=20, message_interval=0.05,
+        )
+
+        self.assertEqual(status, STATUS_TIMEOUT)
+
+    def test_streaming_past_the_cap_stops_early(self):
+        """The request is abandoned rather than drained to the end.
+
+        Reporting TIMEOUT after draining the whole stream would still
+        label the request correctly while the worker stayed occupied,
+        which is the behaviour being fixed.
+        """
+        start = time.time()
+        _result, session = self._execute(
+            timeout=0.3, message_count=20, message_interval=0.05,
+        )
+        elapsed = time.time() - start
+
+        self.assertLess(session.sent, 20)
+        self.assertLess(elapsed, 20 * 0.05)
+
+    def test_request_within_the_cap_succeeds(self):
+        """A request that finishes in time is unaffected."""
+        (status, fields, text, ttft, _tokens), session = self._execute(
+            timeout=30, message_count=3, message_interval=0.01,
+        )
+
+        self.assertEqual(status, STATUS_CREATED)
+        self.assertEqual(text, "answer")
+        self.assertEqual(fields.get("reservation_id"), "abc-1")
+        self.assertEqual(session.sent, 3)
+        self.assertGreater(ttft, 0.0)

--- a/tests/load_tests/unit/test_input_validator.py
+++ b/tests/load_tests/unit/test_input_validator.py
@@ -1,0 +1,154 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+from argparse import Namespace
+from unittest import TestCase
+
+from tests.load_tests.config import DEFAULT_STAGES
+from tests.load_tests.validation.input_validator import InputValidator
+
+
+class TestResolveMaxRequests(TestCase):
+    """
+    Unit tests for InputValidator.resolve_max_requests().
+
+    Non-positive counts must be rejected before anything runs: the
+    cost probe fires a real LLM request, so reaching it with a cap of
+    zero spends tokens on a run that then does nothing.
+    """
+
+    @staticmethod
+    def _validator(*, num_rounds=1, max_requests=None) -> InputValidator:
+        """Build a validator with only the args these methods read."""
+        return InputValidator(Namespace(
+            num_rounds=num_rounds,
+            max_requests=max_requests,
+        ))
+
+    def test_cap_is_stage_total_times_rounds(self):
+        """The default cap covers every stage of every round."""
+        validator = self._validator(num_rounds=3)
+
+        self.assertEqual(validator.resolve_max_requests([2, 4, 8]), 42)
+
+    def test_explicit_max_requests_wins(self):
+        """--max-requests overrides the computed cap."""
+        validator = self._validator(num_rounds=3, max_requests=5)
+
+        self.assertEqual(validator.resolve_max_requests([2, 4, 8]), 5)
+
+    def test_zero_rounds_exits(self):
+        """--num-rounds 0 must exit before the probe spends tokens."""
+        validator = self._validator(num_rounds=0)
+
+        with self.assertRaises(SystemExit) as caught:
+            validator.resolve_max_requests([3])
+
+        self.assertEqual(caught.exception.code, 1)
+
+    def test_negative_rounds_exits(self):
+        """A negative --num-rounds is rejected the same way."""
+        validator = self._validator(num_rounds=-3)
+
+        with self.assertRaises(SystemExit) as caught:
+            validator.resolve_max_requests([3])
+
+        self.assertEqual(caught.exception.code, 1)
+
+    def test_rounds_are_validated_before_explicit_max_requests(self):
+        """--max-requests must not mask an invalid --num-rounds.
+
+        The rounds check runs first, so passing both does not slip
+        past validation through the early return.
+        """
+        validator = self._validator(num_rounds=0, max_requests=5)
+
+        with self.assertRaises(SystemExit) as caught:
+            validator.resolve_max_requests([3])
+
+        self.assertEqual(caught.exception.code, 1)
+
+    def test_zero_max_requests_exits(self):
+        """--max-requests 0 caps the run at nothing, so it is rejected."""
+        validator = self._validator(max_requests=0)
+
+        with self.assertRaises(SystemExit) as caught:
+            validator.resolve_max_requests([3])
+
+        self.assertEqual(caught.exception.code, 1)
+
+
+class TestResolveStages(TestCase):
+    """
+    Unit tests for InputValidator.resolve_stages().
+
+    --stages is raw user input, so malformed values must produce a
+    clear exit rather than a ValueError traceback.
+    """
+
+    @staticmethod
+    def _validator(*, ramp=False, stages=None, num_requests=3):
+        """Build a validator with only the args these methods read."""
+        return InputValidator(Namespace(
+            ramp=ramp,
+            stages=stages,
+            num_requests=num_requests,
+        ))
+
+    def test_flat_mode_is_a_single_stage(self):
+        """Without --ramp the run is one stage of --num-requests."""
+        validator = self._validator(num_requests=7)
+
+        self.assertEqual(validator.resolve_stages(), [7])
+
+    def test_ramp_without_stages_uses_defaults(self):
+        """--ramp alone falls back to the built-in stage list."""
+        validator = self._validator(ramp=True)
+
+        self.assertEqual(validator.resolve_stages(), list(DEFAULT_STAGES))
+
+    def test_stages_are_parsed_and_trailing_commas_ignored(self):
+        """Whitespace and a trailing comma are tolerated."""
+        validator = self._validator(ramp=True, stages=" 2, 4 ,8, ")
+
+        self.assertEqual(validator.resolve_stages(), [2, 4, 8])
+
+    def test_non_integer_stages_exit(self):
+        """Garbage in --stages exits instead of raising ValueError."""
+        validator = self._validator(ramp=True, stages="2,abc")
+
+        with self.assertRaises(SystemExit) as caught:
+            validator.resolve_stages()
+
+        self.assertEqual(caught.exception.code, 1)
+
+    def test_non_positive_stages_exit(self):
+        """A zero stage would run an empty stage, so it is rejected."""
+        validator = self._validator(ramp=True, stages="2,0,8")
+
+        with self.assertRaises(SystemExit) as caught:
+            validator.resolve_stages()
+
+        self.assertEqual(caught.exception.code, 1)
+
+    def test_zero_num_requests_exits(self):
+        """--num-requests 0 is rejected in flat mode."""
+        validator = self._validator(num_requests=0)
+
+        with self.assertRaises(SystemExit) as caught:
+            validator.resolve_stages()
+
+        self.assertEqual(caught.exception.code, 1)

--- a/tests/load_tests/unit/test_output_base.py
+++ b/tests/load_tests/unit/test_output_base.py
@@ -1,0 +1,93 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+from argparse import Namespace
+from unittest import TestCase
+from unittest.mock import patch
+
+from tests.load_tests.load_test_cli import LoadTestOrchestrator
+
+
+# These tests call a deliberately-internal helper directly; suppress
+# protected-access warnings file-wide.
+# pylint: disable=protected-access
+class TestOutputBase(TestCase):
+    """
+    Unit tests for LoadTestOrchestrator._output_base().
+
+    The default lives in the shared temp directory, so it has to be
+    per-user: a fixed name belongs to whoever ran first and everyone
+    else gets a PermissionError creating their run directory.
+    """
+
+    @staticmethod
+    def _orchestrator(output_dir=None) -> LoadTestOrchestrator:
+        """Build an orchestrator with only the args _output_base reads."""
+        orchestrator = LoadTestOrchestrator.__new__(LoadTestOrchestrator)
+        orchestrator.args = Namespace(output_dir=output_dir)
+        return orchestrator
+
+    @patch("tests.load_tests.load_test_cli.tempfile.gettempdir")
+    @patch("tests.load_tests.load_test_cli.getpass.getuser")
+    def test_default_is_per_user(self, get_user, get_temp_dir):
+        """The default path carries the user name, not a fixed one."""
+        get_user.return_value = "alice"
+        get_temp_dir.return_value = "/tmp"
+
+        self.assertEqual(
+            self._orchestrator()._output_base(),
+            "/tmp/load_test_alice",
+        )
+
+    @patch("tests.load_tests.load_test_cli.getpass.getuser")
+    def test_output_dir_argument_wins(self, get_user):
+        """--output-dir overrides the default without consulting the user."""
+        get_user.side_effect = AssertionError("user name not needed")
+
+        self.assertEqual(
+            self._orchestrator(output_dir="/data/runs")._output_base(),
+            "/data/runs",
+        )
+
+    @patch("tests.load_tests.load_test_cli.os.getuid")
+    @patch("tests.load_tests.load_test_cli.tempfile.gettempdir")
+    @patch("tests.load_tests.load_test_cli.getpass.getuser")
+    def test_falls_back_to_uid_without_passwd_entry(
+        self, get_user, get_temp_dir, get_uid,
+    ):
+        """A uid with no passwd entry (containers) must not crash the run."""
+        get_user.side_effect = KeyError("getpwuid(): uid not found")
+        get_temp_dir.return_value = "/tmp"
+        get_uid.return_value = 1000
+
+        self.assertEqual(
+            self._orchestrator()._output_base(),
+            "/tmp/load_test_1000",
+        )
+
+    @patch("tests.load_tests.load_test_cli.tempfile.gettempdir")
+    @patch("tests.load_tests.load_test_cli.getpass.getuser")
+    def test_user_name_cannot_inject_path_separators(
+        self, get_user, get_temp_dir,
+    ):
+        """A domain-style name must stay one directory, not nest."""
+        get_user.return_value = "CORP\\alice"
+        get_temp_dir.return_value = "/tmp"
+
+        self.assertEqual(
+            self._orchestrator()._output_base(),
+            "/tmp/load_test_CORP_alice",
+        )

--- a/tests/load_tests/unit/test_output_validator.py
+++ b/tests/load_tests/unit/test_output_validator.py
@@ -1,0 +1,92 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+from unittest import TestCase
+
+from tests.load_tests.config import STATUS_CREATED
+from tests.load_tests.config import STATUS_FAILED
+from tests.load_tests.config import STATUS_KILLED
+from tests.load_tests.config import STATUS_TIMEOUT
+from tests.load_tests.validation.output_validator import OutputValidator
+
+
+class TestCountResults(TestCase):
+    """
+    Unit tests for OutputValidator.count_results().
+
+    These counts drive the run's verdict and the numbers in
+    raw_results.json, so a request must never vanish between the
+    result list and the totals.
+    """
+
+    def test_each_status_is_counted(self):
+        """Every known status lands in its own bucket."""
+        counts = OutputValidator.count_results([
+            {"status": STATUS_CREATED},
+            {"status": STATUS_CREATED},
+            {"status": STATUS_FAILED},
+            {"status": STATUS_TIMEOUT},
+            {"status": STATUS_KILLED},
+        ])
+
+        self.assertEqual(counts[STATUS_CREATED], 2)
+        self.assertEqual(counts[STATUS_FAILED], 1)
+        self.assertEqual(counts[STATUS_TIMEOUT], 1)
+        self.assertEqual(counts[STATUS_KILLED], 1)
+
+    def test_no_results_counts_zero_not_empty(self):
+        """An aborted stage still reports every bucket, all zero."""
+        counts = OutputValidator.count_results([])
+
+        self.assertEqual(
+            counts,
+            {
+                STATUS_CREATED: 0,
+                STATUS_FAILED: 0,
+                STATUS_TIMEOUT: 0,
+                STATUS_KILLED: 0,
+            },
+        )
+
+    def test_unknown_status_counts_as_failed(self):
+        """An unrecognized status is a failure, never a success.
+
+        Counting it anywhere else -- or dropping it -- would let a
+        run's totals disagree with the number of requests fired.
+        """
+        counts = OutputValidator.count_results([{"status": "WEIRD"}])
+
+        self.assertEqual(counts[STATUS_FAILED], 1)
+        self.assertEqual(counts[STATUS_CREATED], 0)
+
+    def test_missing_status_counts_as_failed(self):
+        """A result with no status recorded is treated as a failure."""
+        counts = OutputValidator.count_results([{}])
+
+        self.assertEqual(counts[STATUS_FAILED], 1)
+
+    def test_totals_match_the_number_of_results(self):
+        """No request is lost or double-counted, whatever its status."""
+        results = [
+            {"status": STATUS_CREATED},
+            {"status": "WEIRD"},
+            {},
+            {"status": STATUS_TIMEOUT},
+        ]
+
+        counts = OutputValidator.count_results(results)
+
+        self.assertEqual(sum(counts.values()), len(results))

--- a/tests/load_tests/unit/test_raw_json_export.py
+++ b/tests/load_tests/unit/test_raw_json_export.py
@@ -1,0 +1,116 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+import json
+import os
+import shutil
+import tempfile
+from argparse import Namespace
+from types import SimpleNamespace
+from unittest import TestCase
+
+from tests.load_tests.config import STATUS_CREATED
+from tests.load_tests.load_test_cli import LoadTestOrchestrator
+
+
+# These tests call a deliberately-internal helper directly; suppress
+# protected-access warnings file-wide.
+# pylint: disable=protected-access
+class TestExportRawJsonAggregates(TestCase):
+    """
+    Unit tests for the aggregates in raw_results.json.
+
+    The same keys are written by a live run and by --rebuild, so they
+    have to mean the same thing in both or a trend built from a mix of
+    the two compares unlike numbers.
+    """
+
+    def setUp(self):
+        """Create an output directory removed again after each test."""
+        self._dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self._dir)
+
+    def _orchestrator(self) -> LoadTestOrchestrator:
+        """Build an orchestrator with only what the export reads."""
+        orchestrator = LoadTestOrchestrator.__new__(LoadTestOrchestrator)
+        orchestrator._output_dir = self._dir
+        orchestrator._server_ns_version = "0.6.92"
+        orchestrator.server_log = None
+        orchestrator.profile = SimpleNamespace(
+            estimated_tokens_per_request=1000,
+        )
+        orchestrator.resource_reporter = SimpleNamespace(
+            resource_rows=[], client_rows=[],
+        )
+        orchestrator.args = Namespace(
+            agent="music_nerd", profile_path=None, level="norm",
+            ramp=False, host="localhost", port=30011,
+            request_timeout=120, idle_timeout=60, stage_timeout=300,
+            total_timeout=600, settle_time=5, max_workers=10,
+            num_rounds=1, num_requests=3, same_prompt=False,
+            chat_filter=None,
+        )
+        return orchestrator
+
+    def _export(self, elapsed_values) -> dict:
+        """Export one stage of successful requests and read it back."""
+        results = [
+            {
+                "request_id": f"request-{index}",
+                "status": STATUS_CREATED,
+                "elapsed": elapsed,
+            }
+            for index, elapsed in enumerate(elapsed_values, start=1)
+        ]
+        # One stage whose wall-clock time is the slowest request,
+        # because the requests ran concurrently.
+        stage_summaries = [{
+            "concurrent": len(results),
+            "results": results,
+            "elapsed": max(elapsed_values),
+        }]
+
+        self._orchestrator()._export_raw_json(
+            stage_summaries, exit_code=0,
+        )
+
+        path = os.path.join(self._dir, "raw_results.json")
+        with open(path, "r", encoding="utf-8") as handle:
+            return json.load(handle)["aggregates"]
+
+    def test_average_latency_is_the_mean_request_time(self):
+        """Concurrency must not divide the reported latency.
+
+        Ten overlapping 30-second requests average 30 seconds, not the
+        3 seconds that dividing wall-clock time by the request count
+        would suggest.
+        """
+        aggregates = self._export([30.0] * 10)
+
+        self.assertEqual(aggregates["avg_latency_seconds"], 30.0)
+
+    def test_average_latency_reflects_uneven_requests(self):
+        """The mean is taken over every request's own elapsed time."""
+        aggregates = self._export([1.0, 2.0, 6.0])
+
+        self.assertEqual(aggregates["avg_latency_seconds"], 3.0)
+
+    def test_wall_clock_total_is_reported_separately(self):
+        """Throughput is still derivable from the elapsed total."""
+        aggregates = self._export([1.0, 2.0, 6.0])
+
+        self.assertEqual(aggregates["total_elapsed_seconds"], 6.0)
+        self.assertEqual(aggregates["total_requests"], 3)

--- a/tests/load_tests/unit/test_rebuild_results.py
+++ b/tests/load_tests/unit/test_rebuild_results.py
@@ -1,0 +1,208 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+import json
+import os
+import shutil
+import tempfile
+from unittest import TestCase
+
+from tests.load_tests.config import STATUS_CREATED
+from tests.load_tests.config import STATUS_FAILED
+from tests.load_tests.config import STATUS_KILLED
+from tests.load_tests.config import STATUS_TIMEOUT
+from tests.load_tests.reporting.rebuild_results import ResultsRebuilder
+
+
+# These tests call deliberately-internal helpers directly; suppress
+# protected-access warnings file-wide.
+# pylint: disable=protected-access
+class TestResolveStatus(TestCase):
+    """
+    Unit tests for ResultsRebuilder._resolve_status().
+
+    --rebuild reconstructs a run's verdict after an interrupted run, so
+    a request must come back with the status the run actually reported.
+    """
+
+    def test_each_reported_status_is_preserved(self):
+        """CREATED, FAILED, TIMEOUT and KILLED all survive a rebuild."""
+        for status in (
+            STATUS_CREATED, STATUS_FAILED, STATUS_TIMEOUT, STATUS_KILLED,
+        ):
+            with self.subTest(status=status):
+                self.assertEqual(
+                    ResultsRebuilder._resolve_status({"status": status}),
+                    status,
+                )
+
+    def test_missing_log_line_counts_as_failed(self):
+        """A request never seen to finish is a failure, not a success.
+
+        Failures past FAILURE_LOG_LIMIT are never printed, so an absent
+        log line is the normal case for a heavily failing run.
+        """
+        self.assertEqual(
+            ResultsRebuilder._resolve_status({}), STATUS_FAILED,
+        )
+
+    def test_unrecognized_status_counts_as_failed(self):
+        """An unknown status word is never promoted to success."""
+        self.assertEqual(
+            ResultsRebuilder._resolve_status({"status": "WEIRD"}),
+            STATUS_FAILED,
+        )
+
+
+# pylint: disable=protected-access
+class TestScanRequests(TestCase):
+    """
+    Unit tests for the status of rebuilt request records.
+
+    A timed-out or killed request usually printed a reservation_id
+    before the client gave up, so partial output must not be read as
+    evidence that the request succeeded.
+    """
+
+    def setUp(self):
+        """Create a run directory removed again after each test."""
+        self._dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self._dir)
+        os.makedirs(os.path.join(self._dir, "requests"))
+
+    def _write_request(self, req_id) -> None:
+        """Write stdout for a request that got as far as reserving."""
+        path = os.path.join(
+            self._dir, "requests", f"request_{req_id}_stdout.txt",
+        )
+        with open(path, "w", encoding="utf-8") as handle:
+            handle.write(
+                '{"reservation_id": "abc-%s",'
+                ' "agent_network_name": "music_nerd"}\n' % req_id
+            )
+
+    def _write_log(self, text) -> None:
+        """Write the run log the rebuild reads timing from."""
+        path = os.path.join(self._dir, "load_test.log")
+        with open(path, "w", encoding="utf-8") as handle:
+            handle.write(text)
+
+    def _rebuild(self):
+        """Rebuild the run and return results keyed by request id."""
+        rebuilder = ResultsRebuilder(self._dir)
+        results = rebuilder._scan_requests(
+            os.path.join(self._dir, "requests"), rebuilder._parse_timing(),
+        )
+        return {result["request_id"]: result for result in results}
+
+    def test_partial_output_does_not_promote_a_timeout(self):
+        """A TIMEOUT with a reservation_id stays a TIMEOUT."""
+        self._write_request(1)
+        self._write_log("Request 1: TIMEOUT (61.00s (1m))\n")
+
+        self.assertEqual(
+            self._rebuild()["request-1"]["status"], STATUS_TIMEOUT,
+        )
+
+    def test_partial_output_does_not_promote_a_kill(self):
+        """A KILLED request with a reservation_id stays KILLED."""
+        self._write_request(1)
+        self._write_log("Request 1: KILLED (5.00s)\n")
+
+        self.assertEqual(
+            self._rebuild()["request-1"]["status"], STATUS_KILLED,
+        )
+
+    def test_partial_output_alone_is_not_success(self):
+        """With no log line, partial output is not counted as passing."""
+        self._write_request(1)
+        self._write_log("")
+
+        self.assertEqual(
+            self._rebuild()["request-1"]["status"], STATUS_FAILED,
+        )
+
+    def test_successful_request_is_still_rebuilt_as_created(self):
+        """The normal case is unaffected."""
+        self._write_request(1)
+        self._write_log("Request 1: CREATED (3.00s)\n")
+
+        result = self._rebuild()["request-1"]
+
+        self.assertEqual(result["status"], STATUS_CREATED)
+        self.assertEqual(result["elapsed"], 3.0)
+
+
+# pylint: disable=protected-access
+class TestRebuiltAggregates(TestCase):
+    """
+    Unit tests for the aggregates a rebuild writes.
+
+    A rebuilt run is often the only surviving record of an interrupted
+    run, so its headline numbers have to mean what they say.
+    """
+
+    def setUp(self):
+        """Create a run directory removed again after each test."""
+        self._dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self._dir)
+        os.makedirs(os.path.join(self._dir, "requests"))
+
+    def _build_run(self, elapsed_by_id) -> dict:
+        """Rebuild a run of successful requests with the given timings."""
+        lines = []
+        for req_id, elapsed in elapsed_by_id.items():
+            path = os.path.join(
+                self._dir, "requests", f"request_{req_id}_stdout.txt",
+            )
+            with open(path, "w", encoding="utf-8") as handle:
+                handle.write(
+                    '{"reservation_id": "abc-%s",'
+                    ' "agent_network_name": "music_nerd"}\n' % req_id
+                )
+            lines.append(f"Request {req_id}: CREATED ({elapsed:.2f}s)\n")
+        log_path = os.path.join(self._dir, "load_test.log")
+        with open(log_path, "w", encoding="utf-8") as handle:
+            handle.writelines(lines)
+
+        ResultsRebuilder(self._dir).run()
+
+        json_path = os.path.join(self._dir, "raw_results.json")
+        with open(json_path, "r", encoding="utf-8") as handle:
+            return json.load(handle)["aggregates"]
+
+    def test_average_latency_is_the_mean_request_time(self):
+        """Latency averages the requests, not the run.
+
+        Requests overlap, so dividing the slowest request by the
+        request count would shrink the average by the concurrency
+        factor and make a slow run look fast.
+        """
+        aggregates = self._build_run({1: 30.0, 2: 30.0, 3: 30.0})
+
+        self.assertEqual(aggregates["avg_latency_seconds"], 30.0)
+
+    def test_average_latency_reflects_uneven_requests(self):
+        """The mean is taken over every request's own elapsed time."""
+        aggregates = self._build_run({1: 1.0, 2: 2.0, 3: 6.0})
+
+        self.assertEqual(aggregates["avg_latency_seconds"], 3.0)
+
+    def test_total_elapsed_is_the_slowest_request(self):
+        """Total elapsed still stands in for the run's wall clock."""
+        aggregates = self._build_run({1: 1.0, 2: 2.0, 3: 6.0})
+
+        self.assertEqual(aggregates["total_elapsed_seconds"], 6.0)

--- a/tests/load_tests/unit/test_server_log_tokens.py
+++ b/tests/load_tests/unit/test_server_log_tokens.py
@@ -1,0 +1,157 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+import json
+import os
+import tempfile
+from unittest import TestCase
+
+from tests.load_tests.monitoring.server_log_monitor import ServerLogMonitor
+
+# The server logs one record per line using the format in
+# neuro_san/deploy/logging.hocon, with the reporting payload rendered by
+# json.dumps(..., indent=4).  The indentation makes each record span
+# several physical lines, and the record's own request_id arrives on the
+# closing line -- which is why blocks are collected across lines rather
+# than parsed one line at a time.
+LOG_RECORD_FORMAT = (
+    '{{"message": "{message}", "user_id": "None", '
+    '"Timestamp": "2026-07-26T19:00:00", "source": "server", '
+    '"message_type": "metrics", "request_id": "{request_id}"}}\n'
+)
+
+
+class TestParseTokenAccountingSince(TestCase):
+    """
+    Unit tests for ServerLogMonitor.parse_token_accounting_since().
+
+    Token, cost, and LLM-call figures come from these blocks whenever
+    the client cannot supply them (notably under --minimal), so the
+    parser is pinned against the server's real log shape: if the
+    server's format drifts, these fail instead of silently reporting
+    zero tokens.
+    """
+
+    def setUp(self):
+        """Create a scratch log file removed again after each test."""
+        handle, self._log_path = tempfile.mkstemp(suffix=".log")
+        os.close(handle)
+        self.addCleanup(os.unlink, self._log_path)
+
+    @staticmethod
+    def _reporting_record(request_id, *, total=1500, model="gpt-4o") -> str:
+        """Render one 'Request reporting' record as the server writes it.
+
+        Prompt and completion tokens are split 4:1 out of ``total`` so
+        the three counts stay consistent with one another.
+        """
+        prompt = total * 4 // 5
+        payload = {
+            "total_cost": 0.0075,
+            "total_tokens": total,
+            "prompt_tokens": prompt,
+            "completion_tokens": total - prompt,
+            "successful_requests": 2,
+            "time_taken_in_seconds": 12.5,
+            "caller_model": model,
+        }
+        message = "Request reporting: " + json.dumps(payload, indent=4)
+        return LOG_RECORD_FORMAT.format(
+            message=message, request_id=request_id,
+        )
+
+    def _write(self, text) -> None:
+        """Write the given log text to the scratch log file."""
+        with open(self._log_path, "w", encoding="utf-8") as handle:
+            handle.write(text)
+
+    def test_fields_are_extracted_from_a_multiline_record(self):
+        """One record yields its token counts, call count, and model."""
+        self._write(self._reporting_record("req-1"))
+        monitor = ServerLogMonitor(self._log_path)
+
+        entries = monitor.parse_token_accounting_since(0)
+
+        self.assertEqual(list(entries), ["req-1"])
+        self.assertEqual(entries["req-1"]["total_tokens"], 1500)
+        self.assertEqual(entries["req-1"]["prompt_tokens"], 1200)
+        self.assertEqual(entries["req-1"]["completion_tokens"], 300)
+        self.assertEqual(entries["req-1"]["llm_calls"], 2)
+        self.assertEqual(entries["req-1"]["model"], "gpt-4o")
+
+    def test_each_request_is_keyed_separately(self):
+        """Concurrent requests must not overwrite one another."""
+        self._write(
+            self._reporting_record("req-1", total=1500)
+            + self._reporting_record("req-2", total=2500)
+        )
+        monitor = ServerLogMonitor(self._log_path)
+
+        entries = monitor.parse_token_accounting_since(0)
+
+        self.assertEqual(entries["req-1"]["total_tokens"], 1500)
+        self.assertEqual(entries["req-2"]["total_tokens"], 2500)
+
+    def test_reporting_agent_comes_from_the_following_done_line(self):
+        """The network name is taken from the Done-with line after it."""
+        self._write(
+            self._reporting_record("req-1")
+            + LOG_RECORD_FORMAT.format(
+                message="Done with music_nerd_pro.StreamingChat",
+                request_id="req-1",
+            )
+        )
+        monitor = ServerLogMonitor(self._log_path)
+
+        entries = monitor.parse_token_accounting_since(0)
+
+        self.assertEqual(
+            entries["req-1"]["reporting_agent"], "music_nerd_pro",
+        )
+
+    def test_only_records_after_the_position_are_parsed(self):
+        """Reading from a saved offset ignores earlier runs' records."""
+        first = self._reporting_record("req-old")
+        self._write(first + self._reporting_record("req-new"))
+        monitor = ServerLogMonitor(self._log_path)
+
+        entries = monitor.parse_token_accounting_since(len(first))
+
+        self.assertEqual(list(entries), ["req-new"])
+
+    def test_unrelated_log_traffic_is_ignored(self):
+        """Ordinary log lines produce no entries."""
+        self._write(
+            LOG_RECORD_FORMAT.format(
+                message="Starting agent server", request_id="None",
+            )
+        )
+        monitor = ServerLogMonitor(self._log_path)
+
+        self.assertEqual(monitor.parse_token_accounting_since(0), {})
+
+    def test_no_server_log_yields_nothing(self):
+        """Runs without --server-log get an empty result, not an error."""
+        monitor = ServerLogMonitor(None)
+
+        self.assertEqual(monitor.parse_token_accounting_since(0), {})
+
+    def test_no_position_yields_nothing(self):
+        """A missing start offset yields an empty result, not an error."""
+        self._write(self._reporting_record("req-1"))
+        monitor = ServerLogMonitor(self._log_path)
+
+        self.assertEqual(monitor.parse_token_accounting_since(None), {})

--- a/tests/load_tests/unit/test_trend_history.py
+++ b/tests/load_tests/unit/test_trend_history.py
@@ -1,0 +1,135 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+import json
+import os
+import tempfile
+from unittest import TestCase
+
+from tests.load_tests.config import HISTORY_FILE_NAME
+from tests.load_tests.reporting.trend_history import TrendHistory
+
+
+# These tests read a deliberately-internal helper directly; suppress
+# protected-access warnings file-wide.
+# pylint: disable=protected-access
+class TestReadRecords(TestCase):
+    """
+    Unit tests for TrendHistory._read_records().
+
+    The history file is append-only and grows one record per run, so a
+    single malformed line -- expected whenever a run is interrupted
+    mid-write -- must not cost the user every earlier data point.
+    """
+
+    def setUp(self):
+        """Create a scratch history file removed again after each test."""
+        handle, self._path = tempfile.mkstemp(suffix=".jsonl")
+        os.close(handle)
+        self.addCleanup(os.unlink, self._path)
+
+    def _write(self, text) -> None:
+        """Write the given text to the scratch history file."""
+        with open(self._path, "w", encoding="utf-8") as handle:
+            handle.write(text)
+
+    def test_records_are_read_in_file_order(self):
+        """Every well-formed line becomes one record."""
+        self._write(
+            json.dumps({"agent": "one"}) + "\n"
+            + json.dumps({"agent": "two"}) + "\n"
+        )
+
+        records = TrendHistory._read_records(self._path)
+
+        self.assertEqual(
+            [record["agent"] for record in records], ["one", "two"],
+        )
+
+    def test_truncated_final_line_does_not_lose_earlier_records(self):
+        """An interrupted run leaves a partial line; the rest survives."""
+        self._write(
+            json.dumps({"agent": "one"}) + "\n"
+            + '{"agent": "two", "requ'
+        )
+
+        records = TrendHistory._read_records(self._path)
+
+        self.assertEqual([record["agent"] for record in records], ["one"])
+
+    def test_blank_lines_are_skipped(self):
+        """Blank lines are not counted as records."""
+        self._write("\n" + json.dumps({"agent": "one"}) + "\n\n")
+
+        self.assertEqual(len(TrendHistory._read_records(self._path)), 1)
+
+    def test_non_object_lines_are_skipped(self):
+        """Valid JSON that is not an object cannot be a record."""
+        self._write("[1, 2, 3]\n" + json.dumps({"agent": "one"}) + "\n")
+
+        records = TrendHistory._read_records(self._path)
+
+        self.assertEqual([record["agent"] for record in records], ["one"])
+
+    def test_unreadable_file_yields_nothing(self):
+        """A missing file warns and returns empty rather than raising."""
+        self.assertEqual(
+            TrendHistory._read_records("/nonexistent/history.jsonl"), [],
+        )
+
+
+# pylint: disable=protected-access
+class TestResolvePath(TestCase):
+    """
+    Unit tests for TrendHistory._resolve_path().
+
+    --trend accepts either the history file or the output directory
+    holding it, because both are printed at the end of a run.
+    """
+
+    def setUp(self):
+        """Create a scratch directory removed again after each test."""
+        self._dir = tempfile.mkdtemp()
+        self.addCleanup(self._remove_dir)
+
+    def _remove_dir(self) -> None:
+        """Remove the scratch directory and anything left in it."""
+        for name in os.listdir(self._dir):
+            os.unlink(os.path.join(self._dir, name))
+        os.rmdir(self._dir)
+
+    def _create_history(self) -> str:
+        """Create a default-named history file in the scratch directory."""
+        path = os.path.join(self._dir, HISTORY_FILE_NAME)
+        with open(path, "w", encoding="utf-8") as handle:
+            handle.write(json.dumps({"agent": "one"}) + "\n")
+        return path
+
+    def test_a_file_path_is_used_directly(self):
+        """Passing the history file itself resolves to that file."""
+        path = self._create_history()
+
+        self.assertEqual(TrendHistory(path)._resolve_path(), path)
+
+    def test_a_directory_resolves_to_its_history_file(self):
+        """Passing the output directory finds history.jsonl inside it."""
+        path = self._create_history()
+
+        self.assertEqual(TrendHistory(self._dir)._resolve_path(), path)
+
+    def test_missing_history_resolves_to_none(self):
+        """A directory with no history file resolves to None."""
+        self.assertIsNone(TrendHistory(self._dir)._resolve_path())

--- a/tests/load_tests/validation/__init__.py
+++ b/tests/load_tests/validation/__init__.py
@@ -1,0 +1,15 @@
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT

--- a/tests/load_tests/validation/environment_validator.py
+++ b/tests/load_tests/validation/environment_validator.py
@@ -1,0 +1,213 @@
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+"""Pre-flight environment checks for real-LLM load testing.
+
+Validates that the runtime environment is configured for real LLM calls:
+  - No mock LLM server or OPENAI_API_BASE override detected
+  - Target server must be reachable on the specified host/port
+  - Auto-detects server log from process CWD when requested
+
+API key validation is intentionally omitted because the load test
+communicates with the server over HTTP — API keys are only needed
+on the server side.  Server-side key errors are caught at runtime
+by the failure_patterns mechanism in agent profiles.
+"""
+
+import logging
+import os
+import socket
+import sys
+from typing import Optional
+
+import psutil
+
+from tests.load_tests.config import SOCKET_CHECK_TIMEOUT
+from tests.load_tests.monitoring.resource_monitor import ResourceMonitor
+
+logger = logging.getLogger(__name__)
+
+
+class EnvironmentValidator:
+    """Validates the runtime environment for load testing.
+
+    Ensures that real LLM infrastructure is in place and no mock
+    environment is accidentally active.  Also locates the neuro-san
+    server process for resource monitoring.
+    """
+
+    @staticmethod
+    def validate_environment() -> None:
+        """Validate that no mock LLM environment is active.
+
+        API key checks are intentionally omitted — the load test
+        client communicates with the server over HTTP, so API keys
+        are only needed on the server side.  Server-side key errors
+        are caught at runtime via failure_patterns in the agent
+        profile.
+        """
+        EnvironmentValidator._check_no_mock_environment()
+
+    @staticmethod
+    def _check_no_mock_environment() -> None:
+        """Exit if a mock LLM environment is detected."""
+        issues = []
+        api_base = os.environ.get("OPENAI_API_BASE")
+        if api_base:
+            issues.append(f"  OPENAI_API_BASE={api_base}")
+        mock_proc = ResourceMonitor.find_process("mock_llm_server")
+        if mock_proc is not None:
+            issues.append(
+                f"  mock_llm_server process running "
+                f"(PID {mock_proc.pid})"
+            )
+        if issues:
+            logger.error(
+                "Mock LLM environment detected — this test requires "
+                "real LLM calls.\n%s\n\n"
+                "Unset OPENAI_API_BASE and stop the mock server "
+                "before running this test.\n"
+                "For mock-based load testing, use "
+                "load_test_mock_llm_service.py instead.",
+                "\n".join(issues),
+            )
+            sys.exit(1)
+        logger.info("No mock LLM environment detected.")
+
+    @staticmethod
+    def is_port_open(host, port) -> bool:
+        """Check if a TCP port is accepting connections."""
+        try:
+            with socket.create_connection(
+                (host, port), timeout=SOCKET_CHECK_TIMEOUT,
+            ):
+                return True
+        except (ConnectionRefusedError, OSError):
+            return False
+
+    @staticmethod
+    def find_local_server(args) -> Optional[psutil.Process]:
+        """Locate the neuro-san server process for resource monitoring.
+
+        Searches by process keyword first, then falls back to port
+        ownership.  Returns the process or None.
+        """
+        if not EnvironmentValidator.is_port_open(args.host, args.port):
+            logger.error(
+                "No service listening on %s:%s.\n"
+                "Start the server first.",
+                args.host, args.port,
+            )
+            sys.exit(1)
+
+        server_proc = None
+        for keyword in ["neuro_san_studio", "server_main_loop"]:
+            server_proc = ResourceMonitor.find_process(keyword)
+            if server_proc is not None:
+                logger.info(
+                    "Found neuro-san server (PID %s) via %s",
+                    server_proc.pid, keyword,
+                )
+                break
+
+        if server_proc is None:
+            server_proc = ResourceMonitor.find_process_by_port(
+                args.port,
+            )
+            if server_proc is not None:
+                logger.info(
+                    "Found neuro-san server (PID %s) via port %s",
+                    server_proc.pid, args.port,
+                )
+
+        if server_proc is None:
+            logger.info(
+                "neuro-san server process not found locally. "
+                "Resource monitoring disabled."
+            )
+            return None
+
+        return server_proc
+
+    @staticmethod
+    def try_auto_detect_server_log(args) -> Optional[str]:
+        """Best-effort local server-log detection; None if unavailable.
+
+        Unlike auto_detect_server_log, this never aborts.  It is used
+        for the default (unrequested) auto-detect so that remote or
+        no-server runs degrade quietly to no server-log analysis
+        instead of failing.
+        """
+        if not EnvironmentValidator.is_port_open(
+                args.host, args.port,
+        ):
+            return None
+        server_proc = None
+        for keyword in ["neuro_san_studio", "server_main_loop"]:
+            server_proc = ResourceMonitor.find_process(keyword)
+            if server_proc is not None:
+                break
+        if server_proc is None:
+            server_proc = ResourceMonitor.find_process_by_port(
+                args.port,
+            )
+        if server_proc is None:
+            return None
+        try:
+            candidate = os.path.join(
+                server_proc.cwd(), "logs", "server.log",
+            )
+            if os.path.isfile(candidate):
+                return candidate
+        except (psutil.AccessDenied, psutil.NoSuchProcess, OSError):
+            return None
+        return None
+
+    @staticmethod
+    def auto_detect_server_log(server_proc) -> str:
+        """Auto-detect server log from server process CWD.
+
+        Looks for logs/server.log relative to the server's working
+        directory.  Aborts with sys.exit(1) when auto-detection
+        fails because the user explicitly requested --server-log.
+        """
+        if server_proc is None:
+            logger.error(
+                "Cannot auto-detect server log: "
+                "server process not found.",
+            )
+            sys.exit(1)
+        try:
+            cwd = server_proc.cwd()
+            candidate = os.path.join(cwd, "logs", "server.log")
+            if os.path.isfile(candidate):
+                logger.info(
+                    "  Auto-detected server log: %s", candidate,
+                )
+                return candidate
+            logger.error(
+                "Server log not found at %s\n"
+                "  Provide the path explicitly: "
+                "--server-log /path/to/server.log",
+                candidate,
+            )
+        except (psutil.AccessDenied, psutil.NoSuchProcess, OSError):
+            logger.error(
+                "Could not determine server working directory.\n"
+                "  Provide the path explicitly: "
+                "--server-log /path/to/server.log",
+            )
+        sys.exit(1)

--- a/tests/load_tests/validation/input_validator.py
+++ b/tests/load_tests/validation/input_validator.py
@@ -1,0 +1,456 @@
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+"""Validates and resolves user input for load test configuration.
+
+Handles stage resolution, max-request capping, and the interactive
+cost-confirmation flow that fires a single probe request to measure
+actual token usage before committing to a full run.
+"""
+
+import logging
+import os
+import sys
+from typing import List
+from typing import Optional
+from typing import Tuple
+
+import psutil
+
+from tests.load_tests.config import DEFAULT_STAGES
+from tests.load_tests.config import LEVEL_ADV
+from tests.load_tests.config import RequestResult
+from tests.load_tests.config import SEPARATOR_WIDTH
+from tests.load_tests.confirm import Confirm
+from tests.load_tests.reporting.system_resources import SystemResources
+
+logger = logging.getLogger(__name__)
+
+
+class InputValidator:
+    """Validates and resolves user input for load test configuration.
+
+    Holds the parsed CLI args so that callers do not need to pass
+    them to every method.
+    """
+
+    def __init__(self, args) -> None:
+        self._args = args
+
+    def validate_agent_name(self) -> None:
+        """Reject --agent values that look like filesystem paths.
+
+        The server resolves agents by registry-relative name
+        (e.g. 'basic/hello_world'), not by absolute path.
+        """
+        agent = self._args.agent
+        if os.path.isabs(agent):
+            logger.error(
+                "ERROR: --agent appears to be a filesystem path:\n"
+                "  %s\n\n"
+                "Use the registry-relative name instead.\n"
+                "For example, if the agent HOCON is at:\n"
+                "  registries/basic/hello_world.hocon\n"
+                "Then use:\n"
+                "  --agent basic/hello_world",
+                agent,
+            )
+            sys.exit(1)
+
+    def resolve_stages(self) -> List[int]:
+        """Return the list of concurrency stages to run.
+
+        If --ramp is set and --stages provided, parse the CSV.
+        If --ramp is set without --stages, use DEFAULT_STAGES.
+        Otherwise return a single-stage list from --num-requests.
+        """
+        if self._args.ramp:
+            if self._args.stages is not None:
+                try:
+                    stages = [
+                        int(s.strip())
+                        for s in self._args.stages.split(",")
+                        if s.strip()
+                    ]
+                except ValueError:
+                    logger.error(
+                        "--stages must be comma-separated integers "
+                        "(e.g. 3,10,30). Got: '%s'",
+                        self._args.stages,
+                    )
+                    sys.exit(1)
+                if not stages or any(s <= 0 for s in stages):
+                    logger.error(
+                        "--stages values must be positive integers. "
+                        "Got: '%s'",
+                        self._args.stages,
+                    )
+                    sys.exit(1)
+                return stages
+            return list(DEFAULT_STAGES)
+        if self._args.num_requests <= 0:
+            logger.error(
+                "--num-requests must be a positive integer. Got: %s",
+                self._args.num_requests,
+            )
+            sys.exit(1)
+        return [self._args.num_requests]
+
+    def resolve_max_requests(self, stages) -> int:
+        """Return the effective max-requests cap."""
+        if self._args.num_rounds <= 0:
+            logger.error(
+                "--num-rounds must be a positive integer. Got: %s",
+                self._args.num_rounds,
+            )
+            sys.exit(1)
+        if self._args.max_requests is not None:
+            if self._args.max_requests <= 0:
+                logger.error(
+                    "--max-requests must be a positive integer. Got: %s",
+                    self._args.max_requests,
+                )
+                sys.exit(1)
+            return self._args.max_requests
+        return sum(stages) * self._args.num_rounds
+
+    # pylint: disable=too-many-arguments
+    def confirm_cost(
+            self, stages, total_cap, *, runner,
+            output_dir=None, stale_log_age=None,
+    ) -> Optional[RequestResult]:
+        """Display PRE-RUN SUMMARY and optionally run a dry-run probe.
+
+        The dry-run probe + cost confirmation runs by default at min
+        and norm levels; --no-dry-run bypasses it. At adv level it does
+        not run by default (adv is an explicit stress test).
+
+        When skipped, shows the summary and returns immediately.
+        Otherwise fires one probe request with --tokens to measure
+        actual token usage, collects warnings, and asks the user to
+        confirm.
+
+        Returns the probe result dict if a probe was run, else None.
+        """
+        total_planned = sum(stages) * self._args.num_rounds
+        capped = min(total_planned, total_cap)
+
+        self._print_summary_header(stages, total_planned, capped)
+
+        if self._args.no_dry_run or self._args.level == LEVEL_ADV:
+            warnings = self._collect_warnings(
+                capped=capped,
+                total_planned=total_planned,
+                stale_log_age=stale_log_age,
+            )
+            self._print_warnings(warnings)
+            logger.info("=" * SEPARATOR_WIDTH)
+            return None
+
+        probe_result, probe_data = (
+            self._run_cost_probe(runner, output_dir)
+        )
+
+        remaining = max(capped - 1, 0)
+        est_stage_duration = self._estimate_stage_duration(
+            probe_data.get("elapsed", 0), remaining,
+        )
+        logger.info(
+            "  Estimated stage duration: ~%ss "
+            "(%.1fs x %s requests)",
+            int(est_stage_duration),
+            probe_data.get("elapsed", 0),
+            remaining,
+        )
+
+        warnings = self._collect_warnings(
+            capped=capped,
+            total_planned=total_planned,
+            stale_log_age=stale_log_age,
+            est_stage_duration=est_stage_duration,
+            probe_tokens=probe_data.get("tokens", 0),
+            probe_cost=probe_data.get("cost", 0.0),
+            probe_model=probe_data.get("model", "unknown"),
+        )
+        self._print_warnings(warnings)
+
+        logger.info(
+            "\n  Tip: use --no-dry-run to skip this confirmation.\n"
+            "       --no-dry-run does not auto-adjust timeouts.",
+        )
+
+        logger.info("=" * SEPARATOR_WIDTH)
+
+        if not Confirm.ask(
+            f"\nProceed with remaining {capped - 1} requests?"
+        ):
+            logger.info("Aborted by user.")
+            sys.exit(0)
+
+        return probe_result
+
+    def _print_summary_header(
+            self, stages, total_planned, capped,
+    ) -> None:
+        """Print the PRE-RUN SUMMARY header block."""
+        args = self._args
+        logger.info("\n%s", "=" * SEPARATOR_WIDTH)
+        logger.info("  PRE-RUN SUMMARY")
+        logger.info("=" * SEPARATOR_WIDTH)
+        logger.info("  Agent:    %s", args.agent)
+        logger.info("  Level:    %s", args.level)
+        if args.ramp:
+            logger.info(
+                "  Stages:   %s", stages,
+            )
+        logger.info(
+            "  Requests: %s x %s round%s = %s total",
+            args.num_requests,
+            args.num_rounds,
+            "s" if args.num_rounds > 1 else "",
+            total_planned,
+        )
+        if capped < total_planned:
+            logger.info(
+                "  Capped:   %s (--max-requests)", capped,
+            )
+        logger.info(
+            "  Workers:  %s (concurrent)", args.max_workers,
+        )
+        logger.info(
+            "  Timeouts: --request-timeout %ss (%sm) / "
+            "--idle-timeout %ss (%sm) / "
+            "--stage-timeout %ss (%sm)",
+            args.request_timeout, args.request_timeout // 60,
+            args.idle_timeout, args.idle_timeout // 60,
+            args.stage_timeout, args.stage_timeout // 60,
+        )
+        if args.total_timeout > 0:
+            logger.info(
+                "            --total-timeout %ss (%sm)",
+                args.total_timeout, args.total_timeout // 60,
+            )
+        else:
+            logger.info(
+                "            --total-timeout disabled",
+            )
+        SystemResources.log_prerun()
+
+    @staticmethod
+    def _estimate_stage_duration(
+            probe_elapsed, remaining,
+    ) -> float:
+        """Estimate stage wall time from probe duration.
+
+        LLM is the bottleneck, so concurrent requests do not
+        scale linearly.  Estimate as probe_time x remaining
+        requests (the probe already ran, so it is excluded).
+        """
+        return probe_elapsed * remaining
+
+    def _collect_warnings(
+            self, *, capped, total_planned,
+            stale_log_age=None,
+            est_stage_duration=None,
+            probe_tokens=None, probe_cost=None,
+            probe_model=None,
+    ) -> List[str]:
+        """Collect all pre-run warnings as a list of strings."""
+        warnings: List[str] = []
+
+        if probe_cost is not None and probe_tokens:
+            est_total_cost = probe_cost * capped
+            est_total_tokens = probe_tokens * capped
+            if est_total_cost > 1.0:
+                warnings.append(
+                    f"Estimated cost exceeds $1:\n"
+                    f"     Probe used ~{probe_tokens:,} "
+                    f"tokens (${probe_cost:.2f}) "
+                    f"x {capped} requests = "
+                    f"~{est_total_tokens:,} tokens "
+                    f"(~${est_total_cost:.2f})\n"
+                    f"     Model: {probe_model}"
+                )
+
+        max_w = self._args.max_workers
+        num_r = self._args.num_requests
+        if not self._args.ramp and max_w < num_r:
+            warnings.append(
+                f"--max-workers ({max_w}) < "
+                f"--num-requests ({num_r}): "
+                f"requests run in batches"
+            )
+
+        if (est_stage_duration is not None
+                and est_stage_duration
+                > self._args.stage_timeout):
+            stage_to = self._args.stage_timeout
+            warnings.append(
+                f"Estimated stage duration "
+                f"~{int(est_stage_duration)}s "
+                f"exceeds --stage-timeout ({stage_to}s).\n"
+                f"     Requests may be killed "
+                f"before completing."
+            )
+
+        if capped < total_planned:
+            warnings.append(
+                f"--max-requests ({capped}) "
+                f"caps planned total ({total_planned})"
+            )
+
+        if stale_log_age is not None:
+            warnings.append(
+                f"Server log appears stale "
+                f"(last modified {stale_log_age}m ago)"
+            )
+
+        warnings.extend(self._token_reporting_warnings())
+
+        mem_warning = self._check_memory_headroom(
+            capped,
+            http_client=getattr(
+                self._args, "http_client", False,
+            ),
+        )
+        if mem_warning:
+            warnings.append(mem_warning)
+
+        return warnings
+
+    def _token_reporting_warnings(self) -> List[str]:
+        """Warn when the chat filter will suppress token reporting.
+
+        Client-side LLM/token numbers arrive as a token-accounting
+        message in the chat stream, which the server's MINIMAL filter
+        drops.  Without a server log to fall back on, the run then
+        reports no LLM or token usage at all.
+        """
+        args = self._args
+        if getattr(args, "chat_filter", "maximal") != "minimal":
+            return []
+        if not getattr(args, "include_tokens", False):
+            return []
+        if (getattr(args, "client_only", False)
+                or getattr(args, "no_server_log", False)):
+            return [
+                "--minimal drops the token-accounting"
+                " message, and this run has no server log to fall"
+                " back on:\n"
+                "     no LLM or token usage will be reported.\n"
+                "     Omit --minimal to report them."
+            ]
+        return [
+            "--minimal drops the token-accounting"
+            " message:\n"
+            "     client-side LLM/token numbers will be"
+            " unavailable (server-log values still apply).\n"
+            "     Omit --minimal to report both."
+        ]
+
+    @staticmethod
+    def _check_memory_headroom(
+            num_requests, *, http_client=False,
+    ) -> Optional[str]:
+        """Warn if available memory looks insufficient.
+
+        Uses a conservative per-request estimate based on
+        typical server thread overhead.
+        """
+        mem = psutil.virtual_memory()
+        avail_gb = mem.available / (1024 ** 3)
+        per_request_mb = 2 if http_client else 50
+        needed_gb = (num_requests * per_request_mb) / 1024
+        if needed_gb > avail_gb * 0.8:
+            return (
+                f"Memory may be insufficient for"
+                f" {num_requests} concurrent requests:\n"
+                f"     Estimated need:"
+                f" ~{needed_gb:.1f}G"
+                f" ({num_requests} x ~{per_request_mb}MB"
+                f" per request)\n"
+                f"     Available: {avail_gb:.1f}G"
+                f" / {mem.total / (1024 ** 3):.1f}G total\n"
+                f"     Consider fewer concurrent workers"
+                f" or a larger instance"
+            )
+        return None
+
+    @staticmethod
+    def _print_warnings(warnings) -> None:
+        """Print numbered warnings or 'No warnings'."""
+        if not warnings:
+            logger.info("\n  No warnings.")
+            return
+
+        logger.warning(
+            "\n  WARNINGS (%s found):", len(warnings),
+        )
+        for idx, warning in enumerate(warnings, 1):
+            lines = warning.split("\n")
+            logger.warning("  %s. %s", idx, lines[0])
+            for line in lines[1:]:
+                logger.warning("  %s", line)
+
+    def _run_cost_probe(
+            self, runner, output_dir,
+    ) -> Tuple[RequestResult, dict]:
+        """Fire one probe request and return results.
+
+        Fires a single request (tokens are enabled by default)
+        and logs the outcome.
+
+        Returns (probe_result, probe_data_dict).
+        """
+        logger.info(
+            "\n  Running 1 dry-run probe to measure actual "
+            "cost...",
+        )
+
+        probe_result = runner.run_one(
+            request_id=0, global_request_id=0,
+            output_dir=output_dir,
+        )
+
+        probe_tokens = probe_result.get("total_tokens", 0)
+        probe_cost = probe_result.get("cost_usd", 0.0)
+        probe_model = probe_result.get("model", "unknown")
+        probe_status = probe_result.get("status", "FAILED")
+        probe_elapsed = probe_result.get("elapsed", 0)
+
+        logger.info(
+            "\n  Probe request completed in %.1fs (%s)",
+            probe_elapsed, probe_status,
+        )
+
+        if probe_tokens > 0:
+            logger.info(
+                "  Probe tokens: %s (model: %s, cost: $%.4f)",
+                f"{probe_tokens:,}", probe_model, probe_cost,
+            )
+        else:
+            logger.info(
+                "  No token data from probe (agent may not "
+                "track tokens).",
+            )
+
+        probe_data = {
+            "tokens": probe_tokens,
+            "cost": probe_cost,
+            "model": probe_model,
+            "elapsed": probe_elapsed,
+        }
+        return probe_result, probe_data

--- a/tests/load_tests/validation/output_validator.py
+++ b/tests/load_tests/validation/output_validator.py
@@ -1,0 +1,317 @@
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+"""Post-run result counting and server-side request verification.
+
+Counts results by status (CREATED, FAILED, TIMEOUT, KILLED), logs
+per-stage summaries, retry activity from the server log, server-side
+request validation (sent vs received), and client disconnections.
+"""
+
+import logging
+
+from typing import List
+
+from tests.load_tests.config import Formatters
+from tests.load_tests.config import RequestResult
+from tests.load_tests.config import RETRY_ERROR_TYPES
+from tests.load_tests.config import RETRY_LABELS
+from tests.load_tests.config import STATUS_CREATED
+from tests.load_tests.config import STATUS_FAILED
+from tests.load_tests.config import STATUS_KILLED
+from tests.load_tests.config import STATUS_TIMEOUT
+from tests.load_tests.config import StatusCounts
+
+logger = logging.getLogger(__name__)
+
+
+class OutputValidator:
+    """Counts results and logs server-side request verification."""
+
+    @staticmethod
+    def count_results(results) -> StatusCounts:
+        """Count results by status type."""
+        counts: StatusCounts = {
+            STATUS_CREATED: 0,
+            STATUS_FAILED: 0,
+            STATUS_TIMEOUT: 0,
+            STATUS_KILLED: 0,
+        }
+        for result in results:
+            status = result.get("status", STATUS_FAILED)
+            if status not in counts:
+                status = STATUS_FAILED
+            counts[status] = counts.get(status, 0) + 1
+        return counts
+
+    # pylint: disable=too-many-arguments
+    @staticmethod
+    def log_stage_results(actual_requests, counts, elapsed, *,
+                          timeout, idle_timeout,
+                          skip_reservation_check=False,
+                          show_counts=True) -> None:
+        """Log per-stage summary of request results.
+
+        When ``show_counts`` is False (single-stage runs, where the
+        counts are repeated verbatim in OVERALL RESULTS), only the
+        Duration/Avg line is printed to avoid duplication.
+        """
+        if show_counts:
+            logger.info("\n  Requests: %s", actual_requests)
+            if skip_reservation_check:
+                confirm_label = "output fields confirmed"
+            else:
+                confirm_label = "success criteria met"
+            logger.info(
+                "    Created: %s  (%s)",
+                counts.get(STATUS_CREATED, 0), confirm_label,
+            )
+            logger.info(
+                "    Failed:  %s  (error or crash)",
+                counts.get(STATUS_FAILED, 0),
+            )
+            logger.info(
+                "    Timed out: %s  (hit %ss hard cap)",
+                counts.get(STATUS_TIMEOUT, 0), timeout,
+            )
+            logger.info(
+                "    Killed:  %s  (no output for %ss, presumed hanging)",
+                counts.get(STATUS_KILLED, 0), idle_timeout,
+            )
+        avg_per = (
+            elapsed / actual_requests
+            if actual_requests else 0
+        )
+        logger.info(
+            "  Duration: %s | Avg: %s per request",
+            Formatters.fmt_duration(elapsed, precision=2),
+            Formatters.fmt_duration(avg_per, precision=2),
+        )
+
+    @staticmethod
+    def log_retry_activity(
+            retries, total_retries, actual_requests,
+    ) -> None:
+        """Log retry activity from server log."""
+        logger.info(
+            "\n  Retry activity (from server log):",
+        )
+        for error_type in RETRY_ERROR_TYPES:
+            count = retries.get(error_type, 0)
+            label = RETRY_LABELS.get(error_type, f"{error_type} retries")
+            logger.info("    %s: %s", label, count)
+        logger.info("    Total retries:  %s", total_retries)
+        amplification = Formatters.compute_amplification(
+            actual_requests, total_retries,
+        )
+        logger.info(
+            "    Amplification:  %.2fx "
+            "(%s total LLM attempts for %s requests)",
+            amplification,
+            actual_requests + total_retries,
+            actual_requests,
+        )
+
+    @staticmethod
+    def log_server_validation(
+            server_counts, actual_requests, agent_name,
+    ) -> None:
+        """Log server-side request validation from log counts.
+
+        Compares the number of requests the server received (from the
+        server log) against the number the client sent, flagging only
+        the case of too few: the log belongs to the server, not to this
+        run, so another client testing the same agent inflates the
+        count.  Extra starts are therefore not treated as a mismatch,
+        while missing ones always are.
+        """
+        if server_counts.get("primary_started") is None:
+            return
+        pri_started = server_counts.get("primary_started")
+        pri_finished = server_counts.get("primary_finished")
+        total_started = server_counts.get("total_started")
+        total_finished = server_counts.get("total_finished")
+        internal_calls = total_started - pri_started
+        match_label = (
+            "OK" if pri_started >= actual_requests else "MISMATCH"
+        )
+        logger.info(
+            "\n  Server-side validation (from server log):",
+        )
+        logger.info(
+            "    %s received:  %s/%s  (%s)",
+            agent_name, pri_started, actual_requests, match_label,
+        )
+        logger.info(
+            "    %s completed: %s/%s",
+            agent_name, pri_finished, actual_requests,
+        )
+        if internal_calls > 0:
+            logger.info(
+                "    Internal calls: %s additional "
+                "streaming_chat calls (recursive)",
+                internal_calls,
+            )
+        logger.info(
+            "    Total server calls: %s started, %s finished",
+            total_started, total_finished,
+        )
+        if pri_started < actual_requests:
+            logger.warning(
+                "    WARNING: Server received %s %s requests "
+                "but %s were sent",
+                pri_started, agent_name, actual_requests,
+            )
+
+    @staticmethod
+    def log_disconnections(disconnections) -> None:
+        """Log client disconnections detected in the current stage."""
+        if not disconnections:
+            return
+        logger.warning(
+            "\n  Client disconnections detected: %s",
+            len(disconnections),
+        )
+        for disc in disconnections:
+            agent = disc.get("agent", "unknown")
+            req_id = disc.get("request_id", "unknown")
+            client_req = disc.get("client_request")
+            label = (
+                f"{client_req}/{req_id}" if client_req
+                else req_id
+            )
+            logger.warning(
+                "    %s: %s still running at disconnect",
+                label, agent,
+            )
+
+    @staticmethod
+    def log_server_errors(server_errors) -> None:
+        """Log server-side "Errors detected:" events for the stage."""
+        if not server_errors:
+            return
+        logger.warning(
+            "\n  Server errors detected: %s",
+            len(server_errors),
+        )
+        for err in server_errors:
+            req_id = err.get("request_id", "unknown")
+            message = err.get("message", "")
+            logger.warning("    %s: %s", req_id, message)
+
+    @staticmethod
+    def log_tool_warnings(tool_warnings) -> None:
+        """Log server-side tool-creation warnings for the stage.
+
+        These mean a requested tool was unavailable to an agent; they
+        don't affect the created network, but a high count under load
+        may indicate tool-creation failures worth investigating.
+        """
+        if not tool_warnings:
+            return
+        logger.warning(
+            "\n  Tool-creation warnings: %s",
+            len(tool_warnings),
+        )
+        for warn in tool_warnings:
+            req_id = warn.get("request_id", "unknown")
+            message = warn.get("message", "")
+            logger.warning("    %s: %s", req_id, message)
+
+    @staticmethod
+    def check_permission_failures(
+            results: List[RequestResult], agent_name: str,
+    ) -> bool:
+        """Check if all requests failed with a permissions error.
+
+        When neuro-san-studio organizes agents under subdirectories
+        (e.g. registries/basic/hello_world), the --agent value must
+        include the subdirectory prefix (basic/hello_world).
+
+        Returns True if the test should abort (all requests failed
+        with a permissions-related error).
+        """
+        if not results:
+            return False
+        all_failed = all(
+            r.get("status") == STATUS_FAILED for r in results
+        )
+        if not all_failed:
+            return False
+        permission_keywords = ["permissions", "permission", "not found"]
+        has_perm_error = any(
+            any(
+                kw in (r.get("error") or "").lower()
+                for kw in permission_keywords
+            )
+            for r in results
+        )
+        if not has_perm_error:
+            return False
+        if "/" in agent_name:
+            logger.error(
+                "\n  ERROR: All requests failed with a permissions "
+                "error for agent '%s'.\n"
+                "  Verify that the agent is registered in the "
+                "server's AGENT_REGISTRY_PATH and that your user\n"
+                "  has the correct permissions for the network.\n\n"
+                "  Aborting test.",
+                agent_name,
+            )
+        else:
+            logger.error(
+                "\n  ERROR: All requests failed with a permissions "
+                "error.\n"
+                "  The --agent value '%s' may need a registry "
+                "subdirectory prefix.\n"
+                "  For example, if the agent is registered under\n"
+                "  registries/basic/, use:\n"
+                "    --agent basic/%s\n\n"
+                "  Aborting test.",
+                agent_name, agent_name,
+            )
+        return True
+
+    @staticmethod
+    def check_timeout_abort(
+            counts: "StatusCounts",
+    ) -> bool:
+        """Check if any requests hit a timeout or were killed.
+
+        Returns True if the test should abort because at least one
+        request exceeded its idle-timeout, request-timeout, or was
+        killed by stage-timeout.
+        """
+        timed_out = counts.get(STATUS_TIMEOUT, 0)
+        killed = counts.get(STATUS_KILLED, 0)
+        total_bad = timed_out + killed
+        if total_bad == 0:
+            return False
+        parts = []
+        if timed_out:
+            parts.append(
+                f"{timed_out} timed out"
+            )
+        if killed:
+            parts.append(
+                f"{killed} killed by stage-timeout"
+            )
+        logger.warning(
+            "\n  ABORT: %s — %s.\n"
+            "  Stopping test and reporting available results.",
+            ", ".join(parts), f"{total_bad} request(s) failed",
+        )
+        return True


### PR DESCRIPTION
Note: This is a tool. I want to see if I can use this tool to help me do what I need. We can always tweak and update it over time to make it more useful, so we don't really need to make it perfect, as that would take a lot of time. I don't need you to put too much time into the PR, but please focus on its options and related details.
Also, it is the right time to set up a dedicated test repo to host this type of tool moving forward. This tool is completely independent. You can point the tool to NSS run from the NS repo or the Studio repo. It does not make any changes to any code to NS or request any changes.

Load-test framework at `tests/load_tests/`, firing concurrent **real-LLM**
requests at any HOCON agent network and reporting latency, resources, tokens,
and server-side behavior. Replaces the single mock-LLM script that was the only
thing under `tests/load_tests/` before.

52 files, all under `tests/load_tests/` — no production code touched.

## What you get from a run

```bash
export PYTHONPATH=$(pwd)
python -m tests.load_tests.load_test_cli --agent hello_world --num-requests 10
```

- Per-request latency, time-to-first-response, and completion timeline
- Server and whole-system CPU, memory, RSS, and thread counts (before / peak / settled)
- Token usage and cost, from the client's `--tokens` output and from the server log
- Server-side validation: requests received vs. sent, retries, and LLM-attempt
  amplification, disconnections, structured errors and tool warnings
- `raw_results.json`, `summary.txt`, `load_test.log`, per-request stdout/stderr
  under `/tmp/load_test_{user}/{level}/{timestamp}/`, or `--output-dir`. The
  default is per-user because a fixed path in a shared temp directory belongs
  To whoever ran first and gives everyone else `PermissionError`

## Interface

| | |
|---|---|
| Transports | `agent_cli` subprocesses (default), or in-thread HTTP streaming (`--http-client`) |
| Levels | `norm` (default; + resource and server-log analysis), `adv` (+ pool reuse analysis). `min` is used automatically by `--client-only` / `--server-only` |
| Topologies | colocated, `--client-only` (remote or already-running server), `--server-only` (server-side resource behavior alone) |
| Cost control | dry-run probe + confirmation before the full run at `min`/`norm`; `--no-dry-run` skips it |
| Load shaping | `--num-requests` / `--max-workers`, `--full-concurrency` to fire all at once, `--ramp --stages 10,30,50,100` |
| Message volume | `--minimal` asks the server for `MINIMAL` instead of `MAXIMAL` in both transports. Named after the client's own flag — see below for what it drops |

## Comparing runs over time

Each run appends one line to a history file — successful runs to
`history.jsonl`, incomplete or unrecognized ones to `history_unknown.jsonl`, so
a bad run can't silently pollute the trend.

```bash
python -m tests.load_tests.load_test_cli --trend runs/          # chronological, one row per run
python -m tests.load_tests.load_test_cli --compare runs/        # scaling comparison across request counts
```

Both skip the load test and only read persisted results.

## Notes for review

- **Real API cost.** Every run makes real LLM calls. The dry-run probe exists to
  price a run before it fires, which is why it is on by default at `min`/`norm`.
- **`--minimal` costs you client-side token data.** `MINIMAL` delivers only the
  final `AgentFrameworkMessage` (the answer plus `chat_context`) and drops every
  intermediate agent and progress message — including the token-accounting
  message. So tokens, cost, and LLM-call counts then come only from the server
  log, and are unavailable if the run has no log access. The run warns about
  this before firing. Use it to measure the server without streaming overhead;
  omit it when you want token numbers from the client.
- **`--request-timeout` is a hard cap in subprocess mode and a near-hard cap in
  HTTP mode.** Subprocess mode kills the `agent_cli` process at the limit. HTTP
  mode abandons the request as the response streams, so it stops within one
  streamed message of the limit rather than exactly at it; that wait is itself
  bounded by `--idle-timeout`. Interrupting a blocking read exactly would cost a
  thread per request, which is what HTTP mode exists to avoid (~1-2 MB per
  request instead of ~96 MB).
- **68 unit tests** in `tests/load_tests/unit/`, covering the pure logic behind
  the bugs this framework actually hit: request-count validation that must exit
  *before* the paid dry-run probe, output-directory resolution, server-log token
  parsing against the record shape `logging.hocon` writes, duration parsing,
  model pricing lookup, history-file tolerance of a truncated final line,
  status counting, mean-latency arithmetic in both result writers, status
  preservation when rebuilding results, and the HTTP request-timeout cap.
  They need no server and make no LLM calls, so they run in the
  normal quality gate. Everything requiring a live server or real traffic is
  still covered only by running the tool.
- `neuro_san/` is untouched. One server-side inconsistency was found while
  testing and deliberately left alone: a client sending lowercase `minimal` in
  `chat_filter_type` gets minimal filtering but still has its request echoed in
  every streamed message, because `message_filter_factory` uppercases the value
  and the request-echo check doesn't. Nothing in neuro-san sends lowercase, so
  no caller is affected today.

The entrypoint is `load_test_cli.py`, matching the repo's existing
`agent_cli` / `hocon_validator_cli` naming. See
`tests/load_tests/README.md` for flags, levels, output format, and
architecture.
