### PR TITLE
More test tweaking.

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -15,5 +15,7 @@ filterwarnings =
     error::RuntimeWarning
     # Ignore warnings about protobuf 4's PyType_Spec metaclass usage
     ignore:Type google\._upb\._message.* uses PyType_Spec with a metaclass that has custom tp_new:DeprecationWarning
+    # Ignore warnings about fork from test_hocon_parse_lock.py
+    ignore:This process \(pid=\d+\) is multi-threaded, use of fork\(\) may lead to deadlocks:DeprecationWarning
 
 asyncio_default_fixture_loop_scope = function

--- a/pytest.ini
+++ b/pytest.ini
@@ -12,8 +12,8 @@ markers =
     smoke_non_default_llm_provider_needs_server: Tests that use a non-default llm provider and need server.
     ollama: Tests that specifically use ollama as the llm provider
 filterwarnings =
+    error::RuntimeWarning
     # Ignore warnings about protobuf 4's PyType_Spec metaclass usage
     ignore:Type google\._upb\._message.* uses PyType_Spec with a metaclass that has custom tp_new:DeprecationWarning
-    error::RuntimeWarning
 
 asyncio_default_fixture_loop_scope = function

--- a/pytest.ini
+++ b/pytest.ini
@@ -14,5 +14,6 @@ markers =
 filterwarnings =
     # Ignore warnings about protobuf 4's PyType_Spec metaclass usage
     ignore:Type google\._upb\._message.* uses PyType_Spec with a metaclass that has custom tp_new:DeprecationWarning
+    error::RuntimeWarning
 
 asyncio_default_fixture_loop_scope = function

--- a/tests/neuro_san/coded_tools/music_nerd_pro/test_accountant.py
+++ b/tests/neuro_san/coded_tools/music_nerd_pro/test_accountant.py
@@ -16,8 +16,6 @@
 # END COPYRIGHT
 from unittest import IsolatedAsyncioTestCase
 
-import pytest
-
 from neuro_san.coded_tools.accountant import Accountant
 
 
@@ -26,7 +24,6 @@ class TestAccountant(IsolatedAsyncioTestCase):
     Unit tests for Accountant class.
     """
 
-    @pytest.mark.asyncio
     async def test_invoke(self):
         """
         Tests the invoke method of the Accountant CodedTool.

--- a/tests/neuro_san/internals/graph/activations/test_branch_activation.py
+++ b/tests/neuro_san/internals/graph/activations/test_branch_activation.py
@@ -19,8 +19,6 @@ from unittest import IsolatedAsyncioTestCase
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 
-import pytest
-
 from langchain_core.messages.ai import AIMessage
 from langchain_core.messages.base import BaseMessage
 
@@ -66,7 +64,6 @@ class TestBranchActivation(IsolatedAsyncioTestCase):
         activation.factory.create_agent_activation = MagicMock(return_value=callable_activation)
         return activation
 
-    @pytest.mark.asyncio
     async def test_use_tool_returns_str_content_unchanged(self) -> None:
         """
         Plain-string content is returned exactly as-is: no stripping, no wrapping.
@@ -75,7 +72,6 @@ class TestBranchActivation(IsolatedAsyncioTestCase):
         result: str = await activation.use_tool("sub_agent", {"arg": "value"}, {})
         assert result == "  the answer  "
 
-    @pytest.mark.asyncio
     async def test_use_tool_projects_block_content_to_text(self) -> None:
         """
         Thinking-first block content from the sub-agent comes back as its text,
@@ -86,7 +82,6 @@ class TestBranchActivation(IsolatedAsyncioTestCase):
         assert isinstance(result, str)
         assert result == "the answer"
 
-    @pytest.mark.asyncio
     async def test_use_tool_releases_sub_activation_resources(self) -> None:
         """
         The sub-agent activation's close_of_work() is always awaited with the

--- a/tests/neuro_san/internals/journals/test_originating_journal.py
+++ b/tests/neuro_san/internals/journals/test_originating_journal.py
@@ -23,8 +23,6 @@ from unittest import IsolatedAsyncioTestCase
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 
-import pytest
-
 from langchain_core.messages.ai import AIMessage
 from langchain_core.messages.base import BaseMessage
 
@@ -72,7 +70,6 @@ class TestOriginatingJournal(IsolatedAsyncioTestCase):
             written.append(call.args[0])
         return written
 
-    @pytest.mark.asyncio
     async def test_exact_dupe_is_suppressed(self) -> None:
         """
         A held AGENT message whose content matches the next message exactly
@@ -87,7 +84,6 @@ class TestOriginatingJournal(IsolatedAsyncioTestCase):
         assert written[0].content == "the answer"
         assert not isinstance(written[0], AgentMessage)
 
-    @pytest.mark.asyncio
     async def test_dupe_comparison_ignores_edge_whitespace(self) -> None:
         """
         The held AGENT content is stripped at capture while the AI content is
@@ -102,7 +98,6 @@ class TestOriginatingJournal(IsolatedAsyncioTestCase):
         assert len(written) == 1
         assert written[0].content == "the answer\n"
 
-    @pytest.mark.asyncio
     async def test_different_content_flushes_pending_first(self) -> None:
         """
         A held AGENT message with genuinely different content is not a dupe:
@@ -118,7 +113,6 @@ class TestOriginatingJournal(IsolatedAsyncioTestCase):
         assert written[0].content == "a thought"
         assert written[1].content == "the answer"
 
-    @pytest.mark.asyncio
     async def test_block_content_dupe_is_suppressed(self) -> None:
         """
         The held AGENT copy is a flattened str while the incoming AI message
@@ -139,7 +133,6 @@ class TestOriginatingJournal(IsolatedAsyncioTestCase):
         assert len(written) == 1
         assert written[0] is incoming
 
-    @pytest.mark.asyncio
     async def test_block_content_with_different_text_flushes_pending(self) -> None:
         """
         Block content whose visible text differs from the held AGENT copy is

--- a/tests/neuro_san/internals/journals/test_originating_journal.py
+++ b/tests/neuro_san/internals/journals/test_originating_journal.py
@@ -153,7 +153,6 @@ class TestOriginatingJournal(IsolatedAsyncioTestCase):
         assert written[0].content == "a thought"
         assert written[1] is incoming
 
-    @pytest.mark.asyncio
     async def test_tool_result_history_copy_is_text_projected(self) -> None:
         """
         A tool result carrying text + image blocks is journaled with its blocks
@@ -180,7 +179,6 @@ class TestOriginatingJournal(IsolatedAsyncioTestCase):
         assert written[0] is tool_result
         assert written[0].content == blocks
 
-    @pytest.mark.asyncio
     async def test_tool_result_str_history_copy_unchanged(self) -> None:
         """
         A plain-string tool result keeps producing a plain AIMessage history
@@ -197,7 +195,6 @@ class TestOriginatingJournal(IsolatedAsyncioTestCase):
         assert isinstance(chat_history[0], AIMessage)
         assert chat_history[0].content == "tool says"
 
-    @pytest.mark.asyncio
     async def test_block_answer_history_copy_is_text_projected(self) -> None:
         """
         An AI answer carrying block content is journaled with its blocks intact,
@@ -226,7 +223,6 @@ class TestOriginatingJournal(IsolatedAsyncioTestCase):
         assert written[0] is answer
         assert isinstance(written[0].content, list)
 
-    @pytest.mark.asyncio
     async def test_str_answer_history_copy_is_same_instance(self) -> None:
         """
         A plain-string AI answer is appended to the chat history as the very

--- a/tests/neuro_san/internals/network_providers/test_expiring_agent_network_storage.py
+++ b/tests/neuro_san/internals/network_providers/test_expiring_agent_network_storage.py
@@ -17,8 +17,6 @@
 import time
 from unittest import IsolatedAsyncioTestCase
 
-import pytest
-
 from neuro_san.interfaces.reservation import Reservation
 from neuro_san.internals.network_providers.expiring_agent_network_storage \
     import ExpiringAgentNetworkStorage
@@ -79,7 +77,6 @@ class TestExpiringAgentNetworkStorage(IsolatedAsyncioTestCase):
         self.assertEqual(0, storage.max_items)
         self.assertEqual(0, len(storage.agents_table))
 
-    @pytest.mark.asyncio
     async def test_add_reservations(self):
         """
         Test that reservations can be added and are tracked in all tables.
@@ -91,7 +88,6 @@ class TestExpiringAgentNetworkStorage(IsolatedAsyncioTestCase):
         self.assertIn("agent_a", storage.reservations_table)
         self.assertIn("agent_a", storage.access_times)
 
-    @pytest.mark.asyncio
     async def test_add_reservations_replaces_existing(self):
         """
         Test that adding a reservation with the same name replaces it.
@@ -140,7 +136,6 @@ class TestExpiringAgentNetworkStorage(IsolatedAsyncioTestCase):
         self.assertEqual(0, storage.max_items)
         self.assertEqual(0, storage.items_overflow_threshold)
 
-    @pytest.mark.asyncio
     async def test_no_eviction_when_unlimited(self):
         """
         Test that no eviction occurs when max_items is 0 (unlimited).
@@ -151,7 +146,6 @@ class TestExpiringAgentNetworkStorage(IsolatedAsyncioTestCase):
             await storage.add_reservations({r: self._make_agent_spec(f"agent_{i}")}, source="test")
         self.assertEqual(20, len(storage.agents_table))
 
-    @pytest.mark.asyncio
     async def test_lru_eviction_on_add(self):
         """
         Test that LRU eviction occurs when adding items beyond the limit.
@@ -181,7 +175,6 @@ class TestExpiringAgentNetworkStorage(IsolatedAsyncioTestCase):
         # Oldest agents should have been evicted
         self.assertTrue(len(listener.removed) > 0)
 
-    @pytest.mark.asyncio
     async def test_lru_eviction_preserves_recently_accessed(self):
         """
         Test that recently accessed items survive LRU eviction.
@@ -213,7 +206,6 @@ class TestExpiringAgentNetworkStorage(IsolatedAsyncioTestCase):
         # Some older agents should have been evicted
         self.assertTrue(len(listener.removed) > 0)
 
-    @pytest.mark.asyncio
     async def test_access_time_updated_on_get(self):
         """
         Test that accessing an agent network updates its access time.
@@ -229,7 +221,6 @@ class TestExpiringAgentNetworkStorage(IsolatedAsyncioTestCase):
         self.assertIsNotNone(provider)
         self.assertGreater(storage.access_times["agent_a"], original_time)
 
-    @pytest.mark.asyncio
     async def test_access_time_set_on_add(self):
         """
         Test that access time is set when a reservation is added.
@@ -244,7 +235,6 @@ class TestExpiringAgentNetworkStorage(IsolatedAsyncioTestCase):
         self.assertGreaterEqual(storage.access_times["agent_a"], before)
         self.assertLessEqual(storage.access_times["agent_a"], after)
 
-    @pytest.mark.asyncio
     async def test_expire_removes_access_times(self):
         """
         Test that expiring a reservation also removes its access time entry.
@@ -261,7 +251,6 @@ class TestExpiringAgentNetworkStorage(IsolatedAsyncioTestCase):
         self.assertNotIn("agent_expired", storage.reservations_table)
         self.assertNotIn("agent_expired", storage.access_times)
 
-    @pytest.mark.asyncio
     async def test_get_expired_removes_access_times(self):
         """
         Test that getting an expired agent removes its access time entry.
@@ -274,7 +263,6 @@ class TestExpiringAgentNetworkStorage(IsolatedAsyncioTestCase):
         self.assertIsNone(provider)
         self.assertNotIn("agent_expired", storage.access_times)
 
-    @pytest.mark.asyncio
     async def test_remove_agent_network_cleans_all_tables(self):
         """
         Test that remove_agent_network removes from all three tables.
@@ -296,7 +284,6 @@ class TestExpiringAgentNetworkStorage(IsolatedAsyncioTestCase):
         storage = self._make_storage()
         storage.remove_agent_network("does_not_exist")
 
-    @pytest.mark.asyncio
     async def test_eviction_notifies_listeners(self):
         """
         Test that listeners are notified when agents are evicted.
@@ -314,7 +301,6 @@ class TestExpiringAgentNetworkStorage(IsolatedAsyncioTestCase):
         # Some agents should have been removed via eviction
         self.assertTrue(len(listener.removed) > 0)
 
-    @pytest.mark.asyncio
     async def test_set_max_evicts_existing(self):
         """
         Test that calling set_max_agent_networks on a storage
@@ -340,7 +326,6 @@ class TestExpiringAgentNetworkStorage(IsolatedAsyncioTestCase):
         self.assertLessEqual(len(storage.agents_table), 3)
         self.assertTrue(len(listener.removed) > 0)
 
-    @pytest.mark.asyncio
     async def test_add_empty_reservations(self):
         """
         Test that adding an empty dict is a no-op.
@@ -357,7 +342,6 @@ class TestExpiringAgentNetworkStorage(IsolatedAsyncioTestCase):
         provider = storage.get_agent_network_provider("does_not_exist")
         self.assertIsNone(provider)
 
-    @pytest.mark.asyncio
     async def test_get_valid_returns_provider(self):
         """
         Test that getting a valid agent returns a non-None provider.
@@ -369,7 +353,6 @@ class TestExpiringAgentNetworkStorage(IsolatedAsyncioTestCase):
         provider = storage.get_agent_network_provider("agent_a")
         self.assertIsNotNone(provider)
 
-    @pytest.mark.asyncio
     async def test_expire_mixed(self):
         """
         Test that only expired reservations are removed, valid ones remain.
@@ -390,7 +373,6 @@ class TestExpiringAgentNetworkStorage(IsolatedAsyncioTestCase):
         self.assertNotIn("expired", storage.agents_table)
         self.assertNotIn("expired", storage.access_times)
 
-    @pytest.mark.asyncio
     async def test_tables_stay_consistent(self):
         """
         Test that agents_table, reservations_table, and access_times

--- a/tests/neuro_san/internals/run_context/langchain/core/test_base_tool_factory.py
+++ b/tests/neuro_san/internals/run_context/langchain/core/test_base_tool_factory.py
@@ -88,7 +88,7 @@ class TestBaseToolFactory:
 
         # The args_schema is what actually reaches the calling LLM.
         param_name: str = BaseToolFactory.DEFAULT_EXTERNAL_PARAMETER_NAME
-        fields = tool.args_schema.__fields__
+        fields = tool.args_schema.model_fields
         assert list(fields.keys()) == [param_name]
         # is_required() is the pydantic v2 FieldInfo API; the v1 models this
         # converter used to build exposed a .required attribute instead.
@@ -122,7 +122,7 @@ class TestBaseToolFactory:
 
         assert tool is not None
         assert tool.parameters == declared_parameters
-        assert list(tool.args_schema.__fields__.keys()) == ["question"]
+        assert list(tool.args_schema.model_fields.keys()) == ["question"]
         factory.journal.write_message.assert_not_awaited()
 
     def test_create_function_tool_does_not_mutate_function_json(self):

--- a/tests/neuro_san/internals/run_context/langchain/core/test_langchain_openai_function_tool.py
+++ b/tests/neuro_san/internals/run_context/langchain/core/test_langchain_openai_function_tool.py
@@ -118,7 +118,7 @@ class TestLangChainOpenAIFunctionTool(IsolatedAsyncioTestCase):
         tool = LangChainOpenAIFunctionTool.from_function_json(function_json, MagicMock())
 
         assert tool.args_schema is not None
-        assert len(tool.args_schema.__fields__) == 0
+        assert len(tool.args_schema.model_fields) == 0
 
     def test_explicit_null_parameters_builds_explicit_empty_args_schema(self):
         """

--- a/tests/neuro_san/internals/run_context/langchain/core/test_langchain_openai_function_tool.py
+++ b/tests/neuro_san/internals/run_context/langchain/core/test_langchain_openai_function_tool.py
@@ -141,7 +141,6 @@ class TestLangChainOpenAIFunctionTool(IsolatedAsyncioTestCase):
         with raises(ToolSpecError, match="parameters to be a dictionary"):
             LangChainOpenAIFunctionTool.from_function_json(function_json, MagicMock())
 
-    @pytest.mark.asyncio
     async def test_arun_projects_block_content_answer_to_text(self) -> None:
         """
         A sub-agent answer carrying reasoning + text blocks comes back as its
@@ -158,7 +157,6 @@ class TestLangChainOpenAIFunctionTool(IsolatedAsyncioTestCase):
 
         assert result == "the answer"
 
-    @pytest.mark.asyncio
     async def test_arun_references_data_blocks_in_text(self) -> None:
         """
         A data block in the answer becomes a short reference in the tool result

--- a/tests/neuro_san/internals/run_context/langchain/core/test_langchain_openai_function_tool.py
+++ b/tests/neuro_san/internals/run_context/langchain/core/test_langchain_openai_function_tool.py
@@ -19,7 +19,7 @@ from unittest import IsolatedAsyncioTestCase
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 
-import pytest
+from pytest import raises
 
 from pydantic import BaseModel
 
@@ -60,7 +60,6 @@ class TestLangChainOpenAIFunctionTool(IsolatedAsyncioTestCase):
             description="a test tool",
             tool_caller=tool_caller)
 
-    @pytest.mark.asyncio
     async def test_arun_returns_message_content_not_message_object(self):
         """
         The sub-agent's answer must come back as the message content,
@@ -77,7 +76,6 @@ class TestLangChainOpenAIFunctionTool(IsolatedAsyncioTestCase):
         assert result == "the answer"
         assert isinstance(result, str)
 
-    @pytest.mark.asyncio
     async def test_arun_returns_none_when_run_has_no_tool_message(self):
         """
         A Run can legitimately carry no tool message (see submit_tool_outputs()
@@ -91,7 +89,6 @@ class TestLangChainOpenAIFunctionTool(IsolatedAsyncioTestCase):
 
         assert result is None
 
-    @pytest.mark.asyncio
     async def test_arun_returns_exception_string_on_failure(self):
         """
         Exceptions from the tool call are reported back to the calling LLM
@@ -141,5 +138,5 @@ class TestLangChainOpenAIFunctionTool(IsolatedAsyncioTestCase):
         instead of raising a raw AttributeError from parameters.get().
         """
         function_json = {"name": "ext_agent", "description": "d", "parameters": "not-a-dict"}
-        with pytest.raises(ToolSpecError, match="parameters to be a dictionary"):
+        with raises(ToolSpecError, match="parameters to be a dictionary"):
             LangChainOpenAIFunctionTool.from_function_json(function_json, MagicMock())

--- a/tests/neuro_san/internals/run_context/langchain/core/test_run_context_runnable.py
+++ b/tests/neuro_san/internals/run_context/langchain/core/test_run_context_runnable.py
@@ -20,7 +20,6 @@ from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 
 import httpx
-import pytest
 
 from langchain_core.messages.ai import AIMessage
 from langchain_core.messages.human import HumanMessage
@@ -93,7 +92,6 @@ class TestRunContextRunnable(IsolatedAsyncioTestCase):
         ]}
         assert runnable.parse_chain_result(chain_result, exception=None) == "the answer"
 
-    @pytest.mark.asyncio
     async def test_parse_chain_result_matches_on_llm_end_projection(self):
         """
         The dupe-leak regression: parse_chain_result and
@@ -122,7 +120,6 @@ class TestRunContextRunnable(IsolatedAsyncioTestCase):
         journaled = calling_agent_journal.write_message_if_next_not_dupe.call_args.args[0]
         assert journaled.content == parsed
 
-    @pytest.mark.asyncio
     async def test_journal_retry_reason_writes_agent_framework_message(self):
         """
         journal_retry_reason should write a single AgentFrameworkMessage carrying the
@@ -149,7 +146,6 @@ class TestRunContextRunnable(IsolatedAsyncioTestCase):
         assert isinstance(message, AgentFrameworkMessage)
         assert message.content == "Retrying: the model's output could not be parsed (ValueError) - bad json"
 
-    @pytest.mark.asyncio
     async def test_invoke_agent_chain_surfaces_retry_reason_before_final_message(self):
         """
         When a recoverable error is retried until attempts are exhausted, each retry
@@ -187,7 +183,6 @@ class TestRunContextRunnable(IsolatedAsyncioTestCase):
             assert msg.content == "Retrying: the model's output could not be parsed (ValueError) - not a parsing error"
         assert isinstance(written[-1], AIMessage)
 
-    @pytest.mark.asyncio
     async def test_invoke_agent_chain_keeps_backtrace_out_of_client_output(self):
         """
         When the agent chain dies with an unhandled exception (e.g. an MCP tool
@@ -231,7 +226,6 @@ class TestRunContextRunnable(IsolatedAsyncioTestCase):
         # The backtrace is logged server-side instead.
         assert any("Traceback" in str(call) for call in sensitive_logger.error.call_args_list)
 
-    @pytest.mark.asyncio
     async def test_invoke_agent_chain_does_not_log_stale_backtrace(self):
         """
         A backtrace captured on an earlier attempt must not be logged when a

--- a/tests/neuro_san/internals/run_context/langchain/journaling/test_journaling_callback_handler.py
+++ b/tests/neuro_san/internals/run_context/langchain/journaling/test_journaling_callback_handler.py
@@ -22,8 +22,6 @@ from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 from uuid import uuid4
 
-import pytest
-
 from langchain_core.messages.ai import AIMessage
 from langchain_core.outputs import LLMResult
 from langchain_core.outputs.chat_generation import ChatGeneration
@@ -69,7 +67,6 @@ class TestJournalingCallbackHandler(IsolatedAsyncioTestCase):
         """Wrap an AIMessage the way it arrives at on_llm_end."""
         return LLMResult(generations=[[ChatGeneration(message=message)]])
 
-    @pytest.mark.asyncio
     async def test_on_llm_end_journals_full_text_of_block_content(self) -> None:
         """
         Thinking-first block content journals its answer text as an AGENT
@@ -81,7 +78,6 @@ class TestJournalingCallbackHandler(IsolatedAsyncioTestCase):
         assert isinstance(message, AgentMessage)
         assert message.content == "the answer"
 
-    @pytest.mark.asyncio
     async def test_on_llm_end_tool_call_only_step_stays_unjournaled(self) -> None:
         """
         A tool-call-only step has no text, so the journaling gate must keep
@@ -95,7 +91,6 @@ class TestJournalingCallbackHandler(IsolatedAsyncioTestCase):
         await handler.on_llm_end(self._llm_result(tool_call_only))
         journal.write_message_if_next_not_dupe.assert_not_called()
 
-    @pytest.mark.asyncio
     async def test_on_llm_end_plain_string_content_still_journaled_stripped(self) -> None:
         """
         Plain-string content keeps its existing behavior: journaled stripped.
@@ -105,7 +100,6 @@ class TestJournalingCallbackHandler(IsolatedAsyncioTestCase):
         message = journal.write_message_if_next_not_dupe.call_args.args[0]
         assert message.content == "padded thought"
 
-    @pytest.mark.asyncio
     async def test_on_tool_start_uses_tool_name_when_present(self) -> None:
         """A serialized tool with a name is reported verbatim."""
         handler, journal = self._make_handler()
@@ -115,7 +109,6 @@ class TestJournalingCallbackHandler(IsolatedAsyncioTestCase):
         assert message.content == "Invoking: `search` with:"
         assert message.structure["invoked_agent_name"] == "search"
 
-    @pytest.mark.asyncio
     async def test_on_tool_start_falls_back_to_placeholder_when_name_missing(self) -> None:
         """A serialized tool with no name yields a diagnostic placeholder label
         instead of an empty "Invoking: ``"; the raw value is still reported."""

--- a/tests/neuro_san/internals/run_context/langchain/journaling/test_journaling_callback_handler.py
+++ b/tests/neuro_san/internals/run_context/langchain/journaling/test_journaling_callback_handler.py
@@ -161,7 +161,6 @@ class TestJournalingCallbackHandler(IsolatedAsyncioTestCase):
         got_result: AgentMessage = base_journal.write_message.call_args_list[-1].args[0]
         return result, got_result
 
-    @pytest.mark.asyncio
     async def test_on_tool_end_str_output_unchanged(self) -> None:
         """
         Plain-string tool output is journaled exactly as before.
@@ -171,7 +170,6 @@ class TestJournalingCallbackHandler(IsolatedAsyncioTestCase):
         assert result.content == "42"
         assert got_result.structure["tool_output"] == "42"
 
-    @pytest.mark.asyncio
     async def test_on_tool_end_preserves_block_list_output(self) -> None:
         """
         A ToolMessage carrying standard content blocks (text + image: the
@@ -184,7 +182,6 @@ class TestJournalingCallbackHandler(IsolatedAsyncioTestCase):
         assert result.content == blocks
         assert got_result.structure["tool_output"] == blocks
 
-    @pytest.mark.asyncio
     async def test_on_tool_end_sanitizes_bytes_in_blocks(self) -> None:
         """
         Bytes payloads inside blocks become base64 strings in both the journaled
@@ -199,7 +196,6 @@ class TestJournalingCallbackHandler(IsolatedAsyncioTestCase):
         json.dumps(result.content)
         json.dumps(got_result.structure)
 
-    @pytest.mark.asyncio
     async def test_on_tool_end_non_block_list_keeps_str_form(self) -> None:
         """
         A list that is not standard content blocks (here list-of-str) keeps the
@@ -210,7 +206,6 @@ class TestJournalingCallbackHandler(IsolatedAsyncioTestCase):
         assert result.content == "['a', 'b']"
         assert got_result.structure["tool_output"] == ["a", "b"]
 
-    @pytest.mark.asyncio
     async def test_on_tool_end_single_text_block_list_is_kept_as_blocks(self) -> None:
         """
         A tool returning a bare text-block list is journaled as that list, so

--- a/tests/neuro_san/internals/run_context/langchain/journaling/test_journaling_exclusive_agent_attribution.py
+++ b/tests/neuro_san/internals/run_context/langchain/journaling/test_journaling_exclusive_agent_attribution.py
@@ -21,7 +21,6 @@ from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 from uuid import uuid4
 
-import pytest
 from langchain_core.messages import AIMessage
 from langchain_core.outputs import ChatGeneration
 from langchain_core.outputs import LLMResult
@@ -51,7 +50,6 @@ class TestJournalingExclusiveAgentAttribution(IsolatedAsyncioTestCase):
         )
         return handler, calling_agent_journal, origination
 
-    @pytest.mark.asyncio
     async def test_descendant_llm_event_is_ignored(self) -> None:
         """An ancestor handler must not journal a descendant's LLM output."""
         ancestor, ancestor_journal, _ = self._make_handler()
@@ -63,7 +61,6 @@ class TestJournalingExclusiveAgentAttribution(IsolatedAsyncioTestCase):
 
         ancestor_journal.write_message_if_next_not_dupe.assert_not_awaited()
 
-    @pytest.mark.asyncio
     async def test_descendant_tool_events_are_ignored_before_origin_allocation(self) -> None:
         """Descendant tool callbacks must be rejected before allocating an origin."""
         ancestor, ancestor_journal, ancestor_origination = self._make_handler()
@@ -82,7 +79,6 @@ class TestJournalingExclusiveAgentAttribution(IsolatedAsyncioTestCase):
         assert not ancestor._tool_journals  # pylint: disable=protected-access
         assert not ancestor._tool_origins  # pylint: disable=protected-access
 
-    @pytest.mark.asyncio
     async def test_nearest_handler_processes_its_own_event(self) -> None:
         """The handler owning the nearest agent scope must process its event."""
         handler, journal, _ = self._make_handler()

--- a/tests/neuro_san/internals/run_context/langchain/token_counting/test_exclusive_model_attribution.py
+++ b/tests/neuro_san/internals/run_context/langchain/token_counting/test_exclusive_model_attribution.py
@@ -16,7 +16,6 @@
 # END COPYRIGHT
 
 from unittest import IsolatedAsyncioTestCase
-import pytest
 
 from langchain_core.messages import AIMessage
 from langchain_core.outputs import ChatGeneration
@@ -48,7 +47,6 @@ class TestExclusiveModelAttribution(IsolatedAsyncioTestCase):
         )
         return LLMResult(generations=[[ChatGeneration(message=message)]])
 
-    @pytest.mark.asyncio
     async def test_own_call_updates_models_and_scalars(self):
         """An LLM call belonging to this handler's own agent updates both tallies."""
         handler = LlmTokenCallbackHandler(llm_infos={})
@@ -61,7 +59,6 @@ class TestExclusiveModelAttribution(IsolatedAsyncioTestCase):
         assert handler.models_token_dict["openai"]["gpt-4"]["total_tokens"] == 15
         assert handler.models_token_dict["openai"]["gpt-4"]["successful_requests"] == 1
 
-    @pytest.mark.asyncio
     async def test_downstream_call_updates_scalars_only(self):
         """
         A downstream agent's LLM call updates the subtree scalars of an ancestor
@@ -90,7 +87,6 @@ class TestExclusiveModelAttribution(IsolatedAsyncioTestCase):
         # And its per-call timer state was never touched.
         assert ancestor_handler.start_time is None
 
-    @pytest.mark.asyncio
     async def test_call_outside_any_agent_scope_updates_scalars_only(self):
         """With no owning agent scope at all, treat the call as not our own."""
         handler = LlmTokenCallbackHandler(llm_infos={})

--- a/tests/neuro_san/internals/run_context/langchain/token_counting/test_nested_token_accounting.py
+++ b/tests/neuro_san/internals/run_context/langchain/token_counting/test_nested_token_accounting.py
@@ -24,8 +24,6 @@ from typing import Optional
 
 from unittest import IsolatedAsyncioTestCase
 
-import pytest
-
 from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import AIMessage
@@ -143,7 +141,6 @@ class TestNestedTokenAccounting(IsolatedAsyncioTestCase):
 
     # A test this end-to-end legitimately needs a handful of actors and captures.
     # pylint: disable=too-many-locals
-    @pytest.mark.asyncio
     async def test_nested_agents_count_each_llm_call_exactly_once(self):
         """
         Three count_tokens() scopes with one LLM call each, shaped like a

--- a/tests/neuro_san/internals/run_context/langchain/token_counting/test_report.py
+++ b/tests/neuro_san/internals/run_context/langchain/token_counting/test_report.py
@@ -19,8 +19,6 @@ from unittest import IsolatedAsyncioTestCase
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 
-import pytest
-
 from neuro_san.internals.run_context.langchain.token_counting.langchain_token_counter import LangChainTokenCounter
 from neuro_san.message.types.agent_message import AgentMessage
 
@@ -83,7 +81,6 @@ class TestReport(IsolatedAsyncioTestCase):
         callback.total_cost = 0.0
         return callback
 
-    @pytest.mark.asyncio
     async def test_report_counts_each_agents_own_calls_exactly_once(self):
         """
         Nested completions must not double count: even though the front man's
@@ -117,7 +114,6 @@ class TestReport(IsolatedAsyncioTestCase):
         assert main_accounting["total_tokens"] == 45
         assert main_accounting["successful_requests"] == 3
 
-    @pytest.mark.asyncio
     async def test_report_separates_main_network_from_total(self):
         """
         Agents of same-server external networks (cloned InvocationContexts)
@@ -157,7 +153,6 @@ class TestReport(IsolatedAsyncioTestCase):
         assert list(request_reporting.keys()) == \
             ["token_accounting", "total_token_accounting"]
 
-    @pytest.mark.asyncio
     async def test_report_late_external_does_not_restamp_request_latency(self):
         """
         A cloned (external) agent completing after the front man - e.g. an
@@ -179,7 +174,6 @@ class TestReport(IsolatedAsyncioTestCase):
         # ... but the request latency remains the front man's.
         assert total_accounting["time_taken_in_seconds"] == 20.0
 
-    @pytest.mark.asyncio
     async def test_report_flags_unattributed_tokens(self):
         """
         When the front man's subtree scalars exceed what completed scopes merged
@@ -200,7 +194,6 @@ class TestReport(IsolatedAsyncioTestCase):
         assert any("An additional 20 tokens" in caveat
                    for caveat in total_accounting["caveats"])
 
-    @pytest.mark.asyncio
     async def test_report_network_message_gating(self):
         """
         Only the front man of the main network (single-element origin, non-cloned

--- a/tests/neuro_san/internals/run_context/utils/test_activation_capsule.py
+++ b/tests/neuro_san/internals/run_context/utils/test_activation_capsule.py
@@ -19,7 +19,7 @@ from unittest import IsolatedAsyncioTestCase
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 
-import pytest
+from pytest import raises
 
 from langchain_core.messages.ai import AIMessage
 from langchain_core.messages.base import BaseMessage
@@ -61,7 +61,6 @@ class TestActivationCapsule(IsolatedAsyncioTestCase):
                                  parent_agent_spec={"name": "caller"},
                                  agent_tool_factory=factory)
 
-    @pytest.mark.asyncio
     async def test_use_tool_returns_str_content_unchanged(self) -> None:
         """
         Plain-string content is returned exactly as-is: no stripping, no wrapping.
@@ -70,7 +69,6 @@ class TestActivationCapsule(IsolatedAsyncioTestCase):
         result: str = await capsule.use_tool("sub_agent", {"arg": "value"}, {})
         assert result == "  the answer  "
 
-    @pytest.mark.asyncio
     async def test_use_tool_projects_block_content_to_text(self) -> None:
         """
         Thinking-first block content from the sub-agent comes back as its text,
@@ -81,12 +79,11 @@ class TestActivationCapsule(IsolatedAsyncioTestCase):
         assert isinstance(result, str)
         assert result == "the answer"
 
-    @pytest.mark.asyncio
     async def test_use_tool_requires_factory_and_spec(self) -> None:
         """
         A capsule created without a factory or parent spec cannot call tools
         and says so, rather than failing deep inside the call.
         """
         capsule: ActivationCapsule = ActivationCapsule(parent_run_context=MagicMock())
-        with pytest.raises(ValueError):
+        with raises(ValueError):
             await capsule.use_tool("sub_agent", {}, {})

--- a/tests/neuro_san/middleware/test_network_copy_middleware.py
+++ b/tests/neuro_san/middleware/test_network_copy_middleware.py
@@ -64,7 +64,6 @@ class TestNetworkCopyMiddleware(IsolatedAsyncioTestCase):
         """
         return {"messages": [AIMessage(content=content)]}
 
-    @pytest.mark.asyncio
     async def test_str_json_content_parses_agent_name(self) -> None:
         """
         Plain-string JSON content, which every Chat Completions model produces,
@@ -78,7 +77,6 @@ class TestNetworkCopyMiddleware(IsolatedAsyncioTestCase):
         restore.assert_called_once_with("hello_world")
         assert "Cannot find agent hello_world" in response["messages"][0].content
 
-    @pytest.mark.asyncio
     async def test_block_content_parses_agent_name(self) -> None:
         """
         The regression: Anthropic-style thinking-first block content whose text

--- a/tests/neuro_san/middleware/test_network_copy_middleware.py
+++ b/tests/neuro_san/middleware/test_network_copy_middleware.py
@@ -19,17 +19,16 @@ from typing import Any
 from typing import Dict
 from typing import List
 
+from unittest import IsolatedAsyncioTestCase
 from unittest.mock import MagicMock
 from unittest.mock import patch
-
-import pytest
 
 from langchain_core.messages.ai import AIMessage
 
 from neuro_san.middleware.network_copy_middleware import NetworkCopyMiddleware
 
 
-class TestNetworkCopyMiddleware:
+class TestNetworkCopyMiddleware(IsolatedAsyncioTestCase):
     """
     Tests for how NetworkCopyMiddleware reads the model's response.
 
@@ -97,7 +96,6 @@ class TestNetworkCopyMiddleware:
         restore.assert_called_once_with("hello_world")
         assert "Cannot find agent hello_world" in response["messages"][0].content
 
-    @pytest.mark.asyncio
     async def test_responses_api_content_parses_agent_name(self) -> None:
         """
         The OpenAI Responses API shape (reasoning item first, then the text
@@ -114,7 +112,6 @@ class TestNetworkCopyMiddleware:
         restore.assert_called_once_with("hello_world")
         assert "Cannot find agent hello_world" in response["messages"][0].content
 
-    @pytest.mark.asyncio
     async def test_list_of_str_content_parses_agent_name(self) -> None:
         """
         List-of-str content is legal per the BaseMessage annotation and also
@@ -128,7 +125,6 @@ class TestNetworkCopyMiddleware:
         restore.assert_called_once_with("hello_world")
         assert "Cannot find agent hello_world" in response["messages"][0].content
 
-    @pytest.mark.asyncio
     async def test_block_content_without_text_asks_for_name(self) -> None:
         """
         Block content with no text block (a tool_use-only turn) projects to "",
@@ -144,7 +140,6 @@ class TestNetworkCopyMiddleware:
         restore.assert_not_called()
         assert response["messages"][0].content == self.ASK_FOR_NAME
 
-    @pytest.mark.asyncio
     async def test_malformed_json_asks_for_name(self) -> None:
         """
         Non-JSON string content keeps producing the "please provide" prompt.
@@ -156,7 +151,6 @@ class TestNetworkCopyMiddleware:
         restore.assert_not_called()
         assert response["messages"][0].content == self.ASK_FOR_NAME
 
-    @pytest.mark.asyncio
     async def test_non_object_json_asks_for_name(self) -> None:
         """
         Valid JSON that is not an object (here a JSON array) has no agent_name

--- a/tests/neuro_san/service/watcher/temp_networks/local/test_local_reservations_storage_expiration.py
+++ b/tests/neuro_san/service/watcher/temp_networks/local/test_local_reservations_storage_expiration.py
@@ -14,13 +14,6 @@
 # limitations under the License.
 #
 # END COPYRIGHT
-"""
-expire_reservations() sweep tests for LocalReservationsStorage.
-
-Verifies that the sweep deletes only files whose expiration timestamp is
-in the past and tolerates a missing storage directory (no crash before
-start()).
-"""
 import pytest
 
 from neuro_san.service.watcher.temp_networks.local.local_reservations_storage import LocalReservationsStorage
@@ -29,7 +22,13 @@ from tests.neuro_san.service.watcher.temp_networks.local.local_reservations_test
 
 
 class TestLocalReservationsStorageExpiration:
-    """expire_reservations() removes only files whose expiration is in the past."""
+    """
+    expire_reservations() sweep tests for LocalReservationsStorage.
+
+    Verifies that the sweep deletes only files whose expiration timestamp is
+    in the past and tolerates a missing storage directory (no crash before
+    start()).
+    """
 
     @pytest.mark.asyncio
     async def test_expire_removes_only_stale_files(self, tmp_path):

--- a/tests/neuro_san/service/watcher/temp_networks/local/test_local_reservations_storage_write_read.py
+++ b/tests/neuro_san/service/watcher/temp_networks/local/test_local_reservations_storage_write_read.py
@@ -14,14 +14,6 @@
 # limitations under the License.
 #
 # END COPYRIGHT
-"""
-Write/read round-trip tests for LocalReservationsStorage.
-
-Covers: write-then-read of a valid reservation, non-mutation of the
-caller's agent_spec, empty-batch no-op, missing-reservation returns
-(None, None), and the documented read-path contract that an already-
-expired reservation is reported as absent.
-"""
 import json
 
 import pytest
@@ -33,8 +25,12 @@ from tests.neuro_san.service.watcher.temp_networks.local.local_reservations_test
 
 class TestLocalReservationsStorageWriteRead:
     """
-    End-to-end: write a batch, read one back, verify JSON shape and that
-    the caller's agent_spec was not mutated.
+    Write/read round-trip tests for LocalReservationsStorage.
+
+    Covers: write-then-read of a valid reservation, non-mutation of the
+    caller's agent_spec, empty-batch no-op, missing-reservation returns
+    (None, None), and the documented read-path contract that an already-
+    expired reservation is reported as absent.
     """
 
     @pytest.mark.asyncio

--- a/tests/neuro_san/service/watcher/temp_networks/s3/s3_reservations_storage_test_base.py
+++ b/tests/neuro_san/service/watcher/temp_networks/s3/s3_reservations_storage_test_base.py
@@ -14,13 +14,6 @@
 # limitations under the License.
 #
 # END COPYRIGHT
-"""
-Shared scaffolding for S3ReservationsStorage tests.
-
-Pytest's default test-file pattern is test_*.py, so this file (which
-does not start with "test_") is not collected as a test module. The
-class defined here is imported by sibling test_*.py modules.
-"""
 import json
 import os
 import time

--- a/tests/neuro_san/service/watcher/temp_networks/s3/test_batch_partial_failure.py
+++ b/tests/neuro_san/service/watcher/temp_networks/s3/test_batch_partial_failure.py
@@ -14,14 +14,7 @@
 # limitations under the License.
 #
 # END COPYRIGHT
-"""
-S3ReservationsStorage.add_reservations writes batch entries one at a
-time in a Python for-loop with no atomic-batch semantics. This module
-exercises the partial-failure case: if a later entry's put_object
-fails, earlier successful writes remain in S3 (no automatic rollback).
-"""
 from unittest.mock import patch
-import pytest
 
 from botocore.exceptions import ClientError
 
@@ -31,6 +24,11 @@ from tests.neuro_san.service.watcher.temp_networks.s3.s3_reservations_storage_te
 
 class TestBatchPartialFailure(S3ReservationsStorageTestBase):
     """
+    S3ReservationsStorage.add_reservations writes batch entries one at a
+    time in a Python for-loop with no atomic-batch semantics. This module
+    exercises the partial-failure case: if a later entry's put_object
+    fails, earlier successful writes remain in S3 (no automatic rollback).
+
     Pin the current partial-success contract of add_reservations:
     earlier iterations of the for-loop are NOT rolled back when a later
     iteration raises. A future change that introduces atomic-batch
@@ -39,7 +37,6 @@ class TestBatchPartialFailure(S3ReservationsStorageTestBase):
     code review rather than letting it slip in silently.
     """
 
-    @pytest.mark.asyncio
     async def test_add_preserves_earlier_successes_when_later_entry_fails(self):
         """
         With a batch of 3 reservations where the 3rd put_object raises

--- a/tests/neuro_san/service/watcher/temp_networks/s3/test_custom_prefix.py
+++ b/tests/neuro_san/service/watcher/temp_networks/s3/test_custom_prefix.py
@@ -14,16 +14,6 @@
 # limitations under the License.
 #
 # END COPYRIGHT
-"""
-S3ReservationsStorage accepts a configurable prefix (default
-"reservations/") that's prepended to every reservation's S3 object
-key. Production deploys may set a non-default prefix for
-multi-tenancy, environment separation (prod/staging), or version
-migration. This module verifies that add_reservations writes objects
-under the configured prefix - catching regressions where the prefix
-is hardcoded or otherwise dropped.
-"""
-import pytest
 
 from neuro_san.service.watcher.temp_networks.s3.s3_reservations_storage \
     import S3ReservationsStorage
@@ -34,6 +24,14 @@ from tests.neuro_san.service.watcher.temp_networks.s3.s3_reservations_storage_te
 
 class TestCustomPrefix(S3ReservationsStorageTestBase):
     """
+    S3ReservationsStorage accepts a configurable prefix (default
+    "reservations/") that's prepended to every reservation's S3 object
+    key. Production deploys may set a non-default prefix for
+    multi-tenancy, environment separation (prod/staging), or version
+    migration. This module verifies that add_reservations writes objects
+    under the configured prefix - catching regressions where the prefix
+    is hardcoded or otherwise dropped.
+
     Existing tests T1-T9 all use the default prefix "reservations/".
     None of them detect a hardcoded-prefix regression in
     get_obj_key_for_reservation, because the hardcoded value matches
@@ -41,7 +39,6 @@ class TestCustomPrefix(S3ReservationsStorageTestBase):
     prefix to surface that class of bug.
     """
 
-    @pytest.mark.asyncio
     async def test_add_uses_configured_prefix_for_object_keys(self):
         """
         A storage configured with a non-default prefix writes objects

--- a/tests/neuro_san/service/watcher/temp_networks/s3/test_empty_batch_is_no_op.py
+++ b/tests/neuro_san/service/watcher/temp_networks/s3/test_empty_batch_is_no_op.py
@@ -14,14 +14,6 @@
 # limitations under the License.
 #
 # END COPYRIGHT
-"""
-S3ReservationsStorage.add_reservations should be a complete no-op
-when called with an empty mapping. Real callers may legitimately
-pass {} when pre-filtering yields no new reservations; the storage
-must handle that without crashing, without writing placeholder
-objects, and without making any S3 calls.
-"""
-import pytest
 
 from tests.neuro_san.service.watcher.temp_networks.s3.s3_reservations_storage_test_base \
     import S3ReservationsStorageTestBase
@@ -29,13 +21,18 @@ from tests.neuro_san.service.watcher.temp_networks.s3.s3_reservations_storage_te
 
 class TestEmptyBatchIsNoOp(S3ReservationsStorageTestBase):
     """
+    S3ReservationsStorage.add_reservations should be a complete no-op
+    when called with an empty mapping. Real callers may legitimately
+    pass {} when pre-filtering yields no new reservations; the storage
+    must handle that without crashing, without writing placeholder
+    objects, and without making any S3 calls.
+
     The empty-batch contract: add_reservations({}) is equivalent to
     not calling add_reservations at all. No exception, no S3 call, no
     bucket mutation. Existing tests T1-T8 all use N>=1 entries, so
     none of them touch this path.
     """
 
-    @pytest.mark.asyncio
     async def test_add_with_empty_dict_is_a_no_op(self):
         """
         add_reservations({}) returns normally, makes zero put_object

--- a/tests/neuro_san/service/watcher/temp_networks/s3/test_json_body_format.py
+++ b/tests/neuro_san/service/watcher/temp_networks/s3/test_json_body_format.py
@@ -14,29 +14,7 @@
 # limitations under the License.
 #
 # END COPYRIGHT
-"""
-S3ReservationsStorage commits to a specific on-disk format for every
-reservation it writes:
-  - Serialization is JSON (we chose json.dumps, not pickle/yaml/proto).
-  - The original agent_spec lives at the top level of the document
-    (no wrap-in-envelope like {"data": ...}).
-  - Storage-injected bookkeeping fields live under a "metadata" key
-    ("reservation" with the serialized Reservation, "stored_at" with
-    the wall-clock timestamp).
-
-External consumers (CLI tools, dashboards, debugging operators) read
-these objects directly and rely on the format being stable. T1's
-round-trip would still pass if the read+write paths were updated
-together but the on-disk format silently changed; this module pins
-the format by reading the raw bytes and validating the parsed
-document against a JSON Schema, independent of the storage's read
-path.
-
-Encoding/line-ending properties (UTF-8, no BOM, no CRLF) are
-boto3+Python concerns and are intentionally NOT tested here.
-"""
 from json import loads
-import pytest
 
 from jsonschema import validate
 
@@ -87,13 +65,27 @@ RESERVATION_OBJECT_SCHEMA = {
 
 class TestJsonBodyFormat(S3ReservationsStorageTestBase):
     """
-    Pin the on-disk JSON shape produced by add_reservations. Reads
-    the raw bytes from the FakeS3Client and validates the parsed
-    document against RESERVATION_OBJECT_SCHEMA, independent of the
-    storage's read path.
+    S3ReservationsStorage commits to a specific on-disk format for every
+    reservation it writes:
+      - Serialization is JSON (we chose json.dumps, not pickle/yaml/proto).
+      - The original agent_spec lives at the top level of the document
+        (no wrap-in-envelope like {"data": ...}).
+      - Storage-injected bookkeeping fields live under a "metadata" key
+        ("reservation" with the serialized Reservation, "stored_at" with
+        the wall-clock timestamp).
+
+    External consumers (CLI tools, dashboards, debugging operators) read
+    these objects directly and rely on the format being stable. T1's
+    round-trip would still pass if the read+write paths were updated
+    together but the on-disk format silently changed; this module pins
+    the format by reading the raw bytes and validating the parsed
+    document against a JSON Schema, independent of the storage's read
+    path.
+
+    Encoding/line-ending properties (UTF-8, no BOM, no CRLF) are
+    boto3+Python concerns and are intentionally NOT tested here.
     """
 
-    @pytest.mark.asyncio
     async def test_add_writes_json_body_with_expected_top_level_shape(self):
         """
         After add_reservations, the S3 object body should:

--- a/tests/neuro_san/service/watcher/temp_networks/s3/test_multiple_reservations.py
+++ b/tests/neuro_san/service/watcher/temp_networks/s3/test_multiple_reservations.py
@@ -14,12 +14,6 @@
 # limitations under the License.
 #
 # END COPYRIGHT
-"""
-S3ReservationsStorage.add_reservations accepts a dict of multiple
-{Reservation: agent_spec} pairs. This module exercises the for-loop
-that iterates over those pairs.
-"""
-import pytest
 
 from tests.neuro_san.service.watcher.temp_networks.s3.s3_reservations_storage_test_base \
     import S3ReservationsStorageTestBase
@@ -27,13 +21,16 @@ from tests.neuro_san.service.watcher.temp_networks.s3.s3_reservations_storage_te
 
 class TestMultipleReservations(S3ReservationsStorageTestBase):
     """
+    S3ReservationsStorage.add_reservations accepts a dict of multiple
+    {Reservation: agent_spec} pairs. This module exercises the for-loop
+    that iterates over those pairs.
+
     Verify that a single add_reservations call with N>1 entries writes
     one S3 object per entry and preserves each spec independently. The
     other tests (#1, #3) only exercise N=1 per call, so the for-loop
     body is never iterated more than once. This test fills that gap.
     """
 
-    @pytest.mark.asyncio
     async def test_add_writes_each_reservation_independently(self):
         """
         One call to add_reservations({r1: s1, r2: s2, r3: s3}) writes

--- a/tests/neuro_san/service/watcher/temp_networks/s3/test_no_retry_on_access_denied.py
+++ b/tests/neuro_san/service/watcher/temp_networks/s3/test_no_retry_on_access_denied.py
@@ -14,17 +14,7 @@
 # limitations under the License.
 #
 # END COPYRIGHT
-"""
-S3ReservationsStorage._is_retryable_client_error classifies errors
-into retryable (transient: throttling, slow-down, 5xx) and
-non-retryable (permanent: AccessDenied, malformed request, etc.).
-This module exercises the non-retryable branch: an AccessDenied
-ClientError must propagate immediately, with no S3 mutation and
-nothing retrievable through the public read path.
-"""
 from unittest.mock import patch
-
-import pytest
 
 from botocore.exceptions import ClientError
 
@@ -34,12 +24,18 @@ from tests.neuro_san.service.watcher.temp_networks.s3.s3_reservations_storage_te
 
 class TestNoRetryOnAccessDenied(S3ReservationsStorageTestBase):
     """
+    S3ReservationsStorage._is_retryable_client_error classifies errors
+    into retryable (transient: throttling, slow-down, 5xx) and
+    non-retryable (permanent: AccessDenied, malformed request, etc.).
+    This module exercises the non-retryable branch: an AccessDenied
+    ClientError must propagate immediately, with no S3 mutation and
+    nothing retrievable through the public read path.
+
     Companion to TestRetryOnThrottling. T6 pinned that transient errors
     DO retry; this test pins that AccessDenied does NOT retry. Together
     they document the storage's full retry policy.
     """
 
-    @pytest.mark.asyncio
     async def test_add_does_not_retry_on_access_denied(self):
         """
         On AccessDenied (HTTP 403 with error code AccessDenied -

--- a/tests/neuro_san/service/watcher/temp_networks/s3/test_object_key_format.py
+++ b/tests/neuro_san/service/watcher/temp_networks/s3/test_object_key_format.py
@@ -14,11 +14,6 @@
 # limitations under the License.
 #
 # END COPYRIGHT
-"""
-S3ReservationsStorage.add_reservations writes each reservation to a
-specific S3 object key. This module pins that key format as a contract.
-"""
-import pytest
 
 from neuro_san.service.watcher.temp_networks.s3.s3_util import S3Util
 
@@ -28,6 +23,9 @@ from tests.neuro_san.service.watcher.temp_networks.s3.s3_reservations_storage_te
 
 class TestObjectKeyFormat(S3ReservationsStorageTestBase):
     """
+    S3ReservationsStorage.add_reservations writes each reservation to a
+    specific S3 object key. This module pins that key format as a contract.
+
     The S3 object key written by add_reservations follows the documented
     format "{prefix}{reservation_id}.json". A refactor that changes the
     layout (e.g., to "{prefix}{id}/data.json") would still let the
@@ -36,7 +34,6 @@ class TestObjectKeyFormat(S3ReservationsStorageTestBase):
     asserting against a hardcoded literal path.
     """
 
-    @pytest.mark.asyncio
     async def test_add_writes_at_expected_object_key(self):
         """
         After add_reservations, the S3 bucket contains exactly one object,

--- a/tests/neuro_san/service/watcher/temp_networks/s3/test_overwrite_duplicate_id.py
+++ b/tests/neuro_san/service/watcher/temp_networks/s3/test_overwrite_duplicate_id.py
@@ -14,12 +14,6 @@
 # limitations under the License.
 #
 # END COPYRIGHT
-"""
-S3ReservationsStorage.add_reservations is last-writer-wins for a given
-reservation id: a second call writes a new JSON blob to the same S3 key,
-replacing the first one.
-"""
-import pytest
 
 from tests.neuro_san.service.watcher.temp_networks.s3.s3_reservations_storage_test_base \
     import S3ReservationsStorageTestBase
@@ -27,6 +21,10 @@ from tests.neuro_san.service.watcher.temp_networks.s3.s3_reservations_storage_te
 
 class TestOverwriteDuplicateId(S3ReservationsStorageTestBase):
     """
+    S3ReservationsStorage.add_reservations is last-writer-wins for a given
+    reservation id: a second call writes a new JSON blob to the same S3 key,
+    replacing the first one.
+
     The storage uses plain put_object with no conditional header, so S3's
     default "second write wins" semantics apply. This is intentional: it
     lets callers refresh a reservation's expiration or swap the agent_spec
@@ -37,7 +35,6 @@ class TestOverwriteDuplicateId(S3ReservationsStorageTestBase):
     replacing.
     """
 
-    @pytest.mark.asyncio
     async def test_add_reservations_overwrites_on_duplicate_id(self):
         """
         Write twice under the same reservation id with different lifetimes

--- a/tests/neuro_san/service/watcher/temp_networks/s3/test_retry_on_throttling.py
+++ b/tests/neuro_san/service/watcher/temp_networks/s3/test_retry_on_throttling.py
@@ -14,14 +14,7 @@
 # limitations under the License.
 #
 # END COPYRIGHT
-"""
-S3ReservationsStorage routes every put_object call through
-_do_with_retries. This module exercises the happy retry path: a
-transient ThrottlingException on the first attempt is retried, the
-retry succeeds, and S3 ends up consistent.
-"""
 from unittest.mock import patch
-import pytest
 
 from botocore.exceptions import ClientError
 
@@ -31,6 +24,11 @@ from tests.neuro_san.service.watcher.temp_networks.s3.s3_reservations_storage_te
 
 class TestRetryOnThrottling(S3ReservationsStorageTestBase):
     """
+    S3ReservationsStorage routes every put_object call through
+    _do_with_retries. This module exercises the happy retry path: a
+    transient ThrottlingException on the first attempt is retried, the
+    retry succeeds, and S3 ends up consistent.
+
     The earlier tests all run against a FakeS3Client that never fails,
     so they never reach the retry branch of _do_with_retries. This test
     fills that gap by injecting a one-shot ThrottlingException on the
@@ -38,7 +36,6 @@ class TestRetryOnThrottling(S3ReservationsStorageTestBase):
     the put succeeds.
     """
 
-    @pytest.mark.asyncio
     async def test_add_retries_on_throttling_then_succeeds(self):
         """
         On a transient ThrottlingException, add_reservations should

--- a/tests/neuro_san/service/watcher/temp_networks/s3/test_round_trip.py
+++ b/tests/neuro_san/service/watcher/temp_networks/s3/test_round_trip.py
@@ -14,10 +14,6 @@
 # limitations under the License.
 #
 # END COPYRIGHT
-"""
-Round-trip a single reservation through S3ReservationsStorage.
-"""
-import pytest
 
 from tests.neuro_san.service.watcher.temp_networks.s3.s3_reservations_storage_test_base \
     import S3ReservationsStorageTestBase
@@ -25,12 +21,12 @@ from tests.neuro_san.service.watcher.temp_networks.s3.s3_reservations_storage_te
 
 class TestRoundTrip(S3ReservationsStorageTestBase):
     """
+    Round-trip a single reservation through S3ReservationsStorage.
     Reservation feature works end-to-end against an S3-like backend:
     writing a reservation and reading it back yields an equivalent
     Reservation and an AgentNetwork carrying the original agent spec.
     """
 
-    @pytest.mark.asyncio
     async def test_add_then_get_returns_equivalent_reservation(self):
         """
         Uses a reservation id and an authored network name that are

--- a/tests/neuro_san/service/watcher/temp_networks/s3/test_spec_without_metadata.py
+++ b/tests/neuro_san/service/watcher/temp_networks/s3/test_spec_without_metadata.py
@@ -14,22 +14,7 @@
 # limitations under the License.
 #
 # END COPYRIGHT
-"""
-The "metadata" key on an agent_spec is documented as optional in the
-project's HOCON registry files (see registries/*.hocon: "Optional
-metadata describing this agent network"). Callers may legitimately
-hand a metadata-less spec to add_reservations. The storage's read
-path requires metadata.reservation on every stored object, so the
-write path must initialize the field when missing - otherwise
-downstream reads would crash.
-
-This module exercises the storage's defensive init branch:
-    if agent_spec.get("metadata") is None:
-        agent_spec["metadata"] = {}
-    agent_spec["metadata"].update(new_metadata)
-"""
 from json import loads
-import pytest
 
 from tests.neuro_san.service.watcher.temp_networks.s3.s3_reservations_storage_test_base \
     import S3ReservationsStorageTestBase
@@ -37,13 +22,25 @@ from tests.neuro_san.service.watcher.temp_networks.s3.s3_reservations_storage_te
 
 class TestSpecWithoutMetadata(S3ReservationsStorageTestBase):
     """
+    The "metadata" key on an agent_spec is documented as optional in the
+    project's HOCON registry files (see registries/*.hocon: "Optional
+    metadata describing this agent network"). Callers may legitimately
+    hand a metadata-less spec to add_reservations. The storage's read
+    path requires metadata.reservation on every stored object, so the
+    write path must initialize the field when missing - otherwise
+    downstream reads would crash.
+
+    This module exercises the storage's defensive init branch:
+        if agent_spec.get("metadata") is None:
+            agent_spec["metadata"] = {}
+        agent_spec["metadata"].update(new_metadata)
+
     Existing tests T1-T10 all pass agent_specs that include a
     pre-populated "metadata" key (built by _make_agent_spec). This
     test exercises the other side of the storage's metadata-init
     branch: input specs that arrive without a "metadata" key.
     """
 
-    @pytest.mark.asyncio
     async def test_add_initializes_metadata_when_spec_lacks_key(self):
         """
         When the input agent_spec has no "metadata" key,

--- a/tests/neuro_san/service/watcher/temp_networks/s3/test_user_authored_metadata.py
+++ b/tests/neuro_san/service/watcher/temp_networks/s3/test_user_authored_metadata.py
@@ -14,15 +14,8 @@
 # limitations under the License.
 #
 # END COPYRIGHT
-"""
-S3ReservationsStorage.add_reservations must merge into agent_spec["metadata"]
-rather than replace it, so user-authored keys (description, tags, etc.)
-survive the round-trip.
-"""
 from typing import Any
 from typing import Dict
-
-import pytest
 
 from tests.neuro_san.service.watcher.temp_networks.s3.s3_reservations_storage_test_base \
     import S3ReservationsStorageTestBase
@@ -30,12 +23,15 @@ from tests.neuro_san.service.watcher.temp_networks.s3.s3_reservations_storage_te
 
 class TestUserAuthoredMetadata(S3ReservationsStorageTestBase):
     """
+    S3ReservationsStorage.add_reservations must merge into agent_spec["metadata"]
+    rather than replace it, so user-authored keys (description, tags, etc.)
+    survive the round-trip.
+
     Real registry entries (e.g. neuro_san/registries/copy_cat.hocon) ship
     with their own metadata.description and metadata.tags. The storage
     must preserve those keys when injecting its own reservation/stored_at.
     """
 
-    @pytest.mark.asyncio
     async def test_add_does_not_clobber_user_authored_metadata(self):
         """
         When the input agent_spec already has a user-authored 'metadata'

--- a/tests/neuro_san/service/watcher/temp_networks/s3/test_writer_credential_recovery.py
+++ b/tests/neuro_san/service/watcher/temp_networks/s3/test_writer_credential_recovery.py
@@ -14,33 +14,10 @@
 # limitations under the License.
 #
 # END COPYRIGHT
-"""
-Pins credential recovery on the reservation WRITE path: a deployment
-batch whose first attempt fails against a bad credential state must
-discard the shared AioSession, re-resolve the chain behind a fresh
-session, retry, and land the write - not lose the batch.
-
-A lost batch is the worst credential failure mode this storage has:
-add_reservations raises, the updater logs and drops the item (there is
-no requeue), and other pods then report the just-created network
-not-found. Covered here for both faces of a rotation window:
-
-  * InvalidToken - S3 rejects the request the batch's client signed
-    with a bad resolved credential state (a ClientError; the same
-    production failure the reader-path test in
-    test_invalid_token_recovery.py pins, see neuro-san-studio #1310).
-  * NoCredentialsError - the chain behind the batch's fresh client
-    resolved to nothing (credentials file caught empty mid-rewrite),
-    raised locally by botocore at request-signing time. This is a
-    BotoCoreError, NOT a ClientError: under a ClientError-only retry
-    gate it escapes with retry budget unused and the batch is lost -
-    the recovery test below fails exactly that way against such a gate.
-"""
 from typing import Any
 from typing import Dict
 
 from unittest.mock import patch
-import pytest
 
 from aiobotocore.session import get_session as real_get_session
 from botocore.exceptions import ClientError
@@ -53,10 +30,30 @@ from tests.neuro_san.service.watcher.temp_networks.s3.s3_reservations_storage_te
 
 class TestWriterCredentialRecovery(S3ReservationsStorageTestBase):
     """
-    Verifies that the async writer's credential retry discards the
-    shared session and completes the batch through a re-resolved chain,
-    for both a ClientError rejection (InvalidToken) and a local
-    resolution failure (NoCredentialsError).
+    Pins credential recovery on the reservation WRITE path: a deployment
+    batch whose first attempt fails against a bad credential state must
+    discard the shared AioSession, re-resolve the chain behind a fresh
+    session, retry, and land the write - not lose the batch.
+
+    A lost batch is the worst credential failure mode this storage has:
+    add_reservations raises, the updater logs and drops the item (there is
+    no requeue), and other pods then report the just-created network
+    not-found. Covered here for both faces of a rotation window:
+
+      * InvalidToken - S3 rejects the request the batch's client signed
+        with a bad resolved credential state (a ClientError; the same
+        production failure the reader-path test in
+        test_invalid_token_recovery.py pins, see neuro-san-studio #1310).
+      * NoCredentialsError - the chain behind the batch's fresh client
+        resolved to nothing (credentials file caught empty mid-rewrite),
+        raised locally by botocore at request-signing time. This is a
+        BotoCoreError, NOT a ClientError: under a ClientError-only retry
+        gate it escapes with retry budget unused and the batch is lost -
+        the recovery test below fails exactly that way against such a gate.
+        Verifies that the async writer's credential retry discards the
+        shared session and completes the batch through a re-resolved chain,
+        for both a ClientError rejection (InvalidToken) and a local
+        resolution failure (NoCredentialsError).
     """
 
     async def _run_batch_with_bad_first_session(self, make_error) -> Dict[str, int]:
@@ -120,7 +117,6 @@ class TestWriterCredentialRecovery(S3ReservationsStorageTestBase):
         )
         return counters
 
-    @pytest.mark.asyncio
     async def test_invalid_token_triggers_session_rebuild_and_batch_succeeds(self):
         """
         S3 rejects the first attempt's request with InvalidToken (HTTP
@@ -141,7 +137,6 @@ class TestWriterCredentialRecovery(S3ReservationsStorageTestBase):
 
         await self._run_batch_with_bad_first_session(make_invalid_token)
 
-    @pytest.mark.asyncio
     async def test_empty_chain_triggers_session_rebuild_and_batch_succeeds(self):
         """
         The first attempt's put_object raises NoCredentialsError at


### PR DESCRIPTION
* Get rid of some warnings in test running that have accumulated
* Take @vince-leaf 's suggestion to have runtime warnings be errors for tests
* Take @vince-leaf 's suggestion to remove pytest.mark.asyncio from IsolatedAsyncioTestCase
* Ignore a warning about os.fork() from test_hocon_parse_lock.py