### PR TITLE
Fix mutation of function tool specifications

### DIFF
--- a/neuro_san/internals/run_context/langchain/core/base_tool_factory.py
+++ b/neuro_san/internals/run_context/langchain/core/base_tool_factory.py
@@ -369,5 +369,6 @@ class BaseToolFactory:
             message: str = f"Could not create tool to call external agent '{name}'. Its function_json is None."
             raise ValueError(message)
 
-        function_json["name"] = name
-        return LangChainOpenAIFunctionTool.from_function_json(function_json, self.tool_caller)
+        use_function_json: Dict[str, Any] = dict(function_json)
+        use_function_json["name"] = name
+        return LangChainOpenAIFunctionTool.from_function_json(use_function_json, self.tool_caller)

--- a/neuro_san/internals/run_context/langchain/core/base_tool_factory.py
+++ b/neuro_san/internals/run_context/langchain/core/base_tool_factory.py
@@ -369,6 +369,14 @@ class BaseToolFactory:
             message: str = f"Could not create tool to call external agent '{name}'. Its function_json is None."
             raise ValueError(message)
 
+        # Copy before adding the name. function_json can be a dictionary that
+        # outlives this call: for a same-server external agent it is the
+        # referenced network's live registry spec (AsyncDirectAgentSession
+        # returns it by reference), and internal and toolbox tools funnel
+        # here with their registry/toolbox entries too. Writing the lookup
+        # name into it would leak this caller's reference string into that
+        # shared state (issue #1230). The copy is deliberately shallow: only
+        # the top-level "name" key is written here, so nested dicts stay shared.
         use_function_json: Dict[str, Any] = dict(function_json)
         use_function_json["name"] = name
         return LangChainOpenAIFunctionTool.from_function_json(use_function_json, self.tool_caller)

--- a/tests/neuro_san/internals/run_context/langchain/core/test_base_tool_factory.py
+++ b/tests/neuro_san/internals/run_context/langchain/core/test_base_tool_factory.py
@@ -122,6 +122,31 @@ class TestBaseToolFactory:
         assert list(tool.args_schema.__fields__.keys()) == ["question"]
         factory.journal.write_message.assert_not_awaited()
 
+    def test_create_function_tool_does_not_mutate_function_json(self):
+        """
+        Creating a tool must not add its lookup name to the caller-owned
+        function specification.
+        """
+        function_json: Dict[str, Any] = {
+            "description": "Answers music questions.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "question": {
+                        "type": "string",
+                        "description": "The question to answer."
+                    }
+                },
+                "required": ["question"]
+            }
+        }
+        factory = self.make_factory(function_json)
+
+        tool = factory.create_function_tool(function_json, self.EXTERNAL_AGENT_NAME)
+
+        assert tool is not None
+        assert "name" not in function_json
+
     @pytest.mark.asyncio
     async def test_external_tool_with_empty_properties_gets_default_schema(self):
         """

--- a/tests/neuro_san/internals/run_context/langchain/core/test_base_tool_factory.py
+++ b/tests/neuro_san/internals/run_context/langchain/core/test_base_tool_factory.py
@@ -17,12 +17,14 @@
 from typing import Any
 from typing import Dict
 
+from copy import deepcopy
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 
 import pytest
 
 from neuro_san.internals.run_context.langchain.core.base_tool_factory import BaseToolFactory
+from neuro_san.internals.utils.external_agent_parsing import ExternalAgentParsing
 
 
 class TestBaseToolFactory:
@@ -140,12 +142,40 @@ class TestBaseToolFactory:
                 "required": ["question"]
             }
         }
+        expected: Dict[str, Any] = deepcopy(function_json)
         factory = self.make_factory(function_json)
 
         tool = factory.create_function_tool(function_json, self.EXTERNAL_AGENT_NAME)
 
-        assert tool is not None
-        assert "name" not in function_json
+        assert function_json == expected
+        assert tool.name == ExternalAgentParsing.get_safe_agent_name(self.EXTERNAL_AGENT_NAME)
+
+    @pytest.mark.asyncio
+    async def test_external_tool_does_not_mutate_function_json(self):
+        """
+        A same-server external agent can return its live registry function
+        specification by reference. Creating a tool from it must not mutate it.
+        """
+        function_json: Dict[str, Any] = {
+            "description": "Answers music questions.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "question": {
+                        "type": "string",
+                        "description": "The question to answer."
+                    }
+                },
+                "required": ["question"]
+            }
+        }
+        expected: Dict[str, Any] = deepcopy(function_json)
+        factory = self.make_factory(function_json)
+
+        tool = await factory.create_external_tool(self.EXTERNAL_AGENT_NAME)
+
+        assert function_json == expected
+        assert tool.name == ExternalAgentParsing.get_safe_agent_name(self.EXTERNAL_AGENT_NAME)
 
     @pytest.mark.asyncio
     async def test_external_tool_with_empty_properties_gets_default_schema(self):


### PR DESCRIPTION
## Summary

Fixes #1230.

Prevent `BaseToolFactory.create_function_tool()` from mutating the caller-owned function specification when adding the tool lookup name.

## Changes

- Create a shallow copy of `function_json` before adding the `"name"` field.
- Pass the copied specification to `LangChainOpenAIFunctionTool`.
- Add a regression test confirming tool creation leaves the original specification unchanged.

A shallow copy is sufficient because only the top-level `"name"` field is modified.