### PR TITLE
Keep use_tool and escape_message str-safe for block content

### DIFF
--- a/neuro_san/internals/chat/chat_history_message_processor.py
+++ b/neuro_san/internals/chat/chat_history_message_processor.py
@@ -18,6 +18,7 @@ from numbers import Number
 from typing import Any
 from typing import Dict
 from typing import List
+from typing import Optional
 
 from copy import copy
 
@@ -113,7 +114,7 @@ class ChatHistoryMessageProcessor(MessageProcessor):
         redacted["text"] = "<redacted>"
         return redacted
 
-    def escape_message(self, chat_message_dict: Dict[str, Any]) -> Dict[str, Any]:
+    def escape_message(self, chat_message_dict: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         """
         Prepare a message such that it can be re-ingested by the system nicely.
         This means properly escaping any text that is sent.

--- a/neuro_san/internals/chat/chat_history_message_processor.py
+++ b/neuro_san/internals/chat/chat_history_message_processor.py
@@ -117,12 +117,24 @@ class ChatHistoryMessageProcessor(MessageProcessor):
         """
         Prepare a message such that it can be re-ingested by the system nicely.
         This means properly escaping any text that is sent.
+
+        :param chat_message_dict: The ChatMessage dictionary to transform
+        :return: A shallow copy of the dictionary with its text escaped,
+                or None if the message carries no text at all
         """
         transformed: Dict[str, Any] = copy(chat_message_dict)
-        text: str = transformed.get("text")
+        text: Any = transformed.get("text")
 
         if text is None:
             return None
+
+        if not isinstance(text, str):
+            # Brace escaping only applies to str text. Every dict reaching this
+            # processor today comes from BaseMessageDictionaryConverter.to_dict,
+            # which always emits str text, so this is a defensive guard for
+            # future non-str text: pass the message through untouched rather
+            # than silently dropping a history entry.
+            return transformed
 
         # Braces are a problem for chat history being read back into the system
         # if they are not properly escaped.

--- a/neuro_san/internals/graph/activations/branch_activation.py
+++ b/neuro_san/internals/graph/activations/branch_activation.py
@@ -34,6 +34,7 @@ from neuro_san.internals.interfaces.callable_activation import CallableActivatio
 from neuro_san.internals.interfaces.invocation_context import InvocationContext
 from neuro_san.internals.run_context.interfaces.run import Run
 from neuro_san.internals.run_context.interfaces.run_context import RunContext
+from neuro_san.message.utils.content_utils import ContentUtils
 
 
 class BranchActivation(CallingActivation, CallableActivation):
@@ -210,8 +211,15 @@ flag to your invocation.
             # load those pools accumulate as leaked sockets.
             await callable_activation.close_of_work(self.run_context)
 
-        # We got a message back, take the content as the return string
-        return message.content
+        # We got a message back. This method's contract is a str. Today the
+        # sub-agent's final message always carries str content (its chain
+        # output is flattened before it is journaled), so this projection is
+        # an identity. Once native block content is preserved through that
+        # message (later rungs of issue #1222), it keeps the contract: callers
+        # hand this value straight to the calling LLM (copyist.py f-strings it
+        # into the tool result) and would otherwise see a Python repr of the
+        # block list.
+        return ContentUtils.flatten_to_text(message)
 
     async def use_reservation(self, reservation_id: str, args: Dict[str, Any], sly_data: Dict[str, Any]) -> str:
         """

--- a/neuro_san/internals/run_context/utils/activation_capsule.py
+++ b/neuro_san/internals/run_context/utils/activation_capsule.py
@@ -31,6 +31,7 @@ from neuro_san.internals.interfaces.context_type_llm_factory import ContextTypeL
 from neuro_san.internals.interfaces.invocation_context import InvocationContext
 from neuro_san.internals.interfaces.lingering_resource import LingeringResource
 from neuro_san.internals.run_context.interfaces.run_context import RunContext
+from neuro_san.message.utils.content_utils import ContentUtils
 
 
 class ActivationCapsule(LingeringResource):
@@ -107,8 +108,15 @@ flag to your invocation.
             # Nope. Just a regular http connection failure given the tool_name. Can't help ya.
             raise exception
 
-        # We got a message back, take the content as the return string
-        return message.content
+        # We got a message back. This method's contract is a str. Today the
+        # sub-agent's final message always carries str content (its chain
+        # output is flattened before it is journaled), so this projection is
+        # an identity. Once native block content is preserved through that
+        # message (later rungs of issue #1222), it keeps the contract: callers
+        # hand this value straight to the calling LLM (copyist.py f-strings it
+        # into the tool result) and would otherwise see a Python repr of the
+        # block list.
+        return ContentUtils.flatten_to_text(message)
 
     def create_chat_model(self, llm_config: Dict[str, Any], sly_data: Dict[str, Any], num_fallbacks: int = None) -> Any:
         """

--- a/tests/neuro_san/internals/chat/test_chat_history_message_processor.py
+++ b/tests/neuro_san/internals/chat/test_chat_history_message_processor.py
@@ -1,0 +1,71 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+from typing import Any
+from typing import Dict
+from typing import List
+
+from neuro_san.internals.chat.chat_history_message_processor import ChatHistoryMessageProcessor
+from neuro_san.message.types.chat_message_type import ChatMessageType
+
+
+class TestChatHistoryMessageProcessor:
+    """
+    Tests for ChatHistoryMessageProcessor.escape_message.
+
+    The escaping is only meaningful for str text. Every dictionary the
+    processor sees today comes from BaseMessageDictionaryConverter.to_dict,
+    which always emits str text, so the non-str guard is defensive; these
+    tests lock the str behavior and the pass-through for anything else.
+    """
+
+    def test_escape_message_escapes_braces_in_str_text(self) -> None:
+        """
+        Braces in str text are normalized to the doubled, template-safe form,
+        whether or not they were already escaped.
+        """
+        processor: ChatHistoryMessageProcessor = ChatHistoryMessageProcessor()
+        original: Dict[str, Any] = {"type": ChatMessageType.AI, "text": "a {b} and {{c}}"}
+
+        result: Dict[str, Any] = processor.escape_message(original)
+
+        assert result["text"] == "a {{b}} and {{c}}"
+        assert result["type"] == ChatMessageType.AI
+        # The input dictionary is copied, never mutated.
+        assert original["text"] == "a {b} and {{c}}"
+
+    def test_escape_message_without_text_returns_none(self) -> None:
+        """
+        A message with no text key at all is dropped from the history.
+        """
+        processor: ChatHistoryMessageProcessor = ChatHistoryMessageProcessor()
+        assert processor.escape_message({"type": ChatMessageType.AI}) is None
+
+    def test_escape_message_passes_non_str_text_through(self) -> None:
+        """
+        Non-str text (block content) cannot be brace-escaped, so the message
+        is passed through untouched rather than dropped or crashed on.
+        """
+        processor: ChatHistoryMessageProcessor = ChatHistoryMessageProcessor()
+        blocks: List[Dict[str, Any]] = [{"type": "text", "text": "{not escaped}"}]
+        original: Dict[str, Any] = {"type": ChatMessageType.AI, "text": blocks}
+
+        result: Dict[str, Any] = processor.escape_message(original)
+
+        assert result is not original
+        assert result["text"] is blocks
+        assert result["type"] == ChatMessageType.AI

--- a/tests/neuro_san/internals/chat/test_chat_history_message_processor.py
+++ b/tests/neuro_san/internals/chat/test_chat_history_message_processor.py
@@ -18,6 +18,7 @@
 from typing import Any
 from typing import Dict
 from typing import List
+from typing import Optional
 
 from neuro_san.internals.chat.chat_history_message_processor import ChatHistoryMessageProcessor
 from neuro_san.message.types.chat_message_type import ChatMessageType
@@ -41,8 +42,9 @@ class TestChatHistoryMessageProcessor:
         processor: ChatHistoryMessageProcessor = ChatHistoryMessageProcessor()
         original: Dict[str, Any] = {"type": ChatMessageType.AI, "text": "a {b} and {{c}}"}
 
-        result: Dict[str, Any] = processor.escape_message(original)
+        result: Optional[Dict[str, Any]] = processor.escape_message(original)
 
+        assert result is not None
         assert result["text"] == "a {{b}} and {{c}}"
         assert result["type"] == ChatMessageType.AI
         # The input dictionary is copied, never mutated.
@@ -64,8 +66,9 @@ class TestChatHistoryMessageProcessor:
         blocks: List[Dict[str, Any]] = [{"type": "text", "text": "{not escaped}"}]
         original: Dict[str, Any] = {"type": ChatMessageType.AI, "text": blocks}
 
-        result: Dict[str, Any] = processor.escape_message(original)
+        result: Optional[Dict[str, Any]] = processor.escape_message(original)
 
+        assert result is not None
         assert result is not original
         assert result["text"] is blocks
         assert result["type"] == ChatMessageType.AI

--- a/tests/neuro_san/internals/graph/activations/test_branch_activation.py
+++ b/tests/neuro_san/internals/graph/activations/test_branch_activation.py
@@ -1,0 +1,98 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+
+import pytest
+
+from langchain_core.messages.ai import AIMessage
+from langchain_core.messages.base import BaseMessage
+
+from neuro_san.internals.graph.activations.branch_activation import BranchActivation
+
+from tests.neuro_san.message.content_fixtures import ContentFixtures
+
+
+class TestBranchActivation:
+    """
+    Tests for the return contract of BranchActivation.use_tool.
+
+    use_tool is documented to return a str, but it used to return the
+    sub-agent's raw message content. Today that content is always a str
+    (the sub-agent's chain output is flattened before it is journaled), so
+    the projection is an identity; once native block content is preserved
+    through that message, callers such as the copy_cat Copyist, which
+    f-string the value straight into the calling LLM's tool result, would
+    otherwise see a Python repr of the block list. These tests lock the
+    text projection and confirm that plain-string content is returned
+    untouched.
+    """
+
+    @staticmethod
+    def make_activation(build_result: BaseMessage) -> BranchActivation:
+        """
+        Build a BranchActivation without running its constructor (which
+        creates a real RunContext), wired with a factory whose activation
+        build() returns the given message.
+
+        :param build_result: The BaseMessage the sub-agent's build() will return
+        :return: A BranchActivation ready for use_tool()
+        """
+        activation: BranchActivation = BranchActivation.__new__(BranchActivation)
+        activation.agent_tool_spec = {"name": "caller"}
+        activation.run_context = MagicMock()
+
+        callable_activation: MagicMock = MagicMock()
+        callable_activation.build = AsyncMock(return_value=build_result)
+        callable_activation.close_of_work = AsyncMock()
+
+        activation.factory = MagicMock()
+        activation.factory.create_agent_activation = MagicMock(return_value=callable_activation)
+        return activation
+
+    @pytest.mark.asyncio
+    async def test_use_tool_returns_str_content_unchanged(self) -> None:
+        """
+        Plain-string content is returned exactly as-is: no stripping, no wrapping.
+        """
+        activation: BranchActivation = self.make_activation(AIMessage(content="  the answer  "))
+        result: str = await activation.use_tool("sub_agent", {"arg": "value"}, {})
+        assert result == "  the answer  "
+
+    @pytest.mark.asyncio
+    async def test_use_tool_projects_block_content_to_text(self) -> None:
+        """
+        Thinking-first block content from the sub-agent comes back as its text,
+        honoring the documented str contract instead of leaking a list repr.
+        """
+        activation: BranchActivation = self.make_activation(ContentFixtures.anthropic_thinking_first())
+        result: str = await activation.use_tool("sub_agent", {"arg": "value"}, {})
+        assert isinstance(result, str)
+        assert result == "the answer"
+
+    @pytest.mark.asyncio
+    async def test_use_tool_releases_sub_activation_resources(self) -> None:
+        """
+        The sub-agent activation's close_of_work() is always awaited with the
+        caller's run context, so its LLM resources are not orphaned.
+        """
+        activation: BranchActivation = self.make_activation(AIMessage(content="the answer"))
+        await activation.use_tool("sub_agent", {}, {})
+
+        callable_activation: MagicMock = activation.factory.create_agent_activation.return_value
+        callable_activation.close_of_work.assert_awaited_once_with(activation.run_context)

--- a/tests/neuro_san/internals/run_context/utils/test_activation_capsule.py
+++ b/tests/neuro_san/internals/run_context/utils/test_activation_capsule.py
@@ -1,0 +1,91 @@
+
+# Copyright © 2023-2026 Cognizant Technology Solutions Corp, www.cognizant.com.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# END COPYRIGHT
+
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+
+import pytest
+
+from langchain_core.messages.ai import AIMessage
+from langchain_core.messages.base import BaseMessage
+
+from neuro_san.internals.run_context.utils.activation_capsule import ActivationCapsule
+
+from tests.neuro_san.message.content_fixtures import ContentFixtures
+
+
+class TestActivationCapsule:
+    """
+    Tests for the return contract of ActivationCapsule.use_tool.
+
+    use_tool is documented to return a str, but it used to return the
+    sub-agent's raw message content. Today that content is always a str
+    (the sub-agent's chain output is flattened before it is journaled), so
+    the projection is an identity; once native block content is preserved
+    through that message, the projection is what keeps the str contract.
+    These tests lock it and confirm that plain-string content is returned
+    untouched.
+    """
+
+    @staticmethod
+    def make_capsule(build_result: BaseMessage) -> ActivationCapsule:
+        """
+        Build a capsule wired with a factory whose activation builds to the given message.
+
+        :param build_result: The BaseMessage the sub-agent's build() will return
+        :return: An ActivationCapsule whose factory yields an activation
+                 that builds to the given message
+        """
+        callable_activation: MagicMock = MagicMock()
+        callable_activation.build = AsyncMock(return_value=build_result)
+
+        factory: MagicMock = MagicMock()
+        factory.create_agent_activation = MagicMock(return_value=callable_activation)
+
+        return ActivationCapsule(parent_run_context=MagicMock(),
+                                 parent_agent_spec={"name": "caller"},
+                                 agent_tool_factory=factory)
+
+    @pytest.mark.asyncio
+    async def test_use_tool_returns_str_content_unchanged(self) -> None:
+        """
+        Plain-string content is returned exactly as-is: no stripping, no wrapping.
+        """
+        capsule: ActivationCapsule = self.make_capsule(AIMessage(content="  the answer  "))
+        result: str = await capsule.use_tool("sub_agent", {"arg": "value"}, {})
+        assert result == "  the answer  "
+
+    @pytest.mark.asyncio
+    async def test_use_tool_projects_block_content_to_text(self) -> None:
+        """
+        Thinking-first block content from the sub-agent comes back as its text,
+        honoring the documented str contract instead of leaking a list repr.
+        """
+        capsule: ActivationCapsule = self.make_capsule(ContentFixtures.anthropic_thinking_first())
+        result: str = await capsule.use_tool("sub_agent", {"arg": "value"}, {})
+        assert isinstance(result, str)
+        assert result == "the answer"
+
+    @pytest.mark.asyncio
+    async def test_use_tool_requires_factory_and_spec(self) -> None:
+        """
+        A capsule created without a factory or parent spec cannot call tools
+        and says so, rather than failing deep inside the call.
+        """
+        capsule: ActivationCapsule = ActivationCapsule(parent_run_context=MagicMock())
+        with pytest.raises(ValueError):
+            await capsule.use_tool("sub_agent", {}, {})


### PR DESCRIPTION
## What

Three defensive guards at places that assume message content is a `str`. None is reachable with list content today, so all three are identities for current traffic; they exist so that the later rungs of #1222 (which preserve block content through the pipeline) cannot leak a list into a `str` contract.

- **`BranchActivation.use_tool`** and **`ActivationCapsule.use_tool`** are documented to return a `str` but returned the sub-agent's raw `message.content`. They now return `ContentUtils.flatten_to_text(message)`. Their one in-repo caller, the copy_cat `Copyist`, f-strings this value into the calling LLM's tool result, which would otherwise see a Python repr of a block list.
- **`ChatHistoryMessageProcessor.escape_message`** called `str.replace` on the message text. It now passes non-`str` text through untouched rather than crashing or silently dropping the history entry. Every dict it sees today comes from `BaseMessageDictionaryConverter.to_dict`, which always emits `str` text. Its docstring now follows the `:param` / `:return:` template.

## Tests

New modules `test_branch_activation.py`, `test_activation_capsule.py` (with the new `tests/neuro_san/internals/run_context/utils/__init__.py` so CI pylint picks it up), and `test_chat_history_message_processor.py`. Each locks the plain-string behavior unchanged and the block-content projection or pass-through.

Part of #1222 (Phase 1), PR 4.3 of the ladder described there. A prerequisite for PR 5; independent of 4.1 and 4.2.