### PR TITLE
Validate MCP tools list response

### DIFF
--- a/neuro_san/session/mcp_service_agent_session.py
+++ b/neuro_san/session/mcp_service_agent_session.py
@@ -17,7 +17,6 @@
 
 from typing import Any
 from typing import Dict
-from typing import List
 from typing import Generator
 
 import json
@@ -41,6 +40,7 @@ class McpServiceAgentSession(AbstractHttpServiceAgentSession, AgentSession):
     This is largely only used by command-line tests.
     """
     MCP_PROTOCOL_VERSION: str = "MCP-Protocol-Version"
+    MAX_TOOLS: int = 1000
 
     # pylint: disable=too-many-arguments,too-many-positional-arguments, too-many-locals
     def __init__(self, host: str = None,
@@ -159,8 +159,21 @@ class McpServiceAgentSession(AbstractHttpServiceAgentSession, AgentSession):
         except Exception as exc:  # pylint: disable=broad-exception-caught
             raise ValueError(self.help_message(path)) from exc
 
-        tools_list: List[Dict[str, Any]] = response_dict.get("result", {}).get("tools", [])
+        if not isinstance(response_dict, dict):
+            raise ValueError("Invalid MCP tools/list response: response must be an object")
+        result_dict: Any = response_dict.get("result", {})
+        if not isinstance(result_dict, dict):
+            raise ValueError("Invalid MCP tools/list response: 'result' must be an object")
+
+        tools_list: Any = result_dict.get("tools", [])
+        if not isinstance(tools_list, list):
+            raise ValueError("Invalid MCP tools/list response: 'tools' must be an array")
+        if len(tools_list) > self.MAX_TOOLS:
+            raise ValueError(f"Invalid MCP tools/list response: too many tools (maximum {self.MAX_TOOLS})")
+
         for tool in tools_list:
+            if not isinstance(tool, dict):
+                raise ValueError("Invalid MCP tools/list response: each tool must be an object")
             name: str = tool.get("name", None)
             if name == self.agent_name:
                 tool_description: str = tool.get("description", None)

--- a/neuro_san/session/mcp_service_agent_session.py
+++ b/neuro_san/session/mcp_service_agent_session.py
@@ -21,10 +21,13 @@ from typing import List
 from typing import Generator
 
 import json
+import jsonschema
 import requests
 
+from leaf_common.serialization.util.text_file_reader import TextFileReader
 from leaf_common.time.timeout import Timeout
 
+from neuro_san import TOP_LEVEL_DIR
 from neuro_san.interfaces.agent_session import AgentSession
 from neuro_san.session.abstract_http_service_agent_session import AbstractHttpServiceAgentSession
 from neuro_san.session.mcp_chat_response_dictionary_converter import McpChatResponseDictionaryConverter
@@ -41,6 +44,7 @@ class McpServiceAgentSession(AbstractHttpServiceAgentSession, AgentSession):
     This is largely only used by command-line tests.
     """
     MCP_PROTOCOL_VERSION: str = "MCP-Protocol-Version"
+    _protocol_schema: Dict[str, Any] = None
 
     # pylint: disable=too-many-arguments,too-many-positional-arguments, too-many-locals
     def __init__(self, host: str = None,
@@ -112,7 +116,7 @@ class McpServiceAgentSession(AbstractHttpServiceAgentSession, AgentSession):
             raise ValueError(self.help_message(path)) from exc
 
         # Extract the protocol version from the handshake response
-        result_dict: Dict[str, Any] = self._get_result_dict(response_dict, "initialize")
+        result_dict: Dict[str, Any] = self._get_result_dict(response_dict, "initialize", "InitializeResult")
         self.protocol_version: str = result_dict.get("protocolVersion", None)
 
         # Confirm the protocol version is supported by this client
@@ -165,10 +169,8 @@ class McpServiceAgentSession(AbstractHttpServiceAgentSession, AgentSession):
         # CheckMarx false positive (Unchecked Input for Loop Condition, #1252):
         # tools_list has already been fully parsed by json.loads above, so this
         # O(n) loop with early return cannot cost more than the parse that
-        # preceded it. The isinstance checks above validate the shape.
+        # preceded it. The MCP schema validation above validates the shape.
         for tool in tools_list:
-            if not isinstance(tool, dict):
-                continue
             name: str = tool.get("name", None)
             if name == self.agent_name:
                 tool_description: str = tool.get("description", None)
@@ -179,10 +181,10 @@ class McpServiceAgentSession(AbstractHttpServiceAgentSession, AgentSession):
 
         return None
 
-    @staticmethod
-    def _get_result_dict(response_dict: Any, method: str) -> Dict[str, Any]:
+    @classmethod
+    def _get_result_dict(cls, response_dict: Any, method: str, result_definition: str) -> Dict[str, Any]:
         """
-        Validates an MCP JSON-RPC response and returns its result object.
+        Validates an MCP JSON-RPC response and its result against the protocol schema.
         """
         if not isinstance(response_dict, dict):
             raise ValueError(f"Invalid MCP {method} response: response must be an object")
@@ -194,18 +196,40 @@ class McpServiceAgentSession(AbstractHttpServiceAgentSession, AgentSession):
         result_dict: Any = response_dict.get("result", None)
         if not isinstance(result_dict, dict):
             raise ValueError(f"Invalid MCP {method} response: 'result' must be an object")
+
+        protocol_schema: Dict[str, Any] = cls._get_protocol_schema()
+        validation_schema: Dict[str, Any] = {
+            "$schema": protocol_schema.get("$schema"),
+            "$ref": f"#/definitions/{result_definition}",
+            "definitions": protocol_schema.get("definitions", {}),
+        }
+        try:
+            jsonschema.validate(instance=result_dict, schema=validation_schema)
+        except jsonschema.exceptions.ValidationError as exc:
+            raise ValueError(
+                f"Invalid MCP {method} response: 'result' does not match {result_definition}"
+            ) from exc
         return result_dict
+
+    @classmethod
+    def _get_protocol_schema(cls) -> Dict[str, Any]:
+        """
+        Loads and caches the MCP protocol schema supported by this session.
+        """
+        if cls._protocol_schema is None:
+            schema_name: str = f"service/mcp/validation/mcp-schema-{MCP_VERSION}.json"
+            schema_path = TOP_LEVEL_DIR.get_file_in_basis(schema_name)
+            schema_str: str = TextFileReader.read_text_file(schema_path)
+            cls._protocol_schema = json.loads(schema_str)
+        return cls._protocol_schema
 
     @classmethod
     def _get_tools_list(cls, response_dict: Any) -> List[Any]:
         """
         Validates an MCP tools/list response and returns its tools array.
         """
-        result_dict: Dict[str, Any] = cls._get_result_dict(response_dict, "tools/list")
-        tools_list: Any = result_dict.get("tools", None)
-        if not isinstance(tools_list, list):
-            raise ValueError("Invalid MCP tools/list response: 'tools' must be an array")
-        return tools_list
+        result_dict: Dict[str, Any] = cls._get_result_dict(response_dict, "tools/list", "ListToolsResult")
+        return result_dict["tools"]
 
     def connectivity(self, request_dict: Dict[str, Any]) -> Dict[str, Any]:
         """

--- a/neuro_san/session/mcp_service_agent_session.py
+++ b/neuro_san/session/mcp_service_agent_session.py
@@ -17,6 +17,7 @@
 
 from typing import Any
 from typing import Dict
+from typing import List
 from typing import Generator
 
 import json
@@ -40,7 +41,6 @@ class McpServiceAgentSession(AbstractHttpServiceAgentSession, AgentSession):
     This is largely only used by command-line tests.
     """
     MCP_PROTOCOL_VERSION: str = "MCP-Protocol-Version"
-    MAX_TOOLS: int = 1000
 
     # pylint: disable=too-many-arguments,too-many-positional-arguments, too-many-locals
     def __init__(self, host: str = None,
@@ -112,7 +112,8 @@ class McpServiceAgentSession(AbstractHttpServiceAgentSession, AgentSession):
             raise ValueError(self.help_message(path)) from exc
 
         # Extract the protocol version from the handshake response
-        self.protocol_version: str = response_dict.get("result", {}).get("protocolVersion", None)
+        result_dict: Dict[str, Any] = self._get_result_dict(response_dict, "initialize")
+        self.protocol_version: str = result_dict.get("protocolVersion", None)
 
         # Confirm the protocol version is supported by this client
         if self.protocol_version not in [MCP_VERSION]:
@@ -159,21 +160,15 @@ class McpServiceAgentSession(AbstractHttpServiceAgentSession, AgentSession):
         except Exception as exc:  # pylint: disable=broad-exception-caught
             raise ValueError(self.help_message(path)) from exc
 
-        if not isinstance(response_dict, dict):
-            raise ValueError("Invalid MCP tools/list response: response must be an object")
-        result_dict: Any = response_dict.get("result", {})
-        if not isinstance(result_dict, dict):
-            raise ValueError("Invalid MCP tools/list response: 'result' must be an object")
+        tools_list: List[Any] = self._get_tools_list(response_dict)
 
-        tools_list: Any = result_dict.get("tools", [])
-        if not isinstance(tools_list, list):
-            raise ValueError("Invalid MCP tools/list response: 'tools' must be an array")
-        if len(tools_list) > self.MAX_TOOLS:
-            raise ValueError(f"Invalid MCP tools/list response: too many tools (maximum {self.MAX_TOOLS})")
-
+        # CheckMarx false positive (Unchecked Input for Loop Condition, #1252):
+        # tools_list has already been fully parsed by json.loads above, so this
+        # O(n) loop with early return cannot cost more than the parse that
+        # preceded it. The isinstance checks above validate the shape.
         for tool in tools_list:
             if not isinstance(tool, dict):
-                raise ValueError("Invalid MCP tools/list response: each tool must be an object")
+                continue
             name: str = tool.get("name", None)
             if name == self.agent_name:
                 tool_description: str = tool.get("description", None)
@@ -183,6 +178,34 @@ class McpServiceAgentSession(AbstractHttpServiceAgentSession, AgentSession):
                     }
 
         return None
+
+    @staticmethod
+    def _get_result_dict(response_dict: Any, method: str) -> Dict[str, Any]:
+        """
+        Validates an MCP JSON-RPC response and returns its result object.
+        """
+        if not isinstance(response_dict, dict):
+            raise ValueError(f"Invalid MCP {method} response: response must be an object")
+
+        error_dict: Any = response_dict.get("error", None)
+        if isinstance(error_dict, dict):
+            raise ValueError(f"MCP {method} error {error_dict.get('code')}: {error_dict.get('message')}")
+
+        result_dict: Any = response_dict.get("result", None)
+        if not isinstance(result_dict, dict):
+            raise ValueError(f"Invalid MCP {method} response: 'result' must be an object")
+        return result_dict
+
+    @classmethod
+    def _get_tools_list(cls, response_dict: Any) -> List[Any]:
+        """
+        Validates an MCP tools/list response and returns its tools array.
+        """
+        result_dict: Dict[str, Any] = cls._get_result_dict(response_dict, "tools/list")
+        tools_list: Any = result_dict.get("tools", None)
+        if not isinstance(tools_list, list):
+            raise ValueError("Invalid MCP tools/list response: 'tools' must be an array")
+        return tools_list
 
     def connectivity(self, request_dict: Dict[str, Any]) -> Dict[str, Any]:
         """

--- a/tests/neuro_san/session/test_mcp_service_agent_session.py
+++ b/tests/neuro_san/session/test_mcp_service_agent_session.py
@@ -1,0 +1,82 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+from typing import Any
+from typing import Dict
+
+import json
+from unittest import TestCase
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from neuro_san.session.mcp_service_agent_session import MCP_VERSION
+from neuro_san.session.mcp_service_agent_session import McpServiceAgentSession
+
+
+class TestMcpServiceAgentSession(TestCase):
+    """
+    Unit tests for McpServiceAgentSession.
+    """
+
+    @staticmethod
+    def create_response(response_dict: Dict[str, Any]) -> MagicMock:
+        """
+        Creates a successful HTTP response containing response_dict.
+        """
+        response: MagicMock = MagicMock()
+        response.text = json.dumps(response_dict)
+        return response
+
+    def call_function(self, tools: Any) -> Dict[str, Any]:
+        """
+        Calls function() with a tools/list response containing tools.
+        """
+        initialize_response: MagicMock = self.create_response({
+            "result": {"protocolVersion": MCP_VERSION}
+        })
+        initialized_response: MagicMock = self.create_response({})
+        tools_response: MagicMock = self.create_response({"result": {"tools": tools}})
+
+        with patch("neuro_san.session.mcp_service_agent_session.requests.post",
+                   side_effect=[initialize_response, initialized_response, tools_response]):
+            session = McpServiceAgentSession(agent_name="hello_world")
+            return session.function({})
+
+    def test_function_accepts_valid_tools(self):
+        """
+        Tests that a valid tools/list response returns the matching tool description.
+        """
+        result: Dict[str, Any] = self.call_function([
+            {"name": "hello_world", "description": "Says hello"}
+        ])
+
+        self.assertEqual({"function": {"description": "Says hello"}}, result)
+
+    def test_function_rejects_invalid_tools(self):
+        """
+        Tests that tools/list response data is validated before iteration.
+        """
+        invalid_tools = (
+            "hello_world",
+            ["hello_world"],
+            [{}] * (McpServiceAgentSession.MAX_TOOLS + 1),
+        )
+
+        for tools in invalid_tools:
+            with self.subTest(tools_type=type(tools), tools_length=len(tools)):
+                with self.assertRaisesRegex(ValueError, "Invalid MCP tools/list response"):
+                    self.call_function(tools)

--- a/tests/neuro_san/session/test_mcp_service_agent_session.py
+++ b/tests/neuro_san/session/test_mcp_service_agent_session.py
@@ -32,6 +32,12 @@ class TestMcpServiceAgentSession(TestCase):
     Unit tests for McpServiceAgentSession.
     """
 
+    VALID_INITIALIZE_RESULT: Dict[str, Any] = {
+        "protocolVersion": MCP_VERSION,
+        "capabilities": {},
+        "serverInfo": {"name": "test_server", "version": "1.0.0"},
+    }
+
     @staticmethod
     def create_response(response_dict: Any) -> MagicMock:
         """
@@ -46,7 +52,7 @@ class TestMcpServiceAgentSession(TestCase):
         Calls function() with the given tools/list response.
         """
         initialize_response: MagicMock = self.create_response({
-            "result": {"protocolVersion": MCP_VERSION}
+            "result": self.VALID_INITIALIZE_RESULT
         })
         initialized_response: MagicMock = self.create_response({})
         tools_response: MagicMock = self.create_response(response_dict)
@@ -62,6 +68,19 @@ class TestMcpServiceAgentSession(TestCase):
         """
         return self.call_function_with_response({"result": {"tools": tools}})
 
+    @staticmethod
+    def create_tool(name: str, description: str = None) -> Dict[str, Any]:
+        """
+        Creates a tool that conforms to the MCP Tool schema.
+        """
+        tool: Dict[str, Any] = {
+            "name": name,
+            "inputSchema": {"type": "object"},
+        }
+        if description is not None:
+            tool["description"] = description
+        return tool
+
     def create_session_with_initialize_response(self, response_dict: Any) -> McpServiceAgentSession:
         """
         Creates an MCP session with the given initialize response.
@@ -76,7 +95,7 @@ class TestMcpServiceAgentSession(TestCase):
         Tests that a valid tools/list response returns the matching tool description.
         """
         result: Dict[str, Any] = self.call_function([
-            {"name": "hello_world", "description": "Says hello"}
+            self.create_tool("hello_world", "Says hello")
         ])
 
         self.assertEqual({"function": {"description": "Says hello"}}, result)
@@ -89,9 +108,14 @@ class TestMcpServiceAgentSession(TestCase):
             ([], "Invalid MCP tools/list response: response must be an object"),
             ({"result": None}, "Invalid MCP tools/list response: 'result' must be an object"),
             ({"result": []}, "Invalid MCP tools/list response: 'result' must be an object"),
-            ({"result": {}}, "Invalid MCP tools/list response: 'tools' must be an array"),
-            ({"result": {"tools": None}}, "Invalid MCP tools/list response: 'tools' must be an array"),
-            ({"result": {"tools": "hello_world"}}, "Invalid MCP tools/list response: 'tools' must be an array"),
+            ({"result": {}},
+             "Invalid MCP tools/list response: 'result' does not match ListToolsResult"),
+            ({"result": {"tools": None}},
+             "Invalid MCP tools/list response: 'result' does not match ListToolsResult"),
+            ({"result": {"tools": "hello_world"}},
+             "Invalid MCP tools/list response: 'result' does not match ListToolsResult"),
+            ({"result": {"tools": [{"name": "hello_world"}]}},
+             "Invalid MCP tools/list response: 'result' does not match ListToolsResult"),
         )
 
         for response_dict, expected_message in invalid_responses:
@@ -113,16 +137,17 @@ class TestMcpServiceAgentSession(TestCase):
 
         self.assertEqual("MCP tools/list error -32602: Invalid params", str(context.exception))
 
-    def test_function_skips_invalid_tool(self):
+    def test_function_rejects_invalid_tool(self):
         """
-        Tests that an invalid entry does not prevent discovery of a valid tool.
+        Tests that a malformed tool causes the ListToolsResult schema validation to fail.
         """
-        result: Dict[str, Any] = self.call_function([
-            None,
-            {"name": "hello_world", "description": "Says hello"},
-        ])
+        with self.assertRaises(ValueError) as context:
+            self.call_function([None, self.create_tool("hello_world", "Says hello")])
 
-        self.assertEqual({"function": {"description": "Says hello"}}, result)
+        self.assertEqual(
+            "Invalid MCP tools/list response: 'result' does not match ListToolsResult",
+            str(context.exception),
+        )
 
     def test_initialize_rejects_invalid_response(self):
         """
@@ -132,6 +157,8 @@ class TestMcpServiceAgentSession(TestCase):
             ([], "Invalid MCP initialize response: response must be an object"),
             ({"result": None}, "Invalid MCP initialize response: 'result' must be an object"),
             ({"result": []}, "Invalid MCP initialize response: 'result' must be an object"),
+            ({"result": {"protocolVersion": MCP_VERSION}},
+             "Invalid MCP initialize response: 'result' does not match InitializeResult"),
         )
 
         for response_dict, expected_message in invalid_responses:
@@ -157,8 +184,8 @@ class TestMcpServiceAgentSession(TestCase):
         """
         Tests that the client does not impose a limit absent from the MCP specification.
         """
-        tools = [{}] * 1001
-        tools.append({"name": "hello_world", "description": "Says hello"})
+        tools = [self.create_tool(f"tool_{index}") for index in range(1001)]
+        tools.append(self.create_tool("hello_world", "Says hello"))
 
         result: Dict[str, Any] = self.call_function(tools)
 

--- a/tests/neuro_san/session/test_mcp_service_agent_session.py
+++ b/tests/neuro_san/session/test_mcp_service_agent_session.py
@@ -33,7 +33,7 @@ class TestMcpServiceAgentSession(TestCase):
     """
 
     @staticmethod
-    def create_response(response_dict: Dict[str, Any]) -> MagicMock:
+    def create_response(response_dict: Any) -> MagicMock:
         """
         Creates a successful HTTP response containing response_dict.
         """
@@ -41,20 +41,35 @@ class TestMcpServiceAgentSession(TestCase):
         response.text = json.dumps(response_dict)
         return response
 
-    def call_function(self, tools: Any) -> Dict[str, Any]:
+    def call_function_with_response(self, response_dict: Any) -> Dict[str, Any]:
         """
-        Calls function() with a tools/list response containing tools.
+        Calls function() with the given tools/list response.
         """
         initialize_response: MagicMock = self.create_response({
             "result": {"protocolVersion": MCP_VERSION}
         })
         initialized_response: MagicMock = self.create_response({})
-        tools_response: MagicMock = self.create_response({"result": {"tools": tools}})
+        tools_response: MagicMock = self.create_response(response_dict)
 
         with patch("neuro_san.session.mcp_service_agent_session.requests.post",
                    side_effect=[initialize_response, initialized_response, tools_response]):
             session = McpServiceAgentSession(agent_name="hello_world")
             return session.function({})
+
+    def call_function(self, tools: Any) -> Dict[str, Any]:
+        """
+        Calls function() with a tools/list response containing tools.
+        """
+        return self.call_function_with_response({"result": {"tools": tools}})
+
+    def create_session_with_initialize_response(self, response_dict: Any) -> McpServiceAgentSession:
+        """
+        Creates an MCP session with the given initialize response.
+        """
+        initialize_response: MagicMock = self.create_response(response_dict)
+        with patch("neuro_san.session.mcp_service_agent_session.requests.post",
+                   return_value=initialize_response):
+            return McpServiceAgentSession(agent_name="hello_world")
 
     def test_function_accepts_valid_tools(self):
         """
@@ -70,13 +85,81 @@ class TestMcpServiceAgentSession(TestCase):
         """
         Tests that tools/list response data is validated before iteration.
         """
-        invalid_tools = (
-            "hello_world",
-            ["hello_world"],
-            [{}] * (McpServiceAgentSession.MAX_TOOLS + 1),
+        invalid_responses = (
+            ([], "Invalid MCP tools/list response: response must be an object"),
+            ({"result": None}, "Invalid MCP tools/list response: 'result' must be an object"),
+            ({"result": []}, "Invalid MCP tools/list response: 'result' must be an object"),
+            ({"result": {}}, "Invalid MCP tools/list response: 'tools' must be an array"),
+            ({"result": {"tools": None}}, "Invalid MCP tools/list response: 'tools' must be an array"),
+            ({"result": {"tools": "hello_world"}}, "Invalid MCP tools/list response: 'tools' must be an array"),
         )
 
-        for tools in invalid_tools:
-            with self.subTest(tools_type=type(tools), tools_length=len(tools)):
-                with self.assertRaisesRegex(ValueError, "Invalid MCP tools/list response"):
-                    self.call_function(tools)
+        for response_dict, expected_message in invalid_responses:
+            with self.subTest(response_dict=response_dict):
+                with self.assertRaises(ValueError) as context:
+                    self.call_function_with_response(response_dict)
+                self.assertEqual(expected_message, str(context.exception))
+
+    def test_function_surfaces_json_rpc_error(self):
+        """
+        Tests that a successful HTTP response containing a JSON-RPC error is surfaced.
+        """
+        response_dict = {
+            "error": {"code": -32602, "message": "Invalid params"}
+        }
+
+        with self.assertRaises(ValueError) as context:
+            self.call_function_with_response(response_dict)
+
+        self.assertEqual("MCP tools/list error -32602: Invalid params", str(context.exception))
+
+    def test_function_skips_invalid_tool(self):
+        """
+        Tests that an invalid entry does not prevent discovery of a valid tool.
+        """
+        result: Dict[str, Any] = self.call_function([
+            None,
+            {"name": "hello_world", "description": "Says hello"},
+        ])
+
+        self.assertEqual({"function": {"description": "Says hello"}}, result)
+
+    def test_initialize_rejects_invalid_response(self):
+        """
+        Tests that the initialize response and its result object are validated.
+        """
+        invalid_responses = (
+            ([], "Invalid MCP initialize response: response must be an object"),
+            ({"result": None}, "Invalid MCP initialize response: 'result' must be an object"),
+            ({"result": []}, "Invalid MCP initialize response: 'result' must be an object"),
+        )
+
+        for response_dict, expected_message in invalid_responses:
+            with self.subTest(response_dict=response_dict):
+                with self.assertRaises(ValueError) as context:
+                    self.create_session_with_initialize_response(response_dict)
+                self.assertEqual(expected_message, str(context.exception))
+
+    def test_initialize_surfaces_json_rpc_error(self):
+        """
+        Tests that a JSON-RPC error in the initialize response is surfaced.
+        """
+        response_dict = {
+            "error": {"code": -32602, "message": "Invalid params"}
+        }
+
+        with self.assertRaises(ValueError) as context:
+            self.create_session_with_initialize_response(response_dict)
+
+        self.assertEqual("MCP initialize error -32602: Invalid params", str(context.exception))
+
+    def test_function_accepts_more_than_one_thousand_tools(self):
+        """
+        Tests that the client does not impose a limit absent from the MCP specification.
+        """
+        tools = [{}] * 1001
+        tools.append({"name": "hello_world", "description": "Says hello"})
+
+        result: Dict[str, Any] = self.call_function(tools)
+
+        self.assertEqual({"function": {"description": "Says hello"}}, result)


### PR DESCRIPTION
## Summary

Fixes #1252.

Validates the MCP `tools/list` response before iterating over tools.

## Changes

- Validate that the JSON-RPC response and `result` are objects.
- Validate that `tools` is an array.
- Reject responses containing more than 1,000 tools.
- Validate that every tool entry is an object.
- Add unit tests for valid, malformed, and oversized responses.