### PR TITLE
Changes for easier transpile

### DIFF
--- a/neuro_san/client/thinking_file_message_processor.py
+++ b/neuro_san/client/thinking_file_message_processor.py
@@ -19,8 +19,8 @@ from typing import Any
 from typing import Dict
 from typing import List
 
-import json
-import uuid
+from json import dumps
+from uuid import uuid4
 
 from pathlib import Path
 from time import localtime
@@ -124,13 +124,13 @@ class ThinkingFileMessageProcessor(MessageProcessor):
             # There is no real text, but there is a structure. JSON-ify it.
             if len(text) > 0:
                 text += "\n"
-            text += f"```json\n{json.dumps(structure, indent=4, sort_keys=True)}\n```"
+            text += f"```json\n{dumps(structure, indent=4, sort_keys=True)}\n```"
 
         if chat_context is not None:
             # There is no real text, but there is a chat_context. JSON-ify it.
             if len(text) > 0:
                 text += "\n"
-            text += f"\nchat_context:\n{json.dumps(chat_context, indent=4, sort_keys=True)}\n"
+            text += f"\nchat_context:\n{dumps(chat_context, indent=4, sort_keys=True)}\n"
 
         # Figure out how we are going to report the origin given the message.
         use_origin: str = self._determine_origin_reporting(response, origin_str)
@@ -149,7 +149,7 @@ class ThinkingFileMessageProcessor(MessageProcessor):
 
                 # Retry with a uuid as file name.
                 # If this fails, there's no helping ya.
-                origin_filename = str(uuid.uuid4())
+                origin_filename = str(uuid4())
                 self._write_to_file(origin_filename, origin_str, message_type_str, use_origin, text, timestamp)
 
                 # Squirell that uuid away so results continue to go to the same

--- a/neuro_san/internals/chat/chat_history_message_processor.py
+++ b/neuro_san/internals/chat/chat_history_message_processor.py
@@ -128,18 +128,18 @@ class ChatHistoryMessageProcessor(MessageProcessor):
         # if they are not properly escaped.
 
         # First replace any pre-escaped braces with normal braces
-        text = text.replace("{{", "{")
-        text = text.replace("}}", "}")
+        text_1 = text.replace("{{", "{")
+        text_2 = text_1.replace("}}", "}")
 
         # Now replace normal braces with escaped braces.
         # Idea is to catch everything pre-escaped or not
-        text = text.replace("{", "{{")
-        text = text.replace("}", "}}")
+        text_3 = text_2.replace("{", "{{")
+        use_text = text_3.replace("}", "}}")
 
         # JSON spec does not allow control characters in strings and newlines in particular
         # can be a problem for http clients that expect one full JSON message per line.
         # Replace any lurking newlines with the 2 raw characters \ and n.
         # DEF - for the future.
 
-        transformed["text"] = text
+        transformed["text"] = use_text
         return transformed

--- a/neuro_san/internals/chat/chat_history_message_processor.py
+++ b/neuro_san/internals/chat/chat_history_message_processor.py
@@ -128,13 +128,13 @@ class ChatHistoryMessageProcessor(MessageProcessor):
         # if they are not properly escaped.
 
         # First replace any pre-escaped braces with normal braces
-        text_1 = text.replace("{{", "{")
-        text_2 = text_1.replace("}}", "}")
+        remove_escaped_curly_open: str = text.replace("{{", "{")
+        remove_escaped_curly_close = remove_escaped_curly_open.replace("}}", "}")
 
         # Now replace normal braces with escaped braces.
         # Idea is to catch everything pre-escaped or not
-        text_3 = text_2.replace("{", "{{")
-        use_text = text_3.replace("}", "}}")
+        escape_curly_open = remove_escaped_curly_close.replace("{", "{{")
+        use_text = escape_curly_open.replace("}", "}}")
 
         # JSON spec does not allow control characters in strings and newlines in particular
         # can be a problem for http clients that expect one full JSON message per line.

--- a/neuro_san/internals/chat/connectivity_reporter.py
+++ b/neuro_san/internals/chat/connectivity_reporter.py
@@ -19,7 +19,8 @@ from typing import Dict
 from typing import List
 from typing import Set
 
-import logging
+from logging import getLogger
+from logging import Logger
 
 from leaf_common.parsers.dictionary_extractor import DictionaryExtractor
 
@@ -80,7 +81,7 @@ class ConnectivityReporter:
         if self.inspector is not None and self.toolbox_factory is None:
             if not ConnectivityReporter.self_build_logged:
                 ConnectivityReporter.self_build_logged = True
-                logger = logging.getLogger(self.__class__.__name__)
+                logger: Logger = getLogger(self.__class__.__name__)
                 logger.info("No toolbox_factory provided. Building one from the agent network config. "
                             "Pass a pre-loaded factory to avoid re-reading toolbox info files per report. "
                             "(Logged once per process.)")

--- a/neuro_san/internals/graph/activations/abstract_class_activation.py
+++ b/neuro_san/internals/graph/activations/abstract_class_activation.py
@@ -154,8 +154,6 @@ class AbstractClassActivation(AbstractCallableActivation):
 
         :return: A BaseMessage produced during this process.
         """
-        message: BaseMessage = None
-
         full_class_ref: str = self.get_full_class_ref()
         self.logger.info("Calling class %s", full_class_ref)
         class_split: List[str] = full_class_ref.split(".")

--- a/neuro_san/internals/graph/activations/abstract_class_activation.py
+++ b/neuro_san/internals/graph/activations/abstract_class_activation.py
@@ -74,7 +74,7 @@ class AbstractClassActivation(AbstractCallableActivation):
     # pylint: disable=too-many-arguments,too-many-positional-arguments
     def __init__(self, parent_run_context: RunContext,
                  factory: AgentToolFactory,
-                 arguments: Dict[str, Any],
+                 args: Dict[str, Any],
                  agent_tool_spec: Dict[str, Any],
                  sly_data: Dict[str, Any]):
         """
@@ -84,7 +84,7 @@ class AbstractClassActivation(AbstractCallableActivation):
                              down its resources to a new RunContext created by
                              this call.
         :param factory: The AgentToolFactory used to create tools
-        :param arguments: A dictionary of the tool function arguments passed in by the LLM
+        :param args: A dictionary of the tool function arguments passed in by the LLM
         :param agent_tool_spec: The dictionary describing the JSON agent tool
                             to be used by the instance
         :param sly_data: A mapping whose keys might be referenceable by agents, but whose
@@ -111,8 +111,8 @@ class AbstractClassActivation(AbstractCallableActivation):
 
         # Put together the arguments to pass to the CodedTool
         self.arguments: Dict[str, Any] = {}
-        if arguments is not None:
-            self.arguments = arguments
+        if args is not None:
+            self.arguments = args
 
         # Set some standard args so CodedTool can know about origin, but only if they are
         # not already set by other infrastructure.
@@ -398,19 +398,19 @@ Some hints:
 
         return coded_tool
 
-    async def attempt_invoke(self, coded_tool: CodedTool, arguments: Dict[str, Any], sly_data: Dict[str, Any]) \
+    async def attempt_invoke(self, coded_tool: CodedTool, args: Dict[str, Any], sly_data: Dict[str, Any]) \
             -> Any:
         """
         Attempt to invoke the coded tool.
 
         :param coded_tool: The CodedTool instance to invoke
-        :param arguments: The arguments dictionary to pass as input to the coded_tool
+        :param args: The arguments dictionary to pass as input to the coded_tool
         :param sly_data: The sly_data dictionary to pass as input to the coded_tool
         :return: The result of the coded_tool, whatever that is.
         """
         retval: Any = None
 
-        arguments_dict: Dict[str, Any] = ToolArgumentReporting.prepare_tool_start_dict(arguments)
+        arguments_dict: Dict[str, Any] = ToolArgumentReporting.prepare_tool_start_dict(args)
         message = AgentMessage(content="Received arguments:", structure=arguments_dict)
         await self.journal.write_message(message)
 
@@ -435,7 +435,7 @@ This can lead to performance problems when running within a server. Consider por
                 invocation_context = self.run_context.get_invocation_context()
                 executor: AsyncioExecutor = invocation_context.get_asyncio_executor()
                 loop: AbstractEventLoop = executor.get_event_loop()
-                retval = await loop.run_in_executor(None, coded_tool.invoke, arguments, sly_data)
+                retval = await loop.run_in_executor(None, coded_tool.invoke, args, sly_data)
         # pylint: disable=broad-exception-caught
         except Exception as exception:
             # There was an error invoking the CodedTool.

--- a/neuro_san/internals/graph/activations/argument_assigner.py
+++ b/neuro_san/internals/graph/activations/argument_assigner.py
@@ -36,9 +36,9 @@ class ArgumentAssigner:
         """
         self.properties: Dict[str, Any] = properties
 
-    def assign(self, arguments: Dict[str, Any]) -> List[str]:
+    def assign(self, args: Dict[str, Any]) -> List[str]:
         """
-        :param arguments: The arguments dictionary with the values as determined
+        :param args: The arguments dictionary with the values as determined
                 by the calling agent.
         :return: A List of text that describes the values of each argument,
                 suitable for transmitting to the chat stream of another agent.
@@ -46,7 +46,7 @@ class ArgumentAssigner:
         assignments: List[str] = []
 
         # Start to build the list of assignments, with one sentence for each argument
-        for args_name, args_value in arguments.items():
+        for args_name, args_value in args.items():
 
             # Skip if the value of the argument is None or empty
             if args_value is None:

--- a/neuro_san/internals/graph/activations/branch_activation.py
+++ b/neuro_san/internals/graph/activations/branch_activation.py
@@ -144,14 +144,14 @@ class BranchActivation(CallingActivation, CallableActivation):
             assignments = assignments + "\n" + command
 
         run: Run = await self.run_context.submit_message(assignments)
-        run = await self.run_context.wait_on_run(run, self.journal)
+        use_run = await self.run_context.wait_on_run(run, self.journal)
 
         messages: List[BaseMessage] = await self.run_context.get_response()
 
-        messages = await self.integrate_callable_response(run, messages)
+        use_messages = await self.integrate_callable_response(use_run, messages)
 
         # Return the last message
-        return messages[-1]
+        return use_messages[-1]
 
     def get_origin(self) -> List[Dict[str, Any]]:
         """

--- a/neuro_san/internals/graph/activations/branch_activation.py
+++ b/neuro_san/internals/graph/activations/branch_activation.py
@@ -47,7 +47,7 @@ class BranchActivation(CallingActivation, CallableActivation):
     # pylint: disable=too-many-arguments, too-many-positional-arguments
     def __init__(self, parent_run_context: RunContext,
                  factory: AgentToolFactory,
-                 arguments: Dict[str, Any],
+                 args: Dict[str, Any],
                  agent_tool_spec: Dict[str, Any],
                  sly_data: Dict[str, Any]):
         """
@@ -57,14 +57,14 @@ class BranchActivation(CallingActivation, CallableActivation):
                              down its resources to a new RunContext created by
                              this call.
         :param factory: The AgentToolFactory used to create tools
-        :param arguments: A dictionary of the tool function arguments passed in
+        :param args: A dictionary of the tool function arguments passed in
         :param agent_tool_spec: The dictionary describing the JSON agent tool
                             to be used by the instance
         :param sly_data: A mapping whose keys might be referenceable by agents, but whose
                  values should not appear in agent chat text. Can be an empty dictionary.
         """
         super().__init__(parent_run_context, factory, agent_tool_spec, sly_data)
-        self.arguments: Dict[str, Any] = arguments
+        self.arguments: Dict[str, Any] = args
 
     def get_assignments(self) -> str:
         """

--- a/neuro_san/internals/graph/activations/branch_activation.py
+++ b/neuro_san/internals/graph/activations/branch_activation.py
@@ -18,7 +18,7 @@ from typing import Any
 from typing import Dict
 from typing import List
 
-import uuid
+from uuid import uuid4
 
 from aiohttp.client_exceptions import ClientConnectionError
 
@@ -133,7 +133,7 @@ class BranchActivation(CallingActivation, CallableActivation):
         assignments: str = self.get_assignments()
         instructions: str = self.get_instructions()
 
-        uuid_str: str = str(uuid.uuid4())
+        uuid_str: str = str(uuid4())
         component_name: str = self.get_name()
         unique_name: str = f"{uuid_str}_{component_name}"
         await self.create_resources(unique_name, instructions, None)

--- a/neuro_san/internals/graph/activations/calling_activation.py
+++ b/neuro_san/internals/graph/activations/calling_activation.py
@@ -94,12 +94,12 @@ class CallingActivation(AbstractCallableActivation, ToolCaller):
 
         overlayer = DictionaryOverlay()
         llm_config: Dict[str, Any] = agent_network_config.get("llm_config", empty)
-        llm_config = overlayer.overlay(llm_config, spec_llm_config)
+        use_llm_config: Dict[str, Any] = overlayer.overlay(llm_config, spec_llm_config)
 
         middleware_config: List[Dict[str, Any]] = agent_tool_spec.get("middleware")
         run_context_config: Dict[str, Any] = {
             "context_type": agent_network_config.get("context_type"),
-            "llm_config": llm_config,
+            "llm_config": use_llm_config,
             "middleware_config": middleware_config
         }
         return run_context_config

--- a/neuro_san/internals/graph/activations/external_activation.py
+++ b/neuro_san/internals/graph/activations/external_activation.py
@@ -60,7 +60,7 @@ class ExternalActivation(AbstractCallableActivation):
     def __init__(self, parent_run_context: RunContext,
                  factory: AgentToolFactory,
                  agent_url: str,
-                 arguments: Dict[str, Any],
+                 args: Dict[str, Any],
                  sly_data: Dict[str, Any],
                  allow_from_downstream: Dict[str, Any],
                  invocation: str):
@@ -74,7 +74,7 @@ class ExternalActivation(AbstractCallableActivation):
         :param agent_url: The string url to find the external agent.
                         Theoretically this has already been verified by use of an
                         ExternalAgentParsing method.
-        :param arguments: A dictionary of the tool function arguments passed in
+        :param args: A dictionary of the tool function arguments passed in
         :param sly_data: A mapping whose keys might be referenceable by agents, but whose
                  values should not appear in agent chat text. Can be an empty dictionary.
                  This gets passed along as a distinct argument to the referenced python class's
@@ -92,7 +92,7 @@ class ExternalActivation(AbstractCallableActivation):
         self.agent_url: str = agent_url
         self.run_context: RunContext = RunContextFactory.create_run_context(parent_run_context, self)
         self.journal: Journal = self.run_context.get_journal()
-        self.arguments: Dict[str, Any] = arguments
+        self.arguments: Dict[str, Any] = args
         self.allow_from_downstream: Dict[str, Any] = allow_from_downstream
 
         self.session: AsyncAgentSession = None

--- a/neuro_san/internals/graph/filters/abstract_common_defs_config_filter.py
+++ b/neuro_san/internals/graph/filters/abstract_common_defs_config_filter.py
@@ -68,11 +68,10 @@ class AbstractCommonDefsConfigFilter(ConfigFilter):
         replacements: Dict[str, Any] = deepcopy(self.starting_replacements)
 
         # Look for something to replace
-        commondefs: Dict[str, Any] = {}
-        commondefs = basis_config.get("commondefs", commondefs)
+        empty: Dict[str, Any] = {}
+        commondefs: Dict[str, Any] = basis_config.get("commondefs", empty)
         if commondefs:          # Empty dictionaries evaluate to False
-            new_replacements: Dict[str, Any] = {}
-            new_replacements = deepcopy(commondefs.get(self.commondefs_key, new_replacements))
+            new_replacements = deepcopy(commondefs.get(self.commondefs_key, empty))
             replacements.update(new_replacements)
 
         if not replacements:               # Empty dictionaries evaluate to False
@@ -84,11 +83,11 @@ class AbstractCommonDefsConfigFilter(ConfigFilter):
 
         # First do replacements among commondef dictionaries themselves
         # Note: These cannot have cycles.
-        replacements = self.filter_one_dict(replacements, replacements)
+        new_replacements = self.filter_one_dict(replacements, replacements)
 
         # Next do replacements among all tools dicts
         tools: List[Dict[str, Any]] = basis_config.get("tools")
-        new_config["tools"] = self.filter_one_list(tools, replacements)
+        new_config["tools"] = self.filter_one_list(tools, new_replacements)
 
         return new_config
 

--- a/neuro_san/internals/graph/filters/defaults_config_filter.py
+++ b/neuro_san/internals/graph/filters/defaults_config_filter.py
@@ -98,11 +98,11 @@ class DefaultsConfigFilter(ConfigFilter):
         basis_extractor = DictionaryExtractor(result_config)
 
         # Loop through all the tools making additions.
-        tools = result_config.get("tools")
+        use_tools: List[Dict[str, Any]] = result_config.get("tools")
 
         idx: int = 0
         tool: Dict[str, Any] = None
-        for idx, tool in enumerate(tools):
+        for idx, tool in enumerate(use_tools):
             tool_extractor = DictionaryExtractor(tool)
 
             # Assume the front-man is the first tool in the list.

--- a/neuro_san/internals/graph/filters/dictionary_common_defs_config_filter.py
+++ b/neuro_san/internals/graph/filters/dictionary_common_defs_config_filter.py
@@ -81,6 +81,6 @@ class DictionaryCommonDefsConfigFilter(AbstractCommonDefsConfigFilter):
 
         # Make a deepcopy in case the replacement is something
         # that gets modified independently by other filtering steps.
-        replacement_value = deepcopy(replacement_value)
+        replacement_value_copy: Any = deepcopy(replacement_value)
 
-        return replacement_value
+        return replacement_value_copy

--- a/neuro_san/internals/graph/preppers/activation_prepper.py
+++ b/neuro_san/internals/graph/preppers/activation_prepper.py
@@ -43,7 +43,7 @@ class ActivationPrepper:
                            name: str,
                            agent_tool_spec: Dict[str, Any],
                            parent_agent_spec: Dict[str, Any],
-                           arguments: Dict[str, Any],
+                           args: Dict[str, Any],
                            sly_data: Dict[str, Any],
                            parent_run_context: RunContext,
                            factory: AgentToolFactory,
@@ -55,7 +55,7 @@ class ActivationPrepper:
         :param name: the name of the agent tool
         :param agent_tool_spec: the agent tool spec dictionary
         :param parent_agent_spec: the parent agent spec dictionary
-        :param arguments: the arguments dictionary
+        :param args: the arguments dictionary
         :param sly_data: the sly data dictionary
         :param parent_run_context: the parent run context
         :param factory: the agent tool factory

--- a/neuro_san/internals/graph/preppers/branch_activation_prepper.py
+++ b/neuro_san/internals/graph/preppers/branch_activation_prepper.py
@@ -42,7 +42,7 @@ class BranchActivationPrepper(ActivationPrepper):
                            name: str,
                            agent_tool_spec: Dict[str, Any],
                            parent_agent_spec: Dict[str, Any],
-                           arguments: Dict[str, Any],
+                           args: Dict[str, Any],
                            sly_data: Dict[str, Any],
                            parent_run_context: RunContext,
                            factory: AgentToolFactory,
@@ -54,12 +54,12 @@ class BranchActivationPrepper(ActivationPrepper):
         :param name: the name of the agent tool
         :param agent_tool_spec: the agent tool spec dictionary
         :param parent_agent_spec: the parent agent spec dictionary
-        :param arguments: the arguments dictionary
+        :param args: the arguments dictionary
         :param sly_data: the sly data dictionary
         :param parent_run_context: the parent run context
         :param factory: the agent tool factory
         :param invocation: the invocation string ("chatbot" or "event")
         :return: a CallableActivation
         """
-        use_args: Dict[str, Any] = self.merge_args(arguments, agent_tool_spec)
+        use_args: Dict[str, Any] = self.merge_args(args, agent_tool_spec)
         return BranchActivation(parent_run_context, factory, use_args, agent_tool_spec, sly_data)

--- a/neuro_san/internals/graph/preppers/class_activation_prepper.py
+++ b/neuro_san/internals/graph/preppers/class_activation_prepper.py
@@ -42,7 +42,7 @@ class ClassActivationPrepper(ActivationPrepper):
                            name: str,
                            agent_tool_spec: Dict[str, Any],
                            parent_agent_spec: Dict[str, Any],
-                           arguments: Dict[str, Any],
+                           args: Dict[str, Any],
                            sly_data: Dict[str, Any],
                            parent_run_context: RunContext,
                            factory: AgentToolFactory,
@@ -54,12 +54,12 @@ class ClassActivationPrepper(ActivationPrepper):
         :param name: the name of the agent tool
         :param agent_tool_spec: the agent tool spec dictionary
         :param parent_agent_spec: the parent agent spec dictionary
-        :param arguments: the arguments dictionary
+        :param args: the arguments dictionary
         :param sly_data: the sly data dictionary
         :param parent_run_context: the parent run context
         :param factory: the agent tool factory
         :param invocation: the invocation string ("chatbot" or "event")
         :return: a CallableActivation
         """
-        use_args: Dict[str, Any] = self.merge_args(arguments, agent_tool_spec)
+        use_args: Dict[str, Any] = self.merge_args(args, agent_tool_spec)
         return ClassActivation(parent_run_context, factory, use_args, agent_tool_spec, sly_data)

--- a/neuro_san/internals/graph/preppers/external_activation_prepper.py
+++ b/neuro_san/internals/graph/preppers/external_activation_prepper.py
@@ -47,7 +47,7 @@ class ExternalActivationPrepper(ActivationPrepper):
                            name: str,
                            agent_tool_spec: Dict[str, Any],
                            parent_agent_spec: Dict[str, Any],
-                           arguments: Dict[str, Any],
+                           args: Dict[str, Any],
                            sly_data: Dict[str, Any],
                            parent_run_context: RunContext,
                            factory: AgentToolFactory,
@@ -59,7 +59,7 @@ class ExternalActivationPrepper(ActivationPrepper):
         :param name: the name of the agent tool
         :param agent_tool_spec: the agent tool spec dictionary
         :param parent_agent_spec: the parent agent spec dictionary
-        :param arguments: the arguments dictionary
+        :param args: the arguments dictionary
         :param sly_data: the sly data dictionary
         :param parent_run_context: the parent run context
         :param factory: the agent tool factory
@@ -78,7 +78,7 @@ class ExternalActivationPrepper(ActivationPrepper):
         empty = {}
         allow_from_downstream: Dict[str, Any] = extractor.get("allow.from_downstream", empty)
 
-        agent_activation = ExternalActivation(parent_run_context, factory, name, arguments, redacted_sly_data,
+        agent_activation = ExternalActivation(parent_run_context, factory, name, args, redacted_sly_data,
                                               allow_from_downstream, invocation)
         return agent_activation
 

--- a/neuro_san/internals/graph/preppers/front_man_activation_prepper.py
+++ b/neuro_san/internals/graph/preppers/front_man_activation_prepper.py
@@ -42,7 +42,7 @@ class FrontManActivationPrepper(ActivationPrepper):
                            name: str,
                            agent_tool_spec: Dict[str, Any],
                            parent_agent_spec: Dict[str, Any],
-                           arguments: Dict[str, Any],
+                           args: Dict[str, Any],
                            sly_data: Dict[str, Any],
                            parent_run_context: RunContext,
                            factory: AgentToolFactory,
@@ -54,7 +54,7 @@ class FrontManActivationPrepper(ActivationPrepper):
         :param name: the name of the agent tool
         :param agent_tool_spec: the agent tool spec dictionary
         :param parent_agent_spec: the parent agent spec dictionary
-        :param arguments: the arguments dictionary
+        :param args: the arguments dictionary
         :param sly_data: the sly data dictionary
         :param parent_run_context: the parent run context
         :param factory: the agent tool factory

--- a/neuro_san/internals/graph/preppers/toolbox_activation_prepper.py
+++ b/neuro_san/internals/graph/preppers/toolbox_activation_prepper.py
@@ -42,7 +42,7 @@ class ToolboxActivationPrepper(ActivationPrepper):
                            name: str,
                            agent_tool_spec: Dict[str, Any],
                            parent_agent_spec: Dict[str, Any],
-                           arguments: Dict[str, Any],
+                           args: Dict[str, Any],
                            sly_data: Dict[str, Any],
                            parent_run_context: RunContext,
                            factory: AgentToolFactory,
@@ -54,12 +54,12 @@ class ToolboxActivationPrepper(ActivationPrepper):
         :param name: the name of the agent tool
         :param agent_tool_spec: the agent tool spec dictionary
         :param parent_agent_spec: the parent agent spec dictionary
-        :param arguments: the arguments dictionary
+        :param args: the arguments dictionary
         :param sly_data: the sly data dictionary
         :param parent_run_context: the parent run context
         :param factory: the agent tool factory
         :param invocation: the invocation string ("chatbot" or "event")
         :return: a CallableActivation
         """
-        use_args: Dict[str, Any] = self.merge_args(arguments, agent_tool_spec)
+        use_args: Dict[str, Any] = self.merge_args(args, agent_tool_spec)
         return ToolboxActivation(parent_run_context, factory, use_args, agent_tool_spec, sly_data)

--- a/neuro_san/internals/graph/registry/activation_factory.py
+++ b/neuro_san/internals/graph/registry/activation_factory.py
@@ -145,8 +145,8 @@ Check to be sure your value for PYTHONPATH includes where you expect where your 
         prepper_class_name: str = None
         agent_prepper_classes: str = environ.get("AGENT_ACTIVATION_PREPPER_CLASSES") or ""
         for prepper_class_name in agent_prepper_classes.split():
-            prepper_class_name = prepper_class_name.strip()
-            prepper: ActivationPrepper = ResolverUtil.create_instance(prepper_class_name,
+            use_prepper_class_name = prepper_class_name.strip()
+            prepper: ActivationPrepper = ResolverUtil.create_instance(use_prepper_class_name,
                                                                       "AGENT_ACTIVATION_PREPPER_CLASSES env var",
                                                                       ActivationPrepper)
             if prepper is not None:

--- a/neuro_san/internals/graph/registry/activation_factory.py
+++ b/neuro_san/internals/graph/registry/activation_factory.py
@@ -169,7 +169,7 @@ Check to be sure your value for PYTHONPATH includes where you expect where your 
                                 parent_agent_spec: Dict[str, Any],
                                 name: str,
                                 sly_data: Dict[str, Any],
-                                arguments: Dict[str, Any] = None,
+                                args: Dict[str, Any] = None,
                                 factory: AgentToolFactory = None,
                                 invocation: str = None) -> CallableActivation:
         """
@@ -181,7 +181,7 @@ Check to be sure your value for PYTHONPATH includes where you expect where your 
         :param name: The name of the agent to get out of the registry
         :param sly_data: A mapping whose keys might be referenceable by agents, but whose
                  values should not appear in agent chat text. Can be an empty dictionary.
-        :param arguments: A dictionary of arguments for the newly constructed agent
+        :param args: A dictionary of arguments for the newly constructed agent
         :param factory: A factory that will be used to create the agent tool
         :param invocation: The invocation style of the activation.
         :return: The CallableActivation agent referred to by the name.
@@ -207,7 +207,7 @@ Check to be sure your value for PYTHONPATH includes where you expect where your 
             name,
             agent_tool_spec,
             parent_agent_spec,
-            arguments,
+            args,
             sly_data,
             parent_run_context,
             factory,

--- a/neuro_san/internals/graph/registry/agent_tool_registry.py
+++ b/neuro_san/internals/graph/registry/agent_tool_registry.py
@@ -46,7 +46,7 @@ class AgentToolRegistry(AgentNetworkInspector, AgentToolFactory):
                                 parent_agent_spec: Dict[str, Any],
                                 name: str,
                                 sly_data: Dict[str, Any],
-                                arguments: Dict[str, Any] = None,
+                                args: Dict[str, Any] = None,
                                 factory: AgentToolFactory = None,
                                 invocation: str = None) -> CallableActivation:
         """
@@ -58,13 +58,13 @@ class AgentToolRegistry(AgentNetworkInspector, AgentToolFactory):
         :param name: The name of the agent to get out of the registry
         :param sly_data: A mapping whose keys might be referenceable by agents, but whose
                  values should not appear in agent chat text. Can be an empty dictionary.
-        :param arguments: A dictionary of arguments for the newly constructed agent
+        :param args: A dictionary of arguments for the newly constructed agent
         :param factory: A factory that will be used to create the agent tool
         :param invocation: The invocation style of the activation.
         :return: The CallableActivation agent referred to by the name.
         """
         return self.factory.create_agent_activation(parent_run_context, parent_agent_spec,
-                                                    name, sly_data, arguments, self, invocation)
+                                                    name, sly_data, args, self, invocation)
 
     def create_front_man(self,
                          sly_data: Dict[str, Any] = None,

--- a/neuro_san/internals/graph/utils/allow_util.py
+++ b/neuro_san/internals/graph/utils/allow_util.py
@@ -51,12 +51,12 @@ class AllowUtil:
         # Get the list of tools to look for
         config: Dict[str, Any] = inspector.get_config()
         tools: List[Dict[str, Any]] = []
-        tools = config.get("tools", tools)
+        use_tools: List[Dict[str, Any]] = config.get("tools", tools)
 
         # Loop through each of the tools/agents
         empty: Dict[str, Any] = {}
         agent_spec: Dict[str, Any] = empty
-        for agent_spec in tools:
+        for agent_spec in use_tools:
             allow = AllowUtil.is_allowed_in_agent_spec(agent_spec, allow_key, deeper_keys)
             if allow:
                 return True

--- a/neuro_san/internals/interfaces/agent_tool_factory.py
+++ b/neuro_san/internals/interfaces/agent_tool_factory.py
@@ -35,7 +35,7 @@ class AgentToolFactory:
                                 parent_agent_spec: Dict[str, Any],
                                 name: str,
                                 sly_data: Dict[str, Any],
-                                arguments: Dict[str, Any] = None,
+                                args: Dict[str, Any] = None,
                                 factory: AgentToolFactory = None,
                                 invocation: str = None) -> CallableActivation:
         """
@@ -46,7 +46,7 @@ class AgentToolFactory:
         :param name: The name of the agent to get out of the registry
         :param sly_data: A mapping whose keys might be referenceable by agents, but whose
                  values should not appear in agent chat text. Can be an empty dictionary.
-        :param arguments: A dictionary of arguments for the newly constructed agent
+        :param args: A dictionary of arguments for the newly constructed agent
         :param factory: A factory that will be used to create the agent tool
         :param invocation: The invocation style of the activation.
         :return: The CallableActivation agent referred to by the name.

--- a/neuro_san/internals/journals/origination.py
+++ b/neuro_san/internals/journals/origination.py
@@ -121,9 +121,9 @@ class Origination:
 
         # Simple replacement of local external agents.
         # DEF - need better recognition of external agent
-        full_path = full_path.replace("./", "/")
+        use_full_path = full_path.replace("./", "/")
 
-        return full_path
+        return use_full_path
 
     def reset(self):
         """

--- a/neuro_san/internals/journals/origination.py
+++ b/neuro_san/internals/journals/origination.py
@@ -58,15 +58,13 @@ class Origination:
         :param agent_name: The agent name to be added to the list.
         :return: The new origin with the agent name at the end of the list
         """
-        new_origin: List[Dict[str, Any]] = []
-
         # Add the name from the spec to the origin, if we have it.
         if origin is None or agent_name is None:
-            return new_origin
+            return []
 
         # Make a shallow copy of the list, as we are going to modify it
         # and don't want to muck with the original
-        new_origin = copy(origin)
+        new_origin: List[Dict[str, Any]] = copy(origin)
 
         # Find the current instantiation index for the tool
         # and increment it in the map for later use

--- a/neuro_san/internals/network_providers/abstract_reservations_storage.py
+++ b/neuro_san/internals/network_providers/abstract_reservations_storage.py
@@ -20,9 +20,11 @@ from typing import Dict
 from typing import Optional
 from typing import Tuple
 
-import logging
-import time
-import threading
+from logging import getLogger
+from logging import Logger
+from time import monotonic
+from threading import Event
+from threading import Thread
 
 from leaf_common.logging.sensitive_logger import SensitiveLogger
 from leaf_common.utils.startable import Startable
@@ -46,15 +48,15 @@ class AbstractReservationsStorage(ReservationsStorage, Startable):
                             If set to 0 or negative, the background thread will not be started.
         """
         super().__init__()
-        self._thread: threading.Thread = None
+        self._thread: Thread = None
         self._check_interval_seconds: float = check_expirations_interval_seconds
-        self._stop_event = threading.Event()
-        self._logger = logging.getLogger(self.__class__.__name__)
+        self._stop_event = Event()
+        self._logger: Logger = getLogger(self.__class__.__name__)
         self._name: str = storage_name
 
     def start(self):
         if self._check_interval_seconds > 0:
-            self._thread = threading.Thread(target=self._run_loop, daemon=True)
+            self._thread = Thread(target=self._run_loop, daemon=True)
             self._thread.start()
             self._logger.debug("%s: Expiration cleanup thread started with period %f sec.",
                                self._name, self._check_interval_seconds)
@@ -73,13 +75,13 @@ class AbstractReservationsStorage(ReservationsStorage, Startable):
     def _run_loop(self):
         while not self._stop_event.is_set():
             # Using "monotonic" time allows us to avoid potential issues with system clock changes
-            start = time.monotonic()
+            start = monotonic()
             try:
                 self.expire_reservations()
             except Exception as exception:  # pylint: disable=broad-except
                 sensitive_logger = SensitiveLogger(self._logger)
                 sensitive_logger.info("%s: Expiration cleanup failed: %s", self._name, exception)
-            elapsed = time.monotonic() - start
+            elapsed = monotonic() - start
             self._logger.debug("%s: Expiration cleanup took %f seconds.", self._name, elapsed)
 
             # Compute remaining sleep time

--- a/neuro_san/internals/network_providers/agent_network_storage.py
+++ b/neuro_san/internals/network_providers/agent_network_storage.py
@@ -18,7 +18,8 @@
 from typing import Dict
 from typing import List
 
-import logging
+from logging import getLogger
+from logging import Logger
 from threading import Lock
 
 from neuro_san.internals.graph.registry.agent_network import AgentNetwork
@@ -38,7 +39,7 @@ class AgentNetworkStorage(AgentStorageSource):
 
     def __init__(self):
         self.agents_table: Dict[str, AgentNetwork] = {}
-        self.logger = logging.getLogger(self.__class__.__name__)
+        self.logger: Logger = getLogger(self.__class__.__name__)
         self.lock = Lock()
         self.listeners: List[AgentStateListener] = []
 

--- a/neuro_san/internals/reservations/reservation_util.py
+++ b/neuro_san/internals/reservations/reservation_util.py
@@ -53,7 +53,6 @@ class ReservationUtil:
                 and a string representing an error message pertaining to the Reservation.  One
                 of the elements of the Tuple will be None.
         """
-        reservation: Reservation = None
         error: str = None
         logger: Logger = getLogger(__name__)
 
@@ -65,10 +64,10 @@ Reservationist is None.  Make sure that temporary networks reservations
 "allow": { "reservations": True } or
  add a NetworkCopyMiddleware entry with allow.reservations = true.
 """
-            return (reservation, error)
+            return (None, error)
 
         # Creating the Reservations can be done outside the Reservationist with-statement
-        reservation = await reservationist.reserve(lifetime_in_seconds=lifetime_in_seconds, prefix=prefix)
+        reservation: Reservation = await reservationist.reserve(lifetime_in_seconds=lifetime_in_seconds, prefix=prefix)
         deployments: Dict[Reservation, Dict[str, Any]] = {
             reservation: agent_spec
         }

--- a/neuro_san/internals/reservations/reservation_util.py
+++ b/neuro_san/internals/reservations/reservation_util.py
@@ -68,8 +68,7 @@ Reservationist is None.  Make sure that temporary networks reservations
             return (reservation, error)
 
         # Creating the Reservations can be done outside the Reservationist with-statement
-        reservation: Reservation = await reservationist.reserve(lifetime_in_seconds=lifetime_in_seconds,
-                                                                prefix=prefix)
+        reservation = await reservationist.reserve(lifetime_in_seconds=lifetime_in_seconds, prefix=prefix)
         deployments: Dict[Reservation, Dict[str, Any]] = {
             reservation: agent_spec
         }

--- a/neuro_san/internals/run_context/factory/master_llm_factory.py
+++ b/neuro_san/internals/run_context/factory/master_llm_factory.py
@@ -65,6 +65,6 @@ class MasterLlmFactory:
         context_type: str = use_config.get("context_type")
         if context_type is None:
             context_type = "langchain"
-        context_type = context_type.lower()
+        lower_context_type: str = context_type.lower()
 
-        return context_type
+        return lower_context_type

--- a/neuro_san/internals/run_context/factory/master_tracing_context_factory.py
+++ b/neuro_san/internals/run_context/factory/master_tracing_context_factory.py
@@ -68,6 +68,6 @@ class MasterTracingContextFactory:
         context_type: str = use_config.get("context_type")
         if context_type is None:
             context_type = "langchain"
-        context_type = context_type.lower()
+        context_type_lower = context_type.lower()
 
-        return context_type
+        return context_type_lower

--- a/neuro_san/internals/run_context/factory/master_tracing_context_factory.py
+++ b/neuro_san/internals/run_context/factory/master_tracing_context_factory.py
@@ -68,6 +68,6 @@ class MasterTracingContextFactory:
         context_type: str = use_config.get("context_type")
         if context_type is None:
             context_type = "langchain"
-        context_type_lower = context_type.lower()
+        lower_context_type = context_type.lower()
 
-        return context_type_lower
+        return lower_context_type

--- a/neuro_san/internals/run_context/factory/run_context_factory.py
+++ b/neuro_san/internals/run_context/factory/run_context_factory.py
@@ -69,7 +69,7 @@ class RunContextFactory:
             "model_name": "gpt-5.2",
             "verbose": False
         }
-        default_llm_config = use_config.get("llm_config") or default_llm_config
+        use_llm_config: Dict[str, Any] = use_config.get("llm_config") or default_llm_config
 
         # Prepare for sanity in checks below
         context_type: str = MasterLlmFactory.get_context_type(use_config)
@@ -82,13 +82,13 @@ class RunContextFactory:
             raise ValueError("OpenAI Assistants implementation is no longer supported by OpenAI.")
 
         if context_type.startswith("langchain"):
-            run_context = LangChainRunContext(default_llm_config, parent_run_context,
+            run_context = LangChainRunContext(use_llm_config, parent_run_context,
                                               tool_caller, use_invocation_context,
                                               chat_context, use_config.get("middleware_config"),
                                               tracing_context=tracing_context)
         else:
             # Default case
-            run_context = LangChainRunContext(default_llm_config, parent_run_context,
+            run_context = LangChainRunContext(use_llm_config, parent_run_context,
                                               tool_caller, use_invocation_context,
                                               chat_context, use_config.get("middleware_config"),
                                               tracing_context=tracing_context)

--- a/neuro_san/internals/run_context/langchain/core/base_tool_factory.py
+++ b/neuro_san/internals/run_context/langchain/core/base_tool_factory.py
@@ -145,8 +145,8 @@ class BaseToolFactory:
             return None
 
         try:
-            function_json = await self.ensure_external_parameters(function_json, name)
-            return self.create_function_tool(function_json, name)
+            use_function_json = await self.ensure_external_parameters(function_json, name)
+            return self.create_function_tool(use_function_json, name)
         except ValueError as exception:
             # The agent was reachable, but what it reported cannot be made into a tool.
             message: str = f"Agent/tool {name} reported an invalid function definition. " + \
@@ -306,9 +306,9 @@ class BaseToolFactory:
             return None
 
         # The allowed tools list might have been updated by the MCP adapter
-        allowed_tools: List[str] = mcp_adapter.client_allowed_tools
+        use_allowed_tools: List[str] = mcp_adapter.client_allowed_tools
         tool_names: List[str] = [tool.name for tool in mcp_tools]
-        invalid_names: Set[str] = set(allowed_tools) - set(tool_names)
+        invalid_names: Set[str] = set(use_allowed_tools) - set(tool_names)
         # Check if there are invalid tool names in the list.
         if invalid_names:
             message = f"The following tools cannot be found in {server_url}: {invalid_names}"

--- a/neuro_san/internals/run_context/langchain/core/base_tool_factory.py
+++ b/neuro_san/internals/run_context/langchain/core/base_tool_factory.py
@@ -237,9 +237,9 @@ class BaseToolFactory:
             await self.journal.write_message(agent_message)
             self.logger.warning(message)
 
-        function_json = dict(function_json)
-        function_json["parameters"] = deepcopy(self.DEFAULT_EXTERNAL_PARAMETERS)
-        return function_json
+        use_function_json: Dict[str, Any] = dict(function_json)
+        use_function_json["parameters"] = deepcopy(self.DEFAULT_EXTERNAL_PARAMETERS)
+        return use_function_json
 
     async def create_internal_tool(self, name: str, agent_spec: Dict[str, Any]) -> BaseTool:
         """

--- a/neuro_san/internals/run_context/langchain/core/langchain_openai_function_tool.py
+++ b/neuro_san/internals/run_context/langchain/core/langchain_openai_function_tool.py
@@ -21,8 +21,9 @@ from typing import Dict
 from typing import Optional
 from typing import Type
 
-import logging
-import traceback
+from logging import getLogger
+from logging import Logger
+from traceback import format_exc
 
 from pydantic_core import ValidationError
 from langchain_core.messages.base import BaseMessage
@@ -249,7 +250,7 @@ It's function_json is described thusly:
             # Report the exception, but return exception as value from function.
             # This actually allows LLMs to recognize that something is wrong
             # and verbally report on that.
-            logger = logging.getLogger(self.__class__.__name__)
+            logger: Logger = getLogger(self.__class__.__name__)
             sensitive_logger = SensitiveLogger(logger)
 
             # CheckMarx false-positive for Information Exposure Through an Error Message
@@ -258,7 +259,7 @@ It's function_json is described thusly:
             # by setting the env var LEAF_LOG_SENSITIVE to "false", while still allowing
             # developers to see the error message.
             sensitive_logger.error("Tool._arun() got Exception: %s", str(exception))
-            sensitive_logger.error(traceback.format_exc())
+            sensitive_logger.error(format_exc())
             run = None
             return str(exception)
 

--- a/neuro_san/internals/run_context/langchain/core/langchain_run_context.py
+++ b/neuro_san/internals/run_context/langchain/core/langchain_run_context.py
@@ -271,9 +271,6 @@ class LangChainRunContext(RunContext):
         :param instructions: The instructions to use for the agent
         :return: An Agent (Runnable)
         """
-        # Initialize our return value
-        agent: Runnable = None
-
         # Get the factory we will use
         llm_factory: ContextTypeLlmFactory = self.invocation_context.get_llm_factory()
         sly_data: Dict[str, Any] = self.tool_caller.get_sly_data()
@@ -312,7 +309,7 @@ class LangChainRunContext(RunContext):
             raise ValueError(error)
 
         self.llm_resources = main_llm_resources
-        agent = self.create_agent(instructions, main_llm_resources.get_model())
+        agent: Runnable = self.create_agent(instructions, main_llm_resources.get_model())
 
         return agent
 

--- a/neuro_san/internals/run_context/langchain/core/langchain_run_context.py
+++ b/neuro_san/internals/run_context/langchain/core/langchain_run_context.py
@@ -32,7 +32,6 @@ from pydantic_core import ValidationError
 from leaf_common.logging.sensitive_logger import SensitiveLogger
 
 from langchain.agents.factory import create_agent
-from langchain.agents.middleware.types import AgentMiddleware
 from langchain_core.language_models.base import BaseLanguageModel
 from langchain_core.messages.base import BaseMessage
 from langchain_core.messages.human import HumanMessage
@@ -313,7 +312,7 @@ class LangChainRunContext(RunContext):
             raise ValueError(error)
 
         self.llm_resources = main_llm_resources
-        agent: Runnable = self.create_agent(instructions, main_llm_resources.get_model())
+        agent = self.create_agent(instructions, main_llm_resources.get_model())
 
         return agent
 
@@ -330,8 +329,8 @@ class LangChainRunContext(RunContext):
         middleware_factory = MiddlewareFactory(self.invocation_context, self.origin, self.chat_history, self.capsule)
         sly_data: Dict[str, Any] = self.tool_caller.get_sly_data()
 
-        middleware: List[AgentMiddleware] = None
-        checkpointer: Any = None
+        # middleware: List[AgentMiddleware]
+        # checkpointer: Any
         middleware, checkpointer = middleware_factory.create_agent_middleware(self.middleware_config, sly_data)
 
         return create_agent(
@@ -392,8 +391,8 @@ class LangChainRunContext(RunContext):
         # Chat history is updated in write_message
         await self.journal.write_message(self.recent_human_message)
 
-        run: Run = LangChainRun(self.run_id_base, self.chat_history)
-        session_id: str = run.get_id()
+        use_run: Run = LangChainRun(self.run_id_base, self.chat_history)
+        session_id: str = use_run.get_id()
 
         runnable = RunContextRunnable(agent_chain=self.agent_chain,
                                       primary_llm=self.llm_resources.get_model(),
@@ -414,7 +413,7 @@ class LangChainRunContext(RunContext):
 
         await chain.ainvoke(input=inputs, config=runnable_config)
 
-        return run
+        return use_run
 
     async def get_response(self) -> List[BaseMessage]:
         """
@@ -445,9 +444,8 @@ class LangChainRunContext(RunContext):
                     await self.journal.write_message(tool_message)
 
         # Create a run to return
-        run = LangChainRun(self.run_id_base, self.chat_history, tool_message=tool_message)
-
-        return run
+        use_run = LangChainRun(self.run_id_base, self.chat_history, tool_message=tool_message)
+        return use_run
 
     def parse_tool_output(self, tool_output: Dict[str, Any]) -> BaseMessage:
         """
@@ -511,20 +509,20 @@ class LangChainRunContext(RunContext):
             tool_chat_list_string = tool_chat_list_string[1:-1]
 
         # Remove escaping
-        tool_chat_list_string = tool_chat_list_string.replace('\\"', '"')
+        intermediate_tool_chat_list_string = tool_chat_list_string.replace('\\"', '"')
         # Put back some escaping of double quotes in messages that are not json.
         # We have to do this because gpt-4o seems to not like json braces in its
         # input, but now we have to deal with the consequences in the output.
         # See ArgumentAssigner.get_args_value_as_string().
-        tool_chat_list_string = tool_chat_list_string.replace('\\"', '\\\\\"')
+        use_tool_chat_list_string = intermediate_tool_chat_list_string.replace('\\"', '\\\\\"')
 
         # Decode the JSON in that string now.
         tool_chat_list: List[Dict[str, Any]] = None
         try:
-            tool_chat_list = loads(tool_chat_list_string)
+            tool_chat_list = loads(use_tool_chat_list_string)
         except JSONDecodeError as exception:
             sensitive_logger = SensitiveLogger(self.logger)
-            sensitive_logger.error("Exception: %s parsing %s", str(exception), str(tool_chat_list_string))
+            sensitive_logger.error("Exception: %s parsing %s", str(exception), str(use_tool_chat_list_string))
             raise exception
 
         # The tool_output seems to contain the entire chat history of

--- a/neuro_san/internals/run_context/langchain/core/langchain_run_context.py
+++ b/neuro_san/internals/run_context/langchain/core/langchain_run_context.py
@@ -326,8 +326,8 @@ class LangChainRunContext(RunContext):
         middleware_factory = MiddlewareFactory(self.invocation_context, self.origin, self.chat_history, self.capsule)
         sly_data: Dict[str, Any] = self.tool_caller.get_sly_data()
 
-        # middleware: List[AgentMiddleware]
-        # checkpointer: Any
+        # middleware is a list of AgentMiddleware instances, perhaps empty.
+        # checkpointer is an opaque object native to langchain.
         middleware, checkpointer = middleware_factory.create_agent_middleware(self.middleware_config, sly_data)
 
         return create_agent(
@@ -430,6 +430,7 @@ class LangChainRunContext(RunContext):
                     "tool_call_id"  The string id of the tool_call being executed
         :return: A potentially updated run handle
         """
+        _ = run
         tool_message: BaseMessage = None
         if tool_outputs is not None and len(tool_outputs) > 0:
             for tool_output in tool_outputs:

--- a/neuro_san/internals/run_context/langchain/core/langchain_run_context.py
+++ b/neuro_san/internals/run_context/langchain/core/langchain_run_context.py
@@ -19,8 +19,9 @@ from typing import Dict
 from typing import List
 from typing import Union
 
-import json
-import uuid
+from json import loads
+from json.decoder import JSONDecodeError
+from uuid import uuid4
 
 from copy import copy
 from logging import Logger
@@ -101,7 +102,7 @@ class LangChainRunContext(RunContext):
 
         # This might get modified in create_resources() (for now)
         self.llm_config: Dict[str, Any] = llm_config
-        self.run_id_base: str = str(uuid.uuid4())
+        self.run_id_base: str = str(uuid4())
 
         self.tools: List[BaseTool] = []
         self.error_detector: ErrorDetector = None
@@ -520,8 +521,8 @@ class LangChainRunContext(RunContext):
         # Decode the JSON in that string now.
         tool_chat_list: List[Dict[str, Any]] = None
         try:
-            tool_chat_list = json.loads(tool_chat_list_string)
-        except json.decoder.JSONDecodeError as exception:
+            tool_chat_list = loads(tool_chat_list_string)
+        except JSONDecodeError as exception:
             sensitive_logger = SensitiveLogger(self.logger)
             sensitive_logger.error("Exception: %s parsing %s", str(exception), str(tool_chat_list_string))
             raise exception

--- a/neuro_san/internals/run_context/langchain/core/langchain_tool_call.py
+++ b/neuro_san/internals/run_context/langchain/core/langchain_tool_call.py
@@ -17,7 +17,7 @@
 from typing import Any
 from typing import Dict
 
-import uuid
+from uuid import uuid4
 
 from neuro_san.internals.run_context.interfaces.tool_call import ToolCall
 
@@ -47,7 +47,7 @@ class LangChainToolCall(ToolCall):
         """
         self.tool_name: str = tool_name
         self.args = args
-        self.id: str = f"tool_call_{run_id}_{uuid.uuid4()}"
+        self.id: str = f"tool_call_{run_id}_{uuid4()}"
         self.invocation: str = invocation
         if invocation is None:
             self.invocation = "chatbot"

--- a/neuro_san/internals/run_context/langchain/llms/standard_langchain_llm_factory.py
+++ b/neuro_san/internals/run_context/langchain/llms/standard_langchain_llm_factory.py
@@ -130,8 +130,8 @@ class StandardLangChainLlmFactory(LangChainLlmFactory):
         if policy_class is not None:
 
             # Use the LlmPolicy type we found in the lookup table to create an call a new instance.
-            llm_policy = policy_class()
-            llm, llm_policy = llm_policy.create_llm_resources_components(config)
+            llm_policy_instance = policy_class()
+            llm, llm_policy = llm_policy_instance.create_llm_resources_components(config)
 
         elif chat_class is None:
             raise ValueError(f"Class name {chat_class} for model_name {model_name} is unspecified.")

--- a/neuro_san/internals/run_context/langchain/mcp/langchain_mcp_adapter.py
+++ b/neuro_san/internals/run_context/langchain/mcp/langchain_mcp_adapter.py
@@ -20,7 +20,7 @@ from typing import Dict
 from typing import List
 from typing import Optional
 
-import copy
+from copy import copy
 from logging import Logger
 from logging import getLogger
 from threading import Lock
@@ -95,7 +95,7 @@ class LangChainMcpAdapter:
         if headers_dict:
             if isinstance(headers_dict, dict):
                 # Use a copy to avoid modifying the original headers dictionary.
-                mcp_tool_dict["headers"] = copy.copy(headers_dict)
+                mcp_tool_dict["headers"] = copy(headers_dict)
             else:
                 self.logger.error("MCP client headers for server %s must be a dictionary.",  server_url)
 

--- a/neuro_san/internals/run_context/langchain/mcp/mcp_servers_info_restorer.py
+++ b/neuro_san/internals/run_context/langchain/mcp/mcp_servers_info_restorer.py
@@ -43,17 +43,17 @@ class McpServersInfoRestorer(AbstractAsyncConfigRestorer):
         """
 
         # Basic file checking help in here
-        basis_config: Optional[Dict[str, Any]] = super().filter_config(basis_config, file_path)
+        use_basis_config: Optional[Dict[str, Any]] = super().filter_config(basis_config, file_path)
 
         # If there is no config (no file, or file not found), just return None to indicate that.
-        if basis_config is None:
+        if use_basis_config is None:
             return None
 
         # Keys (MCP endpoint urls, quoted in HOCON source) are quote-sanitized
         # at parse time (sanitize_keys=True), so only whitespace normalization
         # is left to do here.
         result_dict: Dict[str, Any] = {}
-        for key, value in basis_config.items():
+        for key, value in use_basis_config.items():
             use_key: str = key.strip()
             result_dict[use_key] = value
 

--- a/neuro_san/internals/run_context/langchain/mcp/mcp_tool_error_handler.py
+++ b/neuro_san/internals/run_context/langchain/mcp/mcp_tool_error_handler.py
@@ -20,7 +20,7 @@ from typing import Awaitable
 from typing import Callable
 
 from logging import getLogger
-import traceback
+from traceback import format_exc
 
 from langchain_core.tools import BaseTool
 
@@ -115,7 +115,7 @@ class McpToolErrorHandler:
             # Keep the full traceback in the server logs only;
             # the client-facing tool output is the concise message below.
             self.sensitive_logger.error("Error invoking MCP tool %s: %s", self.tool.name, str(exception))
-            self.sensitive_logger.error("%s", traceback.format_exc())
+            self.sensitive_logger.error("%s", format_exc())
             # Transport failures reach us wrapped in an ExceptionGroup by anyio,
             # whose str() is just "unhandled errors in a TaskGroup (N sub-exceptions)".
             # get_exception_details() recursively unwraps such groups so the LLM

--- a/neuro_san/internals/run_context/langchain/token_counting/langchain_token_counter.py
+++ b/neuro_san/internals/run_context/langchain/token_counting/langchain_token_counter.py
@@ -133,7 +133,7 @@ class LangChainTokenCounter:
         # Attempt to count tokens/costs while invoking the agent.
         # The means by which this happens is on a per-LLM basis, so get the right hook
         # given the LLM we've got.
-        callback: AsyncCallbackHandler = None
+
         # Record origin information in our own context var so we can associate
         # with the langchain callback context vars more easily.
         origin_str: str = Origination.get_full_name_from_origin(self.origin)

--- a/neuro_san/internals/run_context/langchain/token_counting/llm_token_callback_handler.py
+++ b/neuro_san/internals/run_context/langchain/token_counting/llm_token_callback_handler.py
@@ -17,7 +17,8 @@
 
 from asyncio import Lock as AsyncLock
 from contextvars import ContextVar
-import logging
+from logging import getLogger
+from logging import Logger
 from time import time
 from typing import Any
 from typing import Dict
@@ -282,7 +283,8 @@ class LlmTokenCallbackHandler(AsyncCallbackHandler):
             self._get_cost_from_info(model_name, prompt_tokens, "price_per_1k_input_tokens")
 
         if completion_token_cost is None and prompt_token_cost is None:
-            logging.warning("No price info found for model %s in llm info. Token cost defaults to 0.", model_name)
+            logger: Logger = getLogger(__name__)
+            logger.warning("No price info found for model %s in llm info. Token cost defaults to 0.", model_name)
 
         # Return total cost
         return (completion_token_cost or 0.0) + (prompt_token_cost or 0.0)

--- a/neuro_san/internals/run_context/langchain/tracing/neuro_san_runnable.py
+++ b/neuro_san/internals/run_context/langchain/tracing/neuro_san_runnable.py
@@ -204,8 +204,8 @@ class NeuroSanRunnable(RunnablePassthrough, RunTarget):
         request_keys: str = os.getenv("AGENT_TRACING_METADATA_REQUEST_KEYS",
                                       os.getenv("AGENT_FORWARDED_REQUEST_METADATA", "request_id user_id"))
         request_metadata: Dict[str, Any] = self.invocation_context.get_metadata()
-        to_add: Dict[str, Any] = MetadataUtil.minimize_metadata(request_metadata, request_keys)
-        runnable_metadata.update(to_add)
+        use_to_add: Dict[str, Any] = MetadataUtil.minimize_metadata(request_metadata, request_keys)
+        runnable_metadata.update(use_to_add)
 
         return runnable_metadata
 

--- a/neuro_san/session/async_direct_agent_session.py
+++ b/neuro_san/session/async_direct_agent_session.py
@@ -117,8 +117,7 @@ class AsyncDirectAgentSession(AsyncAgentSession):
         """
         self._log_agent_network_usage("function")
         _ = request_dict
-        response_dict: Dict[str, Any] = {
-        }
+        response_dict: Dict[str, Any] = {}
 
         front_man: str = self.agent_network.find_front_man()
         if front_man is not None:
@@ -144,14 +143,12 @@ class AsyncDirectAgentSession(AsyncAgentSession):
         """
         self._log_agent_network_usage("connectivity")
         _ = request_dict
-        response_dict: Dict[str, Any] = {
-        }
 
         reporter = ConnectivityReporter(self.agent_network, self.toolbox_factory)
         config: Dict[str, Any] = self.agent_network.get_config()
         metadata: Dict[str, Any] = config.get("metadata")
         connectivity_info: List[Dict[str, Any]] = reporter.report_network_connectivity()
-        response_dict = {
+        response_dict: Dict[str, Any] = {
             "connectivity_info": connectivity_info,
         }
         if metadata is not None:

--- a/neuro_san/session/async_direct_agent_session.py
+++ b/neuro_san/session/async_direct_agent_session.py
@@ -23,7 +23,8 @@ from typing import Optional
 
 from asyncio import Task
 from contextlib import suppress
-import logging
+from logging import getLogger
+from logging import Logger
 
 from leaf_common.asyncio.asyncio_executor import AsyncioExecutor
 from leaf_common.parsers.dictionary_extractor import DictionaryExtractor
@@ -93,7 +94,7 @@ class AsyncDirectAgentSession(AsyncAgentSession):
             self.toolbox_factory = invocation_context.get_toolbox_factory()
         if metadata is not None:
             self.request_id = metadata.get("request_id")
-        self.logger = logging.getLogger(self.__class__.__name__)
+        self.logger: Logger = getLogger(self.__class__.__name__)
 
     def _log_agent_network_usage(self, operation: str):
         """

--- a/neuro_san/session/direct_agent_session.py
+++ b/neuro_san/session/direct_agent_session.py
@@ -108,8 +108,7 @@ class DirectAgentSession(AgentSession):
                 "function" - the dictionary description of the function
         """
         _ = request_dict
-        response_dict: Dict[str, Any] = {
-        }
+        response_dict: Dict[str, Any] = {}
 
         front_man: str = self.agent_network.find_front_man()
         if front_man is not None:
@@ -134,14 +133,12 @@ class DirectAgentSession(AgentSession):
                                     wants the client ot know about.
         """
         _ = request_dict
-        response_dict: Dict[str, Any] = {
-        }
 
         reporter = ConnectivityReporter(self.agent_network, self.toolbox_factory)
         config: Dict[str, Any] = self.agent_network.get_config()
         metadata: Dict[str, Any] = config.get("metadata")
         connectivity_info: List[Dict[str, Any]] = reporter.report_network_connectivity()
-        response_dict = {
+        response_dict: Dict[str, Any] = {
             "connectivity_info": connectivity_info,
         }
         if metadata is not None:

--- a/neuro_san/session/http_concierge_session.py
+++ b/neuro_san/session/http_concierge_session.py
@@ -19,7 +19,7 @@ from typing import Any
 from typing import Dict
 
 from json import loads
-from requests import get
+from requests import get as http_get
 
 from neuro_san.interfaces.concierge_session import ConciergeSession
 from neuro_san.session.abstract_http_service_agent_session import AbstractHttpServiceAgentSession
@@ -42,8 +42,8 @@ class HttpConciergeSession(AbstractHttpServiceAgentSession, ConciergeSession):
         """
         path: str = self.get_request_path("list")
         try:
-            response = get(path, json=request_dict, headers=self.get_headers(),
-                           timeout=self.timeout_in_seconds)
+            response = http_get(path, json=request_dict, headers=self.get_headers(),
+                                timeout=self.timeout_in_seconds)
             result_dict = loads(response.text)
             return result_dict
         except Exception as exc:  # pylint: disable=broad-exception-caught

--- a/neuro_san/session/http_concierge_session.py
+++ b/neuro_san/session/http_concierge_session.py
@@ -18,8 +18,8 @@
 from typing import Any
 from typing import Dict
 
-import json
-import requests
+from json import loads
+from requests import get
 
 from neuro_san.interfaces.concierge_session import ConciergeSession
 from neuro_san.session.abstract_http_service_agent_session import AbstractHttpServiceAgentSession
@@ -42,9 +42,9 @@ class HttpConciergeSession(AbstractHttpServiceAgentSession, ConciergeSession):
         """
         path: str = self.get_request_path("list")
         try:
-            response = requests.get(path, json=request_dict, headers=self.get_headers(),
-                                    timeout=self.timeout_in_seconds)
-            result_dict = json.loads(response.text)
+            response = get(path, json=request_dict, headers=self.get_headers(),
+                           timeout=self.timeout_in_seconds)
+            result_dict = loads(response.text)
             return result_dict
         except Exception as exc:  # pylint: disable=broad-exception-caught
             raise ValueError(self.help_message(path)) from exc

--- a/neuro_san/session/session_invocation_context.py
+++ b/neuro_san/session/session_invocation_context.py
@@ -326,14 +326,14 @@ class SessionInvocationContext(InvocationContext):
 
         # We need different resources to close
         # Resources are not shared between sub-invocations
-        invocation_context.resources: List[LingeringResource] = []
+        invocation_context.resources = []
 
         # We need a different queue in order to call external agents with direct sessions.
-        invocation_context.queue: AsyncCollatingQueue = AsyncCollatingQueue()
+        invocation_context.queue = AsyncCollatingQueue()
 
         # Now that the queue has changed, we need a new Journal as well
         # to be sure that the messages are sent to the correct queue.
-        invocation_context.journal: Journal = MessageJournal(invocation_context.queue)
+        invocation_context.journal = MessageJournal(invocation_context.queue)
 
         # If an invocation was provided, use it
         if invocation is not None:

--- a/neuro_san/session/session_invocation_context.py
+++ b/neuro_san/session/session_invocation_context.py
@@ -322,7 +322,7 @@ class SessionInvocationContext(InvocationContext):
 
         # We need a different Event to signal work is done
         # Work being all done on a sub-invocation is not the same as work all done on the root.
-        invocation_context.work_done_event: Event = Event()
+        invocation_context.work_done_event = Event()
 
         # We need different resources to close
         # Resources are not shared between sub-invocations

--- a/tests/neuro_san/internals/graph/activations/test_abstract_class_activation.py
+++ b/tests/neuro_san/internals/graph/activations/test_abstract_class_activation.py
@@ -48,8 +48,8 @@ class ConcreteClassActivation(AbstractClassActivation):
     """Concrete implementation for testing purposes."""
     # pylint: disable=too-many-arguments
     # pylint: disable=too-many-positional-arguments
-    def __init__(self, parent_run_context, factory, arguments, agent_tool_spec, sly_data, class_ref: str):
-        super().__init__(parent_run_context, factory, arguments, agent_tool_spec, sly_data)
+    def __init__(self, parent_run_context, factory, args, agent_tool_spec, sly_data, class_ref: str):
+        super().__init__(parent_run_context, factory, args, agent_tool_spec, sly_data)
         self._class_ref = class_ref
 
     def get_full_class_ref(self) -> str:
@@ -71,12 +71,12 @@ class MockBranchActivationTool(CodedTool):
     """
     # pylint: disable=too-many-arguments
     # pylint: disable=too-many-positional-arguments
-    def __init__(self, run_context, factory, arguments, agent_tool_spec, sly_data):
+    def __init__(self, run_context, factory, args, agent_tool_spec, sly_data):
         # Store the initialization parameters for verification
         self.init_params = {
             'run_context': run_context,
             'factory': factory,
-            'arguments': arguments,
+            'args': args,
             'agent_tool_spec': agent_tool_spec,
             'sly_data': sly_data
         }
@@ -147,7 +147,7 @@ def activation_instance(mock_run_context, mock_factory, basic_agent_tool_spec):
             activation = ConcreteClassActivation(
                 parent_run_context=mock_run_context,
                 factory=mock_factory,
-                arguments={"test_arg": "test_value"},
+                args={"test_arg": "test_value"},
                 agent_tool_spec=basic_agent_tool_spec,
                 sly_data={"test_sly": "test_data"},
                 class_ref="test_module.TestClass"
@@ -289,7 +289,7 @@ class TestAbstractClassActivation:
             assert isinstance(result, MockBranchActivationTool)
             # Verify it was initialized with correct parameters
             assert result.init_params['factory'] == mock_factory
-            assert result.init_params['arguments'] == activation_instance.arguments
+            assert result.init_params['args'] == activation_instance.arguments
 
     def test_instantiate_coded_tool_with_constructor_fails(self, activation_instance):
         """Test that instantiating a CodedTool with required constructor args raises TypeError."""
@@ -355,7 +355,7 @@ class TestAbstractClassActivation:
                 activation = ConcreteClassActivation(
                     parent_run_context=mock_run_context,
                     factory=mock_factory,
-                    arguments=None,
+                    args=None,
                     agent_tool_spec=basic_agent_tool_spec,
                     sly_data={},
                     class_ref="test.Class"
@@ -373,7 +373,7 @@ class TestAbstractClassActivation:
                 activation = ConcreteClassActivation(
                     parent_run_context=mock_run_context,
                     factory=mock_factory,
-                    arguments={"origin": existing_origin, "origin_str": "custom_str"},
+                    args={"origin": existing_origin, "origin_str": "custom_str"},
                     agent_tool_spec=basic_agent_tool_spec,
                     sly_data={},
                     class_ref="test.Class"
@@ -400,7 +400,7 @@ class TestAbstractClassActivation:
                 activation = ConcreteClassActivation(
                     parent_run_context=mock_run_context,
                     factory=mock_factory,
-                    arguments={},
+                    args={},
                     agent_tool_spec=agent_tool_spec,
                     sly_data={},
                     class_ref="test.Class"
@@ -437,7 +437,7 @@ def make_activation(mock_run_context, agent_tool_path: str, network_name: str,
             return ConcreteClassActivation(
                 parent_run_context=mock_run_context,
                 factory=factory,
-                arguments={},
+                args={},
                 agent_tool_spec={"name": agent_name, "description": "Test tool"},
                 sly_data={},
                 class_ref="unused.Unused"


### PR DESCRIPTION
Remove unnecessary initialization of local vars
Expand imports to one for each method/class instead of whole package
Rename some reused variables that are method return values.
Don't type hint in secondary assignments.

Tested AND w/ santa