### PR TITLE
Use shared PyPI publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,26 +24,16 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Python environment
-        # 1.0.9
-        uses: cognizant-ai-lab/build-common/actions/setup-python-env@b14b3de23cb9aca02b2165e57542335e0c8f5304
+      - name: Build and publish package
+        # 1.0.10
+        uses: cognizant-ai-lab/build-common/actions/publish-pypi@cb254b1336a6a6034008eab4d5a94a9c034fa89c
         with:
           python-version: '3.10'
-          requirements-file: ''
-          requirements-build-file: ''
-          install-extras: 'build'
-
-      - name: Build wheel and sdist
-        run: python -m build
-
-      # v1.14.0
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
 
       - name: Notify Slack
         if: ${{ !cancelled() }}
-        # 1.0.9
-        uses: cognizant-ai-lab/build-common/actions/slack-notify@b14b3de23cb9aca02b2165e57542335e0c8f5304
+        # 1.0.10
+        uses: cognizant-ai-lab/build-common/actions/slack-notify@cb254b1336a6a6034008eab4d5a94a9c034fa89c
         with:
           status: ${{ job.status }}
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
## Summary
Replace the duplicated Python setup, `python -m build`, and `pypa/gh-action-pypi-publish` steps with build-common 1.0.10's `publish-pypi` composite action. The release trigger, repository guard, `pypi` environment, and `id-token: write` permission stay in this workflow, so the PyPI Trusted Publisher identity (`neuro-san` + `.github/workflows/publish.yml` + `pypi`) is unchanged.

Link to Devin session: https://app.devin.ai/sessions/f5f966f41bb8464bbde2ae5144dd9d48
Requested by: @donn-leaf
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cognizant-ai-lab/neuro-san/pull/1277" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->