### PR TITLE
Flatten list content to full text in the wire converter

### DIFF
--- a/neuro_san/message/types/base_message_dictionary_converter.py
+++ b/neuro_san/message/types/base_message_dictionary_converter.py
@@ -112,6 +112,11 @@ class BaseMessageDictionaryConverter(DictionaryConverter):
                     # displace the real answer.
                     value = None
                 else:
+                    # Deliberately NOT gated on ContentUtils.is_empty_content:
+                    # blank-but-non-empty block content (e.g. reasoning-only)
+                    # already emitted text=""/" " under the old first-block
+                    # flatten, and this projection preserves that wire shape
+                    # exactly.
                     value = ContentUtils.flatten_to_text(value)
 
             if value is not None:

--- a/neuro_san/message/types/base_message_dictionary_converter.py
+++ b/neuro_san/message/types/base_message_dictionary_converter.py
@@ -32,6 +32,7 @@ from neuro_san.message.types.agent_framework_message import AgentFrameworkMessag
 from neuro_san.message.types.agent_progress_message import AgentProgressMessage
 from neuro_san.message.types.agent_tool_result_message import AgentToolResultMessage
 from neuro_san.message.types.chat_message_type import ChatMessageType
+from neuro_san.message.utils.content_utils import ContentUtils
 
 
 class BaseMessageDictionaryConverter(DictionaryConverter):
@@ -97,15 +98,21 @@ class BaseMessageDictionaryConverter(DictionaryConverter):
                 # for, and that is ok.
                 value = None
 
-            # For OpenAI and Ollama, content of AI message is a string but content from
-            # Anthropic AI message can either be a single string or a list of content blocks.
-            # If it is a list, "text" is a key of a dictionary which is the first element of
-            # the list. For more details: https://python.langchain.com/docs/integrations/chat/anthropic/#content-blocks
+            # Content is a plain string for most providers, but can be a list
+            # of content blocks (e.g. Anthropic thinking + text, or list-of-str,
+            # which is also legal per the BaseMessage annotation). Project list
+            # content to its full text: concatenate every text block, not just
+            # the first one - a thinking-first response has no text in its
+            # first block at all.
             if src == "content" and isinstance(value, list):
-                if len(value) > 0:
-                    value = value[0].get("text", "")
-                else:
+                if len(value) == 0:
+                    # Keep omitting the text key for empty-list content:
+                    # emitting text="" instead would make such messages newly
+                    # answer-eligible in AnswerMessageFilter and able to
+                    # displace the real answer.
                     value = None
+                else:
+                    value = ContentUtils.flatten_to_text(value)
 
             if value is not None:
                 chat_message[dest] = value

--- a/tests/neuro_san/message/types/test_base_message_dictionary_converter.py
+++ b/tests/neuro_san/message/types/test_base_message_dictionary_converter.py
@@ -25,20 +25,23 @@ from neuro_san.message.types.agent_tool_result_message import AgentToolResultMes
 from neuro_san.message.types.base_message_dictionary_converter import BaseMessageDictionaryConverter
 from neuro_san.message.types.chat_message_type import ChatMessageType
 
+from tests.neuro_san.message.content_fixtures import ContentFixtures
+
 
 class TestBaseMessageDictionaryConverter:
     """
-    Golden-parity tests for the wire converter.
+    Golden-parity tests for the wire converter, plus the corrected
+    projection of list-form (block) content.
 
-    These lock down the EXACT ChatMessage dictionaries produced for
-    plain-string traffic - the shapes every deployed client sees today.
-    The content-block work (see issue #1222) must keep every test here
+    The plain-string tests lock down the EXACT ChatMessage dictionaries
+    produced for text-only traffic - the shapes every deployed client sees.
+    The content-block work (see issue #1222) must keep every one of them
     green untouched: byte-identical wire output for text-only messages
     is the backward-compatibility guarantee of that whole effort.
 
-    Deliberately absent: list-form (block) content through to_dict. Its
-    current behavior is the bug being fixed (thinking-first content
-    flattens to "", list-of-str crashes), so there is nothing to lock.
+    The list-content tests cover the wire-flatten fix: the full text
+    projection replaces the old first-block-only flatten that produced ""
+    for thinking-first content and crashed on list-of-str.
     """
 
     ORIGIN = [{"tool": "front_man", "instantiation_index": 0}]
@@ -130,6 +133,50 @@ class TestBaseMessageDictionaryConverter:
         """
         converter = BaseMessageDictionaryConverter(langchain_only=True)
         assert converter.from_dict({"type": ChatMessageType.AGENT, "text": "internal"}) is None
+
+    def test_to_dict_thinking_first_content_yields_answer_text(self):
+        """
+        THE headline fix: an Anthropic thinking-first response must produce
+        the answer text on the wire. The old first-block flatten produced ""
+        because the first block is the thinking block, which has no "text".
+        """
+        converter = BaseMessageDictionaryConverter(origin=self.ORIGIN)
+        result = converter.to_dict(ContentFixtures.anthropic_thinking_first())
+        assert result == {
+            "type": ChatMessageType.AI,
+            "origin": self.ORIGIN,
+            "text": "the answer",
+        }
+
+    def test_to_dict_concatenates_all_text_blocks(self):
+        """
+        Text blocks after the first must not be dropped, and a reasoning-only
+        message still emits text="" exactly as the old flatten did.
+        """
+        converter = BaseMessageDictionaryConverter()
+        result = converter.to_dict(ContentFixtures.openai_responses_reasoning())
+        assert result["text"] == "the answer"
+
+        reasoning_only = AIMessage(content=[{"type": "reasoning", "reasoning": "hidden"}])
+        assert converter.to_dict(reasoning_only)["text"] == ""
+
+    def test_to_dict_list_of_str_content_does_not_crash(self):
+        """
+        List-of-strings content is legal per the pydantic annotation and
+        raised AttributeError in the old flatten.
+        """
+        converter = BaseMessageDictionaryConverter()
+        result = converter.to_dict(ContentFixtures.list_of_str())
+        assert result["text"] == "part one, part two"
+
+    def test_to_dict_empty_list_content_still_omits_text(self):
+        """
+        Empty-list content keeps omitting the text key (emitting text=""
+        would make such messages newly answer-eligible in AnswerMessageFilter).
+        """
+        converter = BaseMessageDictionaryConverter()
+        result = converter.to_dict(ContentFixtures.empty_list_content())
+        assert "text" not in result
 
     def test_to_dict_agent_framework_message_optionals_exact_shape(self):
         """

--- a/tests/neuro_san/message/types/test_base_message_dictionary_converter.py
+++ b/tests/neuro_san/message/types/test_base_message_dictionary_converter.py
@@ -178,21 +178,6 @@ class TestBaseMessageDictionaryConverter:
             "text": "part one, part two",
         }
 
-    def test_to_dict_blank_block_content_keeps_emitting_text(self):
-        """
-        Non-empty list content with no visible text keeps emitting the text
-        key, exactly as the old flatten did (value[0].get("text", "") always
-        produced a string). Such messages are answer-eligible on the wire
-        today, and this fix must not change that in either direction:
-        only the empty *list* omits the key.
-        """
-        converter = BaseMessageDictionaryConverter()
-        blank_block = AIMessage(content=[{"type": "text", "text": " "}])
-        assert converter.to_dict(blank_block) == {
-            "type": ChatMessageType.AI,
-            "text": " ",
-        }
-
     def test_to_dict_empty_list_content_still_omits_text(self):
         """
         Empty-list content keeps omitting the text key (emitting text=""

--- a/tests/neuro_san/message/types/test_base_message_dictionary_converter.py
+++ b/tests/neuro_san/message/types/test_base_message_dictionary_converter.py
@@ -155,10 +155,16 @@ class TestBaseMessageDictionaryConverter:
         """
         converter = BaseMessageDictionaryConverter()
         result = converter.to_dict(ContentFixtures.openai_responses_reasoning())
-        assert result["text"] == "the answer"
+        assert result == {
+            "type": ChatMessageType.AI,
+            "text": "the answer",
+        }
 
         reasoning_only = AIMessage(content=[{"type": "reasoning", "reasoning": "hidden"}])
-        assert converter.to_dict(reasoning_only)["text"] == ""
+        assert converter.to_dict(reasoning_only) == {
+            "type": ChatMessageType.AI,
+            "text": "",
+        }
 
     def test_to_dict_list_of_str_content_does_not_crash(self):
         """
@@ -167,7 +173,10 @@ class TestBaseMessageDictionaryConverter:
         """
         converter = BaseMessageDictionaryConverter()
         result = converter.to_dict(ContentFixtures.list_of_str())
-        assert result["text"] == "part one, part two"
+        assert result == {
+            "type": ChatMessageType.AI,
+            "text": "part one, part two",
+        }
 
     def test_to_dict_empty_list_content_still_omits_text(self):
         """
@@ -176,7 +185,9 @@ class TestBaseMessageDictionaryConverter:
         """
         converter = BaseMessageDictionaryConverter()
         result = converter.to_dict(ContentFixtures.empty_list_content())
-        assert "text" not in result
+        assert result == {
+            "type": ChatMessageType.AI,
+        }
 
     def test_to_dict_agent_framework_message_optionals_exact_shape(self):
         """

--- a/tests/neuro_san/message/types/test_base_message_dictionary_converter.py
+++ b/tests/neuro_san/message/types/test_base_message_dictionary_converter.py
@@ -178,6 +178,21 @@ class TestBaseMessageDictionaryConverter:
             "text": "part one, part two",
         }
 
+    def test_to_dict_blank_block_content_keeps_emitting_text(self):
+        """
+        Non-empty list content with no visible text keeps emitting the text
+        key, exactly as the old flatten did (value[0].get("text", "") always
+        produced a string). Such messages are answer-eligible on the wire
+        today, and this fix must not change that in either direction:
+        only the empty *list* omits the key.
+        """
+        converter = BaseMessageDictionaryConverter()
+        blank_block = AIMessage(content=[{"type": "text", "text": " "}])
+        assert converter.to_dict(blank_block) == {
+            "type": ChatMessageType.AI,
+            "text": " ",
+        }
+
     def test_to_dict_empty_list_content_still_omits_text(self):
         """
         Empty-list content keeps omitting the text key (emitting text=""
@@ -187,6 +202,21 @@ class TestBaseMessageDictionaryConverter:
         result = converter.to_dict(ContentFixtures.empty_list_content())
         assert result == {
             "type": ChatMessageType.AI,
+        }
+
+    def test_to_dict_blank_text_block_keeps_emitting_text(self):
+        """
+        Blank-but-non-empty block content keeps emitting its (blank) text,
+        exactly as the old first-block flatten did - only the empty LIST
+        omits the text key. Gating omission on "no visible text" instead
+        would newly omit text for reasoning-only messages, changing their
+        wire shape.
+        """
+        converter = BaseMessageDictionaryConverter()
+        result = converter.to_dict(AIMessage(content=[{"type": "text", "text": " "}]))
+        assert result == {
+            "type": ChatMessageType.AI,
+            "text": " ",
         }
 
     def test_to_dict_agent_framework_message_optionals_exact_shape(self):


### PR DESCRIPTION
## What

Fixes the wire converter's projection of list-form message content. `BaseMessageDictionaryConverter.to_dict` previously flattened list content with `value[0].get("text", "")` — the first block only. That has three failure modes, all reachable today:

- **Thinking-first responses flatten to `""`**: a ChatAnthropic response with extended thinking puts the `thinking` block first, so the answer text was dropped entirely.
- **Text after the first block is dropped**: multi-text-block content (e.g. OpenAI Responses API replies) lost everything past block 0.
- **List-of-str content crashes**: `content=["a", "b"]` is legal per the `BaseMessage` annotation, and `.get()` on a `str` raises `AttributeError`.

The fix projects list content through `ContentUtils.flatten_to_text` (#1276), which implements `BaseMessage.text` semantics: concatenate every text block, in order, never strip.

## Backward compatibility

- Plain-string content is untouched — the golden-parity tests locking down exact wire dicts for text-only traffic all pass unchanged.
- Empty-list content keeps **omitting** the `text` key, exactly as before. Emitting `text=""` instead would make such messages newly answer-eligible in `AnswerMessageFilter` and able to displace the real answer.
- Reasoning-only list content still emits `text=""`, same as the old flatten.

## Tests

Four new tests in the converter's golden-parity suite, using the shared provider-shaped fixtures from #1276: thinking-first content yields the answer text (exact wire dict), all text blocks are concatenated (and reasoning-only still emits `""`), list-of-str no longer crashes, and empty-list content still omits the key.

Part of #1222 (Phase 1), second of the PR ladder described there.