### PR TITLE
NS-1282 Run EventInitiator in only one of neuro-san service instances.

### DIFF
--- a/neuro_san/deploy/Dockerfile
+++ b/neuro_san/deploy/Dockerfile
@@ -345,9 +345,6 @@ ENV AGENT_HTTP_IDLE_CONNECTIONS_TIMEOUT="3600"
 #   Positive integer (N) → Manually specifies number of worker processes.
 # The developer-oriented default is 1, but we set to 0 here to allow pod CPU configuration
 # to dictate the number of server instance processes.
-# Note 7/7/2026: If your installation requires temporary agent networks (aka Reservations),
-# the server systems in place are not yet suitable for the multi-process operation
-# that is implied by a value that is not 1.
 ENV AGENT_HTTP_SERVER_INSTANCES="0"
 
 # If set to a value>0, will start periodic logging of currently used

--- a/neuro_san/deploy/Dockerfile.py314t
+++ b/neuro_san/deploy/Dockerfile.py314t
@@ -498,9 +498,6 @@ ENV AGENT_HTTP_IDLE_CONNECTIONS_TIMEOUT="3600"
 #   Positive integer (N) → Manually specifies number of worker processes.
 # The developer-oriented default is 1, but we set to 0 here to allow pod CPU configuration
 # to dictate the number of server instance processes.
-# Note 7/7/2026: If your installation requires temporary agent networks (aka Reservations),
-# the server systems in place are not yet suitable for the multi-process operation
-# that is implied by a value that is not 1.
 ENV AGENT_HTTP_SERVER_INSTANCES="0"
 
 # If set to a value>0, will start periodic logging of currently used

--- a/neuro_san/service/watcher/event_initiator/periodic_event_initiator.py
+++ b/neuro_san/service/watcher/event_initiator/periodic_event_initiator.py
@@ -53,7 +53,7 @@ class PeriodicEventInitiator(WatcherThread):
         """
         Constructor
         """
-        super().__init__(server_context)
+        super().__init__(server_context, single_instance=True)
         self.verbose: bool = False
         # NB: do NOT construct the AsyncioExecutor here. When Tornado is
         # configured for multiple worker processes (AGENT_HTTP_SERVER_INSTANCES

--- a/neuro_san/service/watcher/interfaces/watcher_thread.py
+++ b/neuro_san/service/watcher/interfaces/watcher_thread.py
@@ -23,6 +23,7 @@ from threading import Thread
 from time import sleep
 
 from leaf_common.utils.startable import Startable
+from xdist.plugin import worker_id
 
 from neuro_san.service.utils.server_context import ServerContext
 
@@ -32,25 +33,45 @@ class WatcherThread(Startable):
     Startable implementation that starts a thread to do its work in run().
     """
 
-    def __init__(self, server_context: ServerContext):
+    def __init__(self, server_context: ServerContext, single_instance: bool = False):
         """
         Constructor
 
         :param server_context: ServerContext for global-ish state
+        :param single_instance: If True, this Startable should only be started
+            in a single service instance in multi-instance server configuration.
+            If False, this Startable should be started in all service instances.
         """
         self.logger: Logger = getLogger(self.__class__.__name__)
         self.update_thread: Thread = Thread(target=self.run, name=self.__class__.__name__, daemon=True)
         self.keep_running: bool = True
         self.update_period_in_seconds: float = 1.0
+        self.single_instance: bool = single_instance
         self.server_context: ServerContext = server_context
 
     def start(self):
         """
         Perform start up.
+        If this WatcherThread is configured as a single instance,
+        it will only be started in one service instance (worker id 0) in multi-instance server configuration.
         """
+        if self.single_instance:
+            num_workers: int = self.server_context.get_num_workers()
+            worker_id: int = self.server_context.get_worker_id()
+            if num_workers > 1 and worker_id != 0:
+                self.logger.info("Not starting %s in worker %d because it is configured as a single instance",
+                                 self.__class__.__name__, worker_id)
+                return
         self.logger.info("Starting %s with %f seconds period",
                          self.__class__.__name__, self.update_period_in_seconds)
         self.update_thread.start()
+
+    def run_single_instance(self) -> bool:
+        """
+        :return: True if this Startable should only be started in a single service instance
+            in multi-instance server configuration. False otherwise.
+        """
+        return self.single_instance
 
     def run(self):
         """

--- a/neuro_san/service/watcher/interfaces/watcher_thread.py
+++ b/neuro_san/service/watcher/interfaces/watcher_thread.py
@@ -56,10 +56,10 @@ class WatcherThread(Startable):
         """
         if self.single_instance:
             num_workers: int = self.server_context.get_num_workers()
-            work_id: int = self.server_context.get_worker_id()
-            if num_workers > 1 and work_id != 0:
+            worker_id: int = self.server_context.get_worker_id()
+            if num_workers > 1 and worker_id != 0:
                 self.logger.info("Not starting %s in worker %d because it is configured as a single instance",
-                                 self.__class__.__name__, work_id)
+                                 self.__class__.__name__, worker_id)
                 return
         self.logger.info("Starting %s with %f seconds period",
                          self.__class__.__name__, self.update_period_in_seconds)

--- a/neuro_san/service/watcher/interfaces/watcher_thread.py
+++ b/neuro_san/service/watcher/interfaces/watcher_thread.py
@@ -23,7 +23,6 @@ from threading import Thread
 from time import sleep
 
 from leaf_common.utils.startable import Startable
-from xdist.plugin import worker_id
 
 from neuro_san.service.utils.server_context import ServerContext
 
@@ -57,10 +56,10 @@ class WatcherThread(Startable):
         """
         if self.single_instance:
             num_workers: int = self.server_context.get_num_workers()
-            worker_id: int = self.server_context.get_worker_id()
-            if num_workers > 1 and worker_id != 0:
+            work_id: int = self.server_context.get_worker_id()
+            if num_workers > 1 and work_id != 0:
                 self.logger.info("Not starting %s in worker %d because it is configured as a single instance",
-                                 self.__class__.__name__, worker_id)
+                                 self.__class__.__name__, work_id)
                 return
         self.logger.info("Starting %s with %f seconds period",
                          self.__class__.__name__, self.update_period_in_seconds)


### PR DESCRIPTION
## Summary
Run the PeriodicEventInitiator in only one worker of a multi-instance neuro-san
service, instead of in every worker.

When the HTTP server is configured for multiple worker processes
(AGENT_HTTP_SERVER_INSTANCES > 1, where Tornado forks one worker per instance),
each worker previously started its own PeriodicEventInitiator. That means the
periodic events it drives fired once per worker -- duplicated N times -- rather
than once for the service. This change makes the initiator start on exactly one
worker.

## Change
- WatcherThread (the base Startable that runs work on a background thread) gains
  a single_instance flag (default False). When True, start() consults the
  ServerContext for the worker id / worker count and, in a multi-instance
  configuration (num_workers > 1), starts the thread only on worker 0; other
  workers log and skip. A run_single_instance() accessor exposes the flag.
- PeriodicEventInitiator opts in by passing single_instance=True to the base
  constructor.

## Behavior
- Single-instance deployments are unchanged: with num_workers <= 1 the guard is
  a no-op and the thread always starts.
- Other WatcherThread subclasses default to single_instance=False, so their
  behavior is unchanged (they still start in every worker).
- Relies on the worker id / worker count already published on the ServerContext
  during the fork (get_worker_id / get_num_workers).

## Testing
- flake8 clean and pylint 10.00/10 on both changed files.
- Behavior is gated purely by ServerContext worker id / count, so a
  single-instance run is unaffected; in a multi-worker run only worker 0 starts
  the initiator (other workers log "Not starting ... because it is configured as
  a single instance").
- Tested by running 5-instance neuro-san server and verifying that only one PeriodicEventInitiator is started.

## Related issue
NS-1282

🤖 Generated with [Claude Code](https://claude.com/claude-code)
