### PR TITLE
Re-enable Anthropic smoke test hocon

### DIFF
--- a/tests/neuro_san/zzz_hocons/test_smoke_test_hocons.py
+++ b/tests/neuro_san/zzz_hocons/test_smoke_test_hocons.py
@@ -46,8 +46,6 @@ class TestSmokeTestHocons(TestCase):
             "Issue #910: disabled until #909 is resolved.",
         "music_nerd_pro_llm_bedrock_claude/combination_responses_with_history_direct.hocon":
             "Issue #910: disabled until #909 is resolved.",
-        "music_nerd_pro_llm_anthropic/combination_responses_with_history_direct.hocon":
-            "Issue #936: disabled until #909 is resolved.",
         "music_nerd_pro_llm_openrouter/combination_responses_with_history_direct.hocon":
             "Disabled until OPENROUTER_API_KEY is added to the GitHub Actions secrets.",
     }


### PR DESCRIPTION
## Summary
Removes `music_nerd_pro_llm_anthropic/combination_responses_with_history_direct.hocon` from `DISABLED_HOCONS` in `tests/neuro_san/zzz_hocons/test_smoke_test_hocons.py`. It was skipped in #936 because the Anthropic key in Actions had no credit balance (#909); a working key is now available.

No workflow change needed: `smoke.yml` already exports `ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}`, so the repo secret `ANTHROPIC_API_KEY` just needs to be set/updated. The Azure and Bedrock entries remain disabled.

Link to Devin session: https://app.devin.ai/sessions/4e2acc51152c4a55ae3f3a18ee0f6888
Open in Devin Desktop: https://app.devin.ai/desktop/session/4e2acc51152c4a55ae3f3a18ee0f6888?variant=devin
Requested by: @donn-leaf
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cognizant-ai-lab/neuro-san/pull/1315" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->