### PR TITLE
Use the shared full-text projection at both capture points

### DIFF
--- a/neuro_san/internals/journals/originating_journal.py
+++ b/neuro_san/internals/journals/originating_journal.py
@@ -101,11 +101,29 @@ class OriginatingJournal(Journal):
 
         if self.pending is not None:
             # Avoid cases where two different kinds of message hold the same content.
-            if self.pending.content != message.content:
+            if not self._is_dupe_of_pending(message):
                 await self.wrapped_journal.write_message(self.pending, use_origin)
             self.pending = None
 
         await self.wrapped_journal.write_message(message, use_origin)
+
+    def _is_dupe_of_pending(self, message: BaseMessage) -> bool:
+        """
+        :param message: The incoming BaseMessage to compare against the held
+                pending message.
+        :return: True if the pending message carries the same content as the
+                incoming message. String content is compared ignoring leading
+                and trailing whitespace: the pending message's content was
+                stripped when it was captured (JournalingCallbackHandler's
+                on_llm_end), while the incoming message's content is not, so
+                an exact comparison would let a mere trailing newline defeat
+                the suppression and send clients both copies of the same text.
+        """
+        pending_content: Any = self.pending.content
+        incoming_content: Any = message.content
+        if isinstance(pending_content, str) and isinstance(incoming_content, str):
+            return pending_content.strip() == incoming_content.strip()
+        return pending_content == incoming_content
 
     def get_chat_history(self) -> List[BaseMessage]:
         """

--- a/neuro_san/internals/journals/originating_journal.py
+++ b/neuro_san/internals/journals/originating_journal.py
@@ -118,6 +118,14 @@ class OriginatingJournal(Journal):
                 on_llm_end), while the incoming message's content is not, so
                 an exact comparison would let a mere trailing newline defeat
                 the suppression and send clients both copies of the same text.
+
+        Normalizing here, rather than stripping at either capture point, is
+        deliberate: both captured texts are client-visible and locked by
+        backward compatibility (the AGENT copy has always been journaled
+        stripped; the AI text reaches the wire and chat history unstripped),
+        so changing either producer would change client-visible output. The
+        dupe decision is internal, which makes this comparison the one place
+        that can reconcile the two without altering any payload.
         """
         pending_content: Any = self.pending.content
         incoming_content: Any = message.content

--- a/neuro_san/internals/run_context/langchain/core/run_context_runnable.py
+++ b/neuro_san/internals/run_context/langchain/core/run_context_runnable.py
@@ -48,6 +48,7 @@ from neuro_san.internals.run_context.langchain.token_counting.langchain_token_co
 from neuro_san.internals.run_context.langchain.tracing.neuro_san_runnable import NeuroSanRunnable
 from neuro_san.internals.run_context.langchain.util.api_key_error_check import ApiKeyErrorCheck
 from neuro_san.message.types.agent_framework_message import AgentFrameworkMessage
+from neuro_san.message.utils.content_utils import ContentUtils
 
 MINUTES: float = 60.0
 
@@ -375,17 +376,16 @@ class RunContextRunnable(NeuroSanRunnable):
                 # We generally want the content of any single AIMessage we found from above
                 output = ai_message.content
 
-        # In general, output is a string, but it can also be a list of content blocks when there are multiple
-        # message types, such as "thinking", "reasoning", etc.
-        # If it is a list, "text" is a key in the dict containing the actual string output we want to return.
+        # In general, output is a string, but it can also be a list of content blocks when there are
+        # multiple message types, such as "thinking", "reasoning", etc. - or a list of plain strings,
+        # which is also legal per the BaseMessage annotation.
+        # Project list output to its full text - every text block, not just the first one - with the
+        # same projection the wire converter and JournalingCallbackHandler.on_llm_end use. Divergent
+        # projections here made the AI message written below differ from the AGENT message journaled
+        # in on_llm_end, defeating its dupe suppression.
         # For more details: https://docs.langchain.com/oss/python/langchain/messages#standard-content-blocks
         if isinstance(output, list):
-            text_output: str = ""
-            for block in output:
-                if isinstance(block, dict) and block.get("type") == "text":
-                    text_output = block.get("text", "")
-                    break
-            output = text_output
+            output = ContentUtils.flatten_to_text(output)
 
         # See if we had some kind of error and format accordingly, if asked for.
         output = self.error_detector.handle_error(output)

--- a/neuro_san/internals/run_context/langchain/core/run_context_runnable.py
+++ b/neuro_san/internals/run_context/langchain/core/run_context_runnable.py
@@ -339,7 +339,7 @@ class RunContextRunnable(NeuroSanRunnable):
         # Initialize our output.
         # The value here might morph a bit between types, but when we return
         # something we expect it to be a string.
-        output: Union[str, List[Dict[str, Any]]] = None
+        output: Optional[Union[str, List[Any]]] = None
 
         if chain_result is None and exception is not None:
             # We got an exception instead of a proper result. Say so.
@@ -379,10 +379,10 @@ class RunContextRunnable(NeuroSanRunnable):
         # In general, output is a string, but it can also be a list of content blocks when there are
         # multiple message types, such as "thinking", "reasoning", etc. - or a list of plain strings,
         # which is also legal per the BaseMessage annotation.
-        # Project list output to its full text - every text block, not just the first one - with the
-        # same projection the wire converter and JournalingCallbackHandler.on_llm_end use. Divergent
-        # projections here made the AI message written below differ from the AGENT message journaled
-        # in on_llm_end, defeating its dupe suppression.
+        # Project list output to its full text through the single projection policy ContentUtils
+        # defines: OriginatingJournal's dupe suppression relies on the AGENT and AI copies of the
+        # same output projecting to the same text. Full text also means the error detector below
+        # scans everything, exactly as it always has for plain-string output.
         # For more details: https://docs.langchain.com/oss/python/langchain/messages#standard-content-blocks
         if isinstance(output, list):
             output = ContentUtils.flatten_to_text(output)

--- a/neuro_san/internals/run_context/langchain/journaling/journaling_callback_handler.py
+++ b/neuro_san/internals/run_context/langchain/journaling/journaling_callback_handler.py
@@ -37,6 +37,7 @@ from neuro_san.internals.journals.origination import Origination
 from neuro_san.internals.journals.tool_argument_reporting import ToolArgumentReporting
 from neuro_san.message.types.agent_message import AgentMessage
 from neuro_san.message.types.agent_tool_result_message import AgentToolResultMessage
+from neuro_san.message.utils.content_utils import ContentUtils
 
 
 # pylint: disable=too-many-ancestors
@@ -112,8 +113,15 @@ class JournalingCallbackHandler(AsyncCallbackHandler):
         generations = response.generations[0]
         first_generation = generations[0]
         if isinstance(first_generation, ChatGeneration):
-            content: str = first_generation.text
-            if content is not None and len(content) > 0:
+            # Project the message content to its full text with the same
+            # projection the wire converter and parse_chain_result use.
+            # ChatGeneration.text happens to agree on the pinned langchain-core,
+            # but its list-content semantics have varied across versions;
+            # capturing through the one shared policy is what keeps the dupe
+            # comparison against the later AI message reliable. Tool-call-only
+            # steps flatten to "" and stay unjournaled, as before.
+            content: str = ContentUtils.flatten_to_text(first_generation.message)
+            if len(content) > 0:
                 # Package up the thinking content as an AgentMessage to stream
                 message = AgentMessage(content=content.strip())
                 # Some AGENT messages that come from this source end up being dupes

--- a/neuro_san/internals/run_context/langchain/journaling/journaling_callback_handler.py
+++ b/neuro_san/internals/run_context/langchain/journaling/journaling_callback_handler.py
@@ -113,13 +113,14 @@ class JournalingCallbackHandler(AsyncCallbackHandler):
         generations = response.generations[0]
         first_generation = generations[0]
         if isinstance(first_generation, ChatGeneration):
-            # Project the message content to its full text with the same
-            # projection the wire converter and parse_chain_result use.
-            # ChatGeneration.text happens to agree on the pinned langchain-core,
-            # but its list-content semantics have varied across versions;
-            # capturing through the one shared policy is what keeps the dupe
-            # comparison against the later AI message reliable. Tool-call-only
-            # steps flatten to "" and stay unjournaled, as before.
+            # Project the message content to its full text through the single
+            # projection policy ContentUtils defines: the dupe comparison
+            # against the later AI message relies on both copies projecting to
+            # the same text. ChatGeneration.text is close but not identical -
+            # it also collects legacy text blocks that carry no "type" key, a
+            # shape no supported provider emits and which is deliberately out
+            # of scope here. Tool-call-only steps flatten to "" and are
+            # skipped by the gate below.
             content: str = ContentUtils.flatten_to_text(first_generation.message)
             if len(content) > 0:
                 # Package up the thinking content as an AgentMessage to stream

--- a/tests/neuro_san/internals/journals/test_originating_journal.py
+++ b/tests/neuro_san/internals/journals/test_originating_journal.py
@@ -1,0 +1,94 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+
+import pytest
+
+from langchain_core.messages.ai import AIMessage
+
+from neuro_san.internals.journals.originating_journal import OriginatingJournal
+from neuro_san.message.types.agent_message import AgentMessage
+
+
+class TestOriginatingJournal:
+    """
+    Tests for OriginatingJournal's held-message dupe suppression.
+
+    JournalingCallbackHandler.on_llm_end holds intermediate LLM output as a
+    STRIPPED AGENT message via write_message_if_next_not_dupe, while the AI
+    message that follows (from parse_chain_result) arrives unstripped. The
+    dupe comparison must therefore ignore leading/trailing whitespace: with
+    an exact comparison, a trailing newline in the final text is enough to
+    send clients both the AGENT and AI copies of the same output.
+    """
+
+    ORIGIN = [{"tool": "front_man", "instantiation_index": 0}]
+
+    def _make_journal(self):
+        """Build a journal whose wrapped journal records written messages."""
+        wrapped = MagicMock()
+        wrapped.write_message = AsyncMock()
+        journal = OriginatingJournal(wrapped_journal=wrapped, origin=self.ORIGIN)
+        return journal, wrapped
+
+    @pytest.mark.asyncio
+    async def test_exact_dupe_is_suppressed(self):
+        """
+        A held AGENT message whose content matches the next message exactly
+        is dropped: only the AI message reaches the wrapped journal.
+        """
+        journal, wrapped = self._make_journal()
+        await journal.write_message_if_next_not_dupe(AgentMessage(content="the answer"))
+        await journal.write_message(AIMessage(content="the answer"))
+
+        written = [call.args[0] for call in wrapped.write_message.call_args_list]
+        assert len(written) == 1
+        assert written[0].content == "the answer"
+        assert not isinstance(written[0], AgentMessage)
+
+    @pytest.mark.asyncio
+    async def test_dupe_comparison_ignores_edge_whitespace(self):
+        """
+        The held AGENT content is stripped at capture while the AI content is
+        not, so the comparison must treat "the answer" and "the answer\\n" as
+        the same content - otherwise clients receive both copies.
+        """
+        journal, wrapped = self._make_journal()
+        await journal.write_message_if_next_not_dupe(AgentMessage(content="the answer"))
+        await journal.write_message(AIMessage(content="the answer\n"))
+
+        written = [call.args[0] for call in wrapped.write_message.call_args_list]
+        assert len(written) == 1
+        assert written[0].content == "the answer\n"
+
+    @pytest.mark.asyncio
+    async def test_different_content_flushes_pending_first(self):
+        """
+        A held AGENT message with genuinely different content is not a dupe:
+        it is flushed ahead of the incoming message, preserving stream order.
+        """
+        journal, wrapped = self._make_journal()
+        await journal.write_message_if_next_not_dupe(AgentMessage(content="a thought"))
+        await journal.write_message(AIMessage(content="the answer"))
+
+        written = [call.args[0] for call in wrapped.write_message.call_args_list]
+        assert len(written) == 2
+        assert isinstance(written[0], AgentMessage)
+        assert written[0].content == "a thought"
+        assert written[1].content == "the answer"

--- a/tests/neuro_san/internals/run_context/langchain/core/test_run_context_runnable.py
+++ b/tests/neuro_san/internals/run_context/langchain/core/test_run_context_runnable.py
@@ -22,10 +22,107 @@ import httpx
 import pytest
 
 from langchain_core.messages.ai import AIMessage
+from langchain_core.messages.human import HumanMessage
+from langchain_core.outputs import LLMResult
+from langchain_core.outputs.chat_generation import ChatGeneration
 from openai import RateLimitError
+
+from neuro_san.internals.run_context.langchain.journaling.journaling_callback_handler import JournalingCallbackHandler
 
 from neuro_san.internals.run_context.langchain.core.run_context_runnable import RunContextRunnable
 from neuro_san.message.types.agent_framework_message import AgentFrameworkMessage
+
+from tests.neuro_san.message.content_fixtures import ContentFixtures
+
+
+class TestParseChainResult:
+    """
+    Tests for the capture-side projection of list-form (block) content in
+    parse_chain_result. The old inline flatten took only the first
+    type=="text" block and skipped plain strings entirely, so multi-text
+    responses lost everything past the first text block and list-of-str
+    content became "".
+    """
+
+    @staticmethod
+    def _make_runnable() -> RunContextRunnable:
+        """Build a runnable whose error detector is a pass-through."""
+        error_detector = MagicMock()
+        error_detector.handle_error = MagicMock(side_effect=lambda output: output)
+        return RunContextRunnable.model_construct(error_detector=error_detector)
+
+    def test_parse_chain_result_thinking_first_returns_answer(self):
+        """
+        An Anthropic thinking-first AIMessage projects to its answer text.
+        """
+        runnable = self._make_runnable()
+        output = runnable.parse_chain_result(ContentFixtures.anthropic_thinking_first(), exception=None)
+        assert output == "the answer"
+
+    def test_parse_chain_result_concatenates_text_blocks(self):
+        """
+        Text blocks after the first must not be dropped: the old flatten
+        stopped at the first type=="text" block and returned "part one, ".
+        """
+        runnable = self._make_runnable()
+        message = AIMessage(content=[
+            {"type": "text", "text": "part one, "},
+            {"type": "thinking", "thinking": "hmm"},
+            {"type": "text", "text": "part two"},
+        ])
+        assert runnable.parse_chain_result(message, exception=None) == "part one, part two"
+
+    def test_parse_chain_result_list_of_str_returns_full_text(self):
+        """
+        List-of-strings content is legal per the pydantic annotation; the old
+        flatten skipped non-dict items and returned "".
+        """
+        runnable = self._make_runnable()
+        output = runnable.parse_chain_result(ContentFixtures.list_of_str(), exception=None)
+        assert output == "part one, part two"
+
+    def test_parse_chain_result_dict_messages_path_flattens_last_ai_message(self):
+        """
+        The normal chain result is a dict whose "messages" hold chat history;
+        the last AIMessage found there gets the same full-text projection.
+        """
+        runnable = self._make_runnable()
+        chain_result = {"messages": [
+            HumanMessage(content="question"),
+            ContentFixtures.anthropic_thinking_first(),
+        ]}
+        assert runnable.parse_chain_result(chain_result, exception=None) == "the answer"
+
+    @pytest.mark.asyncio
+    async def test_parse_chain_result_matches_on_llm_end_projection(self):
+        """
+        The dupe-leak regression: parse_chain_result and
+        JournalingCallbackHandler.on_llm_end must project the same block
+        content to the same text, because OriginatingJournal suppresses the
+        held AGENT message only when the next AI message's content is equal.
+        With the old divergent flattens this content pair differed and both
+        messages reached clients.
+        """
+        message = AIMessage(content=[
+            {"type": "text", "text": "part one, "},
+            {"type": "text", "text": "part two"},
+        ])
+
+        runnable = self._make_runnable()
+        parsed: str = runnable.parse_chain_result(message, exception=None)
+
+        calling_agent_journal = MagicMock()
+        calling_agent_journal.write_message_if_next_not_dupe = AsyncMock()
+        handler = JournalingCallbackHandler(
+            calling_agent_journal=calling_agent_journal,
+            base_journal=MagicMock(),
+            parent_origin=[],
+            origination=MagicMock(),
+        )
+        await handler.on_llm_end(LLMResult(generations=[[ChatGeneration(message=message)]]))
+        journaled = calling_agent_journal.write_message_if_next_not_dupe.call_args.args[0]
+
+        assert parsed == journaled.content == "part one, part two"
 
 
 class TestRunContextRunnable:

--- a/tests/neuro_san/internals/run_context/langchain/core/test_run_context_runnable.py
+++ b/tests/neuro_san/internals/run_context/langchain/core/test_run_context_runnable.py
@@ -35,10 +35,13 @@ from neuro_san.message.types.agent_framework_message import AgentFrameworkMessag
 from tests.neuro_san.message.content_fixtures import ContentFixtures
 
 
-class TestParseChainResult:
+class TestRunContextRunnable:
     """
-    Tests for the capture-side projection of list-form (block) content in
-    parse_chain_result. The old inline flatten took only the first
+    Tests for RunContextRunnable: the capture-side projection of list-form
+    (block) content in parse_chain_result, and the surfacing of
+    recoverable-error retries on the journal.
+
+    The old inline flatten in parse_chain_result took only the first
     type=="text" block and skipped plain strings entirely, so multi-text
     responses lost everything past the first text block and list-of-str
     content became "".
@@ -123,10 +126,6 @@ class TestParseChainResult:
         journaled = calling_agent_journal.write_message_if_next_not_dupe.call_args.args[0]
 
         assert parsed == journaled.content == "part one, part two"
-
-
-class TestRunContextRunnable:
-    """Test cases for surfacing recoverable-error retries on the journal."""
 
     @pytest.mark.asyncio
     async def test_journal_retry_reason_writes_agent_framework_message(self):

--- a/tests/neuro_san/internals/run_context/langchain/core/test_run_context_runnable.py
+++ b/tests/neuro_san/internals/run_context/langchain/core/test_run_context_runnable.py
@@ -68,11 +68,7 @@ class TestRunContextRunnable:
         stopped at the first type=="text" block and returned "part one, ".
         """
         runnable = self._make_runnable()
-        message = AIMessage(content=[
-            {"type": "text", "text": "part one, "},
-            {"type": "thinking", "thinking": "hmm"},
-            {"type": "text", "text": "part two"},
-        ])
+        message = ContentFixtures.multi_text_blocks()
         assert runnable.parse_chain_result(message, exception=None) == "part one, part two"
 
     def test_parse_chain_result_list_of_str_returns_full_text(self):
@@ -102,17 +98,16 @@ class TestRunContextRunnable:
         The dupe-leak regression: parse_chain_result and
         JournalingCallbackHandler.on_llm_end must project the same block
         content to the same text, because OriginatingJournal suppresses the
-        held AGENT message only when the next AI message's content is equal.
-        With the old divergent flattens this content pair differed and both
-        messages reached clients.
+        held AGENT message only when the next AI message carries the same
+        content. The projections agree up to leading/trailing whitespace,
+        which the journal's dupe comparison ignores (covered in
+        test_originating_journal.py).
         """
-        message = AIMessage(content=[
-            {"type": "text", "text": "part one, "},
-            {"type": "text", "text": "part two"},
-        ])
+        message = ContentFixtures.multi_text_blocks()
 
         runnable = self._make_runnable()
         parsed: str = runnable.parse_chain_result(message, exception=None)
+        assert parsed == "part one, part two"
 
         calling_agent_journal = MagicMock()
         calling_agent_journal.write_message_if_next_not_dupe = AsyncMock()
@@ -124,8 +119,7 @@ class TestRunContextRunnable:
         )
         await handler.on_llm_end(LLMResult(generations=[[ChatGeneration(message=message)]]))
         journaled = calling_agent_journal.write_message_if_next_not_dupe.call_args.args[0]
-
-        assert parsed == journaled.content == "part one, part two"
+        assert journaled.content == parsed
 
     @pytest.mark.asyncio
     async def test_journal_retry_reason_writes_agent_framework_message(self):

--- a/tests/neuro_san/internals/run_context/langchain/journaling/test_journaling_callback_handler.py
+++ b/tests/neuro_san/internals/run_context/langchain/journaling/test_journaling_callback_handler.py
@@ -21,8 +21,76 @@ from uuid import uuid4
 
 import pytest
 
+from langchain_core.messages.ai import AIMessage
+from langchain_core.outputs import LLMResult
+from langchain_core.outputs.chat_generation import ChatGeneration
+
 from neuro_san.internals.run_context.langchain.journaling.journaling_callback_handler import JournalingCallbackHandler
 from neuro_san.message.types.agent_message import AgentMessage
+
+from tests.neuro_san.message.content_fixtures import ContentFixtures
+
+
+class TestOnLlmEndProjection:
+    """
+    on_llm_end journals the intermediate LLM output as an AGENT message using
+    the shared full-text projection: block content yields all of its text,
+    tool-call-only steps stay unjournaled, and stripping is preserved.
+    """
+
+    @staticmethod
+    def _make_handler():
+        """Build a handler whose calling-agent journal records held messages."""
+        calling_agent_journal = MagicMock()
+        calling_agent_journal.write_message_if_next_not_dupe = AsyncMock()
+        handler = JournalingCallbackHandler(
+            calling_agent_journal=calling_agent_journal,
+            base_journal=MagicMock(),
+            parent_origin=[],
+            origination=MagicMock(),
+        )
+        return handler, calling_agent_journal
+
+    @staticmethod
+    def _llm_result(message: AIMessage) -> LLMResult:
+        """Wrap an AIMessage the way it arrives at on_llm_end."""
+        return LLMResult(generations=[[ChatGeneration(message=message)]])
+
+    @pytest.mark.asyncio
+    async def test_journals_full_text_of_block_content(self):
+        """
+        Thinking-first block content journals its answer text as an AGENT
+        message, held for dupe comparison against the AI message that follows.
+        """
+        handler, journal = self._make_handler()
+        await handler.on_llm_end(self._llm_result(ContentFixtures.anthropic_thinking_first()))
+        message = journal.write_message_if_next_not_dupe.call_args.args[0]
+        assert isinstance(message, AgentMessage)
+        assert message.content == "the answer"
+
+    @pytest.mark.asyncio
+    async def test_tool_call_only_step_stays_unjournaled(self):
+        """
+        A tool-call-only step has no text, so the journaling gate must keep
+        skipping it - clients see the "Invoking:" message instead.
+        """
+        handler, journal = self._make_handler()
+        tool_call_only = AIMessage(
+            content=[{"type": "tool_use", "id": "toolu_1", "name": "lookup", "input": {"query": "q"}}],
+            tool_calls=[{"name": "lookup", "args": {"query": "q"}, "id": "toolu_1", "type": "tool_call"}],
+        )
+        await handler.on_llm_end(self._llm_result(tool_call_only))
+        journal.write_message_if_next_not_dupe.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_plain_string_content_still_journaled_stripped(self):
+        """
+        Plain-string content keeps its existing behavior: journaled stripped.
+        """
+        handler, journal = self._make_handler()
+        await handler.on_llm_end(self._llm_result(AIMessage(content="  padded thought  ")))
+        message = journal.write_message_if_next_not_dupe.call_args.args[0]
+        assert message.content == "padded thought"
 
 
 class TestOnToolStartInvokingLabel:

--- a/tests/neuro_san/internals/run_context/langchain/journaling/test_journaling_callback_handler.py
+++ b/tests/neuro_san/internals/run_context/langchain/journaling/test_journaling_callback_handler.py
@@ -31,17 +31,23 @@ from neuro_san.message.types.agent_message import AgentMessage
 from tests.neuro_san.message.content_fixtures import ContentFixtures
 
 
-class TestOnLlmEndProjection:
+class TestJournalingCallbackHandler:
     """
+    Tests for JournalingCallbackHandler.
+
     on_llm_end journals the intermediate LLM output as an AGENT message using
     the shared full-text projection: block content yields all of its text,
     tool-call-only steps stay unjournaled, and stripping is preserved.
+
+    on_tool_start should journal a diagnostic "Invoking" label even when the
+    serialized tool carries no name.
     """
 
     @staticmethod
     def _make_handler():
-        """Build a handler whose calling-agent journal records held messages."""
+        """Build a handler whose calling-agent journal records written messages."""
         calling_agent_journal = MagicMock()
+        calling_agent_journal.write_message = AsyncMock()
         calling_agent_journal.write_message_if_next_not_dupe = AsyncMock()
         handler = JournalingCallbackHandler(
             calling_agent_journal=calling_agent_journal,
@@ -57,7 +63,7 @@ class TestOnLlmEndProjection:
         return LLMResult(generations=[[ChatGeneration(message=message)]])
 
     @pytest.mark.asyncio
-    async def test_journals_full_text_of_block_content(self):
+    async def test_on_llm_end_journals_full_text_of_block_content(self):
         """
         Thinking-first block content journals its answer text as an AGENT
         message, held for dupe comparison against the AI message that follows.
@@ -69,7 +75,7 @@ class TestOnLlmEndProjection:
         assert message.content == "the answer"
 
     @pytest.mark.asyncio
-    async def test_tool_call_only_step_stays_unjournaled(self):
+    async def test_on_llm_end_tool_call_only_step_stays_unjournaled(self):
         """
         A tool-call-only step has no text, so the journaling gate must keep
         skipping it - clients see the "Invoking:" message instead.
@@ -83,7 +89,7 @@ class TestOnLlmEndProjection:
         journal.write_message_if_next_not_dupe.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_plain_string_content_still_journaled_stripped(self):
+    async def test_on_llm_end_plain_string_content_still_journaled_stripped(self):
         """
         Plain-string content keeps its existing behavior: journaled stripped.
         """
@@ -92,26 +98,8 @@ class TestOnLlmEndProjection:
         message = journal.write_message_if_next_not_dupe.call_args.args[0]
         assert message.content == "padded thought"
 
-
-class TestOnToolStartInvokingLabel:
-    """on_tool_start should journal a diagnostic "Invoking" label even when the
-    serialized tool carries no name."""
-
-    @staticmethod
-    def _make_handler():
-        """Build a handler whose calling-agent journal records written messages."""
-        calling_agent_journal = MagicMock()
-        calling_agent_journal.write_message = AsyncMock()
-        handler = JournalingCallbackHandler(
-            calling_agent_journal=calling_agent_journal,
-            base_journal=MagicMock(),
-            parent_origin=[],
-            origination=MagicMock(),
-        )
-        return handler, calling_agent_journal
-
     @pytest.mark.asyncio
-    async def test_uses_tool_name_when_present(self):
+    async def test_on_tool_start_uses_tool_name_when_present(self):
         """A serialized tool with a name is reported verbatim."""
         handler, journal = self._make_handler()
         await handler.on_tool_start({"name": "search"}, "input", run_id=uuid4(), tags=[], inputs={})
@@ -121,7 +109,7 @@ class TestOnToolStartInvokingLabel:
         assert message.structure["invoked_agent_name"] == "search"
 
     @pytest.mark.asyncio
-    async def test_falls_back_to_placeholder_when_name_missing(self):
+    async def test_on_tool_start_falls_back_to_placeholder_when_name_missing(self):
         """A serialized tool with no name yields a diagnostic placeholder label
         instead of an empty "Invoking: ``"; the raw value is still reported."""
         handler, journal = self._make_handler()

--- a/tests/neuro_san/message/content_fixtures.py
+++ b/tests/neuro_san/message/content_fixtures.py
@@ -94,6 +94,20 @@ class ContentFixtures:
         )
 
     @staticmethod
+    def multi_text_blocks() -> AIMessage:
+        """
+        :return: An AIMessage whose text is split across multiple text blocks
+                 with a thinking block in between. Its full text is
+                 "part one, part two"; a first-text-block-only flatten sees
+                 only "part one, ".
+        """
+        return AIMessage(content=[
+            {"type": "text", "text": "part one, "},
+            {"type": "thinking", "thinking": "hmm"},
+            {"type": "text", "text": "part two"},
+        ])
+
+    @staticmethod
     def list_of_str() -> AIMessage:
         """
         :return: An AIMessage with list-of-strings content - legal per the


### PR DESCRIPTION
## What

Fixes how list-form (content-block) LLM output is captured, at the two points where it first enters the pipeline:

- **`RunContextRunnable.parse_chain_result`** flattened list content with an inline loop that took only the first `type=="text"` block. Text after the first block was silently dropped, and list-of-str content (legal per the `BaseMessage` annotation) skipped the non-dict items entirely and became `""`.
- **`JournalingCallbackHandler.on_llm_end`** captured via `ChatGeneration.text` — a second, independent projection of the same content. On the pinned langchain-core its output matches `BaseMessage.text` semantics except for legacy typeless `{"text": ...}` blocks — a shape no supported provider emits, declared out of scope at the call site — its list-content behavior has varied across versions, and any divergence between the two projections defeats `OriginatingJournal`'s dupe suppression: the held AGENT message and the following AI message carry different text, so the comparison fails and clients receive both copies.

Both sites now project through `ContentUtils.flatten_to_text` (#1276) — the same projection the wire converter uses since #1281. One policy, three call sites, no way to diverge.

## Behavior preserved

- Plain-string content is untouched at both sites.
- `on_llm_end` keeps its journaling gate and `.strip()`: tool-call-only steps flatten to `""` and stay unjournaled, so clients still see only the "Invoking:" message for those.
- The error-detector pass at the end of `parse_chain_result` is unchanged.

## Tests

- `parse_chain_result`: thinking-first → answer text, multi-text-block concatenation, list-of-str no longer `""`, and the dict-`messages` chain-result path.
- `on_llm_end`: full text of block content journaled as a held AGENT message, tool-call-only steps stay unjournaled, plain-string strip preserved.
- The dupe-leak regression: a test asserting `parse_chain_result` and `on_llm_end` project the same block content to the identical text that `OriginatingJournal`'s equality check compares.

Verified end-to-end with the keyless mock network (`chat_mock_llm_echo` with the thinking marker): a thinking-first response produces the clean answer text.

## Review follow-ups (second pass)

A deeper review pass on this diff surfaced one gap that is fixed here rather than deferred:

- **`OriginatingJournal`'s pending-dupe comparison is strip-normalized** (`_is_dupe_of_pending`, new `test_originating_journal.py`). This is the journal dedupe item from the #1222 ladder pulled forward: the full-text projection exposes the strip asymmetry between the two capture points (`on_llm_end` strips, `parse_chain_result` doesn't), so without it a trailing whitespace-only text block after the first would flip from dupe-suppressed to leaked. Strip-comparison instead of the originally planned flatten-on-both-sides, which is an identity on plain strings and would not have closed the hole.

Also from that pass: the `on_llm_end` comment no longer claims `ChatGeneration.text` agrees with the shared projection (it differs for legacy typeless text blocks, a shape no supported provider emits — declared out of scope in the comment), the fuller error-detector scan surface is documented as deliberate uniformity with plain-string output, a stale local annotation is widened, and the multi-text-block fixture moved into `ContentFixtures`. Pre-existing issues surfaced by the same pass are tracked in #1222 under "Surfaced by review of #1285".

Part of #1222 (Phase 1), third of the PR ladder described there (after #1276 and #1281).


