### PR TITLE
Run unit tests on Python 3.12, 3.13 and 3.14

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,10 +19,11 @@ jobs:
       (github.event_name == 'pull_request' &&
        github.base_ref == 'main' &&
        github.event.pull_request.head.repo.full_name != github.repository)
-    # 1.0.9
-    uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@b14b3de23cb9aca02b2165e57542335e0c8f5304
+    # 1.0.12
+    uses: cognizant-ai-lab/build-common/.github/workflows/_python-quality-gate.yml@3f4cdab31b6ac10382c99452b720eb0b8b2dab8f
     with:
       python-version: '3.12'
+      test-python-versions: '["3.12", "3.13", "3.14"]'
       lint-toolchain: 'legacy'  # flake8 only (black/isort are opt-in)
       pylint-command: 'build_scripts/run_pylint.sh'
       shellcheck-command: 'build_scripts/run_shellcheck.sh'


### PR DESCRIPTION
## Summary
Fixes #1303.

Bumps the quality gate to build-common 1.0.12 and sets its new `test-python-versions` input (cognizant-ai-lab/build-common#36), so the existing `test-command-override` (server_start + pytest) runs once per interpreter in `Unit tests (3.12|3.13|3.14)` jobs while lint/shellcheck/markdownlint/hadolint/README stay on 3.12 in `quality-gate`. One Slack notification is sent for the combined result.

Same change as leaf-common#191 and neuro-san-studio#1388. Only `tests.yml` moves to 1.0.12; other workflows are untouched.


Link to Devin session: https://app.devin.ai/sessions/25fc14ae7bdc496f98837871f43ed0ea
Open in Devin Desktop: https://app.devin.ai/desktop/session/25fc14ae7bdc496f98837871f43ed0ea?variant=devin
Requested by: @donn-leaf
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cognizant-ai-lab/neuro-san/pull/1304" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->