### PR TITLE
Cache dynamically created args_schema models by spec content

### DIFF
--- a/neuro_san/internals/run_context/langchain/core/base_model_dictionary_converter.py
+++ b/neuro_san/internals/run_context/langchain/core/base_model_dictionary_converter.py
@@ -133,11 +133,11 @@ class BaseModelDictionaryConverter(DictionaryConverter):
         # At this point we are not going back to OpenAI functional specs
         raise NotImplementedError
 
-    def from_dict(self, obj_dict: Dict[str, Any]) -> BaseModel:
+    def from_dict(self, obj_dict: Optional[Dict[str, Any]]) -> Optional[Type[BaseModel]]:
         """
         :param obj_dict: The data-only dictionary to be converted into an object
-        :return: An object instance created from the given dictionary.
-                If obj_dict is None, the returned object should also be None.
+        :return: The pydantic model class created from the given dictionary.
+                If obj_dict is None, the returned value should also be None.
                 If obj_dict is not the correct type, it is also reasonable
                 to return None.
 
@@ -163,7 +163,7 @@ class BaseModelDictionaryConverter(DictionaryConverter):
 
         cache: OrderedDict = BaseModelDictionaryConverter._model_cache
         with BaseModelDictionaryConverter._model_cache_lock:
-            base_model: BaseModel = cache.get(cache_key)
+            base_model: Optional[Type[BaseModel]] = cache.get(cache_key)
             if base_model is not None:
                 cache.move_to_end(cache_key)
                 return base_model
@@ -209,15 +209,15 @@ class BaseModelDictionaryConverter(DictionaryConverter):
         # pydantic validation error messages), so it is part of the key.
         return f"{self.top_level_field_name}:{spec_json}"
 
-    def openai_function_to_pydantic(self, name: str, function_dict: Dict[str, Any]) -> BaseModel:
+    def openai_function_to_pydantic(self, name: str, function_dict: Dict[str, Any]) -> Type[BaseModel]:
         """
-        Turns an openai function spec dictionary into a pydantic BaseModel
+        Turns an openai function spec dictionary into a pydantic BaseModel class
         See: https://docs.pydantic.dev/latest/concepts/models/#dynamic-model-creation
 
         :param name: The string name of the object/field undergoing conversion
         :param function_dict: The dictionary describing the OpenAI function to
                     be converted into a pydantic BaseModel
-        :return: The pydantic BaseModel that corresponds to the OpenAI function spec.
+        :return: The pydantic BaseModel class that corresponds to the OpenAI function spec.
         """
 
         # Get stuff from the object-level function dictionary
@@ -315,7 +315,7 @@ class BaseModelDictionaryConverter(DictionaryConverter):
         # crash the run - langchain surfaces them to the calling LLM as a
         # correctable tool-error message, at the cost of a retry round-trip.
         try:
-            model: BaseModel = create_model(name, **fields)
+            model: Type[BaseModel] = create_model(name, **fields)
         except (NameError, TypeError) as exception:
             # Safety net for anything validate_field_name() does not cover:
             # report whatever create_model() rejects as the same spec-error

--- a/neuro_san/internals/run_context/langchain/core/base_model_dictionary_converter.py
+++ b/neuro_san/internals/run_context/langchain/core/base_model_dictionary_converter.py
@@ -101,6 +101,13 @@ class BaseModelDictionaryConverter(DictionaryConverter):
     # specs over the network per request - without a bound, a misbehaving
     # remote agent whose spec varies per response would grow this without
     # limit.  Eviction is least-recently-used.
+    #
+    # Hand-rolled rather than functools.lru_cache: lru_cache can only key
+    # on hashables, so the builder would have to recover the spec with
+    # json.loads(key) and build from the round-tripped dictionary.  This
+    # cache keys on the serialized form but builds from the ORIGINAL
+    # dictionary, so what gets built is byte-for-byte what an uncached
+    # build would have produced.
     MODEL_CACHE_MAX_SIZE: int = 256
     _model_cache: OrderedDict = OrderedDict()
     _model_cache_lock: Lock = Lock()
@@ -133,18 +140,25 @@ class BaseModelDictionaryConverter(DictionaryConverter):
                 If obj_dict is None, the returned object should also be None.
                 If obj_dict is not the correct type, it is also reasonable
                 to return None.
+
+                The returned model class may be shared with every other
+                caller that converted an identical spec (see the cache
+                note on the class attributes above) - treat it as
+                immutable.  Mutating it in place would leak the change
+                into every tool and request sharing the spec.
         """
         # Honor the DictionaryConverter contract stated above.  None reaches
         # here when an external agent reports "parameters": null.
         if obj_dict is None:
             return None
 
-        cache_key: str = self.get_cache_key(obj_dict)
+        cache_key: Optional[str] = self.get_cache_key(obj_dict)
         if cache_key is None:
-            # The spec contains values JSON cannot represent.  Neither hocon
-            # registries nor network specs can produce those (both are born
-            # as JSON), so this is only reachable from in-process callers -
-            # build uncached rather than fail.
+            # The spec cannot be serialized for keying: it contains values
+            # JSON cannot represent, or is nested too deeply to serialize.
+            # Neither hocon registries nor network specs can produce those
+            # (both are born as JSON), so this is only reachable from
+            # in-process callers - build uncached rather than fail.
             return self.openai_function_to_pydantic(self.top_level_field_name, obj_dict)
 
         cache: OrderedDict = BaseModelDictionaryConverter._model_cache
@@ -169,7 +183,7 @@ class BaseModelDictionaryConverter(DictionaryConverter):
 
         return base_model
 
-    def get_cache_key(self, obj_dict: Dict[str, Any]) -> str:
+    def get_cache_key(self, obj_dict: Dict[str, Any]) -> Optional[str]:
         """
         :param obj_dict: The spec dictionary a model is being created from
         :return: A string cache key uniquely identifying the model that
@@ -182,8 +196,13 @@ class BaseModelDictionaryConverter(DictionaryConverter):
             # schema advertised to LLM providers.  Specs that differ only in
             # key order therefore get separate cache entries instead of one
             # of them being served a bytes-different schema.
+            #
+            # RecursionError: dumps() walks the whole spec, including deep
+            # nesting under keys the model builder itself never recurses
+            # into, so it can hit the recursion limit on a spec the
+            # uncached build handles fine.  Fall back to that build.
             spec_json: str = dumps(obj_dict, separators=(",", ":"))
-        except (TypeError, ValueError):
+        except (RecursionError, TypeError, ValueError):
             return None
 
         # The name becomes the created model's class name (visible in

--- a/neuro_san/internals/run_context/langchain/core/base_model_dictionary_converter.py
+++ b/neuro_san/internals/run_context/langchain/core/base_model_dictionary_converter.py
@@ -23,6 +23,10 @@ from typing import Optional
 from typing import Type
 from typing import Union
 
+from collections import OrderedDict
+from json import dumps
+from threading import Lock
+
 from pydantic import BaseModel
 from pydantic import Field
 from pydantic import create_model
@@ -83,6 +87,24 @@ class BaseModelDictionaryConverter(DictionaryConverter):
         "object": Dict[str, Any]
     }
 
+    # Cache of created models, shared by every converter instance.
+    #
+    # pydantic v2's create_model() compiles a Rust core schema per call
+    # (multiplied by nesting depth, since each nested object is its own
+    # create_model() call), and the specs arriving here are overwhelmingly
+    # static registry data that would otherwise be re-converted for every
+    # tool of every agent activation on every request.  Model classes are
+    # immutable once created, so identical specs can safely share one
+    # cached class across threads and requests.  See issue #1209.
+    #
+    # The cache is bounded because external agents send their function
+    # specs over the network per request - without a bound, a misbehaving
+    # remote agent whose spec varies per response would grow this without
+    # limit.  Eviction is least-recently-used.
+    MODEL_CACHE_MAX_SIZE: int = 256
+    _model_cache: OrderedDict = OrderedDict()
+    _model_cache_lock: Lock = Lock()
+
     def __init__(self, top_level_field_name: str):
         """
         Constructor
@@ -117,8 +139,56 @@ class BaseModelDictionaryConverter(DictionaryConverter):
         if obj_dict is None:
             return None
 
-        base_model: BaseModel = self.openai_function_to_pydantic(self.top_level_field_name, obj_dict)
+        cache_key: str = self.get_cache_key(obj_dict)
+        if cache_key is None:
+            # The spec contains values JSON cannot represent.  Neither hocon
+            # registries nor network specs can produce those (both are born
+            # as JSON), so this is only reachable from in-process callers -
+            # build uncached rather than fail.
+            return self.openai_function_to_pydantic(self.top_level_field_name, obj_dict)
+
+        cache: OrderedDict = BaseModelDictionaryConverter._model_cache
+        with BaseModelDictionaryConverter._model_cache_lock:
+            base_model: BaseModel = cache.get(cache_key)
+            if base_model is not None:
+                cache.move_to_end(cache_key)
+                return base_model
+
+        # Build outside the lock: create_model() is the slow part, and two
+        # threads racing to convert the same spec just produce two equivalent
+        # classes, one of which wins the cache below.  Spec errors raised
+        # here propagate uncached, so a bad spec is re-reported every time
+        # it is seen.
+        base_model = self.openai_function_to_pydantic(self.top_level_field_name, obj_dict)
+
+        with BaseModelDictionaryConverter._model_cache_lock:
+            cache[cache_key] = base_model
+            cache.move_to_end(cache_key)
+            while len(cache) > BaseModelDictionaryConverter.MODEL_CACHE_MAX_SIZE:
+                cache.popitem(last=False)
+
         return base_model
+
+    def get_cache_key(self, obj_dict: Dict[str, Any]) -> str:
+        """
+        :param obj_dict: The spec dictionary a model is being created from
+        :return: A string cache key uniquely identifying the model that
+                openai_function_to_pydantic() would build from the spec,
+                or None if the spec cannot be serialized for keying.
+        """
+        try:
+            # Keys are deliberately NOT sorted: the created model preserves
+            # the spec's own field order, which flows through to the JSON
+            # schema advertised to LLM providers.  Specs that differ only in
+            # key order therefore get separate cache entries instead of one
+            # of them being served a bytes-different schema.
+            spec_json: str = dumps(obj_dict, separators=(",", ":"))
+        except (TypeError, ValueError):
+            return None
+
+        # The name becomes the created model's class name (visible in
+        # pydantic validation error messages), so it is part of the key.
+        return f"{self.top_level_field_name}:{spec_json}"
 
     def openai_function_to_pydantic(self, name: str, function_dict: Dict[str, Any]) -> BaseModel:
         """

--- a/neuro_san/internals/validation/network/pydantic_parameters_network_validator.py
+++ b/neuro_san/internals/validation/network/pydantic_parameters_network_validator.py
@@ -62,6 +62,12 @@ class PydanticParametersNetworkValidator(AbstractNetworkValidator):
 
         self.logger.debug("Validating %s parameters via pydantic...", self.network_name)
 
+        # The converter is stateless, so one instance serves every agent.
+        # Its from_dict() caches created models by spec content, so
+        # validating here also warms the cache the tool-creation path
+        # reads from on the first request.
+        converter = BaseModelDictionaryConverter("parameters")
+
         for agent_name, agent_spec in name_to_spec.items():
             params: Any = self._locate_parameters(agent_spec)
 
@@ -87,7 +93,6 @@ class PydanticParametersNetworkValidator(AbstractNetworkValidator):
                 continue
 
             try:
-                converter = BaseModelDictionaryConverter("parameters")
                 converter.from_dict(params)
             except (AttributeError, KeyError, TypeError, ValueError) as exc:
                 detail: str = " ".join(str(exc).split())

--- a/neuro_san/internals/validation/network/pydantic_parameters_network_validator.py
+++ b/neuro_san/internals/validation/network/pydantic_parameters_network_validator.py
@@ -63,9 +63,6 @@ class PydanticParametersNetworkValidator(AbstractNetworkValidator):
         self.logger.debug("Validating %s parameters via pydantic...", self.network_name)
 
         # The converter is stateless, so one instance serves every agent.
-        # Its from_dict() caches created models by spec content, so
-        # validating here also warms the cache the tool-creation path
-        # reads from on the first request.
         converter = BaseModelDictionaryConverter("parameters")
 
         for agent_name, agent_spec in name_to_spec.items():

--- a/tests/neuro_san/internals/run_context/langchain/core/test_base_model_dictionary_converter.py
+++ b/tests/neuro_san/internals/run_context/langchain/core/test_base_model_dictionary_converter.py
@@ -31,21 +31,62 @@ from neuro_san.internals.run_context.langchain.core.base_model_dictionary_conver
 from neuro_san.internals.run_context.langchain.core.tool_spec_error import ToolSpecError
 
 
+# pylint: disable=too-many-public-methods
 class TestBaseModelDictionaryConverter:
     """
     Test cases for the OpenAI-function-spec -> pydantic BaseModel conversion,
-    with emphasis on the handling of bare "object" parameters (no properties).
+    the handling of malformed specs, and the spec-keyed model cache.
 
-    Bare objects map to Dict[str, Any] rather than Any so that the JSON
-    schema advertised to LLM providers declares a real object type.  A bare
-    Any produced an empty schema ({}), which langchain-google-genai degrades
-    to a STRING declaration - Gemini then sends JSON-encoded strings where
-    tools expect dictionaries.
+    Conversion: bare "object" parameters map to Dict[str, Any] rather than
+    Any so that the JSON schema advertised to LLM providers declares a real
+    object type.  A bare Any produced an empty schema ({}), which
+    langchain-google-genai degrades to a STRING declaration - Gemini then
+    sends JSON-encoded strings where tools expect dictionaries.
+
+    Malformed specs: these produce clean ToolSpecErrors (or honor documented
+    contracts) instead of raw AttributeError/TypeError crashes.  Explicit
+    nulls and wrong-typed values are reachable from both hocon registries
+    (pyhocon preserves explicit nulls) and the unvalidated JSON function
+    specs external agents send over the network.
+
+    The cache (issue #1209): specs are static registry data re-converted for
+    every tool of every agent activation on every request, so from_dict()
+    caches the created model class by spec content.  The cache tests pin
+    down that contract: content-keyed sharing across converter instances,
+    key-order sensitivity (field order flows through to the provider-facing
+    JSON schema), LRU eviction, and the uncached fallbacks.
     """
 
-    def _convert(self, parameters: Dict[str, Any]) -> BaseModel:
-        converter = BaseModelDictionaryConverter("parameters")
+    SPEC: Dict[str, Any] = {
+        "properties": {
+            "city": {"type": "string", "description": "Which city"},
+            "days": {"type": "integer"},
+        },
+        "required": ["city"],
+    }
+
+    @pytest.fixture(autouse=True)
+    def clear_model_cache(self):
+        """
+        The model cache is class-level, process-wide state.  Clear it around
+        every test so tests stay order-independent.
+        """
+        BaseModelDictionaryConverter._model_cache.clear()   # pylint: disable=protected-access
+        yield
+        BaseModelDictionaryConverter._model_cache.clear()   # pylint: disable=protected-access
+
+    def _convert(self, parameters: Dict[str, Any], name: str = "parameters") -> BaseModel:
+        """
+        Run the given parameters spec through a fresh converter.
+
+        :param parameters: The parameters spec dictionary to convert
+        :param name: The top-level field name for the converter
+        :return: The pydantic model class from_dict() produces
+        """
+        converter = BaseModelDictionaryConverter(name)
         return converter.from_dict(parameters)
+
+    # ---- Conversion of well-formed specs -----------------------------------
 
     def test_bare_object_accepts_dict_as_plain_dict(self):
         """A well-formed dict argument reaches the tool as the same plain dict."""
@@ -126,20 +167,7 @@ class TestBaseModelDictionaryConverter:
         with pytest.raises(ValidationError):
             model.model_validate({"records": ["not-a-dict"]})
 
-
-class TestMalformedSpecHandling:
-    """
-    Malformed specs produce clean ToolSpecErrors (or honor documented
-    contracts) instead of raw AttributeError/TypeError crashes.
-
-    Explicit nulls and wrong-typed values are reachable from both hocon
-    registries (pyhocon preserves explicit nulls) and the unvalidated
-    JSON function specs external agents send over the network.
-    """
-
-    def _convert(self, parameters):
-        converter = BaseModelDictionaryConverter("parameters")
-        return converter.from_dict(parameters)
+    # ---- Malformed specs ----------------------------------------------------
 
     def test_from_dict_none_returns_none(self):
         """The DictionaryConverter contract: None in -> None out."""
@@ -230,46 +258,7 @@ class TestMalformedSpecHandling:
                 "properties": {"tags": {"type": "array", "items": "cao_item"}},
             })
 
-
-class TestModelCaching:
-    """
-    Test cases for the spec-keyed model cache (issue #1209).
-
-    Specs are static registry data re-converted for every tool of every
-    agent activation on every request, so from_dict() caches the created
-    model class by spec content.  These tests pin down the cache contract:
-    content-keyed sharing across converter instances, key-order sensitivity
-    (field order flows through to the provider-facing JSON schema), LRU
-    eviction, and the uncached fallbacks.
-    """
-
-    SPEC: Dict[str, Any] = {
-        "properties": {
-            "city": {"type": "string", "description": "Which city"},
-            "days": {"type": "integer"},
-        },
-        "required": ["city"],
-    }
-
-    @pytest.fixture(autouse=True)
-    def clear_model_cache(self):
-        """
-        The cache is class-level, process-wide state.  Clear it around each
-        test so tests stay order-independent.
-        """
-        BaseModelDictionaryConverter._model_cache.clear()   # pylint: disable=protected-access
-        yield
-        BaseModelDictionaryConverter._model_cache.clear()   # pylint: disable=protected-access
-
-    def _convert(self, parameters: Dict[str, Any], name: str = "parameters") -> BaseModel:
-        converter = BaseModelDictionaryConverter(name)
-        return converter.from_dict(parameters)
-
-    def test_same_spec_returns_cached_model(self):
-        """The very same spec dict converts to the very same model class."""
-        first = self._convert(self.SPEC)
-        second = self._convert(self.SPEC)
-        assert second is first
+    # ---- The spec-keyed model cache (issue #1209) ---------------------------
 
     def test_equal_content_shares_model_across_instances(self):
         """
@@ -332,11 +321,11 @@ class TestModelCaching:
 
         model_a = self._convert(spec_a)
         model_b = self._convert(spec_b)
-        model_c = self._convert(spec_c)          # evicts spec_a
+        model_c = self._convert(spec_c)               # evicts spec_a
 
-        assert self._convert(spec_c) is model_c  # still cached
-        assert self._convert(spec_b) is model_b  # still cached
-        assert self._convert(spec_a) is not model_a  # was evicted, rebuilt
+        assert self._convert(spec_c) is model_c       # still cached
+        assert self._convert(spec_b) is model_b       # still cached
+        assert self._convert(spec_a) is not model_a   # was evicted, rebuilt
 
     def test_unserializable_spec_builds_uncached(self):
         """
@@ -348,6 +337,26 @@ class TestModelCaching:
         }
         model = self._convert(spec)
         assert issubclass(model, BaseModel)
+        assert len(BaseModelDictionaryConverter._model_cache) == 0   # pylint: disable=protected-access
+
+    def test_deeply_nested_ignored_key_builds_uncached(self):
+        """
+        json.dumps walks the whole spec for keying and can exceed the
+        recursion limit on deep nesting under a key the model builder
+        itself never recurses into.  That RecursionError must fall back
+        to an uncached build, not propagate out of from_dict.
+        """
+        deep: Dict[str, Any] = {}
+        node: Dict[str, Any] = deep
+        for _ in range(10000):
+            node["next"] = {}
+            node = node["next"]
+        spec: Dict[str, Any] = {
+            "properties": {"f": {"type": "string", "extra": deep}},
+        }
+        model = self._convert(spec)
+        assert issubclass(model, BaseModel)
+        assert model.model_validate({"f": "ok"}).f == "ok"
         assert len(BaseModelDictionaryConverter._model_cache) == 0   # pylint: disable=protected-access
 
     def test_bad_spec_raises_every_time_and_is_not_cached(self):

--- a/tests/neuro_san/internals/run_context/langchain/core/test_base_model_dictionary_converter.py
+++ b/tests/neuro_san/internals/run_context/langchain/core/test_base_model_dictionary_converter.py
@@ -17,6 +17,9 @@
 
 from typing import Any
 from typing import Dict
+from typing import List
+
+from threading import Thread
 
 import pytest
 
@@ -226,3 +229,177 @@ class TestMalformedSpecHandling:
             self._convert({
                 "properties": {"tags": {"type": "array", "items": "cao_item"}},
             })
+
+
+class TestModelCaching:
+    """
+    Test cases for the spec-keyed model cache (issue #1209).
+
+    Specs are static registry data re-converted for every tool of every
+    agent activation on every request, so from_dict() caches the created
+    model class by spec content.  These tests pin down the cache contract:
+    content-keyed sharing across converter instances, key-order sensitivity
+    (field order flows through to the provider-facing JSON schema), LRU
+    eviction, and the uncached fallbacks.
+    """
+
+    SPEC: Dict[str, Any] = {
+        "properties": {
+            "city": {"type": "string", "description": "Which city"},
+            "days": {"type": "integer"},
+        },
+        "required": ["city"],
+    }
+
+    @pytest.fixture(autouse=True)
+    def clear_model_cache(self):
+        """
+        The cache is class-level, process-wide state.  Clear it around each
+        test so tests stay order-independent.
+        """
+        BaseModelDictionaryConverter._model_cache.clear()   # pylint: disable=protected-access
+        yield
+        BaseModelDictionaryConverter._model_cache.clear()   # pylint: disable=protected-access
+
+    def _convert(self, parameters: Dict[str, Any], name: str = "parameters") -> BaseModel:
+        converter = BaseModelDictionaryConverter(name)
+        return converter.from_dict(parameters)
+
+    def test_same_spec_returns_cached_model(self):
+        """The very same spec dict converts to the very same model class."""
+        first = self._convert(self.SPEC)
+        second = self._convert(self.SPEC)
+        assert second is first
+
+    def test_equal_content_shares_model_across_instances(self):
+        """
+        The cache is keyed on content, not object identity, and is shared
+        by all converter instances - this is what lets registry validation
+        at load time warm the cache the tool-creation path reads from.
+        """
+        copy_of_spec: Dict[str, Any] = {
+            "properties": {
+                "city": {"type": "string", "description": "Which city"},
+                "days": {"type": "integer"},
+            },
+            "required": ["city"],
+        }
+        first = self._convert(self.SPEC)
+        second = self._convert(copy_of_spec)
+        assert second is first
+
+    def test_key_order_gets_separate_entries(self):
+        """
+        Field order flows through to the JSON schema advertised to LLM
+        providers, so specs differing only in property order deliberately
+        do NOT share a model.
+        """
+        reordered: Dict[str, Any] = {
+            "properties": {
+                "days": {"type": "integer"},
+                "city": {"type": "string", "description": "Which city"},
+            },
+            "required": ["city"],
+        }
+        first = self._convert(self.SPEC)
+        second = self._convert(reordered)
+        assert second is not first
+        assert list(first.model_fields.keys()) == ["city", "days"]
+        assert list(second.model_fields.keys()) == ["days", "city"]
+
+    def test_top_level_field_name_is_part_of_the_key(self):
+        """
+        The converter's top_level_field_name becomes the model's class name,
+        which pydantic uses in validation error messages - same spec under a
+        different name must not share a cache entry.
+        """
+        first = self._convert(self.SPEC, name="parameters")
+        second = self._convert(self.SPEC, name="sly_data_schema")
+        assert second is not first
+        assert first.__name__ == "parameters"
+        assert second.__name__ == "sly_data_schema"
+
+    def test_lru_eviction_at_bound(self, monkeypatch):
+        """
+        Oldest entry falls out once the bound is exceeded; re-converting it
+        afterwards builds a fresh class.
+        """
+        monkeypatch.setattr(BaseModelDictionaryConverter, "MODEL_CACHE_MAX_SIZE", 2)
+
+        spec_a: Dict[str, Any] = {"properties": {"a": {"type": "string"}}}
+        spec_b: Dict[str, Any] = {"properties": {"b": {"type": "string"}}}
+        spec_c: Dict[str, Any] = {"properties": {"c": {"type": "string"}}}
+
+        model_a = self._convert(spec_a)
+        model_b = self._convert(spec_b)
+        model_c = self._convert(spec_c)          # evicts spec_a
+
+        assert self._convert(spec_c) is model_c  # still cached
+        assert self._convert(spec_b) is model_b  # still cached
+        assert self._convert(spec_a) is not model_a  # was evicted, rebuilt
+
+    def test_unserializable_spec_builds_uncached(self):
+        """
+        A spec containing values JSON cannot represent (only reachable from
+        in-process callers) still converts - it just never enters the cache.
+        """
+        spec: Dict[str, Any] = {
+            "properties": {"blob": {"type": "string", "description": b"raw-bytes"}},
+        }
+        model = self._convert(spec)
+        assert issubclass(model, BaseModel)
+        assert len(BaseModelDictionaryConverter._model_cache) == 0   # pylint: disable=protected-access
+
+    def test_bad_spec_raises_every_time_and_is_not_cached(self):
+        """Spec errors propagate uncached so they are re-reported when re-seen."""
+        bad_spec: Dict[str, Any] = {"properties": {"x": {"type": "interger"}}}
+        for _ in range(2):
+            with pytest.raises(ToolSpecError, match="Unrecognized type"):
+                self._convert(bad_spec)
+        assert len(BaseModelDictionaryConverter._model_cache) == 0   # pylint: disable=protected-access
+
+    def test_concurrent_conversion_is_safe(self):
+        """
+        Threads racing on the same spec all get a usable model and the
+        cache converges to one entry per distinct spec.
+        """
+        results: List[Any] = []
+
+        def convert():
+            results.append(self._convert(self.SPEC))
+
+        threads: List[Thread] = [Thread(target=convert) for _ in range(8)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        assert len(results) == 8
+        for model in results:
+            assert issubclass(model, BaseModel)
+            assert model.model_validate({"city": "Lisbon"}).city == "Lisbon"
+        assert len(BaseModelDictionaryConverter._model_cache) == 1   # pylint: disable=protected-access
+
+    def test_edited_spec_gets_fresh_model_not_stale_cache(self):
+        """
+        Hot-reload safety: the server can refresh registries every few
+        seconds without a restart.  The cache is keyed on spec content, so
+        an edited parameters block is a guaranteed miss - the old model
+        cannot be served for it - while the unchanged case reuses a model
+        identical to what a rebuild would produce.
+        """
+        before = self._convert(self.SPEC)
+
+        edited_spec: Dict[str, Any] = {
+            "properties": {
+                "city": {"type": "string", "description": "Which city"},
+                "days": {"type": "integer"},
+                "units": {"type": "string"},   # field added by a hocon edit
+            },
+            "required": ["city"],
+        }
+        after = self._convert(edited_spec)
+
+        assert after is not before
+        assert "units" in after.model_fields
+        assert "units" not in before.model_fields

--- a/tests/neuro_san/internals/run_context/langchain/core/test_base_model_dictionary_converter.py
+++ b/tests/neuro_san/internals/run_context/langchain/core/test_base_model_dictionary_converter.py
@@ -18,6 +18,8 @@
 from typing import Any
 from typing import Dict
 from typing import List
+from typing import Optional
+from typing import Type
 
 from threading import Thread
 
@@ -75,13 +77,15 @@ class TestBaseModelDictionaryConverter:
         yield
         BaseModelDictionaryConverter._model_cache.clear()   # pylint: disable=protected-access
 
-    def _convert(self, parameters: Dict[str, Any], name: str = "parameters") -> BaseModel:
+    def _convert(self, parameters: Optional[Dict[str, Any]],
+                 name: str = "parameters") -> Optional[Type[BaseModel]]:
         """
         Run the given parameters spec through a fresh converter.
 
         :param parameters: The parameters spec dictionary to convert
+                (None exercises the documented None -> None contract)
         :param name: The top-level field name for the converter
-        :return: The pydantic model class from_dict() produces
+        :return: The pydantic model class from_dict() produces, or None
         """
         converter = BaseModelDictionaryConverter(name)
         return converter.from_dict(parameters)


### PR DESCRIPTION
Addresses the model-caching item of #1209.

## Why

`args_schema` pydantic models were rebuilt from scratch for every tool of every agent activation on every request, plus once more per agent at registry load (where the validator built and discarded them). pydantic v2's `create_model()` compiles a Rust core schema on every call — **~0.68 ms** for a representative nested spec, multiplied by nesting depth since each nested object is its own `create_model()` call — even though the specs are static registry data.

## What

- `BaseModelDictionaryConverter.from_dict()` now serves models from a class-level, bounded LRU cache keyed on `top_level_field_name` + an order-preserving canonical JSON serialization of the spec.
- `PydanticParametersNetworkValidator` hoists the (stateless) converter out of its per-agent loop; because the cache is shared, registry validation at load time also warms the entries the tool-creation path reads on the first request.

Design decisions, each commented in code:

- **Key preserves key order** (no `sort_keys`): field order flows through to the JSON schema advertised to providers, so specs differing only in key order get separate entries instead of one being served a bytes-different schema.
- **The model name is part of the key** — it becomes the class name pydantic uses in validation error messages.
- **Builds happen outside the lock**: two threads racing on the same spec build two equivalent classes and one wins; nobody blocks on a compile.
- **Spec errors propagate uncached**, so a bad spec is re-reported every time it is seen.
- **Unserializable or too-deeply-nested specs fall back to uncached builds** (`TypeError`/`ValueError`/`RecursionError` from `json.dumps`).
- **Bounded at 256 entries (LRU)** because external agents send their function specs over the network per request — without a bound, a misbehaving remote agent whose spec varies per response would grow the cache without limit. Eviction degrades gracefully to the pre-change rebuild cost.
- **Hand-rolled rather than `functools.lru_cache`**: `lru_cache` can only key on hashables, forcing a `json.loads` round-trip; this cache keys on the serialized form but builds from the original dict, so output is byte-for-byte what an uncached build produces.

## Correctness properties

- **Hot-reload safe by construction**: the server can refresh registries every few seconds; an edited parameters block is different content, hence a guaranteed cache miss — the old model cannot be served for it. Superseded entries just wait for LRU eviction.
- **Shared classes are safe**: audited every consumer of the returned model — neuro-san assigns it to `tool.args_schema` and reads `model_fields`; langchain-core reads it and stamps per-tool name/description onto a *fresh subset class* (`_create_subset_model_v2`), never onto the shared one. `from_dict()`'s docstring now documents the returned class as shared-immutable.

## Testing

- 9 new cache tests: content-keyed sharing across instances, key-order sensitivity, name-in-key, LRU eviction at the bound, unserializable and deep-nesting fallbacks, errors-not-cached, an 8-thread race, and hot-reload freshness.
- Test file restructured to the repo's one-test-class-per-module convention (single `TestBaseModelDictionaryConverter`, one shared `_convert` helper, cache-clearing fixture around every test).
- Full converter + validator suites: 149 passed; flake8 and pylint clean.