### PR TITLE
Stop sending n=1 and expose use_responses_api for OpenAI models

### DIFF
--- a/docs/agent_hocon_reference.md
+++ b/docs/agent_hocon_reference.md
@@ -25,6 +25,7 @@ Items in ***bold*** are essentials. Try to understand these first.
         - [fallbacks](#fallbacks)
         - [temperature](#temperature)
         - [Other LLM-specific Parameters](#other-llm-specific-parameters)
+        - [OpenAI Reasoning and Responses API Parameters](#openai-reasoning-and-responses-api-parameters)
         - [Client-Provided API Keys](#client-provided-api-keys)
     - [***tools*** - list of agent/tool definitions](#tools)
     - [commondefs](#commondefs)
@@ -318,6 +319,75 @@ file, you can set that parameter in any llm_config within its own technical limi
 Note: _We strongly recommend to **not** set secrets as values within any source file, including hocon files._
 These files tend to creep into source control repos, and it is **very** bad practice
 to expose secrets by checking them in.
+
+#### OpenAI Reasoning and Responses API Parameters
+
+The `openai` class accepts a few parameters that only matter for OpenAI reasoning models and for choosing which
+OpenAI endpoint (Chat Completions or the Responses API) requests are sent to. All of them default to `null`.
+
+- `reasoning`: a dictionary passed through as the Responses API `reasoning` object, for example
+  `{"effort": "low", "summary": "auto"}`. Setting it makes langchain route requests to the Responses API.
+- `reasoning_effort`: a string such as `"low"`, `"medium"` or `"high"` that constrains how much reasoning the
+  model does (`"none"` disables reasoning on models that allow it, such as `gpt-5.6-*`; `gpt-6-astra` rejects
+  it). On the Chat Completions path it is sent as-is. On the Responses API path langchain folds it into
+  `reasoning.effort` **only when `reasoning` is absent**, so set either `reasoning` or `reasoning_effort`, not
+  both. Setting `reasoning_effort` on its own does not change the endpoint.
+- `verbosity`: a string (`"low"`, `"medium"` or `"high"`) that controls how long the model's answers are.
+- `use_responses_api`: a tri-state switch for the endpoint:
+    - `null` (the default): let langchain infer the endpoint from the other parameters and the model name, as
+      documented for
+      [`use_responses_api`](https://reference.langchain.com/python/langchain-openai/chat_models/base/BaseChatOpenAI/use_responses_api).
+      langchain switches to the Responses API when any Responses-only setting is present (`reasoning`, `include`,
+      `truncation`, `context_management`, `previous_response_id`, `text`, or a built-in tool such as web search)
+      or when the model is one it knows to be Responses-only (the `gpt-5.x-pro` and `codex` models). Of those,
+      the `openai` class only exposes `reasoning` and the model name, so everything else keeps using Chat
+      Completions and existing configurations behave exactly as before.
+    - `true`: always use the Responses API.
+    - `false`: always use Chat Completions.
+
+**Models that need the Responses API for tool calling.** OpenAI's newest models no longer accept function (tool)
+calls together with reasoning on Chat Completions, and every agent that lists `tools` is a tool-calling agent.
+A Chat Completions request from a `gpt-5.6-*` model that carries tools is rejected with an error such as:
+
+> Function tools with reasoning_effort are not supported for gpt-5.6-sol in /v1/chat/completions.
+> To use function tools, use /v1/responses or set reasoning_effort to 'none'.
+
+The two model families differ in what you can do about it:
+
+- `gpt-5.6-*` (`gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`): either set `"use_responses_api": true` and keep
+  reasoning, or stay on Chat Completions with `"reasoning_effort": "none"`, which makes tool calls work but
+  without any reasoning.
+- `gpt-6-astra`: the Responses API is the only option. The
+  [OpenAI reasoning guide](https://developers.openai.com/api/docs/guides/reasoning) states that
+  "Chat Completions does not support function calling with GPT-6 Astra" and that GPT-6 Astra
+  "does not support none reasoning effort" (the API answers HTTP 400), so the `"none"` workaround does not exist
+  for it. Any agent that uses tools with gpt-6-astra must set `"use_responses_api": true`.
+
+The minimal configuration is just the endpoint switch. The model's default reasoning effort applies; add
+`reasoning_effort` only when you want a different level.
+
+```hocon
+"llm_config": {
+    "model_name": "gpt-6-astra",
+    "use_responses_api": true
+}
+```
+
+**Parameters the Responses API rejects.** `presence_penalty`, `frequency_penalty`, `seed`, `logprobs` and
+`logit_bias` (plus `stop` on langchain-openai releases before 1.4) exist only on Chat Completions. The Responses
+API rejects requests that carry them, so remove them from any llm_config that reaches the Responses API, whether
+through `"use_responses_api": true` or through auto-routing. OpenAI's
+[migration guide](https://developers.openai.com/api/docs/guides/migrate-to-responses) lists the remaining
+differences between the two endpoints.
+
+**Interaction with fallbacks.** The rejections above surface as exceptions on the client side, but
+[fallbacks](#fallbacks) wrap the model so that any exception moves on to the next llm_config in the list. With
+fallbacks configured, a misconfigured primary model silently fails over instead of reporting the problem, so
+verify a new llm_config without fallbacks first.
+
+**Azure OpenAI.** The `azure-openai` class does not support the Responses API path yet (tracked in
+[#1307](https://github.com/cognizant-ai-lab/neuro-san/issues/1307)), so leave `use_responses_api` unset for
+Azure deployments.
 
 #### class
 

--- a/neuro_san/internals/run_context/langchain/llms/default_llm_info.hocon
+++ b/neuro_san/internals/run_context/langchain/llms/default_llm_info.hocon
@@ -1466,16 +1466,38 @@
                 "logit_bias": null,
                 # streaming defaults to off; set "streaming": true in llm_config to enable.
                 "streaming": false,
-                # n is always 1.  neuro-san will only ever consider a single chat completion.
+                # n is intentionally not sent. The API default of 1 applies (neuro-san only ever
+                # considers a single chat completion), and the Responses API has no n parameter at all.
+                # See https://github.com/cognizant-ai-lab/neuro-san/issues/725 and the n property of
+                # CreateChatCompletionRequest in https://github.com/openai/openai-openapi/blob/main/openapi.yaml
                 "top_p": null,
                 "max_tokens": null,         # This is always for output
                 "tiktoken_model_name": null,
                 "stop": null,
 
                 # The following parameters are for reasoning models only.
+                # Set either "reasoning" or "reasoning_effort", not both: on the Responses API path
+                # reasoning_effort is only folded into reasoning.effort when "reasoning" is absent.
                 "reasoning": null, # Reasoning parameters for reasoning models (Dict[str, Any])
                 "reasoning_effort": null, # Constrains effort on reasoning for reasoning models (str)
                 "verbosity": null, # Controls the verbosity level of responses for reasoning models (str)
+                # Tri-state switch for which OpenAI endpoint requests are sent to (bool or null). See
+                # https://docs.langchain.com/oss/python/integrations/chat/openai#responses-api and
+                # https://reference.langchain.com/python/langchain-openai/chat_models/base/BaseChatOpenAI/use_responses_api
+                #   null  - let langchain infer the endpoint from the other parameters and the model name.
+                #           Any Responses-only setting (with this class that means a "reasoning" dict) or a
+                #           Responses-only model (gpt-5.x-pro, codex) selects the Responses API; otherwise
+                #           requests stay on Chat Completions (the long-standing behavior).
+                #   true  - force the Responses API. Needed for tool calling with reasoning on the newest models,
+                #           because Chat Completions rejects function tools combined with reasoning:
+                #             - gpt-6-astra can only call tools through the Responses API. Chat Completions has
+                #               no function calling for it and it rejects reasoning_effort "none".
+                #             - gpt-5.6-* can either use this, or stay on Chat Completions with
+                #               reasoning_effort "none" (tool calls work, but without reasoning).
+                #           https://developers.openai.com/api/docs/guides/reasoning
+                #           https://developers.openai.com/api/docs/guides/migrate-to-responses
+                #   false - force Chat Completions.
+                "use_responses_api": null,
 
                 # If you really need more parameters, you will likely have to create your own LlmFactory.
             }

--- a/neuro_san/internals/run_context/langchain/llms/openai_llm_policy.py
+++ b/neuro_san/internals/run_context/langchain/llms/openai_llm_policy.py
@@ -156,16 +156,48 @@ class OpenAILlmPolicy(LlmPolicy):
             # usage is collected from AIMessage.usage_metadata in LlmTokenCallbackHandler
             # regardless of streaming mode.
             streaming=ConfigUtil.get_bool(config, "streaming"),
-            n=1,  # n is always 1.  neuro-san will only ever consider one chat completion.
+            # n is intentionally not sent. Chat Completions defaults n to 1, which is all neuro-san
+            # ever consumes, and the Responses API has no n parameter at all. langchain-openai
+            # forwards n whenever it is not None, so an explicit n=1 made every request that
+            # reached the Responses API fail client-side.
+            # See https://github.com/cognizant-ai-lab/neuro-san/issues/725 and the n property of
+            # CreateChatCompletionRequest in https://github.com/openai/openai-openapi/blob/main/openapi.yaml
             top_p=config.get("top_p"),
             max_tokens=config.get("max_tokens"),  # This is always for output
             tiktoken_model_name=config.get("tiktoken_model_name"),
             stop=config.get("stop"),
 
             # The following three parameters are for reasoning models only.
+            # Set either "reasoning" or "reasoning_effort", not both: on the Responses API path
+            # langchain-openai folds reasoning_effort into reasoning["effort"] only when
+            # "reasoning" is absent, so a "reasoning" dict silently wins over reasoning_effort.
             reasoning=config.get("reasoning"),
             reasoning_effort=config.get("reasoning_effort"),
             verbosity=config.get("verbosity"),
+
+            # use_responses_api is a tri-state switch for which OpenAI endpoint ChatOpenAI uses.
+            # https://reference.langchain.com/python/langchain-openai/chat_models/base/BaseChatOpenAI/use_responses_api
+            # https://docs.langchain.com/oss/python/integrations/chat/openai#responses-api
+            #   None  - let langchain-openai infer the endpoint from the other parameters and the
+            #           model name: any Responses-only setting (reasoning, include, truncation,
+            #           context_management, previous_response_id, text, built-in tools) or a
+            #           Responses-only model (gpt-5.x-pro, codex) selects the Responses API. Of those,
+            #           this policy only forwards "reasoning", so everything else stays on Chat
+            #           Completions, which preserves behavior for existing configs.
+            #   True  - force the Responses API. Needed for tool calling with reasoning on the newest
+            #           models, because Chat Completions rejects function tools combined with reasoning.
+            #           gpt-6-astra has no other option: Chat Completions has no function calling for it
+            #           and it rejects reasoning_effort "none". gpt-5.6-* can alternatively stay on
+            #           Chat Completions with reasoning_effort "none" (tool calls work, no reasoning).
+            #           https://developers.openai.com/api/docs/guides/reasoning
+            #           https://developers.openai.com/api/docs/guides/migrate-to-responses
+            #   False - force Chat Completions.
+            # This is deliberately forwarded raw instead of through ConfigUtil.get_bool():
+            # get_bool() turns an absent/null value into False, which would disable langchain's
+            # auto-routing, send a "reasoning" dict to Chat Completions, and pin the *-pro models
+            # to an endpoint OpenAI rejects. Only an explicit true/false in llm_config should
+            # override langchain's choice.
+            use_responses_api=config.get("use_responses_api"),
 
             # If omitted, this defaults to the global verbose value,
             # accessible via langchain_core.globals.get_verbose():

--- a/tests/neuro_san/internals/run_context/langchain/llms/test_openai_llm_policy.py
+++ b/tests/neuro_san/internals/run_context/langchain/llms/test_openai_llm_policy.py
@@ -1,0 +1,212 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+# pylint: disable=protected-access
+
+import asyncio
+import inspect
+
+from typing import Any
+from typing import Dict
+from typing import Iterator
+from typing import List
+
+import pytest
+
+from langchain_core.messages import HumanMessage
+from langchain_openai.chat_models.base import ChatOpenAI
+from openai.resources.responses import AsyncResponses
+
+from neuro_san.internals.run_context.langchain.llms.openai_llm_policy import OpenAILlmPolicy
+
+
+class TestOpenAILlmPolicy:
+    """
+    Test cases for OpenAILlmPolicy.create_llm().
+
+    These tests build the ChatOpenAI exactly the way production does (create_client()
+    followed by create_llm()) and then inspect what was built, without ever making
+    a network call.
+    """
+
+    # Points at a closed local port so that an accidental network call fails fast instead
+    # of reaching a real OpenAI endpoint. The key is a dummy; see the policies fixture.
+    BASE_CONFIG: Dict[str, Any] = {
+        "openai_api_key": "sk-test",
+        "openai_api_base": "http://127.0.0.1:9",
+        "max_retries": 0,
+        "request_timeout": 5,
+        "streaming": False,
+    }
+
+    @pytest.fixture(name="policies")
+    def fixture_policies(self, monkeypatch: pytest.MonkeyPatch) -> Iterator[List[OpenAILlmPolicy]]:
+        """
+        Collects every OpenAILlmPolicy a test builds and releases their httpx clients afterwards.
+
+        ChatOpenAI also builds a synchronous client from the OPENAI_API_KEY environment variable,
+        so the variable is pinned to a dummy value here to guarantee no real key is ever used.
+
+        :param monkeypatch: The pytest fixture used to override the environment
+        :return: A list that tests append their policies to; each one is cleaned up on teardown
+        """
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        created: List[OpenAILlmPolicy] = []
+        yield created
+        for policy in created:
+            asyncio.run(policy.delete_resources())
+
+    def _build_llm(self, policies: List[OpenAILlmPolicy], extra_config: Dict[str, Any],
+                   model_name: str = "gpt-5.2") -> ChatOpenAI:
+        """
+        Builds a ChatOpenAI the way production does: create_client() then create_llm().
+
+        :param policies: The fixture list that tracks policies for teardown
+        :param extra_config: llm_config keys layered on top of BASE_CONFIG
+        :param model_name: The OpenAI model name to build the llm for
+        :return: The ChatOpenAI instance produced by OpenAILlmPolicy.create_llm()
+        """
+        config: Dict[str, Any] = dict(self.BASE_CONFIG)
+        config.update(extra_config)
+
+        policy: OpenAILlmPolicy = OpenAILlmPolicy()
+        # Register before creating anything so teardown still runs if create_llm() raises.
+        policies.append(policy)
+
+        client: Any = policy.create_client(config)
+        llm: ChatOpenAI = policy.create_llm(config, model_name, client)
+        return llm
+
+    @staticmethod
+    def _request_payload(llm: ChatOpenAI) -> Dict[str, Any]:
+        """
+        Computes the request body langchain-openai would send for a single user message.
+
+        :param llm: The ChatOpenAI instance to inspect
+        :return: The keyword arguments that would be passed to the OpenAI SDK create() call
+        """
+        payload: Dict[str, Any] = llm._get_request_payload([HumanMessage("hi")])
+        return payload
+
+    @staticmethod
+    def _assert_binds_to_responses_create(payload: Dict[str, Any]) -> None:
+        """
+        Asserts that the payload only uses keyword arguments the Responses API create() accepts.
+
+        Binding against the real SDK signature is what fails with "unexpected keyword argument 'n'"
+        when n leaks into a Responses API request, which is the exact symptom of issue #725.
+
+        :param payload: The request payload to check
+        """
+        signature: inspect.Signature = inspect.signature(AsyncResponses.create)
+        # The leading None stands in for "self" because create is inspected as an unbound method.
+        signature.bind(None, **payload)
+
+    def test_default_config_keeps_chat_completions_without_n(self, policies: List[OpenAILlmPolicy]) -> None:
+        """
+        A plain gpt-5.2 config stays on Chat Completions, does not force an endpoint, and no longer sends n.
+
+        :param policies: The fixture list that tracks policies for teardown
+        """
+        llm: ChatOpenAI = self._build_llm(policies, {})
+        payload: Dict[str, Any] = self._request_payload(llm)
+
+        assert llm.n is None
+        assert "n" not in payload
+        # None (not False) is what keeps langchain's auto-routing alive for existing configs.
+        assert llm.use_responses_api is None
+        assert llm._use_responses_api(llm._default_params) is False
+        assert "messages" in payload
+
+    def test_reasoning_dict_auto_routes_to_responses_api_without_n(self, policies: List[OpenAILlmPolicy]) -> None:
+        """
+        Regression test for issue #725: a "reasoning" dict makes langchain auto-route to the
+        Responses API, and the resulting payload must be acceptable to that API (no n).
+
+        create_llm() used to pass n=1 unconditionally. Chat Completions tolerates that, but the
+        Responses API has no n parameter, so any config that langchain auto-routed there failed
+        client-side. The fix drops n and forwards "use_responses_api" so agents can pick the endpoint.
+
+        :param policies: The fixture list that tracks policies for teardown
+        """
+        llm: ChatOpenAI = self._build_llm(policies, {"reasoning": {"effort": "low"}})
+        payload: Dict[str, Any] = self._request_payload(llm)
+
+        assert llm.use_responses_api is None
+        assert llm._use_responses_api(llm._default_params) is True
+        assert "n" not in payload
+        assert payload["reasoning"] == {"effort": "low"}
+        self._assert_binds_to_responses_create(payload)
+
+    def test_use_responses_api_true_is_forwarded(self, policies: List[OpenAILlmPolicy]) -> None:
+        """
+        An explicit "use_responses_api": true reaches ChatOpenAI and produces a Responses API payload.
+
+        :param policies: The fixture list that tracks policies for teardown
+        """
+        llm: ChatOpenAI = self._build_llm(policies, {"use_responses_api": True})
+        payload: Dict[str, Any] = self._request_payload(llm)
+
+        assert llm.use_responses_api is True
+        assert llm._use_responses_api(llm._default_params) is True
+        # The Responses API takes "input" where Chat Completions takes "messages".
+        assert "input" in payload
+        assert "messages" not in payload
+        assert "n" not in payload
+        self._assert_binds_to_responses_create(payload)
+
+    def test_use_responses_api_false_is_forwarded_as_false(self, policies: List[OpenAILlmPolicy]) -> None:
+        """
+        An explicit "use_responses_api": false reaches ChatOpenAI as False, not as None.
+
+        :param policies: The fixture list that tracks policies for teardown
+        """
+        llm: ChatOpenAI = self._build_llm(policies, {"use_responses_api": False})
+        payload: Dict[str, Any] = self._request_payload(llm)
+
+        assert llm.use_responses_api is False
+        assert llm._use_responses_api(llm._default_params) is False
+        assert "messages" in payload
+
+    def test_use_responses_api_false_overrides_auto_routing(self, policies: List[OpenAILlmPolicy]) -> None:
+        """
+        An explicit false pins Chat Completions even when a "reasoning" dict would otherwise
+        auto-route to the Responses API. This is why the key must not go through get_bool():
+        an absent key collapsed to False would disable auto-routing for everyone.
+
+        :param policies: The fixture list that tracks policies for teardown
+        """
+        llm: ChatOpenAI = self._build_llm(policies, {"use_responses_api": False,
+                                                     "reasoning": {"effort": "low"}})
+        payload: Dict[str, Any] = self._request_payload(llm)
+
+        assert llm.use_responses_api is False
+        assert llm._use_responses_api(llm._default_params) is False
+        assert "messages" in payload
+
+    def test_reasoning_effort_folds_into_reasoning_on_responses_api(self, policies: List[OpenAILlmPolicy]) -> None:
+        """
+        On the Responses API path langchain rewrites reasoning_effort into reasoning.effort.
+
+        :param policies: The fixture list that tracks policies for teardown
+        """
+        llm: ChatOpenAI = self._build_llm(policies, {"reasoning_effort": "low", "use_responses_api": True})
+        payload: Dict[str, Any] = self._request_payload(llm)
+
+        assert payload["reasoning"] == {"effort": "low"}
+        assert "reasoning_effort" not in payload
+        assert "n" not in payload
+        self._assert_binds_to_responses_create(payload)


### PR DESCRIPTION
## Summary

`OpenAILlmPolicy` always constructed `ChatOpenAI` with `n=1`. langchain-openai forwards `n` whenever it is not `None`, and the Responses API has no `n` parameter, so every request that reached the Responses API failed client-side before any HTTP call:

```
TypeError: AsyncResponses.create() got an unexpected keyword argument 'n'
```

That path is reached by any `llm_config` with a `reasoning` dict (the original report in #725), and, on langchain-openai >= 1.2, by the shipped `gpt-5.5-pro` / `gpt-5.4-pro` entries with no reasoning config at all, because langchain routes those model names to the Responses API by prefix.

It also matters for the newest models: OpenAI rejects function tools combined with reasoning on Chat Completions. `gpt-5.6-*` only works with tools there if `reasoning_effort` is `"none"`, and `gpt-6-astra` has no Chat Completions tool path at all (no function calling, and `"none"` is rejected). neuro-san had no way to select the Responses API.

## Changes

- `openai_llm_policy.py`: stop passing `n` (Chat Completions defaults it to 1, so this is wire-neutral for every existing config). Forward `use_responses_api` from `llm_config` as a raw tri-state via `config.get`, so `null` keeps langchain's own inference and only an explicit `true`/`false` overrides it. Comments explain why `ConfigUtil.get_bool` is deliberately not used and link the langchain and OpenAI references.
- `default_llm_info.hocon`: `"use_responses_api": null` added to `classes.openai.args` with the tri-state semantics; the stale `n` comment replaced; a note that `reasoning` and `reasoning_effort` should not both be set on the Responses path.
- New `tests/.../test_openai_llm_policy.py` (no network): `n` is gone from both payload shapes, `use_responses_api` defaults to `None` and is forwarded when set, the `reasoning`-dict regression payload binds to the real `AsyncResponses.create` signature, and `reasoning_effort` folds into `reasoning.effort` on the Responses path.
- `docs/agent_hocon_reference.md`: new "OpenAI Reasoning and Responses API Parameters" subsection covering `reasoning` vs `reasoning_effort`, `verbosity`, `use_responses_api`, the gpt-5.6 / gpt-6-astra requirements, the Chat-Completions-only parameters the Responses API rejects, and the interaction with `fallbacks`.

Behavior is unchanged for existing configurations: with `use_responses_api` unset, a plain `gpt-5.2` request differs only by the absent `n` key.

## Out of scope, tracked separately

- Azure side of the same bug and Azure Responses support: #1307
- `openai_proxy` config key typo in the same function: #1308
- Stale `llm_config` docs unrelated to this bug: #1309

## Relationship to #1306

#1306 adds the `gpt-6-astra` entry. This PR should land first so that entry does not advertise tool support with no way to use it; the docs example here uses `gpt-6-astra` on that assumption.

Closes #725
