### PR TITLE
disabled test case

### DIFF
--- a/tests/neuro_san/zzz_hocons/test_smoke_test_hocons.py
+++ b/tests/neuro_san/zzz_hocons/test_smoke_test_hocons.py
@@ -50,6 +50,8 @@ class TestSmokeTestHocons(TestCase):
             "Issue #936: disabled until #909 is resolved.",
         "music_nerd_pro_llm_openrouter/combination_responses_with_history_direct.hocon":
             "Disabled until OPENROUTER_API_KEY is added to the GitHub Actions secrets.",
+        "music_nerd_pro_llm_ollama/combination_responses_with_history_http.hocon":
+            "Issue #1226: disabled until #909 is resolved.",
     }
 
     def _skip_if_disabled(self, test_hocon: str) -> None:


### PR DESCRIPTION
I have disabled the Ollama test case above to reduce noise. @Noravee & I will find the best alternative solution. 
1. Tweak the Code Tool account py file (has a risk that would cause other LLMs to fail, and we will end up in a rabbit hole.
2. Find another model (my choice)


Smoke Test is happy now.
`[gw0] SKIPPED tests/neuro_san/zzz_hocons/test_smoke_test_hocons.py::TestSmokeTestHocons::test_hocon_with_server_non_default_llm_0_music_nerd_pro_llm_ollama_combination_responses_with_history_http`

Will re-enable the test case once we have the fix.
