### PR TITLE
1299 Capture root cause of HTTP load-test failures

### DIFF
--- a/tests/load_tests/README.md
+++ b/tests/load_tests/README.md
@@ -329,7 +329,7 @@ At `adv` level this includes:
 | `server_receipts.log` | Per-request server receipt details (with `--server-log`) |
 | `server_tokens.log`   | Per-request token breakdown (when token data available) |
 | `summary.txt`         | Human-readable summary (`adv` level only)        |
-| `requests/`           | Raw stdout/stderr per request                    |
+| `requests/`           | Raw stdout/stderr per request; failed HTTP requests write the exception traceback to `request_N_stderr.txt` |
 
 ### `raw_results.json`
 

--- a/tests/load_tests/README.md
+++ b/tests/load_tests/README.md
@@ -163,6 +163,7 @@ then moves to the next. Output labels each batch as `[STAGE N]`.
 | `--total-timeout`          | 0 (disabled)| Hard timeout for entire load test. Accepts seconds or an `s`/`m`/`h` suffix. Kills run when exceeded |
 | `--settle-time`            | 15 (15s)    | Wait after each stage for server cleanup. Accepts seconds or an `s`/`m`/`h` suffix |
 | `--same-prompt`            | off         | Use identical prompt for all requests        |
+| `--allow-caching`          | off         | Send pool prompts verbatim so caches can serve them. By default a unique `(request N)` suffix is appended to defeat caching |
 | `--no-dry-run`             | off         | Skip the dry-run probe + cost confirmation (which run by default at min/norm; adv skips them already) |
 | `--full-concurrency`       | off         | Match `--max-workers` to `--num-requests` so all fire at once |
 | `--scale`                  | 1           | Multiply `--num-requests`, `--max-workers`, `--request-timeout`, `--idle-timeout`, `--stage-timeout`, `--total-timeout` by this factor. `--max-requests` auto-adjusts. |

--- a/tests/load_tests/traffic/http_client.py
+++ b/tests/load_tests/traffic/http_client.py
@@ -25,6 +25,7 @@ request to ~1-2 MB per thread.
 
 import logging
 import time
+import traceback
 from typing import Any
 from typing import Dict
 from typing import List
@@ -143,12 +144,16 @@ class HttpClient:
         # decode, gRPC/transport errors) is not enumerable here.  This
         # is a per-request isolation boundary — any single request must
         # be recorded as FAILED/TIMEOUT without aborting the load test.
-        except Exception as exc:  # pylint: disable=broad-exception-caught
+        except Exception:  # pylint: disable=broad-exception-caught
             elapsed = time.time() - start
             if elapsed >= timeout:
                 return (STATUS_TIMEOUT, {}, "", 0.0, {})
-            logger.debug("HTTP request failed: %s", exc)
-            return (STATUS_FAILED, {}, str(exc), 0.0, {})
+            # Include the full chained traceback so the root cause
+            # (ReadTimeout, ConnectionError, HTTPError, ...) survives
+            # the generic help text raised by the session client.
+            error_text = traceback.format_exc()
+            logger.debug("HTTP request failed:\n%s", error_text)
+            return (STATUS_FAILED, {}, error_text, 0.0, {})
 
         elapsed = time.time() - start
         if elapsed >= timeout:

--- a/tests/load_tests/traffic/runner.py
+++ b/tests/load_tests/traffic/runner.py
@@ -232,16 +232,26 @@ class TrafficRunner:
         elif status == STATUS_FAILED and not response_text:
             failure_reason = "empty response from agent"
 
+        # A FAILED status with no failure_reason at this point means
+        # HttpClient caught an exception and returned its traceback as
+        # response_text.  Route that to stderr (like subprocess mode)
+        # instead of saving it as the agent's answer.
+        stderr = ""
+        stdout = self._http_saved_stdout(response_text, token_data)
+        if status == STATUS_FAILED and failure_reason is None:
+            stderr = response_text
+            stdout = ""
+            failure_reason = CliBuilder.last_stderr_line(stderr)
+
         self._save_request_output(
-            output_dir, request_id,
-            self._http_saved_stdout(response_text, token_data), "",
+            output_dir, request_id, stdout, stderr,
         )
 
         self._log_request_result(
             request_id, status, elapsed,
             parsed_fields=parsed_fields,
             failure_reason=failure_reason,
-            stderr="",
+            stderr=stderr,
             output_dir=output_dir,
         )
 

--- a/tests/load_tests/traffic/runner.py
+++ b/tests/load_tests/traffic/runner.py
@@ -160,7 +160,7 @@ class TrafficRunner:
         finally:
             CliBuilder.cleanup_prompt_file(prompt_file)
 
-    # pylint: disable=too-many-locals
+    # pylint: disable=too-many-locals,too-many-branches
     def run_one_http(self, request_id, global_request_id,
                      output_dir=None) -> RequestResult:
         """Execute a single request via direct HTTP.


### PR DESCRIPTION
In HTTP mode, a failed request only saved the generic "Some basic suggestions to help debug connectivity issues" help text from HttpServiceAgentSession to request_N_stdout.txt, and no stderr file was written — so the actual error (timeout, connection reset, HTTP 5xx, etc.) was lost.

http_client.py: return the full chained traceback (traceback.format_exc()) instead of str(exc).
runner.py: for exception failures, write that traceback to request_N_stderr.txt, leave stdout empty, and use its last line as failure_reason.