### PR TITLE
Add a flag to allow prompt caching in load test

### DIFF
--- a/tests/load_tests/load_test_arguments.py
+++ b/tests/load_tests/load_test_arguments.py
@@ -207,6 +207,17 @@ class LoadTestArguments:
                  "prompts from the agent's prompt pool.",
         )
         parser.add_argument(
+            "--allow-caching",
+            action="store_true",
+            default=False,
+            help="Send prompts verbatim from the agent's prompt "
+                 "pool so caches along the path can serve them. "
+                 "By default a unique '(request N)' suffix is "
+                 "appended to defeat caching; pass this flag to "
+                 "measure cached behavior instead. No effect with "
+                 "--same-prompt, which is already cacheable.",
+        )
+        parser.add_argument(
             "--no-dry-run",
             action="store_true",
             default=False,

--- a/tests/load_tests/load_test_cli.py
+++ b/tests/load_tests/load_test_cli.py
@@ -2270,6 +2270,8 @@ class LoadTestOrchestrator:  # pylint: disable=too-many-instance-attributes
             )
 
         prompt_mode = "same" if self.args.same_prompt else "varied"
+        if self.args.allow_caching:
+            prompt_mode = f"{prompt_mode} (caching allowed)"
         mode = "ramp" if self.args.ramp else "flat"
         logger.info(
             "\nConfig: agent=%s, mode=%s, level=%s, "
@@ -2732,6 +2734,7 @@ class LoadTestOrchestrator:  # pylint: disable=too-many-instance-attributes
                 "num_rounds": self.args.num_rounds,
                 "num_requests": self.args.num_requests,
                 "same_prompt": self.args.same_prompt,
+                "allow_caching": self.args.allow_caching,
                 "chat_filter": self.args.chat_filter,
                 "server_log": self.server_log,
                 "estimated_tokens_per_request": (

--- a/tests/load_tests/prompts/agent_profile.py
+++ b/tests/load_tests/prompts/agent_profile.py
@@ -103,6 +103,9 @@ class AgentProfile:
         base_prompt = prompts[request_id % len(prompts)]
         if allow_caching:
             return base_prompt
+        # The suffix makes every prompt unique, so no cache along the
+        # path (LLM prompt cache, agent network, proxy) can serve the
+        # response and the run measures real work, not cache hits.
         return f"{base_prompt} (request {request_id})"
 
     @classmethod

--- a/tests/load_tests/prompts/agent_profile.py
+++ b/tests/load_tests/prompts/agent_profile.py
@@ -77,11 +77,17 @@ class AgentProfile:
         """
         return self._data.get("failure_patterns", [])
 
-    def get_prompt(self, request_id, same_prompt=False) -> str:
+    def get_prompt(self, request_id, same_prompt=False,
+                   allow_caching=False) -> str:
         """Return the prompt for a given request.
 
         In same_prompt mode, always returns the first prompt.
         In varied mode, cycles through the pool and appends the request_id.
+        The request_id suffix keeps every prompt unique so that no
+        cache along the path (LLM prompt cache, agent network, proxy)
+        can serve the response.  In allow_caching mode the suffix is
+        dropped, so requests that reuse a pool prompt are eligible
+        for those caches.
         """
         prompts = self.prompts
         if not prompts:
@@ -95,6 +101,8 @@ class AgentProfile:
         if same_prompt:
             return prompts[0]
         base_prompt = prompts[request_id % len(prompts)]
+        if allow_caching:
+            return base_prompt
         return f"{base_prompt} (request {request_id})"
 
     @classmethod

--- a/tests/load_tests/reporting/json_metadata.py
+++ b/tests/load_tests/reporting/json_metadata.py
@@ -50,6 +50,10 @@ class JsonMetadata:
             "config.same_prompt":
                 "If true, all requests use the same prompt "
                 "(collision stress test).",
+            "config.allow_caching":
+                "If true, prompts are sent verbatim and caches may "
+                "serve responses. If false, a unique per-request "
+                "suffix defeats caching.",
             "aggregates.total_elapsed_seconds":
                 "Sum of wall-clock time across all stages.",
             "aggregates.avg_latency_seconds":

--- a/tests/load_tests/traffic/runner.py
+++ b/tests/load_tests/traffic/runner.py
@@ -96,6 +96,7 @@ class TrafficRunner:
         """
         prompt = self._profile.get_prompt(
             global_request_id, same_prompt=self._args.same_prompt,
+            allow_caching=self._args.allow_caching,
         )
         prompt_file = CliBuilder.write_prompt_file(global_request_id, prompt)
 
@@ -171,6 +172,7 @@ class TrafficRunner:
         prompt = self._profile.get_prompt(
             global_request_id,
             same_prompt=self._args.same_prompt,
+            allow_caching=self._args.allow_caching,
         )
         start = time.time()
         status, parsed_fields, response_text, ttft, token_data = (

--- a/tests/load_tests/unit/test_agent_profile_prompt.py
+++ b/tests/load_tests/unit/test_agent_profile_prompt.py
@@ -1,0 +1,67 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+from unittest import TestCase
+
+from tests.load_tests.prompts.agent_profile import AgentProfile
+
+
+class TestAgentProfilePrompt(TestCase):
+    """
+    Unit tests for AgentProfile.get_prompt().
+
+    The per-request suffix is what keeps a run from measuring cache
+    hits, so a wrong answer here silently changes what is measured.
+    """
+
+    def setUp(self):
+        """Build a profile with a two-prompt pool."""
+        self.profile = AgentProfile(
+            "music_nerd", {"prompts": ["first", "second"]},
+        )
+
+    def test_varied_mode_appends_request_id(self):
+        """Default mode makes every prompt unique."""
+        self.assertEqual(
+            self.profile.get_prompt(0), "first (request 0)",
+        )
+        self.assertEqual(
+            self.profile.get_prompt(3), "second (request 3)",
+        )
+
+    def test_allow_caching_keeps_pool_prompt_verbatim(self):
+        """Cacheable mode still cycles the pool, without a suffix."""
+        self.assertEqual(
+            self.profile.get_prompt(0, allow_caching=True), "first",
+        )
+        self.assertEqual(
+            self.profile.get_prompt(3, allow_caching=True), "second",
+        )
+
+    def test_same_prompt_wins_over_allow_caching(self):
+        """same_prompt already repeats prompt zero verbatim."""
+        self.assertEqual(
+            self.profile.get_prompt(
+                3, same_prompt=True, allow_caching=True,
+            ),
+            "first",
+        )
+
+    def test_empty_prompt_pool_aborts(self):
+        """A profile with no prompts is a hard error."""
+        empty = AgentProfile("music_nerd", {"prompts": []})
+        with self.assertRaises(SystemExit):
+            empty.get_prompt(0)

--- a/tests/load_tests/unit/test_raw_json_export.py
+++ b/tests/load_tests/unit/test_raw_json_export.py
@@ -61,7 +61,7 @@ class TestExportRawJsonAggregates(TestCase):
             request_timeout=120, idle_timeout=60, stage_timeout=300,
             total_timeout=600, settle_time=5, max_workers=10,
             num_rounds=1, num_requests=3, same_prompt=False,
-            chat_filter=None,
+            allow_caching=False, chat_filter=None,
         )
         return orchestrator
 


### PR DESCRIPTION
This is needed to allow us to run LT again on our boombox LLM caching. It will be saving tokens.

The load test appends a unique (request N) suffix to every varied-mode prompt so that no cache along the path (LLM prompt cache, agent network, proxy) can serve a response — keeping a run from degenerating into a cache benchmark. This adds --allow-caching to drop that suffix on purpose, so a run can measure cached behavior.