### PR TITLE
Bump build-common pins to 1.0.12

### DIFF
--- a/.github/workflows/checkmarx.yml
+++ b/.github/workflows/checkmarx.yml
@@ -12,8 +12,8 @@ on:
 
 jobs:
   checkmarx:
-    # 1.0.9
-    uses: cognizant-ai-lab/build-common/.github/workflows/_checkmarx.yml@b14b3de23cb9aca02b2165e57542335e0c8f5304
+    # 1.0.11
+    uses: cognizant-ai-lab/build-common/.github/workflows/_checkmarx.yml@a70df67b0d623e56f34159de26c38989cd315d26
     with:
       base-uri: ${{ vars.CX_BASE_URI }}
       cx-tenant: ${{ vars.CX_TENANT }}

--- a/.github/workflows/checkmarx.yml
+++ b/.github/workflows/checkmarx.yml
@@ -15,6 +15,8 @@ jobs:
     # 1.0.11
     uses: cognizant-ai-lab/build-common/.github/workflows/_checkmarx.yml@a70df67b0d623e56f34159de26c38989cd315d26
     with:
+      # 1.0.11
+      build-common-ref: 'a70df67b0d623e56f34159de26c38989cd315d26'
       base-uri: ${{ vars.CX_BASE_URI }}
       cx-tenant: ${{ vars.CX_TENANT }}
       cx-client-id: ${{ vars.CX_CLIENT_ID }}

--- a/.github/workflows/checkmarx.yml
+++ b/.github/workflows/checkmarx.yml
@@ -12,11 +12,11 @@ on:
 
 jobs:
   checkmarx:
-    # 1.0.11
-    uses: cognizant-ai-lab/build-common/.github/workflows/_checkmarx.yml@a70df67b0d623e56f34159de26c38989cd315d26
+    # 1.0.12
+    uses: cognizant-ai-lab/build-common/.github/workflows/_checkmarx.yml@3f4cdab31b6ac10382c99452b720eb0b8b2dab8f
     with:
-      # 1.0.11
-      build-common-ref: 'a70df67b0d623e56f34159de26c38989cd315d26'
+      # 1.0.12
+      build-common-ref: '3f4cdab31b6ac10382c99452b720eb0b8b2dab8f'
       base-uri: ${{ vars.CX_BASE_URI }}
       cx-tenant: ${{ vars.CX_TENANT }}
       cx-client-id: ${{ vars.CX_CLIENT_ID }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,8 +12,8 @@ jobs:
   test:
     # don't run this job in sync'd clones
     if: github.repository == 'cognizant-ai-lab/neuro-san'
-    # 1.0.9
-    uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@b14b3de23cb9aca02b2165e57542335e0c8f5304
+    # 1.0.11
+    uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@a70df67b0d623e56f34159de26c38989cd315d26
     with:
       python-version: '3.12'
       lint-command-override: 'true'  # no lint in this workflow

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -15,6 +15,8 @@ jobs:
     # 1.0.11
     uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@a70df67b0d623e56f34159de26c38989cd315d26
     with:
+      # 1.0.11
+      build-common-ref: 'a70df67b0d623e56f34159de26c38989cd315d26'
       python-version: '3.12'
       lint-command-override: 'true'  # no lint in this workflow
       run-pytest: false

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,11 +12,11 @@ jobs:
   test:
     # don't run this job in sync'd clones
     if: github.repository == 'cognizant-ai-lab/neuro-san'
-    # 1.0.11
-    uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@a70df67b0d623e56f34159de26c38989cd315d26
+    # 1.0.12
+    uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@3f4cdab31b6ac10382c99452b720eb0b8b2dab8f
     with:
-      # 1.0.11
-      build-common-ref: 'a70df67b0d623e56f34159de26c38989cd315d26'
+      # 1.0.12
+      build-common-ref: '3f4cdab31b6ac10382c99452b720eb0b8b2dab8f'
       python-version: '3.12'
       lint-command-override: 'true'  # no lint in this workflow
       run-pytest: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,8 +25,8 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Python environment
-        # 1.0.9
-        uses: cognizant-ai-lab/build-common/actions/setup-python-env@b14b3de23cb9aca02b2165e57542335e0c8f5304
+        # 1.0.11
+        uses: cognizant-ai-lab/build-common/actions/setup-python-env@a70df67b0d623e56f34159de26c38989cd315d26
         with:
           python-version: '3.10'
           requirements-file: ''
@@ -42,8 +42,8 @@ jobs:
 
       - name: Notify Slack
         if: ${{ !cancelled() }}
-        # 1.0.9
-        uses: cognizant-ai-lab/build-common/actions/slack-notify@b14b3de23cb9aca02b2165e57542335e0c8f5304
+        # 1.0.11
+        uses: cognizant-ai-lab/build-common/actions/slack-notify@a70df67b0d623e56f34159de26c38989cd315d26
         with:
           status: ${{ job.status }}
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,8 +25,8 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Python environment
-        # 1.0.11
-        uses: cognizant-ai-lab/build-common/actions/setup-python-env@a70df67b0d623e56f34159de26c38989cd315d26
+        # 1.0.12
+        uses: cognizant-ai-lab/build-common/actions/setup-python-env@3f4cdab31b6ac10382c99452b720eb0b8b2dab8f
         with:
           python-version: '3.12'
           requirements-file: ''
@@ -42,8 +42,8 @@ jobs:
 
       - name: Notify Slack
         if: ${{ !cancelled() }}
-        # 1.0.11
-        uses: cognizant-ai-lab/build-common/actions/slack-notify@a70df67b0d623e56f34159de26c38989cd315d26
+        # 1.0.12
+        uses: cognizant-ai-lab/build-common/actions/slack-notify@3f4cdab31b6ac10382c99452b720eb0b8b2dab8f
         with:
           status: ${{ job.status }}
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -96,8 +96,8 @@ jobs:
 
       - name: Notify Slack
         if: ${{ !cancelled() }}
-        # 1.0.9
-        uses: cognizant-ai-lab/build-common/actions/slack-notify@b14b3de23cb9aca02b2165e57542335e0c8f5304
+        # 1.0.11
+        uses: cognizant-ai-lab/build-common/actions/slack-notify@a70df67b0d623e56f34159de26c38989cd315d26
         with:
           status: ${{ job.status }}
           details: ${{ steps.smoke.outputs.summary }}

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -96,8 +96,8 @@ jobs:
 
       - name: Notify Slack
         if: ${{ !cancelled() }}
-        # 1.0.11
-        uses: cognizant-ai-lab/build-common/actions/slack-notify@a70df67b0d623e56f34159de26c38989cd315d26
+        # 1.0.12
+        uses: cognizant-ai-lab/build-common/actions/slack-notify@3f4cdab31b6ac10382c99452b720eb0b8b2dab8f
         with:
           status: ${{ job.status }}
           details: ${{ steps.smoke.outputs.summary }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,6 +22,8 @@ jobs:
     # 1.0.11
     uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@a70df67b0d623e56f34159de26c38989cd315d26
     with:
+      # 1.0.11
+      build-common-ref: 'a70df67b0d623e56f34159de26c38989cd315d26'
       python-version: '3.12'
       lint-toolchain: 'legacy'  # flake8 only (black/isort are opt-in)
       pylint-command: 'build_scripts/run_pylint.sh'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,8 +19,8 @@ jobs:
       (github.event_name == 'pull_request' &&
        github.base_ref == 'main' &&
        github.event.pull_request.head.repo.full_name != github.repository)
-    # 1.0.9
-    uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@b14b3de23cb9aca02b2165e57542335e0c8f5304
+    # 1.0.11
+    uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@a70df67b0d623e56f34159de26c38989cd315d26
     with:
       python-version: '3.12'
       lint-toolchain: 'legacy'  # flake8 only (black/isort are opt-in)


### PR DESCRIPTION
## Summary

Refreshes this repo's build-common pins from 1.0.9 (`b14b3de`) to the current 1.0.12 release (`3f4cdab`), version comments included, and passes `build-common-ref` to the reusable workflows so they check out the same build-common revision they were called at.

Main had already moved `tests.yml` to 1.0.12 in #1304 for the Python 3.12/3.13/3.14 matrix, which is what conflicted with this PR's original 1.0.11 pin. The conflict is resolved by taking main's 1.0.12 `uses:` line and moving every other workflow (checkmarx, integration, publish, smoke) to 1.0.12 as well so the repo is on one build-common version.

Between 1.0.9 and 1.0.12 build-common removed the two unusable PyPI publish paths, added the build-only `build-python-dists` action, and (1.0.12) added the `test-python-versions` matrix to `_python-quality-gate.yml` plus the `python-ci-setup` action. `setup-python-env`, `slack-notify`, and `_checkmarx.yml` did not change, so this is a pin refresh with no behavior change beyond what main already had.

Link to Devin session: https://app.devin.ai/sessions/72b0e182dab241098c7ab8f5fea86b7a
Open in Devin Desktop: https://app.devin.ai/desktop/session/72b0e182dab241098c7ab8f5fea86b7a?variant=devin
Requested by: @donn-leaf
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cognizant-ai-lab/neuro-san/pull/1286" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->