### PR TITLE
Fix openai_proxy config key in OpenAILlmPolicy

### DIFF
--- a/neuro_san/internals/run_context/langchain/llms/openai_llm_policy.py
+++ b/neuro_san/internals/run_context/langchain/llms/openai_llm_policy.py
@@ -137,7 +137,7 @@ class OpenAILlmPolicy(LlmPolicy):
                                                   "OPENAI_API_BASE", client),
             openai_organization=self.get_value_or_env(config, "openai_organization",
                                                       "OPENAI_ORG_ID", client),
-            openai_proxy=self.get_value_or_env(config, "openai_organization",
+            openai_proxy=self.get_value_or_env(config, "openai_proxy",
                                                "OPENAI_PROXY", client),
             request_timeout=self.get_value_or_env(config, "request_timeout", None, client),
             max_retries=self.get_value_or_env(config, "max_retries", None, client),

--- a/tests/neuro_san/internals/run_context/langchain/llms/test_openai_llm_policy.py
+++ b/tests/neuro_san/internals/run_context/langchain/llms/test_openai_llm_policy.py
@@ -1,0 +1,140 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+"""
+Unit tests for OpenAILlmPolicy.
+"""
+import asyncio
+from unittest.mock import MagicMock
+
+from neuro_san.internals.run_context.langchain.llms.openai_llm_policy import OpenAILlmPolicy
+
+
+class TestOpenAILlmPolicy:
+    """
+    Test cases for OpenAILlmPolicy.
+    """
+
+    def test_create_llm_config_keys(self):
+        """
+        Test that create_llm reads the correct config keys for the client-supplied kwargs group,
+        specifically ensuring openai_proxy reads 'openai_proxy' and not 'openai_organization'.
+        """
+        captured_kwargs = {}
+
+        def mock_chat_openai(**kwargs):
+            captured_kwargs.update(kwargs)
+            return MagicMock()
+
+        policy = OpenAILlmPolicy()
+        policy.resolver.resolve_class_in_module = MagicMock(return_value=mock_chat_openai)
+
+        config = {
+            "openai_api_key": "sk-test-key",
+            "openai_api_base": "https://custom.api.com",
+            "openai_organization": "org-12345",
+            "openai_proxy": "http://proxy.test:8080",
+            "request_timeout": 60,
+            "max_retries": 3,
+            "temperature": 0.7,
+        }
+
+        policy.create_llm(config=config, model_name="gpt-4o", client=None)
+
+        assert captured_kwargs.get("openai_organization") == "org-12345"
+        assert captured_kwargs.get("openai_proxy") == "http://proxy.test:8080"
+        assert captured_kwargs.get("openai_api_key") == "sk-test-key"
+        assert captured_kwargs.get("openai_api_base") == "https://custom.api.com"
+        assert captured_kwargs.get("request_timeout") == 60
+        assert captured_kwargs.get("max_retries") == 3
+
+    def test_create_llm_calls_get_value_or_env_keys(self):
+        """
+        Verify each get_value_or_env call for the optional connection parameters
+        passes the corresponding config key, env var name, and client instance.
+        """
+        policy = OpenAILlmPolicy()
+        policy.resolver.resolve_class_in_module = MagicMock(return_value=MagicMock())
+
+        calls = []
+        original_get_value_or_env = policy.get_value_or_env
+
+        def spy_get_value_or_env(config, key, env_key, none_obj=None):
+            calls.append((key, env_key, none_obj))
+            return original_get_value_or_env(config, key, env_key, none_obj)
+
+        policy.get_value_or_env = spy_get_value_or_env
+
+        dummy_client = object()
+        config = {
+            "openai_organization": "org-test",
+            "openai_proxy": "http://proxy.test:8080",
+        }
+
+        policy.create_llm(config=config, model_name="gpt-4o", client=dummy_client)
+
+        expected_calls = [
+            ("openai_api_key", "OPENAI_API_KEY", dummy_client),
+            ("openai_api_base", "OPENAI_API_BASE", dummy_client),
+            ("openai_organization", "OPENAI_ORG_ID", dummy_client),
+            ("openai_proxy", "OPENAI_PROXY", dummy_client),
+            ("request_timeout", None, dummy_client),
+            ("max_retries", None, dummy_client),
+        ]
+
+        for expected in expected_calls:
+            assert expected in calls, f"Expected get_value_or_env call {expected} not found in {calls}"
+
+    def test_create_llm_with_client_forces_none(self):
+        """
+        When a client is provided, the connection parameters must all be None.
+        """
+        captured_kwargs = {}
+
+        def mock_chat_openai(**kwargs):
+            captured_kwargs.update(kwargs)
+            return MagicMock()
+
+        policy = OpenAILlmPolicy()
+        policy.resolver.resolve_class_in_module = MagicMock(return_value=mock_chat_openai)
+
+        dummy_client = object()
+        config = {
+            "openai_api_key": "sk-test-key",
+            "openai_api_base": "https://custom.api.com",
+            "openai_organization": "org-12345",
+            "openai_proxy": "http://proxy.test:8080",
+            "request_timeout": 60,
+            "max_retries": 3,
+        }
+
+        policy.create_llm(config=config, model_name="gpt-4o", client=dummy_client)
+
+        assert captured_kwargs.get("openai_api_key") is None
+        assert captured_kwargs.get("openai_api_base") is None
+        assert captured_kwargs.get("openai_organization") is None
+        assert captured_kwargs.get("openai_proxy") is None
+        assert captured_kwargs.get("request_timeout") is None
+        assert captured_kwargs.get("max_retries") is None
+
+    def test_delete_resources(self):
+        """
+        Test that delete_resources clears the async_openai_client reference.
+        """
+        policy = OpenAILlmPolicy()
+        policy.async_openai_client = MagicMock()
+        asyncio.run(policy.delete_resources())
+        assert policy.async_openai_client is None


### PR DESCRIPTION
Fixes #1308

## Summary

OpenAILlmPolicy.create_llm previously read the wrong config key openai_organization when building the openai_proxy kwarg for ChatOpenAI. This change updates the key to openai_proxy matching AzureLlmPolicy.

## Changes

- Corrected the config key from openai_organization to openai_proxy in neuro_san/internals/run_context/langchain/llms/openai_llm_policy.py
- Added unit tests in tests/neuro_san/internals/run_context/langchain/llms/test_openai_llm_policy.py asserting the config keys passed to get_value_or_env and verifying ChatOpenAI receives the expected proxy setting

## Verification

- Ran pytest on tests/neuro_san/internals/run_context/langchain/llms/test_openai_llm_policy.py and verified all 4 tests pass
- Confirmed test failures on the unpatched code
- Verified flake8 and pylint run cleanly with 10/10 score
