### PR TITLE
Make neuro-san formally require Python 3.12 or above

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
         # 1.0.9
         uses: cognizant-ai-lab/build-common/actions/setup-python-env@b14b3de23cb9aca02b2165e57542335e0c8f5304
         with:
-          python-version: '3.10'
+          python-version: '3.12'
           requirements-file: ''
           requirements-build-file: ''
           install-extras: 'build'

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ venv2/
 venv3/
 .venv/
 
+# UV lock file
+uv.lock
+
 # Python byte code
 *.pyc
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,9 +16,12 @@ keywords = ["LLM", "langchain", "agent", "multi-agent"]
 # https://packaging.python.org/en/latest/guides/licensing-examples-and-user-scenarios/
 license = "Apache-2.0"
 license-files = ["LICENSE.txt"]
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 classifiers = [
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Operating System :: OS Independent",
 
     # How mature is this project? Common values are

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 # requirements-build.txt
 
 # In-house dependencies
-leaf-common>=1.3.1
+leaf-common>=1.4.0
 
 # Downgraded secondary dependencies for error-free pip installs
 pyhocon>=0.3.60


### PR DESCRIPTION
Makes neuro-san formally require Python 3.12 or above.
The code itself doesn't work with Python 3.11 since version `0.6.84` and leaf-common `1.2.49`.

Fixes #1293 