### PR TITLE
Accept LLM endpoint base URL without /v1 in record/playback proxy.

### DIFF
--- a/tests/record_playback_llm_server/README.md
+++ b/tests/record_playback_llm_server/README.md
@@ -80,7 +80,7 @@ required in `record` mode and used for cache-miss fetches in `hybrid` mode:
 
 | Variable | Purpose |
 |---|---|
-| `RECORD_PLAYBACK_UPSTREAM_BASE_URL` | Base URL of the real host, including the version segment. e.g. `https://api.openai.com/v1`. Required in record mode; optional in hybrid mode. |
+| `RECORD_PLAYBACK_UPSTREAM_BASE_URL` | Base URL of the real host, e.g. `https://api.openai.com` or `https://api.openai.com/v1`. The OpenAI-style `/v1` segment is optional and is appended when absent. Required in record mode; optional in hybrid mode. |
 | `RECORD_PLAYBACK_UPSTREAM_API_KEY` | Bearer credential for that host. Optional (a warning is logged if absent, for hosts that need no auth). |
 | `RECORD_PLAYBACK_UPSTREAM_REQUEST_TIMEOUT_SECONDS` | Whole-request timeout when forwarding to the real host. Default `600`. |
 | `RECORD_PLAYBACK_UPSTREAM_CONNECT_TIMEOUT_SECONDS` | Connection timeout when forwarding to the real host. Default `30`. |

--- a/tests/record_playback_llm_server/tests/test_upstream_client.py
+++ b/tests/record_playback_llm_server/tests/test_upstream_client.py
@@ -1,0 +1,56 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+"""
+Tests for UpstreamClient base-URL normalization.
+"""
+from tests.record_playback_llm_server.upstream_client import UpstreamClient
+
+
+class TestUpstreamClient:
+    """
+    Base-URL normalization: the OpenAI-style /v1 segment is optional. Asserted
+    through the public constructor's stored base_url.
+    """
+
+    @staticmethod
+    def _base_url_for(configured: str) -> str:
+        """Construct an UpstreamClient with the given base URL and return the normalized value."""
+        return UpstreamClient(base_url=configured, api_key=None).base_url
+
+    def test_appends_v1_when_absent(self):
+        """A base URL without /v1 gets the version segment appended."""
+        assert self._base_url_for("https://api.openai.com") == "https://api.openai.com/v1"
+
+    def test_trailing_slash_stripped_then_v1_appended(self):
+        """A trailing slash is stripped before appending /v1."""
+        assert self._base_url_for("https://api.openai.com/") == "https://api.openai.com/v1"
+
+    def test_existing_v1_left_as_is(self):
+        """A base URL that already ends in /v1 is unchanged."""
+        assert self._base_url_for("https://api.openai.com/v1") == "https://api.openai.com/v1"
+
+    def test_existing_v1_trailing_slash_normalized(self):
+        """A base URL ending in /v1/ is normalized to /v1 (no trailing slash)."""
+        assert self._base_url_for("https://api.openai.com/v1/") == "https://api.openai.com/v1"
+
+    def test_localhost_without_v1(self):
+        """A host:port base URL without /v1 gets the segment appended."""
+        assert self._base_url_for("http://localhost:9000") == "http://localhost:9000/v1"
+
+    def test_empty_passed_through(self):
+        """An empty base URL is passed through untouched (server enforces required-ness)."""
+        assert self._base_url_for("") == ""

--- a/tests/record_playback_llm_server/upstream_client.py
+++ b/tests/record_playback_llm_server/upstream_client.py
@@ -61,8 +61,10 @@ class UpstreamClient:
         max_clients: int = DEFAULT_MAX_CLIENTS,
     ) -> None:
         """
-        :param base_url: Base URL of the external LLM host, including any
-                         version path segment (e.g. "https://api.openai.com/v1").
+        :param base_url: Base URL of the external LLM host. The OpenAI-style
+                         "/v1" version segment is optional: it is appended when
+                         absent, so both "https://api.openai.com" and
+                         "https://api.openai.com/v1" are accepted.
         :param api_key: Bearer credential for the external host. May be None
                         for hosts that do not require authentication.
         :param request_timeout: Whole-request timeout in seconds.
@@ -70,7 +72,7 @@ class UpstreamClient:
         :param max_clients: Maximum number of simultaneous in-flight requests to
                             the upstream host before further requests queue.
         """
-        self.base_url: str = base_url.rstrip("/") if base_url else base_url
+        self.base_url: str = self._normalize_base_url(base_url)
         self.api_key: Optional[str] = api_key
         self.request_timeout: float = request_timeout
         self.connect_timeout: float = connect_timeout
@@ -81,6 +83,23 @@ class UpstreamClient:
         self.client: tornado.httpclient.AsyncHTTPClient = \
             tornado.httpclient.AsyncHTTPClient(force_instance=True, max_clients=max_clients)
         self.ssl_context: ssl.SSLContext = self._build_ssl_context()
+
+    @staticmethod
+    def _normalize_base_url(base_url: str) -> str:
+        """
+        Normalize the upstream base URL: strip a trailing slash and append the
+        OpenAI-style "/v1" version segment when it is absent. This lets callers
+        pass either "https://host" or "https://host/v1"; both resolve to the
+        same "https://host/v1". A URL that already ends in "/v1" is left as-is.
+        :param base_url: The configured base URL (may be empty/None).
+        :return: The normalized base URL.
+        """
+        if not base_url:
+            return base_url
+        normalized: str = base_url.rstrip("/")
+        if not normalized.endswith("/v1"):
+            normalized = f"{normalized}/v1"
+        return normalized
 
     @staticmethod
     def _build_ssl_context() -> ssl.SSLContext:


### PR DESCRIPTION
## Summary
Let the record/playback proxy accept an LLM endpoint base URL with or without
the OpenAI-style `/v1` version segment. Previously the configured
RECORD_PLAYBACK_UPSTREAM_BASE_URL had to already include `/v1`
(e.g. https://api.openai.com/v1); a value without it (https://api.openai.com)
produced wrong upstream paths. Now the `/v1` segment is appended when absent, so
both forms work.

This is tests-only tooling under tests/record_playback_llm_server/; no production
neuro_san code is touched.

## Change
- UpstreamClient normalizes the base URL in a new static _normalize_base_url:
  strip a trailing slash, then append "/v1" only when the URL does not already
  end in "/v1". Applied in the constructor (the request-building code, which
  concatenates base_url + path, is unchanged).
- Examples of the normalization:
    https://api.openai.com      -> https://api.openai.com/v1
    https://api.openai.com/     -> https://api.openai.com/v1
    https://api.openai.com/v1   -> https://api.openai.com/v1   (unchanged)
    https://api.openai.com/v1/  -> https://api.openai.com/v1
    ""                          -> ""   (empty passed through; server still
                                          enforces that record mode requires a URL)

## Tests / docs
- Adds TestUpstreamClient (one class per file, in the tests/ subfolder) covering
  the normalization cases. It asserts through the public constructor's stored
  base_url rather than the private helper.
- Updates the README's RECORD_PLAYBACK_UPSTREAM_BASE_URL note to say the `/v1`
  segment is optional and appended when absent. (The separate note that a
  neuro-san agent's openai_api_base must include /v1 is unrelated -- that is the
  client -> proxy URL, an OpenAI-SDK requirement -- and is left as-is.)

## Verification
- flake8 clean and pylint 10.00/10 across the package (tests included).
- 29 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
