### PR TITLE
Re-enabled Ollama nightly test case

### DIFF
--- a/tests/neuro_san/zzz_hocons/test_smoke_test_hocons.py
+++ b/tests/neuro_san/zzz_hocons/test_smoke_test_hocons.py
@@ -50,8 +50,6 @@ class TestSmokeTestHocons(TestCase):
             "Issue #936: disabled until #909 is resolved.",
         "music_nerd_pro_llm_openrouter/combination_responses_with_history_direct.hocon":
             "Disabled until OPENROUTER_API_KEY is added to the GitHub Actions secrets.",
-        "music_nerd_pro_llm_ollama/combination_responses_with_history_http.hocon":
-            "Issue #1226: disabled until #909 is resolved.",
     }
 
     def _skip_if_disabled(self, test_hocon: str) -> None:


### PR DESCRIPTION
@Noravee has been replaced with another Ollama model that addresses the failure. This PR re-enables the test case that was temporarily disabled.

It is now enabled and passed.
[

> gw1] PASSED tests/neuro_san/zzz_hocons/test_smoke_test_hocons.py::TestSmokeTestHocons::test_hocon_with_server_non_default_llm_0_music_nerd_pro_llm_ollama_combination_responses_with_history_http 