### PR TITLE
NS-1246 Add record/playback LLM proxy for neuro-san load & regression testing.

### DIFF
--- a/neuro_san/registries/music_nerd.hocon
+++ b/neuro_san/registries/music_nerd.hocon
@@ -29,9 +29,7 @@
         ]
     },
     "llm_config": {
-#        "model_name": "gpt-5.2"
-        "model_name": "gpt-5.2",
-        "openai_api_base": "http://localhost:8899/v1"
+        "model_name": "gpt-5.2"
     },
     "tools": [
         # This first agent definition is regarded as the "Front Man", which

--- a/neuro_san/registries/music_nerd.hocon
+++ b/neuro_san/registries/music_nerd.hocon
@@ -29,7 +29,9 @@
         ]
     },
     "llm_config": {
-        "model_name": "gpt-5.2"
+#        "model_name": "gpt-5.2"
+        "model_name": "gpt-5.2",
+        "openai_api_base": "http://localhost:8899/v1"
     },
     "tools": [
         # This first agent definition is regarded as the "Front Man", which

--- a/tests/record_playback_llm_server/README.md
+++ b/tests/record_playback_llm_server/README.md
@@ -1,0 +1,175 @@
+# Record / Playback LLM Server
+
+A standalone OpenAI-compatible HTTP proxy for **recording** a neuro-san
+session against a real external LLM host and **playing it back** offline.
+
+Two goals:
+
+1. **Free** — record once against the paid host, then replay from disk with
+   zero token cost.
+2. **Repeatable** — replaying byte-identical recorded responses removes the
+   random nature of LLM output, so load and regression tests become
+   deterministic.
+
+It is wire-compatible with the OpenAI Chat Completions API, so any neuro-san
+agent network configured for `class = "openai"` can be redirected at it with a
+single `openai_api_base` change — the same seam the sibling `mock_llm_server`
+uses.
+
+There is **no synthetic mode** here: every response is either forwarded from
+the real host (record) or served from a prior recording (playback).
+
+## Modes
+
+| Mode | What it does |
+|---|---|
+| `record` | Forwards each request to the external LLM host (endpoint + key from env vars), relays the real response back to neuro-san, and tees it into the cassette file. |
+| `playback` | Serves responses from the cassette by matching the canonical request signature. No network, no tokens. An unmatched request fails hard with HTTP 504. |
+
+## External host configuration (record mode)
+
+The external LLM host is configured **only** via environment variables:
+
+| Variable | Purpose |
+|---|---|
+| `RECORD_PLAYBACK_UPSTREAM_BASE_URL` | Base URL of the real host, including the version segment. e.g. `https://api.openai.com/v1`. Required in record mode. |
+| `RECORD_PLAYBACK_UPSTREAM_API_KEY` | Bearer credential for that host. Optional (a warning is logged if absent, for hosts that need no auth). |
+| `RECORD_PLAYBACK_UPSTREAM_REQUEST_TIMEOUT_SECONDS` | Whole-request timeout when forwarding to the real host. Default `600`. |
+| `RECORD_PLAYBACK_UPSTREAM_CONNECT_TIMEOUT_SECONDS` | Connection timeout when forwarding to the real host. Default `30`. |
+| `RECORD_PLAYBACK_UPSTREAM_MAX_CLIENTS` | Maximum simultaneous in-flight requests to the real host before further requests queue. Default `100`. |
+
+The incoming request's own `openai_api_key` (pointed at this proxy) is ignored
+and replaced with the real credential above.
+
+All timeout/limit variables accept a positive number; an invalid or
+non-positive value logs a warning and falls back to the default. They apply in
+**record mode only** (playback never contacts the network).
+
+> **If you are seeing timeout errors while recording under load**, raising
+> `RECORD_PLAYBACK_UPSTREAM_REQUEST_TIMEOUT_SECONDS` alone may not be enough:
+> Tornado's client serves only `max_clients` requests at once and queues the
+> rest, and time spent queued counts against the request timeout. Raise
+> `RECORD_PLAYBACK_UPSTREAM_MAX_CLIENTS` to at least your peak concurrency.
+
+## Running
+
+The package is runnable as a module:
+
+```bash
+export PYTHONPATH=$(pwd)
+
+# 1) Record a session against the real host (costs tokens, once).
+export RECORD_PLAYBACK_UPSTREAM_BASE_URL="https://api.openai.com/v1"
+export RECORD_PLAYBACK_UPSTREAM_API_KEY="sk-..."
+python -m tests.record_playback_llm_server.record_playback_llm_server \
+    --mode record --port 8899 --cassette ./session.cassette.json
+
+# ... run your load/integration test against neuro-san, then Ctrl-C ...
+
+# 2) Replay it forever, for free, deterministically (no env vars needed).
+python -m tests.record_playback_llm_server.record_playback_llm_server \
+    --mode playback --port 8899 --cassette ./session.cassette.json
+```
+
+### CLI options
+
+| Flag | Default | Description |
+|---|---|---|
+| `--host` | `localhost` | Bind interface. |
+| `--port` | `8899` | Bind port (differs from the mock's 8888 so both can run at once). |
+| `--mode` | _(required)_ | `record` or `playback`. |
+| `--cassette` | `./llm_cassette.json` | Path to the cassette JSON file. |
+| `--stream-replay-delay` | `0.0` | Seconds between streamed SSE frames during playback, to emulate inter-token cadence. `0` replays as fast as possible. |
+
+## Pointing a neuro-san agent network at the proxy
+
+```hocon
+llm_config {
+    class = "openai"
+    model_name = "gpt-4.1"
+    openai_api_base = "http://localhost:8899/v1"
+    openai_api_key = "not-needed"
+}
+```
+
+- `openai_api_base` must include the `/v1` path segment.
+- Use the **same** agent network and inputs for record and playback — the
+  match key is derived from the request, so a changed prompt is a new
+  (unrecorded) request.
+
+## How matching works
+
+The response of an LLM is non-deterministic, but the **request** is a
+deterministic function of the agent network plus its inputs. In a multi-turn
+agent flow, each request embeds the previous responses (assistant messages,
+`tool_call` ids, tool results). Because playback returns **byte-identical**
+recorded responses, every downstream request reconstructs identically — so a
+hash of the canonicalized request body is a stable key across the whole
+conversation.
+
+Canonicalization (`RequestCanonicalizer`):
+
+- Parses the JSON body and re-serializes it with **sorted keys**, so
+  incidental key ordering does not change the key.
+- Keeps the `stream` flag as part of the key (a streamed request and a
+  one-shot request map to different recorded responses).
+- Drops any fields listed in `VOLATILE_BODY_KEYS` (empty by default; extend it
+  if a client is found to inject a per-run random value into the body).
+
+The key is `sha256(f"{METHOD} {path}\n{canonical_body}")`.
+
+## Cassette format
+
+An ordered, human-diffable JSON array — commit it to git as a test fixture:
+
+```json
+{
+  "version": 1,
+  "entries": [
+    {
+      "key": "<sha256>",
+      "method": "POST",
+      "path": "/chat/completions",
+      "request": "POST /chat/completions\n{...canonical body...}",
+      "response": {
+        "kind": "json",
+        "status": 200,
+        "body": { "id": "chatcmpl-...", "choices": [ ... ] }
+      }
+    }
+  ]
+}
+```
+
+A streamed response is stored with `"kind": "stream"` and a `"chunks"` array
+of the individual SSE frames (`data: {...}\n\n`, terminated by
+`data: [DONE]\n\n`), re-emitted verbatim on playback.
+
+## Internal layout
+
+One class per file:
+
+| File | Class | Responsibility |
+|---|---|---|
+| `record_playback_llm_server.py` | `RecordPlaybackLlmServer` | CLI entry point; reads env config, builds the app, runs the loop. |
+| `proxy_state.py` | `ProxyState` | Process-wide state: mode, cassette, upstream client, replay pacing. |
+| `proxy_handler.py` | `ProxyHandler` | Shared record/playback logic for both proxied endpoints (base class). |
+| `chat_completions_handler.py` | `ChatCompletionsHandler` | `POST /v1/chat/completions`. |
+| `models_handler.py` | `ModelsHandler` | `GET /v1/models`. |
+| `health_handler.py` | `HealthHandler` | `GET /healthz`. |
+| `upstream_client.py` | `UpstreamClient` | Async HTTP client to the real host (record mode), one-shot and streaming. |
+| `cassette.py` | `Cassette` | Load/lookup/store/atomic-save of recorded interactions. |
+| `request_canonicalizer.py` | `RequestCanonicalizer` | Canonical request string + sha256 cassette key. |
+
+## Known limitations
+
+- **OpenAI wire format only.** Hosts reachable via an OpenAI-compatible
+  `base_url` are supported. Anthropic/Bedrock/Gemini native wire formats are
+  not handled.
+- **Playback miss = hard 504.** By design, so tests surface gaps
+  deterministically rather than silently faking a response. Re-record when the
+  agent network or inputs change.
+- **One key → one response.** Identical requests replay the same recorded
+  response. Recorded response variety for the same request is not preserved.
+- **Single process, single event loop.** A test tool: no supervisor, no
+  metrics, no auth. Bind to `localhost`.

--- a/tests/record_playback_llm_server/README.md
+++ b/tests/record_playback_llm_server/README.md
@@ -26,6 +26,37 @@ Selected with `--mode`:
 | `playback` | Serves responses from the cassette by matching the canonical request signature. No network, no tokens. An unmatched request fails hard with HTTP 504. |
 | `hybrid` | Like `playback`, but a cache **miss** falls through to the real host (when an upstream is configured via the env vars below), records the result into the **current** cassette, and returns it — a self-healing cassette that fills in gaps on demand. With no upstream configured, a miss behaves like plain playback (504). |
 
+**Only successful responses are recorded.** In `record` and `hybrid` modes a
+non-2xx upstream response (rate limit `429`, auth `401`, upstream `5xx`, …) is
+relayed back to the caller but **not** written to the cassette, so a transient
+failure can't poison it — a later retry records a good response instead. To
+repair a cassette recorded before this behavior existed, see
+[Cleaning a cassette](#cleaning-a-cassette).
+
+### Cleaning a cassette
+
+`cleanup_cassette.py` repairs a cassette left with failure responses by an
+interrupted or throttled recording session, making it safe for playback/hybrid:
+
+- Single-response entries with a non-2xx status are dropped.
+- Multi-response entries have their non-2xx variants removed; the entry is
+  dropped only if no successful variant remains.
+- All other data (requests, keys, latencies, unknown fields, `version`) is
+  preserved.
+
+```bash
+export PYTHONPATH=$(pwd)
+# Non-destructive: writes <cassette>.clean.json next to the input.
+python -m tests.record_playback_llm_server.cleanup_cassette session.cassette.json
+# Overwrite in place (a <cassette>.bak is made first).
+python -m tests.record_playback_llm_server.cleanup_cassette session.cassette.json --in-place
+# Report what would be removed without writing anything.
+python -m tests.record_playback_llm_server.cleanup_cassette session.cassette.json --dry-run
+```
+
+Note: cleanup is status-based; a provider that returns HTTP 200 with an error
+body is not detected.
+
 ### Multi-response (round-robin)
 
 The `--multi-response` flag is orthogonal to `record`/`playback`:
@@ -239,6 +270,7 @@ One class per file:
 | `cassette.py` | `Cassette` | Load/lookup/store/atomic-save of recorded interactions (single and multi-response). |
 | `playback_delay.py` | `PlaybackDelay` | Per-response up-front delay policy (none/recorded/fixed/random). |
 | `request_canonicalizer.py` | `RequestCanonicalizer` | Canonical request string + sha256 cassette key. |
+| `cleanup_cassette.py` | `CassetteCleaner` | Standalone tool: strip non-2xx (failure) responses from a cassette. |
 
 ## Known limitations
 

--- a/tests/record_playback_llm_server/README.md
+++ b/tests/record_playback_llm_server/README.md
@@ -16,23 +16,40 @@ agent network configured for `class = "openai"` can be redirected at it with a
 single `openai_api_base` change — the same seam the sibling `mock_llm_server`
 uses.
 
-There is **no synthetic mode** here: every response is either forwarded from
-the real host (record) or served from a prior recording (playback).
-
 ## Modes
+
+Selected with `--mode`:
 
 | Mode | What it does |
 |---|---|
-| `record` | Forwards each request to the external LLM host (endpoint + key from env vars), relays the real response back to neuro-san, and tees it into the cassette file. |
+| `record` | Forwards each request to the external LLM host (endpoint + key from env vars), relays the real response back to neuro-san, and tees it into the cassette file (capturing wall-clock latency). |
 | `playback` | Serves responses from the cassette by matching the canonical request signature. No network, no tokens. An unmatched request fails hard with HTTP 504. |
+| `hybrid` | Like `playback`, but a cache **miss** falls through to the real host (when an upstream is configured via the env vars below), records the result into the **current** cassette, and returns it — a self-healing cassette that fills in gaps on demand. With no upstream configured, a miss behaves like plain playback (504). |
 
-## External host configuration (record mode)
+### Multi-response (round-robin)
 
-The external LLM host is configured **only** via environment variables:
+The `--multi-response` flag is orthogonal to `record`/`playback`:
+
+- In **record**, every *distinct* response seen for a given request is
+  accumulated under that request's key (identical repeats are de-duplicated,
+  ignoring latency). Because recording forwards each occurrence to the real
+  host, this captures the LLM's natural variability — at the cost of one real
+  call per occurrence.
+- In **playback**, the recorded responses for a key are served **round-robin**.
+
+Without the flag (the default), a request maps to a single response
+(last-writer-wins on record, deterministic on playback). Under concurrency the
+round-robin order is not guaranteed stable — use the default when strict
+determinism matters.
+
+## External host configuration (record and hybrid modes)
+
+The external LLM host is configured **only** via environment variables. It is
+required in `record` mode and used for cache-miss fetches in `hybrid` mode:
 
 | Variable | Purpose |
 |---|---|
-| `RECORD_PLAYBACK_UPSTREAM_BASE_URL` | Base URL of the real host, including the version segment. e.g. `https://api.openai.com/v1`. Required in record mode. |
+| `RECORD_PLAYBACK_UPSTREAM_BASE_URL` | Base URL of the real host, including the version segment. e.g. `https://api.openai.com/v1`. Required in record mode; optional in hybrid mode. |
 | `RECORD_PLAYBACK_UPSTREAM_API_KEY` | Bearer credential for that host. Optional (a warning is logged if absent, for hosts that need no auth). |
 | `RECORD_PLAYBACK_UPSTREAM_REQUEST_TIMEOUT_SECONDS` | Whole-request timeout when forwarding to the real host. Default `600`. |
 | `RECORD_PLAYBACK_UPSTREAM_CONNECT_TIMEOUT_SECONDS` | Connection timeout when forwarding to the real host. Default `30`. |
@@ -42,8 +59,9 @@ The incoming request's own `openai_api_key` (pointed at this proxy) is ignored
 and replaced with the real credential above.
 
 All timeout/limit variables accept a positive number; an invalid or
-non-positive value logs a warning and falls back to the default. They apply in
-**record mode only** (playback never contacts the network).
+non-positive value logs a warning and falls back to the default. They apply
+whenever the proxy contacts the network (record mode, and hybrid-mode
+misses); plain playback never does.
 
 > **If you are seeing timeout errors while recording under load**, raising
 > `RECORD_PLAYBACK_UPSTREAM_REQUEST_TIMEOUT_SECONDS` alone may not be enough:
@@ -69,6 +87,18 @@ python -m tests.record_playback_llm_server.record_playback_llm_server \
 # 2) Replay it forever, for free, deterministically (no env vars needed).
 python -m tests.record_playback_llm_server.record_playback_llm_server \
     --mode playback --port 8899 --cassette ./session.cassette.json
+
+# Or self-healing playback: serve from the cassette, but fetch+record any miss.
+export RECORD_PLAYBACK_UPSTREAM_BASE_URL="https://api.openai.com/v1"
+export RECORD_PLAYBACK_UPSTREAM_API_KEY="sk-..."
+python -m tests.record_playback_llm_server.record_playback_llm_server \
+    --mode hybrid --cassette ./session.cassette.json
+
+# Capture response variability and replay it round-robin:
+python -m tests.record_playback_llm_server.record_playback_llm_server \
+    --mode record --multi-response --cassette ./session.cassette.json
+python -m tests.record_playback_llm_server.record_playback_llm_server \
+    --mode playback --multi-response --cassette ./session.cassette.json
 ```
 
 ### CLI options
@@ -77,9 +107,42 @@ python -m tests.record_playback_llm_server.record_playback_llm_server \
 |---|---|---|
 | `--host` | `localhost` | Bind interface. |
 | `--port` | `8899` | Bind port (differs from the mock's 8888 so both can run at once). |
-| `--mode` | _(required)_ | `record` or `playback`. |
+| `--mode` | _(required)_ | `record`, `playback`, or `hybrid` (playback + record-on-miss). |
 | `--cassette` | `./llm_cassette.json` | Path to the cassette JSON file. |
+| `--multi-response` | off | Record (and hybrid misses) save every distinct response per request; playback serves them round-robin. |
 | `--stream-replay-delay` | `0.0` | Seconds between streamed SSE frames during playback, to emulate inter-token cadence. `0` replays as fast as possible. |
+| `--delay-mode` | `none` | Up-front per-response delay before serving a cache hit: `none`, `recorded`, `fixed`, `random`. |
+| `--delay-seconds` | `0.0` | Delay for `--delay-mode fixed`. |
+| `--delay-min` / `--delay-max` | `0.0` / `0.0` | Range for `--delay-mode random` (uniform). |
+
+### Playback delay
+
+`--delay-mode` emulates how long the real LLM took, applied as an up-front
+sleep **before serving each cache hit** (playback mode, and hybrid hits). It is
+independent of `--stream-replay-delay` (which paces the gaps *between* streamed
+SSE frames):
+
+| `--delay-mode` | Delay applied per response |
+|---|---|
+| `none` (default) | None — serve immediately. |
+| `recorded` | The response's own recorded wall-clock latency: `first_byte_seconds` (time-to-first-token) for streams, `latency_seconds` for one-shot responses. |
+| `fixed` | A constant `--delay-seconds`. |
+| `random` | Uniform in `[--delay-min, --delay-max]`. |
+
+With `--multi-response`, `recorded` honors **each variant's own** recorded
+latency: since playback rotates through the responses and each carries its own
+`latency_seconds`, each turn is delayed by exactly what that recording took.
+
+```bash
+# Replay with each response delayed by exactly what it took to record:
+python -m tests.record_playback_llm_server.record_playback_llm_server \
+    --mode playback --cassette ./session.cassette.json --delay-mode recorded
+
+# Replay with a random 0.5–2.0s delay per response:
+python -m tests.record_playback_llm_server.record_playback_llm_server \
+    --mode playback --cassette ./session.cassette.json \
+    --delay-mode random --delay-min 0.5 --delay-max 2.0
+```
 
 ## Pointing a neuro-san agent network at the proxy
 
@@ -134,7 +197,8 @@ An ordered, human-diffable JSON array — commit it to git as a test fixture:
       "response": {
         "kind": "json",
         "status": 200,
-        "body": { "id": "chatcmpl-...", "choices": [ ... ] }
+        "body": { "id": "chatcmpl-...", "choices": [ ... ] },
+        "latency_seconds": 1.732
       }
     }
   ]
@@ -143,7 +207,21 @@ An ordered, human-diffable JSON array — commit it to git as a test fixture:
 
 A streamed response is stored with `"kind": "stream"` and a `"chunks"` array
 of the individual SSE frames (`data: {...}\n\n`, terminated by
-`data: [DONE]\n\n`), re-emitted verbatim on playback.
+`data: [DONE]\n\n`), re-emitted verbatim on playback. Stream responses also
+record `"first_byte_seconds"` (time to the first chunk — the LLM's
+time-to-first-token) alongside `"latency_seconds"` (total).
+
+**Latency** (`latency_seconds`, and `first_byte_seconds` for streams) is the
+wall-clock time the real host took, captured during recording. `--delay-mode
+recorded` reproduces per-response timing on playback (see
+[Playback delay](#playback-delay)), using `first_byte_seconds` for streams and
+`latency_seconds` for one-shot responses. `--stream-replay-delay` remains an
+independent knob for inter-frame pacing.
+
+**Multi-response** entries replace the single `"response"` with a `"responses"`
+array holding each distinct variant (each with its own latency); playback
+rotates through them. Single-response cassettes (with `"response"`) still
+replay unchanged, so existing fixtures keep working.
 
 ## Internal layout
 
@@ -152,13 +230,14 @@ One class per file:
 | File | Class | Responsibility |
 |---|---|---|
 | `record_playback_llm_server.py` | `RecordPlaybackLlmServer` | CLI entry point; reads env config, builds the app, runs the loop. |
-| `proxy_state.py` | `ProxyState` | Process-wide state: mode, cassette, upstream client, replay pacing. |
-| `proxy_handler.py` | `ProxyHandler` | Shared record/playback logic for both proxied endpoints (base class). |
+| `proxy_state.py` | `ProxyState` | Process-wide state: mode, cassette, upstream client, hybrid responder, replay pacing, round-robin cursors. |
+| `proxy_handler.py` | `ProxyHandler` | Shared record/playback/hybrid logic for both proxied endpoints (base class). |
 | `chat_completions_handler.py` | `ChatCompletionsHandler` | `POST /v1/chat/completions`. |
 | `models_handler.py` | `ModelsHandler` | `GET /v1/models`. |
 | `health_handler.py` | `HealthHandler` | `GET /healthz`. |
 | `upstream_client.py` | `UpstreamClient` | Async HTTP client to the real host (record mode), one-shot and streaming. |
-| `cassette.py` | `Cassette` | Load/lookup/store/atomic-save of recorded interactions. |
+| `cassette.py` | `Cassette` | Load/lookup/store/atomic-save of recorded interactions (single and multi-response). |
+| `playback_delay.py` | `PlaybackDelay` | Per-response up-front delay policy (none/recorded/fixed/random). |
 | `request_canonicalizer.py` | `RequestCanonicalizer` | Canonical request string + sha256 cassette key. |
 
 ## Known limitations
@@ -169,7 +248,9 @@ One class per file:
 - **Playback miss = hard 504.** By design, so tests surface gaps
   deterministically rather than silently faking a response. Re-record when the
   agent network or inputs change.
-- **One key → one response.** Identical requests replay the same recorded
-  response. Recorded response variety for the same request is not preserved.
+- **Round-robin order isn't concurrency-stable.** With `--multi-response`,
+  which recorded variant a given concurrent request receives is not
+  guaranteed run-to-run. Use single-response mode when strict determinism
+  matters.
 - **Single process, single event loop.** A test tool: no supervisor, no
   metrics, no auth. Bind to `localhost`.

--- a/tests/record_playback_llm_server/cassette.py
+++ b/tests/record_playback_llm_server/cassette.py
@@ -45,7 +45,7 @@ class Cassette:
             "method": "POST",
             "path": "/chat/completions",
             "request": "<canonical request string>",
-            "response": { ... see record modes below ... }
+            "responses": [{ ... see record modes below ... }]
         }
 
     A non-streamed response is stored as:

--- a/tests/record_playback_llm_server/cassette.py
+++ b/tests/record_playback_llm_server/cassette.py
@@ -97,6 +97,42 @@ class Cassette:
         self.entries[key] = entry
         self.save()
 
+    def append_response(self, key: str, meta: Dict[str, Any], response: Dict[str, Any]) -> None:
+        """
+        Multi-response record: append a distinct response for a key, keeping all
+        variants under a "responses" list for round-robin playback. Responses
+        whose content matches an existing one (ignoring timing fields) are not
+        duplicated. Persists the whole cassette.
+        :param key: The request signature key.
+        :param meta: Request metadata (method, path, request) for a new entry.
+        :param response: The response dict to append.
+        """
+        entry: Optional[Dict[str, Any]] = self.entries.get(key)
+        if entry is None:
+            entry = dict(meta)
+            entry["key"] = key
+            entry["responses"] = [response]
+            self.entries[key] = entry
+            self._order.append(key)
+        else:
+            responses: List[Dict[str, Any]] = entry.setdefault("responses", [])
+            if not any(self._same_content(existing, response) for existing in responses):
+                responses.append(response)
+        self.save()
+
+    @staticmethod
+    def _same_content(first: Dict[str, Any], second: Dict[str, Any]) -> bool:
+        """Compare two responses for equality ignoring per-call timing fields."""
+        return Cassette._content_key(first) == Cassette._content_key(second)
+
+    @staticmethod
+    def _content_key(response: Dict[str, Any]) -> str:
+        """Serialize a response for de-duplication, stripping volatile timing fields."""
+        trimmed: Dict[str, Any] = dict(response)
+        trimmed.pop("latency_seconds", None)
+        trimmed.pop("first_byte_seconds", None)
+        return json.dumps(trimmed, sort_keys=True)
+
     def save(self) -> None:
         """
         Write the cassette to disk atomically (temp file + os.replace) so a

--- a/tests/record_playback_llm_server/cassette.py
+++ b/tests/record_playback_llm_server/cassette.py
@@ -71,8 +71,11 @@ class Cassette:
         """Load entries from disk into memory. A missing file is not an error."""
         if not self.path or not os.path.exists(self.path):
             return
-        with open(self.path, "r", encoding="utf-8") as cassette_file:
-            data: Dict[str, Any] = json.load(cassette_file)
+        try:
+            with open(self.path, "r", encoding="utf-8") as cassette_file:
+                data: Dict[str, Any] = json.load(cassette_file)
+        except (OSError, json.JSONDecodeError) as exc:
+            raise SystemExit(f"Failed to load cassette '{self.path}': {exc}") from exc
         for entry in data.get("entries", []):
             key: Optional[str] = entry.get("key")
             if key is None:

--- a/tests/record_playback_llm_server/cassette.py
+++ b/tests/record_playback_llm_server/cassette.py
@@ -1,0 +1,116 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+"""
+See class comment for details.
+"""
+from __future__ import annotations
+
+import json
+import os
+
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
+
+
+class Cassette:
+    """
+    On-disk store of recorded request -> response interactions.
+
+    Entries are keyed by the sha256 request signature produced by
+    RequestCanonicalizer. In memory they live in a dict for O(1) lookup; on
+    disk they are written as an ordered JSON array so the file stays
+    human-diffable and reviewable in git -- which is where the test
+    repeatability actually comes from: the recorded run becomes a committed
+    fixture.
+
+    Each entry is a dict of the shape:
+        {
+            "key": "<sha256>",
+            "method": "POST",
+            "path": "/chat/completions",
+            "request": "<canonical request string>",
+            "response": { ... see record modes below ... }
+        }
+
+    A non-streamed response is stored as:
+        {"kind": "json", "status": 200, "body": <parsed JSON or raw string>}
+
+    A streamed response is stored as:
+        {"kind": "stream", "status": 200, "chunks": ["data: {...}\\n\\n", ...]}
+    """
+
+    VERSION: int = 1
+
+    def __init__(self, path: str) -> None:
+        """
+        :param path: Filesystem path of the cassette JSON file. Loaded now if
+                     it exists; created on the first save otherwise.
+        """
+        self.path: str = path
+        self.entries: Dict[str, Dict[str, Any]] = {}
+        self._order: List[str] = []
+        self.load()
+
+    def load(self) -> None:
+        """Load entries from disk into memory. A missing file is not an error."""
+        if not self.path or not os.path.exists(self.path):
+            return
+        with open(self.path, "r", encoding="utf-8") as cassette_file:
+            data: Dict[str, Any] = json.load(cassette_file)
+        for entry in data.get("entries", []):
+            key: Optional[str] = entry.get("key")
+            if key is None:
+                continue
+            if key not in self.entries:
+                self._order.append(key)
+            self.entries[key] = entry
+
+    def get(self, key: str) -> Optional[Dict[str, Any]]:
+        """:return: The recorded entry for the key, or None if not present."""
+        return self.entries.get(key)
+
+    def put(self, key: str, entry: Dict[str, Any]) -> None:
+        """
+        Insert or overwrite the entry for a key and persist the whole cassette.
+        :param key: The request signature key.
+        :param entry: The entry dict; its "key" field is set from `key`.
+        """
+        entry["key"] = key
+        if key not in self.entries:
+            self._order.append(key)
+        self.entries[key] = entry
+        self.save()
+
+    def save(self) -> None:
+        """
+        Write the cassette to disk atomically (temp file + os.replace) so a
+        crash mid-write cannot corrupt an existing cassette.
+        """
+        data: Dict[str, Any] = {
+            "version": self.VERSION,
+            "entries": [self.entries[key] for key in self._order],
+        }
+        tmp_path: str = f"{self.path}.tmp"
+        with open(tmp_path, "w", encoding="utf-8") as cassette_file:
+            json.dump(data, cassette_file, indent=2, ensure_ascii=False)
+        os.replace(tmp_path, self.path)
+
+    def __len__(self) -> int:
+        """:return: Number of recorded entries."""
+        return len(self.entries)

--- a/tests/record_playback_llm_server/chat_completions_handler.py
+++ b/tests/record_playback_llm_server/chat_completions_handler.py
@@ -1,0 +1,34 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+"""
+See class comment for details.
+"""
+from __future__ import annotations
+
+from tests.record_playback_llm_server.proxy_handler import ProxyHandler
+
+
+class ChatCompletionsHandler(ProxyHandler):
+    """
+    Implements POST /v1/chat/completions by recording against, or replaying
+    from, the cassette. The streaming vs one-shot decision is taken from the
+    request body's `stream` flag, exactly as a real OpenAI endpoint would.
+    """
+
+    async def post(self) -> None:
+        """Record or replay a chat-completions request."""
+        await self.handle_request("POST", self.request.body or b"")

--- a/tests/record_playback_llm_server/cleanup_cassette.py
+++ b/tests/record_playback_llm_server/cleanup_cassette.py
@@ -95,13 +95,16 @@ class CassetteCleaner:
                     response for response in responses
                     if isinstance(response, dict) and cls._is_success(response.get("status"))
                 ]
-                stats["variants_removed"] += len(responses) - len(good)
                 if good:
+                    # Partial trim of a surviving entry: count the removed variants.
+                    stats["variants_removed"] += len(responses) - len(good)
                     new_entry: Dict[str, Any] = dict(entry)
                     new_entry["responses"] = good
                     cleaned.append(new_entry)
                     stats["kept"] += 1
                 else:
+                    # No successful variant: the whole entry is dropped, counted
+                    # as a dropped entry (not as trimmed variants).
                     stats["dropped_failure"] += 1
                 continue
 

--- a/tests/record_playback_llm_server/cleanup_cassette.py
+++ b/tests/record_playback_llm_server/cleanup_cassette.py
@@ -1,0 +1,203 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+"""
+Standalone tool that cleans a cassette recorded by the record/playback proxy so
+it is safe for playback/hybrid: it removes any recorded FAILURE responses (a
+non-2xx status such as a 429 rate limit, 401 auth error, or upstream 5xx) that
+an interrupted or throttled recording session may have left behind.
+
+Rules:
+  - Single-response entry ("response"): dropped if its status is not 2xx.
+  - Multi-response entry ("responses"): non-2xx variants are removed; the whole
+    entry is dropped if no successful variant remains.
+  - Structurally invalid entries (no usable response) are dropped.
+
+Everything else -- request metadata, keys, latencies, unknown fields, the file's
+"version" -- is preserved untouched. The tool works on the raw JSON so it is
+forward-compatible with cassette fields it does not know about.
+
+Usage:
+    export PYTHONPATH=$(pwd)
+    # Non-destructive: writes <cassette>.clean.json next to the input.
+    python -m tests.record_playback_llm_server.cleanup_cassette session.cassette.json
+
+    # Overwrite in place (a <cassette>.bak copy is made first).
+    python -m tests.record_playback_llm_server.cleanup_cassette session.cassette.json --in-place
+
+    # Report what would change without writing anything.
+    python -m tests.record_playback_llm_server.cleanup_cassette session.cassette.json --dry-run
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import shutil
+
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Tuple
+
+
+class CassetteCleaner:
+    """
+    Loads a cassette, strips recorded non-2xx (failure) responses, and writes a
+    cleaned copy. See the module docstring for the exact rules.
+    """
+
+    @staticmethod
+    def _is_success(status: Any) -> bool:
+        """:return: True if the value is an HTTP 2xx status code."""
+        return isinstance(status, int) and 200 <= status < 300
+
+    @classmethod
+    def clean_entries(cls, entries: List[Dict[str, Any]]) -> Tuple[List[Dict[str, Any]], Dict[str, int]]:
+        """
+        Produce a cleaned list of entries and a stats summary.
+        :param entries: The raw "entries" list from a cassette file.
+        :return: (cleaned_entries, stats) where stats counts what happened.
+        """
+        cleaned: List[Dict[str, Any]] = []
+        stats: Dict[str, int] = {
+            "scanned": 0,
+            "kept": 0,
+            "dropped_failure": 0,
+            "dropped_malformed": 0,
+            "variants_removed": 0,
+        }
+
+        for entry in entries:
+            stats["scanned"] += 1
+            if not isinstance(entry, dict):
+                stats["dropped_malformed"] += 1
+                continue
+
+            responses: Any = entry.get("responses")
+            if isinstance(responses, list):
+                good: List[Dict[str, Any]] = [
+                    response for response in responses
+                    if isinstance(response, dict) and cls._is_success(response.get("status"))
+                ]
+                stats["variants_removed"] += len(responses) - len(good)
+                if good:
+                    new_entry: Dict[str, Any] = dict(entry)
+                    new_entry["responses"] = good
+                    cleaned.append(new_entry)
+                    stats["kept"] += 1
+                else:
+                    stats["dropped_failure"] += 1
+                continue
+
+            response: Any = entry.get("response")
+            if isinstance(response, dict) and cls._is_success(response.get("status")):
+                cleaned.append(entry)
+                stats["kept"] += 1
+            elif isinstance(response, dict):
+                stats["dropped_failure"] += 1
+            else:
+                stats["dropped_malformed"] += 1
+
+        return cleaned, stats
+
+    @staticmethod
+    def load(path: str) -> Dict[str, Any]:
+        """Load and minimally validate a cassette file, exiting with a clear error on failure."""
+        if not os.path.exists(path):
+            raise SystemExit(f"cassette not found: {path}")
+        try:
+            with open(path, "r", encoding="utf-8") as cassette_file:
+                data: Any = json.load(cassette_file)
+        except (OSError, json.JSONDecodeError) as exception:
+            raise SystemExit(f"failed to read cassette {path}: {exception}") from exception
+        if not isinstance(data, dict) or not isinstance(data.get("entries"), list):
+            raise SystemExit(f"{path} is not a valid cassette (expected an object with an 'entries' list)")
+        return data
+
+    @staticmethod
+    def write(path: str, data: Dict[str, Any]) -> None:
+        """Write cassette data atomically (temp file + os.replace)."""
+        tmp_path: str = f"{path}.tmp"
+        with open(tmp_path, "w", encoding="utf-8") as cassette_file:
+            json.dump(data, cassette_file, indent=2, ensure_ascii=False)
+        os.replace(tmp_path, path)
+
+    @staticmethod
+    def default_output(path: str) -> str:
+        """:return: The default cleaned-output path derived from the input path."""
+        if path.endswith(".json"):
+            return f"{path[:-5]}.clean.json"
+        return f"{path}.clean.json"
+
+    @staticmethod
+    def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+        """Parse CLI arguments for the cleanup tool."""
+        parser = argparse.ArgumentParser(
+            description="Clean a record/playback cassette by removing non-2xx (failure) responses")
+        parser.add_argument("cassette", help="Path to the cassette JSON file to clean")
+        destination = parser.add_mutually_exclusive_group()
+        destination.add_argument("--output", default=None,
+                                 help="Where to write the cleaned cassette (default: <cassette>.clean.json)")
+        destination.add_argument("--in-place", action="store_true",
+                                 help="Overwrite the input cassette in place (a <cassette>.bak copy is made first)")
+        parser.add_argument("--dry-run", action="store_true",
+                            help="Report what would be removed without writing anything")
+        return parser.parse_args(argv)
+
+    @classmethod
+    def run(cls, args: argparse.Namespace) -> None:
+        """Load, clean, report, and (unless dry-run) write the cleaned cassette."""
+        data: Dict[str, Any] = cls.load(args.cassette)
+        cleaned, stats = cls.clean_entries(data["entries"])
+
+        logging.info(
+            "scanned=%d kept=%d dropped_failure=%d dropped_malformed=%d variants_removed=%d",
+            stats["scanned"], stats["kept"], stats["dropped_failure"],
+            stats["dropped_malformed"], stats["variants_removed"])
+
+        removed_entries: int = stats["dropped_failure"] + stats["dropped_malformed"]
+        if removed_entries == 0 and stats["variants_removed"] == 0:
+            logging.info("cassette is already clean; nothing to remove")
+
+        if args.dry_run:
+            logging.info("dry run: no file written")
+            return
+
+        data["entries"] = cleaned
+
+        if args.in_place:
+            backup_path: str = f"{args.cassette}.bak"
+            shutil.copy2(args.cassette, backup_path)
+            logging.info("backed up original to %s", backup_path)
+            output_path: str = args.cassette
+        else:
+            output_path = args.output or cls.default_output(args.cassette)
+
+        cls.write(output_path, data)
+        logging.info("wrote cleaned cassette to %s (%d entries)", output_path, len(cleaned))
+
+    @classmethod
+    def main(cls, argv: Optional[List[str]] = None) -> None:
+        """CLI entry point: configure logging, parse args, run."""
+        logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+        cls.run(cls.parse_args(argv))
+
+
+if __name__ == "__main__":
+    CassetteCleaner.main()

--- a/tests/record_playback_llm_server/conftest.py
+++ b/tests/record_playback_llm_server/conftest.py
@@ -1,0 +1,31 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+"""
+Local pytest configuration for the record/playback proxy tests.
+"""
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def configure_llm_provider_keys():
+    """
+    Override the repo-wide autouse fixture of the same name (tests/conftest.py),
+    which skips tests when no LLM provider API key is present. These proxy tests
+    drive a local in-process fake upstream and never contact a real LLM, so no
+    provider key is required.
+    """
+    yield

--- a/tests/record_playback_llm_server/health_handler.py
+++ b/tests/record_playback_llm_server/health_handler.py
@@ -1,0 +1,37 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+"""
+See class comment for details.
+"""
+from __future__ import annotations
+
+import tornado.web
+
+
+class HealthHandler(tornado.web.RequestHandler):
+    """
+    Liveness probe at GET /healthz. Returns a fixed JSON object so external
+    schedulers (Kubernetes, Docker, etc.) can confirm the process is up.
+    """
+
+    def get(self) -> None:
+        """Return a fixed liveness payload."""
+        self.write({"status": "ok"})
+
+    def data_received(self, chunk):
+        """Required override of RequestHandler abstract method; no-op for GET."""
+        return

--- a/tests/record_playback_llm_server/models_handler.py
+++ b/tests/record_playback_llm_server/models_handler.py
@@ -1,0 +1,35 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+"""
+See class comment for details.
+"""
+from __future__ import annotations
+
+from tests.record_playback_llm_server.proxy_handler import ProxyHandler
+
+
+class ModelsHandler(ProxyHandler):
+    """
+    Implements GET /v1/models by recording against, or replaying from, the
+    cassette. Most LangChain chat clients never call this, but it is proxied
+    for parity with a real OpenAI endpoint so clients that introspect models
+    still work fully offline in playback.
+    """
+
+    async def get(self) -> None:
+        """Record or replay a models-list request."""
+        await self.handle_request("GET", b"")

--- a/tests/record_playback_llm_server/playback_delay.py
+++ b/tests/record_playback_llm_server/playback_delay.py
@@ -1,0 +1,89 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+"""
+See class comment for details.
+"""
+from __future__ import annotations
+
+import random
+
+from typing import Any
+from typing import Dict
+from typing import List
+
+
+class PlaybackDelay:
+    """
+    Policy for the up-front delay applied before serving a cache hit during
+    playback/hybrid, emulating how long the real LLM took to respond. This is
+    distinct from inter-frame stream pacing (stream_replay_delay).
+
+    Delay policies:
+      none     -- no delay (serve immediately).
+      recorded -- use the response's own recorded wall-clock latency: for
+                  streams the time-to-first-token (first_byte_seconds), falling
+                  back to total latency_seconds for one-shot responses. In
+                  multi-response playback each rotated response carries its own
+                  latency, so each is delayed by exactly what it took to record.
+      fixed    -- a constant delay in seconds.
+      random   -- a delay drawn uniformly from [min_seconds, max_seconds].
+    """
+
+    MODE_NONE: str = "none"
+    MODE_RECORDED: str = "recorded"
+    MODE_FIXED: str = "fixed"
+    MODE_RANDOM: str = "random"
+    ALL_MODES: List[str] = [MODE_NONE, MODE_RECORDED, MODE_FIXED, MODE_RANDOM]
+
+    def __init__(
+        self,
+        mode: str = MODE_NONE,
+        fixed_seconds: float = 0.0,
+        min_seconds: float = 0.0,
+        max_seconds: float = 0.0,
+    ) -> None:
+        """
+        :param mode: One of ALL_MODES.
+        :param fixed_seconds: Delay used in fixed mode.
+        :param min_seconds: Lower bound used in random mode.
+        :param max_seconds: Upper bound used in random mode.
+        """
+        self.mode: str = mode
+        self.fixed_seconds: float = fixed_seconds
+        self.min_seconds: float = min_seconds
+        self.max_seconds: float = max_seconds
+
+    def seconds_for(self, response: Dict[str, Any]) -> float:
+        """
+        Compute the delay to apply before serving a given recorded response.
+        :param response: The recorded response dict being replayed.
+        :return: The delay in seconds (>= 0); 0 means serve immediately.
+        """
+        if self.mode == self.MODE_RECORDED:
+            # For streams, first_byte_seconds (time-to-first-token) is the natural
+            # up-front delay; fall back to total latency_seconds (e.g. one-shot
+            # JSON responses, which carry no first_byte_seconds).
+            for field in ("first_byte_seconds", "latency_seconds"):
+                recorded: Any = response.get(field)
+                if isinstance(recorded, (int, float)) and recorded > 0:
+                    return float(recorded)
+            return 0.0
+        if self.mode == self.MODE_FIXED:
+            return max(0.0, self.fixed_seconds)
+        if self.mode == self.MODE_RANDOM:
+            return random.uniform(self.min_seconds, self.max_seconds)
+        return 0.0

--- a/tests/record_playback_llm_server/proxy_handler.py
+++ b/tests/record_playback_llm_server/proxy_handler.py
@@ -415,18 +415,56 @@ class ProxyHandler(tornado.web.RequestHandler):
         except (json.JSONDecodeError, ValueError):
             return raw_body.decode("utf-8", errors="replace")
 
+    @staticmethod
+    def _split_sse_frame_bytes(raw: bytes) -> List[bytes]:
+        """
+        Split an accumulated SSE byte stream into event frames while preserving
+        the exact original delimiter bytes. Supports both LF and CRLF blank-line
+        delimiters and leaves any trailing unterminated bytes unchanged.
+        """
+        frames: List[bytes] = []
+        start: int = 0
+        raw_length: int = len(raw)
+
+        while start < raw_length:
+            lf_index: int = raw.find(b"\n\n", start)
+            crlf_index: int = raw.find(b"\r\n\r\n", start)
+
+            delimiter_index: int = -1
+            delimiter: bytes = b""
+            if lf_index == -1:
+                delimiter_index = crlf_index
+                delimiter = b"\r\n\r\n" if crlf_index != -1 else b""
+            elif crlf_index == -1 or lf_index < crlf_index:
+                delimiter_index = lf_index
+                delimiter = b"\n\n"
+            else:
+                delimiter_index = crlf_index
+                delimiter = b"\r\n\r\n"
+
+            if delimiter_index == -1:
+                if start < raw_length:
+                    frames.append(raw[start:])
+                break
+
+            frame_end: int = delimiter_index + len(delimiter)
+            if frame_end > start:
+                frames.append(raw[start:frame_end])
+            start = frame_end
+
+        return frames
+
     @classmethod
     def _split_sse_frames(cls, raw: bytes) -> List[str]:
         """
         Split an accumulated SSE byte stream into individual event frames.
         The recorded byte chunks are TCP-sized, not frame-aligned, so we
-        re-split on the SSE blank-line delimiter and re-append it to each
-        frame. This yields semantic event units for clean replay.
+        re-split on the SSE blank-line delimiter while preserving the exact
+        delimiter bytes found upstream. This yields semantic event units for
+        clean replay without changing the recorded byte stream.
         """
-        text: str = raw.decode("utf-8", errors="replace")
-        frames: List[str] = []
-        for part in text.split(cls.SSE_FRAME_DELIMITER):
-            if part == "":
-                continue
-            frames.append(f"{part}{cls.SSE_FRAME_DELIMITER}")
-        return frames
+        return [
+            frame.decode("utf-8", errors="replace")
+            for frame in cls._split_sse_frame_bytes(raw)
+            if frame != b""
+        ]

--- a/tests/record_playback_llm_server/proxy_handler.py
+++ b/tests/record_playback_llm_server/proxy_handler.py
@@ -185,7 +185,8 @@ class ProxyHandler(tornado.web.RequestHandler):
                 # Flush on the event loop so the caller sees tokens progressively.
                 tornado.ioloop.IOLoop.current().spawn_callback(self._safe_flush)
             except tornado.iostream.StreamClosedError:
-                return
+                # Client disconnected mid-stream; nothing more to do.
+                pass
 
         try:
             response: tornado.httpclient.HTTPResponse = await self.state.upstream.fetch_stream(

--- a/tests/record_playback_llm_server/proxy_handler.py
+++ b/tests/record_playback_llm_server/proxy_handler.py
@@ -176,13 +176,16 @@ class ProxyHandler(tornado.web.RequestHandler):
         def on_chunk(chunk: bytes) -> None:
             if stream_state["first_byte_seconds"] is None:
                 stream_state["first_byte_seconds"] = time.monotonic() - started
-            if not stream_state["headers_started"]:
-                self._begin_stream_relay(stream_state["status"], stream_state["content_type"])
-                stream_state["headers_started"] = True
             accumulated.extend(chunk)
-            self.write(bytes(chunk))
-            # Flush on the event loop so the caller sees tokens progressively.
-            tornado.ioloop.IOLoop.current().spawn_callback(self._safe_flush)
+            try:
+                if not stream_state["headers_started"]:
+                    self._begin_stream_relay(stream_state["status"], stream_state["content_type"])
+                    stream_state["headers_started"] = True
+                self.write(bytes(chunk))
+                # Flush on the event loop so the caller sees tokens progressively.
+                tornado.ioloop.IOLoop.current().spawn_callback(self._safe_flush)
+            except tornado.iostream.StreamClosedError:
+                return
 
         try:
             response: tornado.httpclient.HTTPResponse = await self.state.upstream.fetch_stream(

--- a/tests/record_playback_llm_server/proxy_handler.py
+++ b/tests/record_playback_llm_server/proxy_handler.py
@@ -128,14 +128,14 @@ class ProxyHandler(tornado.web.RequestHandler):
         self.set_header("Content-Type", "application/json")
         self.write(bytes(raw_body))
 
-        self._store(method, body_bytes, key, {
+        if self._store(method, body_bytes, key, {
             "kind": "json",
             "status": response.code,
             "body": self._decode_body(raw_body),
             "latency_seconds": round(latency_seconds, 6),
-        })
-        self.logger.info("recorded json response (%d bytes, %.3fs) key=%s",
-                         len(raw_body), latency_seconds, key[:12])
+        }):
+            self.logger.info("recorded json response (%d bytes, %.3fs) key=%s",
+                             len(raw_body), latency_seconds, key[:12])
 
     async def _record_stream(self, method: str, body_bytes: bytes, key: str) -> None:
         """Record and relay a streamed SSE response, teeing chunks to disk with latency."""
@@ -167,22 +167,31 @@ class ProxyHandler(tornado.web.RequestHandler):
 
         await self._safe_flush()
         frames: List[str] = self._split_sse_frames(bytes(accumulated))
-        self._store(method, body_bytes, key, {
+        if self._store(method, body_bytes, key, {
             "kind": "stream",
             "status": response.code,
             "chunks": frames,
             "latency_seconds": round(latency_seconds, 6),
             "first_byte_seconds": round(first_byte[0], 6) if first_byte[0] is not None else None,
-        })
-        self.logger.info("recorded stream response (%d frames, %.3fs) key=%s",
-                         len(frames), latency_seconds, key[:12])
+        }):
+            self.logger.info("recorded stream response (%d frames, %.3fs) key=%s",
+                             len(frames), latency_seconds, key[:12])
 
-    def _store(self, method: str, body_bytes: bytes, key: str, response: Dict[str, Any]) -> None:
+    def _store(self, method: str, body_bytes: bytes, key: str, response: Dict[str, Any]) -> bool:
         """
-        Persist a recorded response. In single-response mode the entry keeps one
-        "response"; in multi-response mode distinct responses accumulate under a
-        "responses" list for round-robin playback.
+        Persist a recorded response, but only when it is a success (HTTP 2xx).
+        Non-2xx responses (rate limits, auth errors, upstream 5xx, ...) are
+        relayed to the caller but never cached, so a transient failure cannot
+        poison the cassette; a later retry can record a good response instead.
+
+        In single-response mode the entry keeps one "response"; in multi-response
+        mode distinct responses accumulate under a "responses" list.
+        :return: True if the response was persisted, False if skipped as non-2xx.
         """
+        status: int = response.get("status", 0)
+        if not self._is_success(status):
+            self.logger.warning("not recording non-2xx response (status=%s) key=%s", status, key[:12])
+            return False
         meta: Dict[str, Any] = {
             "method": method.upper(),
             "path": self.upstream_path,
@@ -194,6 +203,12 @@ class ProxyHandler(tornado.web.RequestHandler):
             entry: Dict[str, Any] = dict(meta)
             entry["response"] = response
             self.state.cassette.put(key, entry)
+        return True
+
+    @staticmethod
+    def _is_success(status: int) -> bool:
+        """:return: True if the HTTP status is a 2xx success."""
+        return 200 <= status < 300
 
     async def _playback(self, method: str, body_bytes: bytes, key: str) -> None:
         """

--- a/tests/record_playback_llm_server/proxy_handler.py
+++ b/tests/record_playback_llm_server/proxy_handler.py
@@ -354,7 +354,7 @@ class ProxyHandler(tornado.web.RequestHandler):
         self.logger.error("upstream request to %s failed: %s", self.upstream_path, str(exception))
         self.set_status(502)
         self.set_header("Content-Type", "application/json")
-        self.write(json.dumps({"error": {"message": f"upstream request failed: {exception}"}}))
+        self.write(json.dumps({"error": {"message": "upstream request failed"}}))
 
     @staticmethod
     def _decode_body(raw_body: bytes) -> Any:

--- a/tests/record_playback_llm_server/proxy_handler.py
+++ b/tests/record_playback_llm_server/proxy_handler.py
@@ -1,0 +1,310 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+"""
+See class comment for details.
+"""
+from __future__ import annotations
+
+import asyncio
+import difflib
+import json
+import logging
+import os
+
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Tuple
+
+import tornado.httpclient
+import tornado.iostream
+import tornado.web
+
+from tests.record_playback_llm_server.proxy_state import ProxyState
+from tests.record_playback_llm_server.request_canonicalizer import RequestCanonicalizer
+
+
+class ProxyHandler(tornado.web.RequestHandler):
+    """
+    Shared record/playback logic for the proxy endpoints.
+
+    In RECORD mode the handler forwards the request to the real external LLM
+    host, tees the response into the cassette, and relays it back to the
+    caller (both one-shot JSON and streamed SSE). In PLAYBACK mode it looks
+    the request up in the cassette by its canonical signature and replays the
+    recorded response, never touching the network.
+
+    On a playback miss the handler fails hard with HTTP 504 so a
+    load/regression test surfaces the gap deterministically rather than
+    silently substituting fabricated data.
+    """
+
+    SSE_FRAME_DELIMITER: str = "\n\n"
+
+    def initialize(self, state: ProxyState, upstream_path: str) -> None:
+        """
+        Receive shared state and the upstream sub-path for this route.
+        :param state: The process-wide ProxyState.
+        :param upstream_path: The path to forward to on the external host,
+                              e.g. "/chat/completions".
+        """
+        # pylint: disable=attribute-defined-outside-init
+        self.state: ProxyState = state
+        self.upstream_path: str = upstream_path
+        self.logger: logging.Logger = logging.getLogger("record-playback-llm")
+
+    def data_received(self, chunk):
+        """Required override of RequestHandler abstract method; full body comes via self.request.body."""
+        return
+
+    async def handle_request(self, method: str, body_bytes: bytes) -> None:
+        """
+        Entry point used by the concrete endpoint handlers.
+        :param method: HTTP method of the incoming request.
+        :param body_bytes: Raw request body bytes (may be empty).
+        """
+        key: str = RequestCanonicalizer.key(method, self.upstream_path, body_bytes)
+        if self.state.is_playback():
+            await self._playback(key)
+        else:
+            await self._record(method, body_bytes, key)
+
+    def _wants_stream(self, body_bytes: bytes) -> bool:
+        """:return: True if the request body asks for a streamed (SSE) response."""
+        body: Dict[str, Any] = RequestCanonicalizer.parsed_body(body_bytes)
+        return bool(body.get("stream", False))
+
+    async def _record(self, method: str, body_bytes: bytes, key: str) -> None:
+        """Forward to the external host, relay the response, and store it."""
+        if self.state.upstream is None:
+            self.set_status(500)
+            self.set_header("Content-Type", "application/json")
+            self.write(json.dumps({"error": {"message": "record mode has no upstream configured"}}))
+            return
+
+        if self._wants_stream(body_bytes):
+            await self._record_stream(method, body_bytes, key)
+        else:
+            await self._record_json(method, body_bytes, key)
+
+    async def _record_json(self, method: str, body_bytes: bytes, key: str) -> None:
+        """Record and relay a one-shot JSON response."""
+        try:
+            response: tornado.httpclient.HTTPResponse = \
+                await self.state.upstream.fetch(self.upstream_path, method, body_bytes)
+        except (OSError, tornado.httpclient.HTTPError) as exception:
+            self._fail_upstream(exception)
+            return
+
+        raw_body: bytes = response.body or b""
+        self.set_status(response.code)
+        self.set_header("Content-Type", "application/json")
+        self.write(bytes(raw_body))
+
+        self.state.cassette.put(key, {
+            "method": method.upper(),
+            "path": self.upstream_path,
+            "request": RequestCanonicalizer.canonical_string(method, self.upstream_path, body_bytes),
+            "response": {
+                "kind": "json",
+                "status": response.code,
+                "body": self._decode_body(raw_body),
+            },
+        })
+        self.logger.info("recorded json response (%d bytes) key=%s", len(raw_body), key[:12])
+
+    async def _record_stream(self, method: str, body_bytes: bytes, key: str) -> None:
+        """Record and relay a streamed SSE response, teeing chunks to disk."""
+        self.set_header("Content-Type", "text/event-stream")
+        self.set_header("Cache-Control", "no-cache")
+        self.set_header("X-Accel-Buffering", "no")
+
+        accumulated = bytearray()
+
+        def on_chunk(chunk: bytes) -> None:
+            accumulated.extend(chunk)
+            self.write(bytes(chunk))
+            # Flush must happen on the event loop; schedule it as a coroutine so
+            # the caller (neuro-san) sees tokens progressively during recording.
+            tornado.ioloop.IOLoop.current().spawn_callback(self._safe_flush)
+
+        try:
+            response: tornado.httpclient.HTTPResponse = await self.state.upstream.fetch_stream(
+                self.upstream_path, method, body_bytes, on_chunk)
+        except (OSError, tornado.httpclient.HTTPError) as exception:
+            self._fail_upstream(exception)
+            return
+
+        await self._safe_flush()
+        frames: List[str] = self._split_sse_frames(bytes(accumulated))
+        self.state.cassette.put(key, {
+            "method": method.upper(),
+            "path": self.upstream_path,
+            "request": RequestCanonicalizer.canonical_string(method, self.upstream_path, body_bytes),
+            "response": {
+                "kind": "stream",
+                "status": response.code,
+                "chunks": frames,
+            },
+        })
+        self.logger.info("recorded stream response (%d frames) key=%s", len(frames), key[:12])
+
+    async def _playback(self, key: str) -> None:
+        """Replay a recorded response, or fail hard on a miss."""
+        entry: Dict[str, Any] = self.state.cassette.get(key)
+        if entry is None:
+            self.logger.warning("playback miss for key=%s (%s %s)", key[:12], self.request.method, self.upstream_path)
+            self._dump_miss_diff(key)
+            self.set_status(504)
+            self.set_header("Content-Type", "application/json")
+            self.write(json.dumps({"error": {
+                "message": "no recorded response for this request in playback mode",
+                "key": key,
+            }}))
+            return
+
+        response: Dict[str, Any] = entry.get("response", {})
+        if response.get("kind") == "stream":
+            await self._replay_stream(response)
+        else:
+            self._replay_json(response)
+
+    async def _replay_stream(self, response: Dict[str, Any]) -> None:
+        """Re-emit recorded SSE frames, optionally pacing between them."""
+        self.set_status(response.get("status", 200))
+        self.set_header("Content-Type", "text/event-stream")
+        self.set_header("Cache-Control", "no-cache")
+        self.set_header("X-Accel-Buffering", "no")
+        try:
+            for frame in response.get("chunks", []):
+                self.write(frame)
+                await self.flush()
+                if self.state.stream_replay_delay > 0:
+                    await asyncio.sleep(self.state.stream_replay_delay)
+        except tornado.iostream.StreamClosedError:
+            # Client disconnected mid-stream; nothing more to do.
+            return
+
+    def _replay_json(self, response: Dict[str, Any]) -> None:
+        """Write back a recorded one-shot JSON response."""
+        self.set_status(response.get("status", 200))
+        self.set_header("Content-Type", "application/json")
+        body: Any = response.get("body")
+        if isinstance(body, (dict, list)):
+            self.write(json.dumps(body))
+        elif body is not None:
+            self.write(str(body))
+
+    def _dump_miss_diff(self, key: str) -> None:
+        """
+        Debug aid for playback misses. When RECORD_PLAYBACK_DEBUG_MISS is set,
+        write a readable diff between the (missed) incoming request and its
+        closest recorded neighbor to "<cassette>.miss-<key8>.diff", so the
+        exact non-deterministic field can be pinpointed. Best-effort: never
+        let diagnostics disturb request handling.
+        """
+        if not os.environ.get("RECORD_PLAYBACK_DEBUG_MISS"):
+            return
+        try:
+            incoming: str = RequestCanonicalizer.canonical_string(
+                self.request.method, self.upstream_path, self.request.body or b"")
+            best, ratio = self._closest_recorded(incoming)
+            diff_text: str = "\n".join(difflib.unified_diff(
+                self._pretty(best).splitlines(),
+                self._pretty(incoming).splitlines(),
+                fromfile="closest_recorded_request",
+                tofile="incoming_playback_request",
+                lineterm=""))
+            out_path: str = f"{self.state.cassette.path}.miss-{key[:8]}.diff"
+            with open(out_path, "w", encoding="utf-8") as diff_file:
+                diff_file.write(f"# closest recorded request match ratio: {ratio:.3f}\n")
+                diff_file.write(diff_text)
+            self.logger.warning("wrote playback-miss diff to %s (closest match ratio %.3f)", out_path, ratio)
+        except Exception as exception:  # pylint: disable=broad-exception-caught
+            self.logger.error("failed to write playback-miss diff: %s", str(exception))
+
+    def _closest_recorded(self, incoming: str) -> Tuple[str, float]:
+        """Find the recorded request most similar to the incoming one."""
+        matcher = difflib.SequenceMatcher()
+        matcher.set_seq2(incoming)
+        best: str = ""
+        best_ratio: float = 0.0
+        for entry in self.state.cassette.entries.values():
+            candidate: str = entry.get("request", "")
+            matcher.set_seq1(candidate)
+            ratio: float = matcher.quick_ratio()
+            if ratio > best_ratio:
+                best_ratio = ratio
+                best = candidate
+        return best, best_ratio
+
+    @staticmethod
+    def _pretty(canonical: str) -> str:
+        """Pretty-print the JSON body of a canonical request for readable diffing."""
+        header: str = canonical
+        body_text: str = ""
+        newline_index: int = canonical.find("\n")
+        if newline_index >= 0:
+            header = canonical[:newline_index]
+            body_text = canonical[newline_index + 1:]
+        parsed: Optional[Any] = None
+        try:
+            parsed = json.loads(body_text)
+        except (json.JSONDecodeError, ValueError):
+            return canonical
+        return header + "\n" + json.dumps(parsed, indent=2, sort_keys=True, ensure_ascii=False)
+
+    async def _safe_flush(self) -> None:
+        """Flush the response buffer, tolerating a client that has disconnected."""
+        try:
+            await self.flush()
+        except tornado.iostream.StreamClosedError:
+            return
+
+    def _fail_upstream(self, exception: Exception) -> None:
+        """Report an upstream forwarding failure as a 502 without recording it."""
+        self.logger.error("upstream request to %s failed: %s", self.upstream_path, str(exception))
+        self.set_status(502)
+        self.set_header("Content-Type", "application/json")
+        self.write(json.dumps({"error": {"message": f"upstream request failed: {exception}"}}))
+
+    @staticmethod
+    def _decode_body(raw_body: bytes) -> Any:
+        """Parse a response body as JSON for diff-friendly storage; fall back to text."""
+        if not raw_body:
+            return ""
+        try:
+            return json.loads(raw_body)
+        except (json.JSONDecodeError, ValueError):
+            return raw_body.decode("utf-8", errors="replace")
+
+    @classmethod
+    def _split_sse_frames(cls, raw: bytes) -> List[str]:
+        """
+        Split an accumulated SSE byte stream into individual event frames.
+        The recorded byte chunks are TCP-sized, not frame-aligned, so we
+        re-split on the SSE blank-line delimiter and re-append it to each
+        frame. This yields semantic event units for clean replay.
+        """
+        text: str = raw.decode("utf-8", errors="replace")
+        frames: List[str] = []
+        for part in text.split(cls.SSE_FRAME_DELIMITER):
+            if part == "":
+                continue
+            frames.append(f"{part}{cls.SSE_FRAME_DELIMITER}")
+        return frames

--- a/tests/record_playback_llm_server/proxy_handler.py
+++ b/tests/record_playback_llm_server/proxy_handler.py
@@ -24,6 +24,7 @@ import difflib
 import json
 import logging
 import os
+import time
 
 from typing import Any
 from typing import Dict
@@ -41,17 +42,24 @@ from tests.record_playback_llm_server.request_canonicalizer import RequestCanoni
 
 class ProxyHandler(tornado.web.RequestHandler):
     """
-    Shared record/playback logic for the proxy endpoints.
+    Shared record/playback/hybrid logic for the proxy endpoints.
 
     In RECORD mode the handler forwards the request to the real external LLM
-    host, tees the response into the cassette, and relays it back to the
-    caller (both one-shot JSON and streamed SSE). In PLAYBACK mode it looks
-    the request up in the cassette by its canonical signature and replays the
-    recorded response, never touching the network.
+    host, tees the response into the cassette (capturing wall-clock latency),
+    and relays it back to the caller (both one-shot JSON and streamed SSE). In
+    PLAYBACK mode it looks the request up in the cassette by its canonical
+    signature and replays the recorded response, never touching the network. In
+    HYBRID mode it behaves like playback, except a miss falls through to the
+    real host (when one is configured), records the result into the current
+    cassette, and returns it -- a self-healing cassette.
 
-    On a playback miss the handler fails hard with HTTP 504 so a
-    load/regression test surfaces the gap deterministically rather than
-    silently substituting fabricated data.
+    With multi-response enabled, RECORD (and hybrid-mode record-on-miss)
+    accumulate every distinct response for a request and PLAYBACK serves them
+    round-robin; otherwise a request maps to a single response.
+
+    On a genuine playback miss (playback mode, or hybrid mode with no
+    upstream) the handler fails hard with HTTP 504 so a load/regression test
+    surfaces the gap deterministically rather than silently faking data.
     """
 
     SSE_FRAME_DELIMITER: str = "\n\n"
@@ -79,10 +87,12 @@ class ProxyHandler(tornado.web.RequestHandler):
         :param body_bytes: Raw request body bytes (may be empty).
         """
         key: str = RequestCanonicalizer.key(method, self.upstream_path, body_bytes)
-        if self.state.is_playback():
-            await self._playback(key)
-        else:
+        if self.state.is_record():
             await self._record(method, body_bytes, key)
+        else:
+            # playback and hybrid both serve from the cassette; they differ
+            # only in what happens on a miss (see _playback).
+            await self._playback(method, body_bytes, key)
 
     def _wants_stream(self, body_bytes: bytes) -> bool:
         """:return: True if the request body asks for a streamed (SSE) response."""
@@ -103,40 +113,44 @@ class ProxyHandler(tornado.web.RequestHandler):
             await self._record_json(method, body_bytes, key)
 
     async def _record_json(self, method: str, body_bytes: bytes, key: str) -> None:
-        """Record and relay a one-shot JSON response."""
+        """Record and relay a one-shot JSON response, capturing upstream latency."""
+        started: float = time.monotonic()
         try:
             response: tornado.httpclient.HTTPResponse = \
                 await self.state.upstream.fetch(self.upstream_path, method, body_bytes)
         except (OSError, tornado.httpclient.HTTPError) as exception:
             self._fail_upstream(exception)
             return
+        latency_seconds: float = time.monotonic() - started
 
         raw_body: bytes = response.body or b""
         self.set_status(response.code)
         self.set_header("Content-Type", "application/json")
         self.write(bytes(raw_body))
 
-        self.state.cassette.put(key, {
-            "method": method.upper(),
-            "path": self.upstream_path,
-            "request": RequestCanonicalizer.canonical_string(method, self.upstream_path, body_bytes),
-            "response": {
-                "kind": "json",
-                "status": response.code,
-                "body": self._decode_body(raw_body),
-            },
+        self._store(method, body_bytes, key, {
+            "kind": "json",
+            "status": response.code,
+            "body": self._decode_body(raw_body),
+            "latency_seconds": round(latency_seconds, 6),
         })
-        self.logger.info("recorded json response (%d bytes) key=%s", len(raw_body), key[:12])
+        self.logger.info("recorded json response (%d bytes, %.3fs) key=%s",
+                         len(raw_body), latency_seconds, key[:12])
 
     async def _record_stream(self, method: str, body_bytes: bytes, key: str) -> None:
-        """Record and relay a streamed SSE response, teeing chunks to disk."""
+        """Record and relay a streamed SSE response, teeing chunks to disk with latency."""
         self.set_header("Content-Type", "text/event-stream")
         self.set_header("Cache-Control", "no-cache")
         self.set_header("X-Accel-Buffering", "no")
 
         accumulated = bytearray()
+        started: float = time.monotonic()
+        # One-element list so the sync on_chunk callback can record time-to-first-byte.
+        first_byte: List[Optional[float]] = [None]
 
         def on_chunk(chunk: bytes) -> None:
+            if first_byte[0] is None:
+                first_byte[0] = time.monotonic() - started
             accumulated.extend(chunk)
             self.write(bytes(chunk))
             # Flush must happen on the event loop; schedule it as a coroutine so
@@ -149,25 +163,50 @@ class ProxyHandler(tornado.web.RequestHandler):
         except (OSError, tornado.httpclient.HTTPError) as exception:
             self._fail_upstream(exception)
             return
+        latency_seconds: float = time.monotonic() - started
 
         await self._safe_flush()
         frames: List[str] = self._split_sse_frames(bytes(accumulated))
-        self.state.cassette.put(key, {
+        self._store(method, body_bytes, key, {
+            "kind": "stream",
+            "status": response.code,
+            "chunks": frames,
+            "latency_seconds": round(latency_seconds, 6),
+            "first_byte_seconds": round(first_byte[0], 6) if first_byte[0] is not None else None,
+        })
+        self.logger.info("recorded stream response (%d frames, %.3fs) key=%s",
+                         len(frames), latency_seconds, key[:12])
+
+    def _store(self, method: str, body_bytes: bytes, key: str, response: Dict[str, Any]) -> None:
+        """
+        Persist a recorded response. In single-response mode the entry keeps one
+        "response"; in multi-response mode distinct responses accumulate under a
+        "responses" list for round-robin playback.
+        """
+        meta: Dict[str, Any] = {
             "method": method.upper(),
             "path": self.upstream_path,
             "request": RequestCanonicalizer.canonical_string(method, self.upstream_path, body_bytes),
-            "response": {
-                "kind": "stream",
-                "status": response.code,
-                "chunks": frames,
-            },
-        })
-        self.logger.info("recorded stream response (%d frames) key=%s", len(frames), key[:12])
+        }
+        if self.state.multi_response:
+            self.state.cassette.append_response(key, meta, response)
+        else:
+            entry: Dict[str, Any] = dict(meta)
+            entry["response"] = response
+            self.state.cassette.put(key, entry)
 
-    async def _playback(self, key: str) -> None:
-        """Replay a recorded response, or fail hard on a miss."""
+    async def _playback(self, method: str, body_bytes: bytes, key: str) -> None:
+        """
+        Serve a recorded response. On a miss: in hybrid mode with an upstream
+        configured, fall through to the real host and record the result into the
+        current cassette (self-healing); otherwise fail hard with 504.
+        """
         entry: Dict[str, Any] = self.state.cassette.get(key)
         if entry is None:
+            if self.state.is_hybrid() and self.state.upstream is not None:
+                self.logger.info("hybrid miss key=%s -> forwarding to upstream and recording", key[:12])
+                await self._record(method, body_bytes, key)
+                return
             self.logger.warning("playback miss for key=%s (%s %s)", key[:12], self.request.method, self.upstream_path)
             self._dump_miss_diff(key)
             self.set_status(504)
@@ -178,11 +217,30 @@ class ProxyHandler(tornado.web.RequestHandler):
             }}))
             return
 
-        response: Dict[str, Any] = entry.get("response", {})
+        response: Dict[str, Any] = self._select_response(entry, key)
+
+        # Up-front latency emulation before serving the hit. Each response
+        # carries its own recorded latency, so in multi-response round-robin the
+        # per-response recorded delay is honored.
+        delay_seconds: float = self.state.playback_delay.seconds_for(response)
+        if delay_seconds > 0:
+            await asyncio.sleep(delay_seconds)
+
         if response.get("kind") == "stream":
             await self._replay_stream(response)
         else:
             self._replay_json(response)
+
+    def _select_response(self, entry: Dict[str, Any], key: str) -> Dict[str, Any]:
+        """
+        Pick the response to replay. Multi-response entries carry a "responses"
+        list served round-robin; single-response entries carry one "response".
+        """
+        responses: Any = entry.get("responses")
+        if isinstance(responses, list) and responses:
+            index: int = self.state.next_rotation_index(key, len(responses))
+            return responses[index]
+        return entry.get("response", {})
 
     async def _replay_stream(self, response: Dict[str, Any]) -> None:
         """Re-emit recorded SSE frames, optionally pacing between them."""

--- a/tests/record_playback_llm_server/proxy_handler.py
+++ b/tests/record_playback_llm_server/proxy_handler.py
@@ -35,6 +35,7 @@ from typing import Tuple
 import tornado.httpclient
 import tornado.iostream
 import tornado.web
+import tornado.ioloop
 
 from tests.record_playback_llm_server.proxy_state import ProxyState
 from tests.record_playback_llm_server.request_canonicalizer import RequestCanonicalizer

--- a/tests/record_playback_llm_server/proxy_handler.py
+++ b/tests/record_playback_llm_server/proxy_handler.py
@@ -218,12 +218,12 @@ class ProxyHandler(tornado.web.RequestHandler):
         (LLM error bodies are JSON, not SSE).
         """
         code: int = status if status is not None else 200
+        self.set_status(code)
         if 200 <= code < 300:
             self.set_header("Content-Type", "text/event-stream")
             self.set_header("Cache-Control", "no-cache")
             self.set_header("X-Accel-Buffering", "no")
         else:
-            self.set_status(code)
             self.set_header("Content-Type", content_type or "application/json")
 
     def _store(self, method: str, body_bytes: bytes, key: str, response: Dict[str, Any]) -> bool:

--- a/tests/record_playback_llm_server/proxy_handler.py
+++ b/tests/record_playback_llm_server/proxy_handler.py
@@ -139,44 +139,92 @@ class ProxyHandler(tornado.web.RequestHandler):
                              len(raw_body), latency_seconds, key[:12])
 
     async def _record_stream(self, method: str, body_bytes: bytes, key: str) -> None:
-        """Record and relay a streamed SSE response, teeing chunks to disk with latency."""
-        self.set_header("Content-Type", "text/event-stream")
-        self.set_header("Cache-Control", "no-cache")
-        self.set_header("X-Accel-Buffering", "no")
+        """
+        Record and relay a streamed response, teeing chunks to disk with latency.
 
+        The upstream status is not known until its headers arrive, which (via
+        header_callback) precedes the first body chunk. The client's status and
+        headers are therefore set on the first chunk rather than up front: a 2xx
+        is streamed as SSE; a non-2xx (401/429/5xx, whose body is typically JSON,
+        not SSE) is relayed with the real status and content-type. Only
+        successful responses are recorded (see _store).
+        """
         accumulated = bytearray()
         started: float = time.monotonic()
-        # One-element list so the sync on_chunk callback can record time-to-first-byte.
-        first_byte: List[Optional[float]] = [None]
+        # Mutable state shared with the synchronous header/chunk callbacks.
+        stream_state: Dict[str, Any] = {
+            "status": None, "content_type": None,
+            "headers_started": False, "first_byte_seconds": None,
+        }
+
+        def on_header(line: str) -> None:
+            stripped: str = line.strip()
+            if not stripped:
+                return
+            if stripped.startswith("HTTP/"):
+                # Status line, e.g. "HTTP/1.1 429 Too Many Requests". Reset the
+                # content-type so a redirect/retry block cannot leak a stale one.
+                parts = stripped.split(None, 2)
+                if len(parts) >= 2 and parts[1].isdigit():
+                    stream_state["status"] = int(parts[1])
+                stream_state["content_type"] = None
+                return
+            name, separator, value = stripped.partition(":")
+            if separator and name.strip().lower() == "content-type":
+                stream_state["content_type"] = value.strip()
 
         def on_chunk(chunk: bytes) -> None:
-            if first_byte[0] is None:
-                first_byte[0] = time.monotonic() - started
+            if stream_state["first_byte_seconds"] is None:
+                stream_state["first_byte_seconds"] = time.monotonic() - started
+            if not stream_state["headers_started"]:
+                self._begin_stream_relay(stream_state["status"], stream_state["content_type"])
+                stream_state["headers_started"] = True
             accumulated.extend(chunk)
             self.write(bytes(chunk))
-            # Flush must happen on the event loop; schedule it as a coroutine so
-            # the caller (neuro-san) sees tokens progressively during recording.
+            # Flush on the event loop so the caller sees tokens progressively.
             tornado.ioloop.IOLoop.current().spawn_callback(self._safe_flush)
 
         try:
             response: tornado.httpclient.HTTPResponse = await self.state.upstream.fetch_stream(
-                self.upstream_path, method, body_bytes, on_chunk)
+                self.upstream_path, method, body_bytes, on_chunk, on_header)
         except (OSError, tornado.httpclient.HTTPError) as exception:
             self._fail_upstream(exception)
             return
         latency_seconds: float = time.monotonic() - started
 
+        # Empty body (e.g. an error with no body): no chunk arrived, so set the
+        # status now that the response object is known.
+        if not stream_state["headers_started"]:
+            self._begin_stream_relay(response.code, response.headers.get("Content-Type"))
+
         await self._safe_flush()
+        first_byte: Optional[float] = stream_state["first_byte_seconds"]
         frames: List[str] = self._split_sse_frames(bytes(accumulated))
         if self._store(method, body_bytes, key, {
             "kind": "stream",
             "status": response.code,
             "chunks": frames,
             "latency_seconds": round(latency_seconds, 6),
-            "first_byte_seconds": round(first_byte[0], 6) if first_byte[0] is not None else None,
+            "first_byte_seconds": round(first_byte, 6) if first_byte is not None else None,
         }):
             self.logger.info("recorded stream response (%d frames, %.3fs) key=%s",
                              len(frames), latency_seconds, key[:12])
+
+    def _begin_stream_relay(self, status: Optional[int], content_type: Optional[str]) -> None:
+        """
+        Set the client response status/headers for a streamed relay once the
+        upstream status is known. A 2xx is streamed as Server-Sent Events; any
+        other status is relayed with the upstream's real status and content-type
+        (LLM error bodies are JSON, not SSE).
+        """
+        code: int = status if status is not None else 200
+        if 200 <= code < 300:
+            self.set_header("Content-Type", "text/event-stream")
+            self.set_header("Cache-Control", "no-cache")
+            self.set_header("X-Accel-Buffering", "no")
+        else:
+            self.set_status(code)
+            self.set_header("Content-Type", content_type or "application/json")
 
     def _store(self, method: str, body_bytes: bytes, key: str, response: Dict[str, Any]) -> bool:
         """

--- a/tests/record_playback_llm_server/proxy_state.py
+++ b/tests/record_playback_llm_server/proxy_state.py
@@ -19,42 +19,64 @@ See class comment for details.
 """
 from __future__ import annotations
 
+from typing import Dict
 from typing import Optional
 
 from tests.record_playback_llm_server.cassette import Cassette
+from tests.record_playback_llm_server.playback_delay import PlaybackDelay
 from tests.record_playback_llm_server.upstream_client import UpstreamClient
 
 
 class ProxyState:
     """
-    Process-wide state shared across all request handlers of the
-    record/playback proxy server: which mode it runs in, the cassette store,
-    and (in record mode) the client to the real external LLM host.
+    Process-wide state shared across all request handlers of the proxy server:
+    which mode it runs in, the cassette store, the client to the real external
+    LLM host (record and hybrid modes), and the round-robin rotation
+    counters (multi-response playback).
+
+    Modes:
+      record    -- forward every request to the real host and store it.
+      playback  -- serve only from the cassette; a miss fails hard (504).
+      hybrid    -- playback, but on a miss fall through to the real host (if an
+                    upstream is configured), record the result into the current
+                    cassette, and return it (self-healing playback).
     """
 
     MODE_RECORD: str = "record"
     MODE_PLAYBACK: str = "playback"
+    MODE_HYBRID: str = "hybrid"
 
+    # pylint: disable=too-many-arguments, too-many-positional-arguments
     def __init__(
         self,
         mode: str,
         cassette: Cassette,
         upstream: Optional[UpstreamClient] = None,
         stream_replay_delay: float = 0.0,
+        multi_response: bool = False,
+        playback_delay: Optional[PlaybackDelay] = None,
     ) -> None:
         """
-        :param mode: MODE_RECORD or MODE_PLAYBACK.
-        :param cassette: The Cassette used for lookup (playback) or storage (record).
+        :param mode: MODE_RECORD, MODE_PLAYBACK, or MODE_HYBRID.
+        :param cassette: The Cassette used for lookup (playback/hybrid) or storage.
         :param upstream: UpstreamClient to the real LLM host; required in record
-                         mode, unused (None) in playback mode.
+                         mode, optional in hybrid mode, unused in playback.
         :param stream_replay_delay: Seconds to sleep between streamed SSE frames
                          during playback, to emulate inter-token cadence. 0 = as
                          fast as possible.
+        :param multi_response: When True, record/hybrid append each distinct
+                         response per request and playback serves them round-robin.
+        :param playback_delay: Up-front per-response delay policy applied before
+                         serving a cache hit; None means no delay.
         """
         self.mode: str = mode
         self.cassette: Cassette = cassette
         self.upstream: Optional[UpstreamClient] = upstream
         self.stream_replay_delay: float = stream_replay_delay
+        self.multi_response: bool = multi_response
+        self.playback_delay: PlaybackDelay = playback_delay or PlaybackDelay(PlaybackDelay.MODE_NONE)
+        # Per-request round-robin cursor for multi-response playback.
+        self._rotation: Dict[str, int] = {}
 
     def is_record(self) -> bool:
         """:return: True when running in record mode."""
@@ -63,3 +85,18 @@ class ProxyState:
     def is_playback(self) -> bool:
         """:return: True when running in playback mode."""
         return self.mode == self.MODE_PLAYBACK
+
+    def is_hybrid(self) -> bool:
+        """:return: True when running in hybrid (record-on-miss) mode."""
+        return self.mode == self.MODE_HYBRID
+
+    def next_rotation_index(self, key: str, count: int) -> int:
+        """
+        Advance and return the round-robin index for a request key.
+        :param key: The request signature key.
+        :param count: Number of recorded responses available for that key.
+        :return: The 0-based index of the response to serve this time.
+        """
+        index: int = self._rotation.get(key, 0) % count
+        self._rotation[key] = index + 1
+        return index

--- a/tests/record_playback_llm_server/proxy_state.py
+++ b/tests/record_playback_llm_server/proxy_state.py
@@ -1,0 +1,65 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+"""
+See class comment for details.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+from tests.record_playback_llm_server.cassette import Cassette
+from tests.record_playback_llm_server.upstream_client import UpstreamClient
+
+
+class ProxyState:
+    """
+    Process-wide state shared across all request handlers of the
+    record/playback proxy server: which mode it runs in, the cassette store,
+    and (in record mode) the client to the real external LLM host.
+    """
+
+    MODE_RECORD: str = "record"
+    MODE_PLAYBACK: str = "playback"
+
+    def __init__(
+        self,
+        mode: str,
+        cassette: Cassette,
+        upstream: Optional[UpstreamClient] = None,
+        stream_replay_delay: float = 0.0,
+    ) -> None:
+        """
+        :param mode: MODE_RECORD or MODE_PLAYBACK.
+        :param cassette: The Cassette used for lookup (playback) or storage (record).
+        :param upstream: UpstreamClient to the real LLM host; required in record
+                         mode, unused (None) in playback mode.
+        :param stream_replay_delay: Seconds to sleep between streamed SSE frames
+                         during playback, to emulate inter-token cadence. 0 = as
+                         fast as possible.
+        """
+        self.mode: str = mode
+        self.cassette: Cassette = cassette
+        self.upstream: Optional[UpstreamClient] = upstream
+        self.stream_replay_delay: float = stream_replay_delay
+
+    def is_record(self) -> bool:
+        """:return: True when running in record mode."""
+        return self.mode == self.MODE_RECORD
+
+    def is_playback(self) -> bool:
+        """:return: True when running in playback mode."""
+        return self.mode == self.MODE_PLAYBACK

--- a/tests/record_playback_llm_server/record_playback_llm_server.py
+++ b/tests/record_playback_llm_server/record_playback_llm_server.py
@@ -201,8 +201,9 @@ class RecordPlaybackLlmServer:
                     "(e.g. https://api.openai.com/v1)")
             return None
         if not api_key:
-            logging.warning("%s is not set; forwarding requests to %s without an Authorization header",
-                            cls.ENV_UPSTREAM_API_KEY, base_url)
+            logging.warning(
+                "Upstream API key is not set; forwarding requests to %s without an Authorization header",
+                base_url)
         upstream = UpstreamClient(
             base_url=base_url,
             api_key=api_key or None,

--- a/tests/record_playback_llm_server/record_playback_llm_server.py
+++ b/tests/record_playback_llm_server/record_playback_llm_server.py
@@ -1,0 +1,214 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+"""
+Standalone OpenAI-compatible HTTP proxy for neuro-san that RECORDS a session
+against a real external LLM host and PLAYS it back offline -- for free and
+deterministically.
+
+Modes:
+    record   -- forward every request to the external host (endpoint + key
+                from environment variables), relay the real response back to
+                neuro-san, and tee it into a cassette file on disk.
+    playback -- serve responses from the cassette by matching the canonical
+                request signature. No network, no tokens, no cost. A request
+                with no recorded match fails hard with HTTP 504.
+
+Endpoints (OpenAI wire-compatible):
+    POST /v1/chat/completions   (honors stream=true via SSE)
+    GET  /v1/models
+    GET  /healthz               (liveness probe)
+
+External LLM host (record mode) is configured via environment variables:
+    RECORD_PLAYBACK_UPSTREAM_BASE_URL   e.g. "https://api.openai.com/v1"
+    RECORD_PLAYBACK_UPSTREAM_API_KEY    bearer credential for that host
+
+Point a neuro-san agent network at this proxy exactly like a real endpoint:
+
+    llm_config {
+        class = "openai"
+        model_name = "gpt-4.1"
+        openai_api_base = "http://localhost:8899/v1"
+        openai_api_key = "not-needed"
+    }
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+
+from typing import List
+from typing import Optional
+
+import tornado.web
+
+from tests.record_playback_llm_server.cassette import Cassette
+from tests.record_playback_llm_server.chat_completions_handler import ChatCompletionsHandler
+from tests.record_playback_llm_server.health_handler import HealthHandler
+from tests.record_playback_llm_server.models_handler import ModelsHandler
+from tests.record_playback_llm_server.proxy_state import ProxyState
+from tests.record_playback_llm_server.upstream_client import UpstreamClient
+
+
+class RecordPlaybackLlmServer:
+    """
+    Entry point that wires the record/playback proxy together: parses CLI
+    flags, reads the external-host configuration from the environment,
+    constructs the shared ProxyState, builds the Tornado application, and
+    runs the asyncio event loop.
+    """
+
+    ENV_UPSTREAM_BASE_URL: str = "RECORD_PLAYBACK_UPSTREAM_BASE_URL"
+    ENV_UPSTREAM_API_KEY: str = "RECORD_PLAYBACK_UPSTREAM_API_KEY"
+    ENV_UPSTREAM_REQUEST_TIMEOUT: str = "RECORD_PLAYBACK_UPSTREAM_REQUEST_TIMEOUT_SECONDS"
+    ENV_UPSTREAM_CONNECT_TIMEOUT: str = "RECORD_PLAYBACK_UPSTREAM_CONNECT_TIMEOUT_SECONDS"
+    ENV_UPSTREAM_MAX_CLIENTS: str = "RECORD_PLAYBACK_UPSTREAM_MAX_CLIENTS"
+
+    DEFAULT_PORT: int = 8899
+    DEFAULT_CASSETTE: str = "./llm_cassette.json"
+
+    @staticmethod
+    def build_app(state: ProxyState) -> tornado.web.Application:
+        """Construct the Tornado Application with all routes wired up."""
+        return tornado.web.Application(
+            [
+                (r"/v1/chat/completions", ChatCompletionsHandler,
+                 {"state": state, "upstream_path": "/chat/completions"}),
+                (r"/v1/models", ModelsHandler,
+                 {"state": state, "upstream_path": "/models"}),
+                (r"/healthz", HealthHandler),
+            ]
+        )
+
+    @staticmethod
+    def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+        """Parse CLI arguments for the record/playback proxy server."""
+        parser = argparse.ArgumentParser(
+            description="Record/playback OpenAI-compatible LLM proxy for neuro-san")
+        parser.add_argument("--host", default="localhost", help="Bind host (default: localhost)")
+        parser.add_argument("--port", type=int, default=RecordPlaybackLlmServer.DEFAULT_PORT,
+                            help=f"Bind port (default: {RecordPlaybackLlmServer.DEFAULT_PORT})")
+        parser.add_argument("--mode", required=True, choices=[ProxyState.MODE_RECORD, ProxyState.MODE_PLAYBACK],
+                            help="record: forward to the real host and store; playback: serve from cassette")
+        parser.add_argument("--cassette", default=RecordPlaybackLlmServer.DEFAULT_CASSETTE,
+                            help="Path to the cassette JSON file "
+                                 f"(default: {RecordPlaybackLlmServer.DEFAULT_CASSETTE})")
+        parser.add_argument("--stream-replay-delay", type=float, default=0.0,
+                            help="Seconds between streamed SSE frames during playback (default: 0.0)")
+        return parser.parse_args(argv)
+
+    @classmethod
+    def build_state(cls, args: argparse.Namespace) -> ProxyState:
+        """
+        Build the ProxyState from parsed args and the environment. Exits with a
+        clear error if record mode is missing its required upstream base URL.
+        """
+        cassette = Cassette(args.cassette)
+        upstream: Optional[UpstreamClient] = None
+
+        if args.mode == ProxyState.MODE_RECORD:
+            base_url: str = os.environ.get(cls.ENV_UPSTREAM_BASE_URL, "").strip()
+            api_key: str = os.environ.get(cls.ENV_UPSTREAM_API_KEY, "").strip()
+            if not base_url:
+                raise SystemExit(
+                    f"record mode requires the {cls.ENV_UPSTREAM_BASE_URL} environment variable "
+                    "(e.g. https://api.openai.com/v1)")
+            if not api_key:
+                logging.warning("%s is not set; forwarding requests to %s without an Authorization header",
+                                cls.ENV_UPSTREAM_API_KEY, base_url)
+            upstream = UpstreamClient(
+                base_url=base_url,
+                api_key=api_key or None,
+                request_timeout=cls._env_float(
+                    cls.ENV_UPSTREAM_REQUEST_TIMEOUT, UpstreamClient.DEFAULT_REQUEST_TIMEOUT_SECONDS),
+                connect_timeout=cls._env_float(
+                    cls.ENV_UPSTREAM_CONNECT_TIMEOUT, UpstreamClient.DEFAULT_CONNECT_TIMEOUT_SECONDS),
+                max_clients=cls._env_int(
+                    cls.ENV_UPSTREAM_MAX_CLIENTS, UpstreamClient.DEFAULT_MAX_CLIENTS),
+            )
+            logging.info(
+                "upstream %s (request_timeout=%.1fs connect_timeout=%.1fs max_clients=%d)",
+                base_url, upstream.request_timeout, upstream.connect_timeout, upstream.max_clients)
+        else:
+            if not os.path.exists(args.cassette):
+                logging.warning("playback cassette %s does not exist yet; all requests will 504 until recorded",
+                                args.cassette)
+
+        return ProxyState(
+            mode=args.mode,
+            cassette=cassette,
+            upstream=upstream,
+            stream_replay_delay=max(0.0, args.stream_replay_delay),
+        )
+
+    @staticmethod
+    def _env_float(name: str, default: float) -> float:
+        """Read a positive float from the environment, warning and falling back on bad input."""
+        raw: str = os.environ.get(name, "").strip()
+        if not raw:
+            return default
+        try:
+            value: float = float(raw)
+        except ValueError:
+            logging.warning("invalid %s=%r; falling back to %s", name, raw, default)
+            return default
+        if value <= 0:
+            logging.warning("%s must be > 0 (got %s); falling back to %s", name, value, default)
+            return default
+        return value
+
+    @staticmethod
+    def _env_int(name: str, default: int) -> int:
+        """Read a positive int from the environment, warning and falling back on bad input."""
+        raw: str = os.environ.get(name, "").strip()
+        if not raw:
+            return default
+        try:
+            value: int = int(raw)
+        except ValueError:
+            logging.warning("invalid %s=%r; falling back to %s", name, raw, default)
+            return default
+        if value <= 0:
+            logging.warning("%s must be > 0 (got %s); falling back to %s", name, value, default)
+            return default
+        return value
+
+    @classmethod
+    async def run(cls, args: argparse.Namespace) -> None:
+        """Build the app, start listening, and wait forever."""
+        state: ProxyState = cls.build_state(args)
+        app = cls.build_app(state)
+        app.listen(args.port, address=args.host)
+        logging.info(
+            "record-playback-llm listening on http://%s:%d (mode=%s, cassette=%s, entries=%d)",
+            args.host, args.port, state.mode, args.cassette, len(state.cassette))
+        await asyncio.Event().wait()
+
+    @classmethod
+    def main(cls, argv: Optional[List[str]] = None) -> None:
+        """CLI entry point: configure logging, parse args, run until interrupted."""
+        logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+        args = cls.parse_args(argv)
+        try:
+            asyncio.run(cls.run(args))
+        except KeyboardInterrupt:
+            logging.info("record-playback-llm shutting down")
+
+
+if __name__ == "__main__":
+    RecordPlaybackLlmServer.main()

--- a/tests/record_playback_llm_server/record_playback_llm_server.py
+++ b/tests/record_playback_llm_server/record_playback_llm_server.py
@@ -20,19 +20,24 @@ against a real external LLM host and PLAYS it back offline -- for free and
 deterministically.
 
 Modes:
-    record   -- forward every request to the external host (endpoint + key
-                from environment variables), relay the real response back to
-                neuro-san, and tee it into a cassette file on disk.
-    playback -- serve responses from the cassette by matching the canonical
-                request signature. No network, no tokens, no cost. A request
-                with no recorded match fails hard with HTTP 504.
+    record    -- forward every request to the external host (endpoint + key
+                 from environment variables), relay the real response back to
+                 neuro-san, and tee it into a cassette file on disk.
+    playback  -- serve responses from the cassette by matching the canonical
+                 request signature. No network, no tokens, no cost. A request
+                 with no recorded match fails hard with HTTP 504.
+    hybrid    -- like playback, but a cache miss falls through to the real host
+                 (when one is configured), records the result into the current
+                 cassette, and returns it -- a self-healing cassette. With no
+                 upstream configured, a miss behaves like plain playback (504).
 
 Endpoints (OpenAI wire-compatible):
     POST /v1/chat/completions   (honors stream=true via SSE)
     GET  /v1/models
     GET  /healthz               (liveness probe)
 
-External LLM host (record mode) is configured via environment variables:
+External LLM host (record mode, and hybrid-mode misses) is configured via
+environment variables:
     RECORD_PLAYBACK_UPSTREAM_BASE_URL   e.g. "https://api.openai.com/v1"
     RECORD_PLAYBACK_UPSTREAM_API_KEY    bearer credential for that host
 
@@ -60,6 +65,7 @@ import tornado.web
 from tests.record_playback_llm_server.cassette import Cassette
 from tests.record_playback_llm_server.chat_completions_handler import ChatCompletionsHandler
 from tests.record_playback_llm_server.health_handler import HealthHandler
+from tests.record_playback_llm_server.playback_delay import PlaybackDelay
 from tests.record_playback_llm_server.models_handler import ModelsHandler
 from tests.record_playback_llm_server.proxy_state import ProxyState
 from tests.record_playback_llm_server.upstream_client import UpstreamClient
@@ -103,13 +109,29 @@ class RecordPlaybackLlmServer:
         parser.add_argument("--host", default="localhost", help="Bind host (default: localhost)")
         parser.add_argument("--port", type=int, default=RecordPlaybackLlmServer.DEFAULT_PORT,
                             help=f"Bind port (default: {RecordPlaybackLlmServer.DEFAULT_PORT})")
-        parser.add_argument("--mode", required=True, choices=[ProxyState.MODE_RECORD, ProxyState.MODE_PLAYBACK],
-                            help="record: forward to the real host and store; playback: serve from cassette")
+        parser.add_argument(
+            "--mode", required=True,
+            choices=[ProxyState.MODE_RECORD, ProxyState.MODE_PLAYBACK, ProxyState.MODE_HYBRID],
+            help="record: forward to the real host and store; playback: serve from cassette (504 on miss); "
+                 "hybrid: playback, but on a miss forward to the real host (if configured) and record it")
         parser.add_argument("--cassette", default=RecordPlaybackLlmServer.DEFAULT_CASSETTE,
                             help="Path to the cassette JSON file "
                                  f"(default: {RecordPlaybackLlmServer.DEFAULT_CASSETTE})")
+        parser.add_argument("--multi-response", action="store_true",
+                            help="record/hybrid: save every distinct response per request; "
+                                 "playback: serve them round-robin")
         parser.add_argument("--stream-replay-delay", type=float, default=0.0,
                             help="Seconds between streamed SSE frames during playback (default: 0.0)")
+        parser.add_argument("--delay-mode", default=PlaybackDelay.MODE_NONE, choices=PlaybackDelay.ALL_MODES,
+                            help="Up-front per-response delay before serving a cache hit: none (default); "
+                                 "recorded (each response's own recorded latency); fixed (--delay-seconds); "
+                                 "random (uniform in [--delay-min, --delay-max])")
+        parser.add_argument("--delay-seconds", type=float, default=0.0,
+                            help="Delay in seconds for --delay-mode fixed (default: 0.0)")
+        parser.add_argument("--delay-min", type=float, default=0.0,
+                            help="Lower bound in seconds for --delay-mode random (default: 0.0)")
+        parser.add_argument("--delay-max", type=float, default=0.0,
+                            help="Upper bound in seconds for --delay-mode random (default: 0.0)")
         return parser.parse_args(argv)
 
     @classmethod
@@ -122,39 +144,79 @@ class RecordPlaybackLlmServer:
         upstream: Optional[UpstreamClient] = None
 
         if args.mode == ProxyState.MODE_RECORD:
-            base_url: str = os.environ.get(cls.ENV_UPSTREAM_BASE_URL, "").strip()
-            api_key: str = os.environ.get(cls.ENV_UPSTREAM_API_KEY, "").strip()
-            if not base_url:
-                raise SystemExit(
-                    f"record mode requires the {cls.ENV_UPSTREAM_BASE_URL} environment variable "
-                    "(e.g. https://api.openai.com/v1)")
-            if not api_key:
-                logging.warning("%s is not set; forwarding requests to %s without an Authorization header",
-                                cls.ENV_UPSTREAM_API_KEY, base_url)
-            upstream = UpstreamClient(
-                base_url=base_url,
-                api_key=api_key or None,
-                request_timeout=cls._env_float(
-                    cls.ENV_UPSTREAM_REQUEST_TIMEOUT, UpstreamClient.DEFAULT_REQUEST_TIMEOUT_SECONDS),
-                connect_timeout=cls._env_float(
-                    cls.ENV_UPSTREAM_CONNECT_TIMEOUT, UpstreamClient.DEFAULT_CONNECT_TIMEOUT_SECONDS),
-                max_clients=cls._env_int(
-                    cls.ENV_UPSTREAM_MAX_CLIENTS, UpstreamClient.DEFAULT_MAX_CLIENTS),
-            )
-            logging.info(
-                "upstream %s (request_timeout=%.1fs connect_timeout=%.1fs max_clients=%d)",
-                base_url, upstream.request_timeout, upstream.connect_timeout, upstream.max_clients)
+            # Record must forward every request; an upstream is mandatory.
+            upstream = cls._build_upstream(required=True)
+        elif args.mode == ProxyState.MODE_HYBRID:
+            # Hybrid forwards only on a cache miss; an upstream is optional.
+            # Without one, a miss behaves like plain playback (504).
+            upstream = cls._build_upstream(required=False)
+            if upstream is None:
+                logging.warning("hybrid mode has no %s set; misses will 504 like plain playback",
+                                cls.ENV_UPSTREAM_BASE_URL)
         else:
             if not os.path.exists(args.cassette):
                 logging.warning("playback cassette %s does not exist yet; all requests will 504 until recorded",
                                 args.cassette)
+
+        if args.mode == ProxyState.MODE_RECORD and args.delay_mode != PlaybackDelay.MODE_NONE:
+            logging.warning("--delay-mode is ignored in record mode (it applies when serving cache hits)")
 
         return ProxyState(
             mode=args.mode,
             cassette=cassette,
             upstream=upstream,
             stream_replay_delay=max(0.0, args.stream_replay_delay),
+            multi_response=args.multi_response,
+            playback_delay=cls._build_playback_delay(args),
         )
+
+    @staticmethod
+    def _build_playback_delay(args: argparse.Namespace) -> PlaybackDelay:
+        """Build the PlaybackDelay policy from parsed args, validating the range."""
+        min_seconds: float = max(0.0, args.delay_min)
+        max_seconds: float = max(min_seconds, args.delay_max)
+        if args.delay_mode == PlaybackDelay.MODE_RANDOM and args.delay_max < args.delay_min:
+            logging.warning("--delay-max (%s) < --delay-min (%s); clamping max up to min",
+                            args.delay_max, args.delay_min)
+        return PlaybackDelay(
+            mode=args.delay_mode,
+            fixed_seconds=max(0.0, args.delay_seconds),
+            min_seconds=min_seconds,
+            max_seconds=max_seconds,
+        )
+
+    @classmethod
+    def _build_upstream(cls, required: bool) -> Optional[UpstreamClient]:
+        """
+        Construct the UpstreamClient from environment variables.
+        :param required: When True (record mode) a missing base URL is a fatal
+                         error; when False (hybrid mode) it returns None.
+        """
+        base_url: str = os.environ.get(cls.ENV_UPSTREAM_BASE_URL, "").strip()
+        api_key: str = os.environ.get(cls.ENV_UPSTREAM_API_KEY, "").strip()
+        if not base_url:
+            if required:
+                raise SystemExit(
+                    f"record mode requires the {cls.ENV_UPSTREAM_BASE_URL} environment variable "
+                    "(e.g. https://api.openai.com/v1)")
+            return None
+        if not api_key:
+            logging.warning("%s is not set; forwarding requests to %s without an Authorization header",
+                            cls.ENV_UPSTREAM_API_KEY, base_url)
+        upstream = UpstreamClient(
+            base_url=base_url,
+            api_key=api_key or None,
+            request_timeout=cls._env_float(
+                cls.ENV_UPSTREAM_REQUEST_TIMEOUT, UpstreamClient.DEFAULT_REQUEST_TIMEOUT_SECONDS),
+            connect_timeout=cls._env_float(
+                cls.ENV_UPSTREAM_CONNECT_TIMEOUT, UpstreamClient.DEFAULT_CONNECT_TIMEOUT_SECONDS),
+            max_clients=cls._env_int(
+                cls.ENV_UPSTREAM_MAX_CLIENTS, UpstreamClient.DEFAULT_MAX_CLIENTS),
+        )
+        logging.info(
+            "upstream %s (request_timeout=%.1fs connect_timeout=%.1fs max_clients=%d)",
+            base_url, upstream.request_timeout, upstream.connect_timeout, upstream.max_clients)
+        return upstream
 
     @staticmethod
     def _env_float(name: str, default: float) -> float:
@@ -195,8 +257,10 @@ class RecordPlaybackLlmServer:
         app = cls.build_app(state)
         app.listen(args.port, address=args.host)
         logging.info(
-            "record-playback-llm listening on http://%s:%d (mode=%s, cassette=%s, entries=%d)",
-            args.host, args.port, state.mode, args.cassette, len(state.cassette))
+            "record-playback-llm listening on http://%s:%d "
+            "(mode=%s, multi_response=%s, delay_mode=%s, cassette=%s, entries=%d)",
+            args.host, args.port, state.mode, state.multi_response,
+            state.playback_delay.mode, args.cassette, len(state.cassette))
         await asyncio.Event().wait()
 
     @classmethod

--- a/tests/record_playback_llm_server/request_canonicalizer.py
+++ b/tests/record_playback_llm_server/request_canonicalizer.py
@@ -24,7 +24,7 @@ import json
 
 from typing import Any
 from typing import Dict
-from typing import List
+from typing import Tuple
 
 
 class RequestCanonicalizer:
@@ -46,17 +46,19 @@ class RequestCanonicalizer:
     and a one-shot request map to different recorded responses.
     """
 
-    # Fields removed from the body before hashing. Empty by default; extend
-    # this if a client is found to inject a per-run volatile value (a random
-    # request id, a timestamp, etc.) into the request body.
-    VOLATILE_BODY_KEYS: List[str] = []
+    # Fields removed from the body before hashing. An immutable tuple so it
+    # cannot be mutated at run time (which would silently change keying for
+    # every caller in-process). Empty by default; extend this tuple in source
+    # if a client is found to inject a per-run volatile value (a random request
+    # id, a timestamp, etc.) into the request body.
+    VOLATILE_BODY_KEYS: Tuple[str, ...] = ()
 
     @staticmethod
     def canonical_string(method: str, path: str, body_bytes: bytes) -> str:
         """
         :param method: HTTP method, e.g. "POST" or "GET".
         :param path: Upstream path the request targets, e.g. "/chat/completions".
-        :param body_bytes: Raw request body bytes (may be empty).
+        :param body_bytes: Raw request body bytes (maybe empty).
         :return: A canonical, deterministic string representation of the request.
         """
         body_repr: str = RequestCanonicalizer._canonical_body(body_bytes)

--- a/tests/record_playback_llm_server/request_canonicalizer.py
+++ b/tests/record_playback_llm_server/request_canonicalizer.py
@@ -1,0 +1,109 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+"""
+See class comment for details.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+
+from typing import Any
+from typing import Dict
+from typing import List
+
+
+class RequestCanonicalizer:
+    """
+    Turns an incoming HTTP request (method + upstream path + body) into a
+    stable canonical string and a content hash used as the cassette key.
+
+    The response of an LLM is non-deterministic, but the *request* is a
+    deterministic function of the agent network plus its inputs. In a
+    multi-turn agent flow each request embeds the previous responses
+    (assistant messages, tool_call ids, tool results); as long as playback
+    returns byte-identical recorded responses, every downstream request
+    reconstructs identically -- so hashing the canonicalized request body is
+    a stable key across an entire conversation.
+
+    Canonicalization parses the JSON body and re-serializes it with sorted
+    keys so that incidental key ordering does not change the hash. The
+    `stream` flag is deliberately kept as part of the key: a streamed request
+    and a one-shot request map to different recorded responses.
+    """
+
+    # Fields removed from the body before hashing. Empty by default; extend
+    # this if a client is found to inject a per-run volatile value (a random
+    # request id, a timestamp, etc.) into the request body.
+    VOLATILE_BODY_KEYS: List[str] = []
+
+    @staticmethod
+    def canonical_string(method: str, path: str, body_bytes: bytes) -> str:
+        """
+        :param method: HTTP method, e.g. "POST" or "GET".
+        :param path: Upstream path the request targets, e.g. "/chat/completions".
+        :param body_bytes: Raw request body bytes (may be empty).
+        :return: A canonical, deterministic string representation of the request.
+        """
+        body_repr: str = RequestCanonicalizer._canonical_body(body_bytes)
+        return f"{method.upper()} {path}\n{body_repr}"
+
+    @staticmethod
+    def key(method: str, path: str, body_bytes: bytes) -> str:
+        """
+        :param method: HTTP method, e.g. "POST" or "GET".
+        :param path: Upstream path the request targets, e.g. "/chat/completions".
+        :param body_bytes: Raw request body bytes (may be empty).
+        :return: A hex sha256 digest of the canonical string, used as cassette key.
+        """
+        canonical: str = RequestCanonicalizer.canonical_string(method, path, body_bytes)
+        return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+    @staticmethod
+    def _canonical_body(body_bytes: bytes) -> str:
+        """
+        Produce a deterministic representation of the request body. JSON bodies
+        are parsed, stripped of volatile keys, and re-serialized with sorted
+        keys. Non-JSON bodies fall back to their raw decoded text.
+        """
+        if not body_bytes:
+            return ""
+        try:
+            parsed: Any = json.loads(body_bytes)
+        except (json.JSONDecodeError, ValueError):
+            return body_bytes.decode("utf-8", errors="replace")
+
+        if isinstance(parsed, dict):
+            for volatile_key in RequestCanonicalizer.VOLATILE_BODY_KEYS:
+                parsed.pop(volatile_key, None)
+
+        return json.dumps(parsed, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+    @staticmethod
+    def parsed_body(body_bytes: bytes) -> Dict[str, Any]:
+        """
+        Best-effort parse of a JSON object request body for inspection
+        (e.g. detecting the `stream` flag). Returns an empty dict when the
+        body is missing or not a JSON object.
+        """
+        if not body_bytes:
+            return {}
+        try:
+            parsed: Any = json.loads(body_bytes)
+        except (json.JSONDecodeError, ValueError):
+            return {}
+        return parsed if isinstance(parsed, dict) else {}

--- a/tests/record_playback_llm_server/test_record_playback_llm_server.py
+++ b/tests/record_playback_llm_server/test_record_playback_llm_server.py
@@ -289,7 +289,7 @@ class TestProxyIntegration:
         pb = ProxyState(mode=ProxyState.MODE_PLAYBACK, cassette=Cassette(path))
         pb_url = start_app(RecordPlaybackLlmServer.build_app(pb))
         code2, body2 = await _post(pb_url + CHAT_PATH, PAYLOAD)
-        assert code2 == 200 and json.loads(body2) == json.loads(body)   # byte-identical replay
+        assert code2 == 200 and json.loads(body2) == json.loads(body)   # JSON equivalent replay
         assert box["n"] == 1                                            # upstream NOT hit on playback
 
     @pytest.mark.asyncio

--- a/tests/record_playback_llm_server/test_record_playback_llm_server.py
+++ b/tests/record_playback_llm_server/test_record_playback_llm_server.py
@@ -374,3 +374,18 @@ class TestProxyIntegration:
         assert code == 429 and b"Too Many Requests" in body           # relayed to caller
         assert len(Cassette(path)) == 0                               # not recorded
         assert not os.path.exists(path)                              # nothing written at all
+
+    @pytest.mark.asyncio
+    async def test_stream_non_2xx_relayed_with_correct_status(self, start_app, tmp_path):
+        """
+        A streamed request whose upstream returns a non-2xx must be relayed with
+        the real status (not a bogus 200 text/event-stream) and not recorded.
+        """
+        upstream = start_app(tornado.web.Application([(CHAT_PATH, _RateLimitedUpstream)]))
+        path = str(tmp_path / "c.json")
+        state = ProxyState(mode=ProxyState.MODE_RECORD, cassette=Cassette(path), upstream=_upstream_client(upstream))
+        url = start_app(RecordPlaybackLlmServer.build_app(state))
+
+        code, body = await _post(url + CHAT_PATH, PAYLOAD, stream=True)
+        assert code == 429 and b"Too Many Requests" in body           # real status, not 200
+        assert len(Cassette(path)) == 0                               # not recorded

--- a/tests/record_playback_llm_server/test_record_playback_llm_server.py
+++ b/tests/record_playback_llm_server/test_record_playback_llm_server.py
@@ -1,0 +1,376 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+"""
+Unit and in-process integration tests for the record/playback LLM proxy.
+
+The integration tests spin up an in-process fake "upstream" Tornado app plus the
+real proxy application on ephemeral loopback ports, so they need neither a real
+LLM host nor a running neuro-san server. They run as part of the default unit
+suite.
+"""
+# Fixture parameters intentionally share the fixture's name (standard pytest).
+# pylint: disable=redefined-outer-name
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Tuple
+
+import json
+import os
+
+import pytest
+
+import tornado.httpclient
+import tornado.httpserver
+import tornado.web
+
+from tornado.testing import bind_unused_port
+
+from tests.record_playback_llm_server.cassette import Cassette
+from tests.record_playback_llm_server.cleanup_cassette import CassetteCleaner
+from tests.record_playback_llm_server.playback_delay import PlaybackDelay
+from tests.record_playback_llm_server.proxy_state import ProxyState
+from tests.record_playback_llm_server.record_playback_llm_server import RecordPlaybackLlmServer
+from tests.record_playback_llm_server.request_canonicalizer import RequestCanonicalizer
+from tests.record_playback_llm_server.upstream_client import UpstreamClient
+
+
+CHAT_PATH: str = "/v1/chat/completions"
+PAYLOAD: Dict[str, Any] = {"model": "m", "messages": [{"role": "user", "content": "hey"}]}
+
+
+class _CountingUpstream(tornado.web.RequestHandler):
+    """Fake OpenAI upstream returning a distinct body ("resp-N") per call."""
+
+    def initialize(self, box: Dict[str, int]) -> None:
+        """Receive a shared call-counter box from the application."""
+        # pylint: disable=attribute-defined-outside-init
+        self.box = box
+
+    def data_received(self, chunk):
+        """Unused; the full body arrives via self.request.body."""
+        return
+
+    async def post(self) -> None:
+        """Return a one-shot completion whose content increments each call."""
+        self.box["n"] += 1
+        self.write({
+            "id": "chatcmpl-fake", "object": "chat.completion",
+            "choices": [{"index": 0, "message": {"role": "assistant", "content": f"resp-{self.box['n']}"},
+                         "finish_reason": "stop"}],
+        })
+
+
+class _StreamUpstream(tornado.web.RequestHandler):
+    """Fake OpenAI upstream that emits a short SSE stream."""
+
+    def initialize(self, box: Dict[str, int]) -> None:
+        """Receive a shared call-counter box from the application."""
+        # pylint: disable=attribute-defined-outside-init
+        self.box = box
+
+    def data_received(self, chunk):
+        """Unused; the full body arrives via self.request.body."""
+        return
+
+    async def post(self) -> None:
+        """Stream three content tokens as SSE, then a [DONE] terminator."""
+        self.box["n"] += 1
+        self.set_header("Content-Type", "text/event-stream")
+        for token in ["Hello", " from", " upstream"]:
+            self.write(f'data: {json.dumps({"choices": [{"delta": {"content": token}}]})}\n\n')
+            await self.flush()
+        self.write("data: [DONE]\n\n")
+        await self.flush()
+
+
+class _RateLimitedUpstream(tornado.web.RequestHandler):
+    """Fake OpenAI upstream that always rate-limits with HTTP 429."""
+
+    def data_received(self, chunk):
+        """Unused; the full body arrives via self.request.body."""
+        return
+
+    async def post(self) -> None:
+        """Always respond 429 Too Many Requests."""
+        self.set_status(429)
+        self.write({"error": {"message": "Too Many Requests"}})
+
+
+@pytest.fixture
+def start_app():
+    """
+    Return a factory that binds a Tornado app to an unused loopback port and
+    returns its base URL; all started servers are stopped on teardown.
+    """
+    servers: List[tornado.httpserver.HTTPServer] = []
+
+    def _start(app: tornado.web.Application) -> str:
+        sock, port = bind_unused_port()
+        server = tornado.httpserver.HTTPServer(app)
+        server.add_socket(sock)
+        servers.append(server)
+        return f"http://127.0.0.1:{port}"
+
+    try:
+        yield _start
+    finally:
+        for server in servers:
+            server.stop()
+
+
+async def _post(url: str, payload: Dict[str, Any], stream: bool = False) -> Tuple[int, bytes]:
+    """POST JSON to url; when stream=True, accumulate and return the streamed body."""
+    client = tornado.httpclient.AsyncHTTPClient(force_instance=True)
+    body: Dict[str, Any] = {**payload, "stream": True} if stream else payload
+    chunks = bytearray()
+    response = await client.fetch(
+        url, method="POST", body=json.dumps(body),
+        headers={"Content-Type": "application/json"},
+        streaming_callback=(chunks.extend if stream else None),
+        request_timeout=30, raise_error=False)
+    return response.code, (bytes(chunks) if stream else response.body)
+
+
+def _content(body: bytes) -> str:
+    """Extract the assistant text from a one-shot chat completion body."""
+    return json.loads(body)["choices"][0]["message"]["content"]
+
+
+def _upstream_client(base_url: str) -> UpstreamClient:
+    """Build an UpstreamClient pointed at a fake upstream's /v1 base."""
+    return UpstreamClient(base_url=f"{base_url}/v1", api_key=None)
+
+
+class TestRequestCanonicalizer:
+    """Canonical-key stability guarantees the record/playback matching relies on."""
+
+    def test_key_ignores_json_key_order(self):
+        """Requests differing only in JSON key order hash to the same key."""
+        body_a = json.dumps({"model": "m", "stream": False, "messages": []}).encode()
+        body_b = json.dumps({"messages": [], "stream": False, "model": "m"}).encode()
+        assert RequestCanonicalizer.key("POST", CHAT_PATH, body_a) == \
+            RequestCanonicalizer.key("POST", CHAT_PATH, body_b)
+
+    def test_stream_flag_changes_key(self):
+        """A streamed request and a one-shot request map to different keys."""
+        one = json.dumps({"model": "m", "stream": False}).encode()
+        streamed = json.dumps({"model": "m", "stream": True}).encode()
+        assert RequestCanonicalizer.key("POST", CHAT_PATH, one) != \
+            RequestCanonicalizer.key("POST", CHAT_PATH, streamed)
+
+    def test_path_and_method_participate(self):
+        """Method and path are part of the key, not just the body."""
+        body = b"{}"
+        assert RequestCanonicalizer.key("POST", "/chat/completions", body) != \
+            RequestCanonicalizer.key("GET", "/chat/completions", body)
+
+
+class TestCassette:
+    """On-disk store: round-trip, atomic save, multi-response de-duplication."""
+
+    def test_put_get_roundtrip(self, tmp_path):
+        """A put entry is persisted and re-readable from a fresh Cassette."""
+        path = str(tmp_path / "c.json")
+        cassette = Cassette(path)
+        cassette.put("k1", {"request": "r", "response": {"kind": "json", "status": 200}})
+        assert os.path.exists(path)
+        assert Cassette(path).get("k1")["response"]["status"] == 200
+
+    def test_append_response_dedupes_ignoring_latency(self, tmp_path):
+        """Identical response content (differing only in latency) is not duplicated."""
+        path = str(tmp_path / "c.json")
+        cassette = Cassette(path)
+        meta = {"request": "r"}
+        cassette.append_response("k", meta, {"kind": "json", "status": 200, "body": {"a": 1}, "latency_seconds": 0.1})
+        cassette.append_response("k", meta, {"kind": "json", "status": 200, "body": {"a": 1}, "latency_seconds": 0.9})
+        cassette.append_response("k", meta, {"kind": "json", "status": 200, "body": {"a": 2}, "latency_seconds": 0.2})
+        assert len(cassette.get("k")["responses"]) == 2
+
+
+class TestPlaybackDelay:
+    """Per-response delay policy."""
+
+    def test_none(self):
+        """none mode never delays."""
+        assert PlaybackDelay(PlaybackDelay.MODE_NONE).seconds_for({"latency_seconds": 1.0}) == 0.0
+
+    def test_recorded_json_uses_latency(self):
+        """recorded mode uses latency_seconds for a one-shot response."""
+        assert PlaybackDelay(PlaybackDelay.MODE_RECORDED).seconds_for(
+            {"kind": "json", "latency_seconds": 1.25}) == 1.25
+
+    def test_recorded_stream_prefers_first_byte(self):
+        """recorded mode uses first_byte_seconds for a streamed response."""
+        response = {"kind": "stream", "latency_seconds": 5.0, "first_byte_seconds": 0.7}
+        assert PlaybackDelay(PlaybackDelay.MODE_RECORDED).seconds_for(response) == 0.7
+
+    def test_recorded_stream_falls_back_to_latency(self):
+        """recorded mode falls back to latency_seconds when first_byte is absent."""
+        response = {"kind": "stream", "latency_seconds": 5.0, "first_byte_seconds": None}
+        assert PlaybackDelay(PlaybackDelay.MODE_RECORDED).seconds_for(response) == 5.0
+
+    def test_recorded_missing_is_zero(self):
+        """recorded mode with no recorded latency yields no delay."""
+        assert PlaybackDelay(PlaybackDelay.MODE_RECORDED).seconds_for({"kind": "json"}) == 0.0
+
+    def test_fixed(self):
+        """fixed mode returns the configured constant."""
+        assert PlaybackDelay(PlaybackDelay.MODE_FIXED, fixed_seconds=0.4).seconds_for({}) == 0.4
+
+    def test_random_within_range(self):
+        """random mode returns values within the configured range."""
+        delay = PlaybackDelay(PlaybackDelay.MODE_RANDOM, min_seconds=0.2, max_seconds=0.5)
+        assert all(0.2 <= delay.seconds_for({}) <= 0.5 for _ in range(50))
+
+
+class TestCassetteCleaner:
+    """Removing recorded failures while preserving valid entries and unknown fields."""
+
+    def test_clean_entries_mixed(self):
+        """Failures are dropped/trimmed; successes and unknown fields survive; stats are correct."""
+        entries = [
+            {"key": "k1", "response": {"kind": "json", "status": 200}},                       # keep
+            {"key": "k2", "response": {"kind": "json", "status": 429}},                        # drop (failure)
+            {"key": "k3", "responses": [                                                       # trim to 2xx
+                {"kind": "json", "status": 200, "body": {"a": 1}},
+                {"kind": "json", "status": 500, "body": {}},
+                {"kind": "json", "status": 200, "body": {"a": 2}},
+            ]},
+            {"key": "k4", "responses": [{"kind": "json", "status": 503}]},                     # drop (all failure)
+            {"key": "k5"},                                                                     # drop (malformed)
+        ]
+        cleaned, stats = CassetteCleaner.clean_entries(entries)
+        assert [entry["key"] for entry in cleaned] == ["k1", "k3"]
+        assert [r["body"]["a"] for r in cleaned[1]["responses"]] == [1, 2]
+        assert stats["kept"] == 2
+        assert stats["dropped_failure"] == 2
+        assert stats["dropped_malformed"] == 1
+        assert stats["variants_removed"] == 1
+
+    def test_clean_is_idempotent(self):
+        """Cleaning an already-clean cassette removes nothing."""
+        entries = [{"key": "k1", "response": {"kind": "json", "status": 200}}]
+        once, _ = CassetteCleaner.clean_entries(entries)
+        twice, stats = CassetteCleaner.clean_entries(once)
+        assert len(twice) == 1 and stats["dropped_failure"] == 0 and stats["variants_removed"] == 0
+
+
+class TestProxyIntegration:
+    """In-process record/playback/hybrid behavior against a fake upstream."""
+
+    @pytest.mark.asyncio
+    async def test_record_then_playback_json(self, start_app, tmp_path):
+        """Record a one-shot response, then replay it byte-identical without hitting upstream."""
+        box = {"n": 0}
+        upstream = start_app(tornado.web.Application([(CHAT_PATH, _CountingUpstream, {"box": box})]))
+        path = str(tmp_path / "c.json")
+
+        rec = ProxyState(mode=ProxyState.MODE_RECORD, cassette=Cassette(path), upstream=_upstream_client(upstream))
+        rec_url = start_app(RecordPlaybackLlmServer.build_app(rec))
+        code, body = await _post(rec_url + CHAT_PATH, PAYLOAD)
+        assert code == 200 and _content(body) == "resp-1"
+        assert box["n"] == 1
+
+        pb = ProxyState(mode=ProxyState.MODE_PLAYBACK, cassette=Cassette(path))
+        pb_url = start_app(RecordPlaybackLlmServer.build_app(pb))
+        code2, body2 = await _post(pb_url + CHAT_PATH, PAYLOAD)
+        assert code2 == 200 and json.loads(body2) == json.loads(body)   # byte-identical replay
+        assert box["n"] == 1                                            # upstream NOT hit on playback
+
+    @pytest.mark.asyncio
+    async def test_record_then_playback_stream(self, start_app, tmp_path):
+        """Record a streamed SSE response, then replay it without hitting upstream."""
+        box = {"n": 0}
+        upstream = start_app(tornado.web.Application([(CHAT_PATH, _StreamUpstream, {"box": box})]))
+        path = str(tmp_path / "c.json")
+
+        rec = ProxyState(mode=ProxyState.MODE_RECORD, cassette=Cassette(path), upstream=_upstream_client(upstream))
+        rec_url = start_app(RecordPlaybackLlmServer.build_app(rec))
+        code, body = await _post(rec_url + CHAT_PATH, PAYLOAD, stream=True)
+        assert code == 200 and b"from" in body and b"[DONE]" in body
+
+        pb = ProxyState(mode=ProxyState.MODE_PLAYBACK, cassette=Cassette(path))
+        pb_url = start_app(RecordPlaybackLlmServer.build_app(pb))
+        code2, body2 = await _post(pb_url + CHAT_PATH, PAYLOAD, stream=True)
+        assert code2 == 200 and b"Hello" in body2 and b"upstream" in body2 and b"[DONE]" in body2
+        assert box["n"] == 1                                            # upstream NOT hit on playback
+
+    @pytest.mark.asyncio
+    async def test_playback_miss_returns_504(self, start_app, tmp_path):
+        """A request with no recorded match fails hard with HTTP 504 in playback mode."""
+        pb = ProxyState(mode=ProxyState.MODE_PLAYBACK, cassette=Cassette(str(tmp_path / "empty.json")))
+        pb_url = start_app(RecordPlaybackLlmServer.build_app(pb))
+        code, body = await _post(pb_url + CHAT_PATH, PAYLOAD)
+        assert code == 504 and b"no recorded response" in body
+
+    @pytest.mark.asyncio
+    async def test_multi_response_roundrobin(self, start_app, tmp_path):
+        """Multi-response records distinct variants and plays them back round-robin."""
+        box = {"n": 0}
+        upstream = start_app(tornado.web.Application([(CHAT_PATH, _CountingUpstream, {"box": box})]))
+        path = str(tmp_path / "c.json")
+
+        rec = ProxyState(mode=ProxyState.MODE_RECORD, cassette=Cassette(path),
+                         upstream=_upstream_client(upstream), multi_response=True)
+        rec_url = start_app(RecordPlaybackLlmServer.build_app(rec))
+        for _ in range(3):
+            await _post(rec_url + CHAT_PATH, PAYLOAD)
+        assert len(list(Cassette(path).entries.values())[0]["responses"]) == 3
+
+        pb = ProxyState(mode=ProxyState.MODE_PLAYBACK, cassette=Cassette(path), multi_response=True)
+        pb_url = start_app(RecordPlaybackLlmServer.build_app(pb))
+        seen = [_content((await _post(pb_url + CHAT_PATH, PAYLOAD))[1]) for _ in range(4)]
+        assert seen == ["resp-1", "resp-2", "resp-3", "resp-1"]         # round-robin with wrap
+
+    @pytest.mark.asyncio
+    async def test_hybrid_records_on_miss_then_hits(self, start_app, tmp_path):
+        """Hybrid fetches+records on a miss, then serves the recorded response on a hit."""
+        box = {"n": 0}
+        upstream = start_app(tornado.web.Application([(CHAT_PATH, _CountingUpstream, {"box": box})]))
+        path = str(tmp_path / "c.json")
+
+        state = ProxyState(mode=ProxyState.MODE_HYBRID, cassette=Cassette(path), upstream=_upstream_client(upstream))
+        url = start_app(RecordPlaybackLlmServer.build_app(state))
+
+        _, first = await _post(url + CHAT_PATH, PAYLOAD)                # miss -> fetch + record
+        assert box["n"] == 1
+        _, second = await _post(url + CHAT_PATH, PAYLOAD)              # hit -> from cassette
+        assert box["n"] == 1                                           # upstream NOT hit again
+        assert _content(first) == _content(second)
+        assert len(Cassette(path)) == 1
+
+    @pytest.mark.asyncio
+    async def test_hybrid_miss_without_upstream_returns_504(self, start_app, tmp_path):
+        """Hybrid with no upstream behaves like plain playback: a miss is a 504."""
+        state = ProxyState(mode=ProxyState.MODE_HYBRID, cassette=Cassette(str(tmp_path / "empty.json")), upstream=None)
+        url = start_app(RecordPlaybackLlmServer.build_app(state))
+        code, _ = await _post(url + CHAT_PATH, PAYLOAD)
+        assert code == 504
+
+    @pytest.mark.asyncio
+    async def test_non_2xx_relayed_but_not_recorded(self, start_app, tmp_path):
+        """A non-2xx upstream response is relayed to the caller but never cached."""
+        upstream = start_app(tornado.web.Application([(CHAT_PATH, _RateLimitedUpstream)]))
+        path = str(tmp_path / "c.json")
+        state = ProxyState(mode=ProxyState.MODE_RECORD, cassette=Cassette(path), upstream=_upstream_client(upstream))
+        url = start_app(RecordPlaybackLlmServer.build_app(state))
+
+        code, body = await _post(url + CHAT_PATH, PAYLOAD)
+        assert code == 429 and b"Too Many Requests" in body           # relayed to caller
+        assert len(Cassette(path)) == 0                               # not recorded
+        assert not os.path.exists(path)                              # nothing written at all

--- a/tests/record_playback_llm_server/upstream_client.py
+++ b/tests/record_playback_llm_server/upstream_client.py
@@ -114,6 +114,7 @@ class UpstreamClient:
         method: str,
         body_bytes: bytes,
         on_chunk: Callable[[bytes], None],
+        on_header: Optional[Callable[[str], None]] = None,
     ) -> tornado.httpclient.HTTPResponse:
         """
         Forward a streaming request, invoking on_chunk for each received byte
@@ -122,10 +123,15 @@ class UpstreamClient:
         :param method: HTTP method.
         :param body_bytes: Raw request body (ignored for GET).
         :param on_chunk: Synchronous callback invoked with each raw byte chunk.
+        :param on_header: Optional callback invoked with each response header
+                          line (status line included) BEFORE any body chunk, so
+                          the caller can learn the upstream status/content-type
+                          before writing a response.
         :return: The tornado HTTPResponse (its body is empty when streaming).
         """
         request: tornado.httpclient.HTTPRequest = self._build_request(
-            path, method, body_bytes, stream=True, streaming_callback=on_chunk)
+            path, method, body_bytes, stream=True,
+            streaming_callback=on_chunk, header_callback=on_header)
         return await self.client.fetch(request, raise_error=False)
 
     # pylint: disable=too-many-arguments, too-many-positional-arguments
@@ -136,6 +142,7 @@ class UpstreamClient:
         body_bytes: bytes,
         stream: bool,
         streaming_callback: Optional[Callable[[bytes], None]] = None,
+        header_callback: Optional[Callable[[str], None]] = None,
     ) -> tornado.httpclient.HTTPRequest:
         """Construct the HTTPRequest for the external host."""
         return tornado.httpclient.HTTPRequest(
@@ -146,6 +153,7 @@ class UpstreamClient:
             request_timeout=self.request_timeout,
             connect_timeout=self.connect_timeout,
             streaming_callback=streaming_callback,
+            header_callback=header_callback,
             # ssl_options is used only for https URLs; ignored for plain http.
             ssl_options=self.ssl_context,
         )

--- a/tests/record_playback_llm_server/upstream_client.py
+++ b/tests/record_playback_llm_server/upstream_client.py
@@ -1,0 +1,159 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+"""
+See class comment for details.
+"""
+from __future__ import annotations
+
+import ssl
+
+from typing import Callable
+from typing import Dict
+from typing import Optional
+
+import tornado.httpclient
+
+try:
+    import certifi
+except ImportError:
+    certifi = None
+
+
+class UpstreamClient:
+    """
+    Thin async HTTP client used in RECORD mode to forward a request to the
+    real external LLM host and return (or stream) its response.
+
+    The endpoint base URL and API key come from the server's environment
+    configuration, not from the incoming request -- the incoming request's
+    own Authorization header (a placeholder pointed at this proxy) is dropped
+    and replaced with the real credential here.
+    """
+
+    # LLM streaming responses can run for a long time; use generous timeouts.
+    DEFAULT_REQUEST_TIMEOUT_SECONDS: float = 600.0
+    DEFAULT_CONNECT_TIMEOUT_SECONDS: float = 30.0
+    # Tornado's default is only 10 simultaneous requests; the rest queue and can
+    # time out under a load test. Default higher so concurrent recording works.
+    DEFAULT_MAX_CLIENTS: int = 100
+
+    # pylint: disable=too-many-arguments, too-many-positional-arguments
+    def __init__(
+        self,
+        base_url: str,
+        api_key: Optional[str],
+        request_timeout: float = DEFAULT_REQUEST_TIMEOUT_SECONDS,
+        connect_timeout: float = DEFAULT_CONNECT_TIMEOUT_SECONDS,
+        max_clients: int = DEFAULT_MAX_CLIENTS,
+    ) -> None:
+        """
+        :param base_url: Base URL of the external LLM host, including any
+                         version path segment (e.g. "https://api.openai.com/v1").
+        :param api_key: Bearer credential for the external host. May be None
+                        for hosts that do not require authentication.
+        :param request_timeout: Whole-request timeout in seconds.
+        :param connect_timeout: Connection timeout in seconds.
+        :param max_clients: Maximum number of simultaneous in-flight requests to
+                            the upstream host before further requests queue.
+        """
+        self.base_url: str = base_url.rstrip("/") if base_url else base_url
+        self.api_key: Optional[str] = api_key
+        self.request_timeout: float = request_timeout
+        self.connect_timeout: float = connect_timeout
+        self.max_clients: int = max_clients
+        # force_instance=True gives this client its own dedicated connection pool
+        # with the requested max_clients, rather than the shared per-loop singleton
+        # whose max_clients would otherwise be fixed by whoever created it first.
+        self.client: tornado.httpclient.AsyncHTTPClient = \
+            tornado.httpclient.AsyncHTTPClient(force_instance=True, max_clients=max_clients)
+        self.ssl_context: ssl.SSLContext = self._build_ssl_context()
+
+    @staticmethod
+    def _build_ssl_context() -> ssl.SSLContext:
+        """
+        Build the TLS context for outbound HTTPS. Tornado otherwise trusts the
+        OS/OpenSSL default CA store, which on some platforms (notably macOS
+        python.org builds) is empty and fails to verify hosts fronted by public
+        CAs. Anchoring to the certifi bundle -- the same one the OpenAI/httpx
+        SDKs use -- makes verification behave like the real SDKs.
+        """
+        if certifi is not None:
+            return ssl.create_default_context(cafile=certifi.where())
+        return ssl.create_default_context()
+
+    async def fetch(self, path: str, method: str, body_bytes: bytes) -> tornado.httpclient.HTTPResponse:
+        """
+        Forward a one-shot (non-streaming) request and return the full response.
+        :param path: Upstream sub-path, e.g. "/chat/completions".
+        :param method: HTTP method.
+        :param body_bytes: Raw request body (ignored for GET).
+        :return: The tornado HTTPResponse (errors are captured, not raised).
+        """
+        request: tornado.httpclient.HTTPRequest = self._build_request(path, method, body_bytes, stream=False)
+        # raise_error=False: capture non-2xx responses instead of raising, so
+        # failures can be recorded and replayed just like successful responses.
+        return await self.client.fetch(request, raise_error=False)
+
+    async def fetch_stream(
+        self,
+        path: str,
+        method: str,
+        body_bytes: bytes,
+        on_chunk: Callable[[bytes], None],
+    ) -> tornado.httpclient.HTTPResponse:
+        """
+        Forward a streaming request, invoking on_chunk for each received byte
+        chunk as it arrives, and return the completed response.
+        :param path: Upstream sub-path, e.g. "/chat/completions".
+        :param method: HTTP method.
+        :param body_bytes: Raw request body (ignored for GET).
+        :param on_chunk: Synchronous callback invoked with each raw byte chunk.
+        :return: The tornado HTTPResponse (its body is empty when streaming).
+        """
+        request: tornado.httpclient.HTTPRequest = self._build_request(
+            path, method, body_bytes, stream=True, streaming_callback=on_chunk)
+        return await self.client.fetch(request, raise_error=False)
+
+    # pylint: disable=too-many-arguments, too-many-positional-arguments
+    def _build_request(
+        self,
+        path: str,
+        method: str,
+        body_bytes: bytes,
+        stream: bool,
+        streaming_callback: Optional[Callable[[bytes], None]] = None,
+    ) -> tornado.httpclient.HTTPRequest:
+        """Construct the HTTPRequest for the external host."""
+        return tornado.httpclient.HTTPRequest(
+            url=f"{self.base_url}{path}",
+            method=method.upper(),
+            headers=self._headers(stream),
+            body=body_bytes if method.upper() != "GET" else None,
+            request_timeout=self.request_timeout,
+            connect_timeout=self.connect_timeout,
+            streaming_callback=streaming_callback,
+            # ssl_options is used only for https URLs; ignored for plain http.
+            ssl_options=self.ssl_context,
+        )
+
+    def _headers(self, stream: bool) -> Dict[str, str]:
+        """Build request headers, injecting the real credential."""
+        headers: Dict[str, str] = {"Content-Type": "application/json"}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+        headers["Accept"] = "text/event-stream" if stream else "application/json"
+        return headers


### PR DESCRIPTION
## Summary
Adds a standalone, OpenAI-compatible HTTP proxy under
tests/record_playback_llm_server/ that records a neuro-san session against a
real LLM host and plays it back offline. It solves two problems with our
load/regression tests: they cost real tokens, and LLM responses are
non-deterministic. Recording once and replaying from disk makes those tests
free and repeatable.

It is wire-compatible with the OpenAI Chat Completions API, so any agent
network configured for class = "openai" is redirected at it with a single
openai_api_base change -- the same seam the existing tests/mock_llm_server uses.
This is test-only tooling; no production code is changed.

## Modes (selected with --mode)
- record: forward every request to the real host (endpoint + key from env
  vars), relay the real response back, and tee it into a cassette file,
  capturing wall-clock latency.
- playback: serve responses from the cassette by matching a canonical request
  signature. No network, no tokens. An unmatched request fails hard with 504,
  so tests surface gaps deterministically instead of silently faking data.
- hybrid: like playback, but a cache miss falls through to the real host (when
  configured), records the result into the current cassette, and returns it --
  a self-healing cassette.

## Additional capabilities
- Multi-response (--multi-response): record accumulates every distinct response
  for a request; playback serves them round-robin.
- Playback delay (--delay-mode none|recorded|fixed|random): an up-front
  per-response delay before serving a cache hit, emulating LLM latency.
  "recorded" uses each response's own recorded latency (first_byte_seconds for
  streams, latency_seconds for one-shot); in multi-response each variant uses
  its own.
- Latency capture: each recorded response stores wall-clock latency_seconds
  (and first_byte_seconds for streams).
- Success-only recording: non-2xx upstream responses (429/401/5xx) are relayed
  to the caller but never cached, so a transient failure cannot poison a
  cassette.
- Cassette cleaner (cleanup_cassette.py): a standalone tool that strips any
  non-2xx responses from an existing cassette (dropping single-response entries,
  trimming multi-response variants) to make an older cassette safe for playback.
- TLS verification anchored to the certifi CA bundle (matches the OpenAI/httpx
  SDKs) so recording against public hosts works on macOS python.org builds.
- Configurable upstream timeouts and max in-flight requests via env vars, to
  avoid spurious timeouts under load.

## How matching works
The response is non-deterministic but the request is a deterministic function of
the agent network and its inputs. In multi-turn flows each request embeds the
prior responses (assistant messages, tool_call ids, tool results); because
playback returns byte-identical recorded responses, downstream requests
reconstruct identically, so a sha256 of the canonicalized request body is a
stable key across a whole conversation.

## Configuration (record and hybrid modes), via environment variables
- RECORD_PLAYBACK_UPSTREAM_BASE_URL, RECORD_PLAYBACK_UPSTREAM_API_KEY
- RECORD_PLAYBACK_UPSTREAM_REQUEST_TIMEOUT_SECONDS,
  RECORD_PLAYBACK_UPSTREAM_CONNECT_TIMEOUT_SECONDS,
  RECORD_PLAYBACK_UPSTREAM_MAX_CLIENTS

## Layout
One class per file: RecordPlaybackLlmServer (CLI entry point), ProxyState,
ProxyHandler (shared record/playback/hybrid logic) with ChatCompletionsHandler
and ModelsHandler endpoints, HealthHandler, UpstreamClient, Cassette,
PlaybackDelay, RequestCanonicalizer, and the CassetteCleaner tool. A README
documents usage for every mode, the cleaner, and the cassette format.

## Testing
- flake8 clean and pylint 10.00/10 on the whole package.
- Committed pytest at tests/record_playback_llm_server/test_record_playback_llm_server.py
  (21 tests) runs in the default unit suite with no server or LLM key required.
  It covers: request canonicalization key stability; Cassette round-trip and
  multi-response de-duplication; all PlaybackDelay policies (including stream
  first-byte vs one-shot latency); CassetteCleaner drop/trim rules; and
  in-process record/playback/hybrid integration against a fake upstream --
  json + stream byte-identical replay with no upstream contact on hits, hard 504
  on a playback miss, multi-response round-robin, hybrid record-on-miss then hit,
  and non-2xx relayed but not recorded.

## Related issue
NS-1246

## Notes for reviewers
- Test-only: everything lives under tests/, no neuro_san/ production code is
  modified.
- The proxy is OpenAI-wire only (hosts reachable via an OpenAI-compatible
  base_url); native Anthropic/Bedrock/Gemini wire formats are out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
