### PR TITLE
Flatten both sides of the journal dupe comparison

### DIFF
--- a/neuro_san/internals/journals/originating_journal.py
+++ b/neuro_san/internals/journals/originating_journal.py
@@ -25,6 +25,7 @@ from langchain_core.messages.system import SystemMessage
 from neuro_san.internals.journals.journal import Journal
 from neuro_san.message.types.agent_tool_result_message import AgentToolResultMessage
 from neuro_san.message.types.base_message_dictionary_converter import BaseMessageDictionaryConverter
+from neuro_san.message.utils.content_utils import ContentUtils
 
 
 class OriginatingJournal(Journal):
@@ -109,15 +110,23 @@ class OriginatingJournal(Journal):
 
     def _is_dupe_of_pending(self, message: BaseMessage) -> bool:
         """
-        :param message: The incoming BaseMessage to compare against the held
-                pending message.
-        :return: True if the pending message carries the same content as the
-                incoming message. String content is compared ignoring leading
-                and trailing whitespace: the pending message's content was
-                stripped when it was captured (JournalingCallbackHandler's
-                on_llm_end), while the incoming message's content is not, so
-                an exact comparison would let a mere trailing newline defeat
-                the suppression and send clients both copies of the same text.
+        Decide whether the held pending message carries the same visible text
+        as the incoming message, so that only one of the two reaches clients.
+
+        Both contents are projected to text with ContentUtils.flatten_to_text
+        and compared ignoring leading and trailing whitespace. The whitespace
+        normalization is needed because the pending message's content was
+        stripped when it was captured (JournalingCallbackHandler's on_llm_end),
+        while the incoming message's content is not, so an exact comparison
+        would let a mere trailing newline defeat the suppression and send
+        clients both copies of the same text.
+
+        Projecting both sides to text matters once an incoming message can
+        carry list content (block content preserved from the provider): the
+        held AGENT copy is always a flattened str, so a raw equality against
+        a block list could never match and clients would receive both copies.
+        flatten_to_text is an identity on str, so string-only traffic compares
+        exactly as it did before.
 
         Normalizing here, rather than stripping at either capture point, is
         deliberate: both captured texts are client-visible and locked by
@@ -126,12 +135,15 @@ class OriginatingJournal(Journal):
         so changing either producer would change client-visible output. The
         dupe decision is internal, which makes this comparison the one place
         that can reconcile the two without altering any payload.
+
+        :param message: The incoming BaseMessage to compare against the held
+                pending message.
+        :return: True if the pending message carries the same visible text as
+                the incoming message.
         """
-        pending_content: Any = self.pending.content
-        incoming_content: Any = message.content
-        if isinstance(pending_content, str) and isinstance(incoming_content, str):
-            return pending_content.strip() == incoming_content.strip()
-        return pending_content == incoming_content
+        pending_text: str = ContentUtils.flatten_to_text(self.pending)
+        incoming_text: str = ContentUtils.flatten_to_text(message)
+        return pending_text.strip() == incoming_text.strip()
 
     def get_chat_history(self) -> List[BaseMessage]:
         """

--- a/tests/neuro_san/internals/journals/test_originating_journal.py
+++ b/tests/neuro_san/internals/journals/test_originating_journal.py
@@ -15,12 +15,17 @@
 #
 # END COPYRIGHT
 
+from typing import Any
+from typing import Dict
+from typing import List
+
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 
 import pytest
 
 from langchain_core.messages.ai import AIMessage
+from langchain_core.messages.base import BaseMessage
 
 from neuro_san.internals.journals.originating_journal import OriginatingJournal
 from neuro_san.message.types.agent_message import AgentMessage
@@ -36,6 +41,12 @@ class TestOriginatingJournal:
     dupe comparison must therefore ignore leading/trailing whitespace: with
     an exact comparison, a trailing newline in the final text is enough to
     send clients both the AGENT and AI copies of the same output.
+
+    The comparison also projects both sides to text: the held AGENT copy is
+    always a flattened str, while the incoming AI message can carry block
+    content (reasoning + text) once native messages are preserved. A raw
+    equality between a str and a block list could never match, so without
+    the projection every block-content answer would leak both copies.
     """
 
     ORIGIN = [{"tool": "front_man", "instantiation_index": 0}]
@@ -47,8 +58,21 @@ class TestOriginatingJournal:
         journal = OriginatingJournal(wrapped_journal=wrapped, origin=self.ORIGIN)
         return journal, wrapped
 
+    @staticmethod
+    def _written_messages(wrapped: MagicMock) -> List[BaseMessage]:
+        """
+        Collect the messages that reached the wrapped journal.
+
+        :param wrapped: The wrapped journal mock whose write_message calls to inspect
+        :return: The messages written to the wrapped journal, in order
+        """
+        written: List[BaseMessage] = []
+        for call in wrapped.write_message.call_args_list:
+            written.append(call.args[0])
+        return written
+
     @pytest.mark.asyncio
-    async def test_exact_dupe_is_suppressed(self):
+    async def test_exact_dupe_is_suppressed(self) -> None:
         """
         A held AGENT message whose content matches the next message exactly
         is dropped: only the AI message reaches the wrapped journal.
@@ -57,13 +81,13 @@ class TestOriginatingJournal:
         await journal.write_message_if_next_not_dupe(AgentMessage(content="the answer"))
         await journal.write_message(AIMessage(content="the answer"))
 
-        written = [call.args[0] for call in wrapped.write_message.call_args_list]
+        written: List[BaseMessage] = self._written_messages(wrapped)
         assert len(written) == 1
         assert written[0].content == "the answer"
         assert not isinstance(written[0], AgentMessage)
 
     @pytest.mark.asyncio
-    async def test_dupe_comparison_ignores_edge_whitespace(self):
+    async def test_dupe_comparison_ignores_edge_whitespace(self) -> None:
         """
         The held AGENT content is stripped at capture while the AI content is
         not, so the comparison must treat "the answer" and "the answer\\n" as
@@ -73,12 +97,12 @@ class TestOriginatingJournal:
         await journal.write_message_if_next_not_dupe(AgentMessage(content="the answer"))
         await journal.write_message(AIMessage(content="the answer\n"))
 
-        written = [call.args[0] for call in wrapped.write_message.call_args_list]
+        written: List[BaseMessage] = self._written_messages(wrapped)
         assert len(written) == 1
         assert written[0].content == "the answer\n"
 
     @pytest.mark.asyncio
-    async def test_different_content_flushes_pending_first(self):
+    async def test_different_content_flushes_pending_first(self) -> None:
         """
         A held AGENT message with genuinely different content is not a dupe:
         it is flushed ahead of the incoming message, preserving stream order.
@@ -87,8 +111,46 @@ class TestOriginatingJournal:
         await journal.write_message_if_next_not_dupe(AgentMessage(content="a thought"))
         await journal.write_message(AIMessage(content="the answer"))
 
-        written = [call.args[0] for call in wrapped.write_message.call_args_list]
+        written: List[BaseMessage] = self._written_messages(wrapped)
         assert len(written) == 2
         assert isinstance(written[0], AgentMessage)
         assert written[0].content == "a thought"
         assert written[1].content == "the answer"
+
+    @pytest.mark.asyncio
+    async def test_block_content_dupe_is_suppressed(self) -> None:
+        """
+        The held AGENT copy is a flattened str while the incoming AI message
+        carries reasoning + text blocks with the same visible text. Both sides
+        are projected to text, so the AGENT copy is still recognized as a dupe
+        and only the AI message reaches the wrapped journal.
+        """
+        journal, wrapped = self._make_journal()
+        await journal.write_message_if_next_not_dupe(AgentMessage(content="the answer"))
+        blocks: List[Dict[str, Any]] = [
+            {"type": "reasoning", "reasoning": "hidden"},
+            {"type": "text", "text": "the answer\n"},
+        ]
+        incoming: AIMessage = AIMessage(content=blocks)
+        await journal.write_message(incoming)
+
+        written: List[BaseMessage] = self._written_messages(wrapped)
+        assert len(written) == 1
+        assert written[0] is incoming
+
+    @pytest.mark.asyncio
+    async def test_block_content_with_different_text_flushes_pending(self) -> None:
+        """
+        Block content whose visible text differs from the held AGENT copy is
+        not a dupe: the AGENT copy is flushed first, then the AI message.
+        """
+        journal, wrapped = self._make_journal()
+        await journal.write_message_if_next_not_dupe(AgentMessage(content="a thought"))
+        incoming: AIMessage = AIMessage(content=[{"type": "text", "text": "the answer"}])
+        await journal.write_message(incoming)
+
+        written: List[BaseMessage] = self._written_messages(wrapped)
+        assert len(written) == 2
+        assert isinstance(written[0], AgentMessage)
+        assert written[0].content == "a thought"
+        assert written[1] is incoming


### PR DESCRIPTION
## What

`OriginatingJournal._is_dupe_of_pending` decides whether the held AGENT copy of an LLM's output (from `on_llm_end`) is the same content as the AI message that follows it, so clients receive only one. Since #1285 it strip-compares when both contents are `str`, and otherwise falls back to a raw `==`.

The held AGENT copy is always a flattened `str`. Once an incoming AI message carries block content (reasoning + text, the next rung of #1222), that raw `==` compares `str == list`, never matches, and both copies leak to clients. This PR makes the comparison text-projected on both sides, ahead of the change that would expose it.

## Fix

Project both `self.pending` and the incoming message through `ContentUtils.flatten_to_text`, then keep the existing strip-compare. `flatten_to_text` is an identity on `str`, so today's string-only traffic compares exactly as before. The method's docstring is restructured to the summary / `:param` / `:return:` template and explains the projection.

## Tests

Two new cases in `test_originating_journal.py`: block content (reasoning + text) with the same visible text as the held AGENT copy is deduped, and block content with different text flushes the AGENT copy first. The three existing tests are unchanged in behavior and now share a small loop-based helper for collecting written messages.

Part of #1222 (Phase 1), PR 4.2 of the ladder described there. A prerequisite for PR 5; independent of 4.1 and 4.3.