### PR TITLE
Fail tests that return an un-awaited coroutine

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -12,6 +12,7 @@ markers =
     smoke_non_default_llm_provider_needs_server: Tests that use a non-default llm provider and need server.
     ollama: Tests that specifically use ollama as the llm provider
 filterwarnings =
+    # Fail async tests on a plain TestCase (method returns an un-awaited coroutine)
     error:It is deprecated to return a value that is not None from a test case:DeprecationWarning
     # Ignore warnings about protobuf 4's PyType_Spec metaclass usage
     ignore:Type google\._upb\._message.* uses PyType_Spec with a metaclass that has custom tp_new:DeprecationWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -12,7 +12,7 @@ markers =
     smoke_non_default_llm_provider_needs_server: Tests that use a non-default llm provider and need server.
     ollama: Tests that specifically use ollama as the llm provider
 filterwarnings =
-    error::RuntimeWarning
+    error:It is deprecated to return a value that is not None from a test case:DeprecationWarning
     # Ignore warnings about protobuf 4's PyType_Spec metaclass usage
     ignore:Type google\._upb\._message.* uses PyType_Spec with a metaclass that has custom tp_new:DeprecationWarning
     # Ignore warnings about fork from test_hocon_parse_lock.py


### PR DESCRIPTION
This fix is a follow-up to #1323.

error::RuntimeWarning in pytest.ini does not fail a test whose coroutine is never awaited (the #1319 failure mode). The "coroutine ... was never awaited" RuntimeWarning is emitted from the coroutine's finalizer during garbage collection, after the test has already been marked as passed, so as an error, it only becomes a PytestUnraisableExceptionWarning.

This replaces that line with a filter on the DeprecationWarning unittest raises synchronously when a test method returns a non-None value (which is what happens when an async def test sits on a plain TestCase):

`error:It is deprecated to return a value that is not None from a test case:DeprecationWarning`

I have verified:
1. Full unit suite: 708 passed, 1 skipped — same as main.
2. The 12 IsolatedAsyncioTestCase files from #1319: 83 passed, identical to main.
3. Sanity check: switching TestReport from IsolatedAsyncioTestCase to TestCase now gives 5 failures (was 5 passed with error::RuntimeWarning).


Confirmed from my local branch:

##### 1. Bug re-created (TestReport on plain TestCase), pytest.ini as on main:
15:    error::RuntimeWarning
5 passed, 10 warnings in 0.11s
 
##### 2. Same broken file, pytest.ini with suggested line:
15:    error:It is deprecated to return a value that is not None from a test case:DeprecationWarning
FAILED ...test_report.py::TestReport::test_report_counts_each_agents_own_calls_exactly_once
FAILED ...test_report.py::TestReport::test_report_flags_unattributed_tokens
FAILED ...test_report.py::TestReport::test_report_late_external_does_not_restamp_request_latency
FAILED ...test_report.py::TestReport::test_report_network_message_gating
FAILED ...test_report.py::TestReport::test_report_separates_main_network_from_total
5 failed, 5 warnings in 0.22s
 
##### 3. File restored (IsolatedAsyncioTestCase), suggested line kept:
5 passed in 0.15s
 
##### 4. Full unit suite with suggested line:
708 passed, 1 skipped, 12 subtests passed in 18.34s
 
##### restored: 0 files modified
So: current line lets the bug through (1); suggested line catches it (2), doesn't touch correct tests (3), and the whole suite stays green (4). Working tree left clean.
