### PR TITLE
Journal the provider-native answer when it carries block content

### DIFF
--- a/neuro_san/internals/run_context/langchain/core/run_context_runnable.py
+++ b/neuro_san/internals/run_context/langchain/core/run_context_runnable.py
@@ -30,7 +30,9 @@ from pydantic import ConfigDict
 from langchain_core.agents import AgentFinish
 from langchain_core.callbacks.base import BaseCallbackHandler
 from langchain_core.messages.ai import AIMessage
+from langchain_core.messages.ai import AIMessageChunk
 from langchain_core.messages.base import BaseMessage
+from langchain_core.messages.utils import message_chunk_to_message
 from langchain_core.runnables.base import Runnable
 from langchain_core.runnables.config import ensure_config
 from langchain_core.runnables.config import merge_configs
@@ -298,7 +300,7 @@ class RunContextRunnable(NeuroSanRunnable):
             self.sensitive_logger.error("%s", backtrace)
 
         output: str = self.parse_chain_result(chain_result, exception)
-        return_message: BaseMessage = AIMessage(output)
+        return_message: BaseMessage = self.build_return_message(chain_result, output)
 
         # Chat history is updated in write_message
         await self.journal.write_message(return_message)
@@ -416,3 +418,62 @@ class RunContextRunnable(NeuroSanRunnable):
         # See if we had some kind of error and format accordingly, if asked for.
         output = self.error_detector.handle_error(output)
         return output
+
+    def build_return_message(self, chain_result: Optional[Union[Dict[str, Any], AgentFinish, AIMessage]],
+                             output: str) -> BaseMessage:
+        """
+        Build the AIMessage that is journaled as this agent's answer for the turn.
+
+        Plain-string answers, error paths, and anything the ErrorDetector
+        rewrote keep the exact shape they have always had: a fresh AIMessage
+        carrying only the parsed text. When the provider-native message
+        carries block content (Anthropic thinking, OpenAI Responses reasoning,
+        ...), that message is preserved instead, with its content normalized
+        to standard v1 blocks (see ContentUtils.normalize_message) so the
+        blocks and its usage_metadata reach the journal. The wire is the
+        same either way: the converter projects block content to the same
+        text and emits nothing else for it in this phase.
+
+        The chat history does not depend on which shape is chosen:
+        OriginatingJournal.write_message appends a text-only copy of any
+        block-content AI message, so what is handed to a provider (or a
+        fallback provider) stays provider-agnostic.
+
+        :param chain_result: The result from invoking the agent chain
+        :param output: The parsed, error-checked text from parse_chain_result()
+        :return: The BaseMessage to journal as the answer
+        """
+        ai_message: Optional[AIMessage] = self.find_ai_message(chain_result)
+        if ai_message is None:
+            # Exception, API-key error text or a bare "output": nothing native to preserve.
+            return AIMessage(output)
+
+        if output != ContentUtils.flatten_to_text(ai_message):
+            # The ErrorDetector rewrote the text. The client-visible answer is
+            # the formatted error, not the native content.
+            return AIMessage(output)
+
+        if isinstance(ai_message, AIMessageChunk):
+            # normalize_message is for complete messages only: chunk-only
+            # shapes are not content. Chains return complete messages today,
+            # but a custom middleware could hand back a chunk, and preserving
+            # its class would give the journaled answer an unknown wire type.
+            ai_message = message_chunk_to_message(ai_message)
+
+        preserved: BaseMessage = ContentUtils.normalize_message(ai_message)
+        if isinstance(preserved.content, str):
+            # Trivial (text-only) content: keep the exact message shape that has
+            # always been journaled for it. Preserving the native object would
+            # change nothing a client can see and would only drag provider
+            # bookkeeping (ids, metadata) along with it.
+            return AIMessage(output)
+
+        if ContentUtils.flatten_to_text(preserved) != output:
+            # Fail closed. The provider translators behind normalize_message
+            # skip content items they do not recognize (e.g. a bare string
+            # inside a block list), which can drop text. The client-visible
+            # answer must stay the parsed text, so blocks are preserved only
+            # while they still project to it.
+            return AIMessage(output)
+
+        return preserved

--- a/tests/neuro_san/internals/run_context/langchain/core/test_run_context_runnable.py
+++ b/tests/neuro_san/internals/run_context/langchain/core/test_run_context_runnable.py
@@ -386,7 +386,6 @@ class TestRunContextRunnable(IsolatedAsyncioTestCase):  # pylint: disable=too-ma
             block_types.append(block["type"])
         return block_types
 
-    @pytest.mark.asyncio
     async def test_invoke_agent_chain_preserves_block_content_answer(self) -> None:
         """
         A thinking-first native answer is journaled as the native message with
@@ -407,7 +406,6 @@ class TestRunContextRunnable(IsolatedAsyncioTestCase):  # pylint: disable=too-ma
         assert final.response_metadata["model_provider"] == "anthropic"
         assert final.usage_metadata == usage
 
-    @pytest.mark.asyncio
     async def test_invoke_agent_chain_keeps_text_only_answer_shape(self) -> None:
         """
         A plain-string native answer keeps the shape it has always had: a fresh
@@ -427,7 +425,6 @@ class TestRunContextRunnable(IsolatedAsyncioTestCase):  # pylint: disable=too-ma
         assert final.response_metadata == {}
         assert final.usage_metadata is None
 
-    @pytest.mark.asyncio
     async def test_invoke_agent_chain_error_rewrite_wins_over_native_blocks(self) -> None:
         """
         When the ErrorDetector rewrites the answer text, the journaled message
@@ -442,7 +439,6 @@ class TestRunContextRunnable(IsolatedAsyncioTestCase):  # pylint: disable=too-ma
         final: BaseMessage = written[-1]
         assert final.content == "formatted error"
 
-    @pytest.mark.asyncio
     async def test_invoke_agent_chain_preserved_answer_excludes_tool_call_blocks(self) -> None:
         """
         A preserved block-content answer that still carries a tool call (the
@@ -465,7 +461,6 @@ class TestRunContextRunnable(IsolatedAsyncioTestCase):  # pylint: disable=too-ma
         assert self._block_types(final) == ["reasoning", "text"]
         assert ContentUtils.flatten_to_text(final) == "the answer"
 
-    @pytest.mark.asyncio
     async def test_invoke_agent_chain_tool_use_turn_collapses_to_text(self) -> None:
         """
         A text + tool_use native answer (every Anthropic tool-calling turn
@@ -482,7 +477,6 @@ class TestRunContextRunnable(IsolatedAsyncioTestCase):  # pylint: disable=too-ma
         assert final.response_metadata == {}
         assert final.tool_calls == []
 
-    @pytest.mark.asyncio
     async def test_invoke_agent_chain_list_of_str_answer_collapses_to_text(self) -> None:
         """
         List-of-strings native content carries no block structure, so it is
@@ -495,7 +489,6 @@ class TestRunContextRunnable(IsolatedAsyncioTestCase):  # pylint: disable=too-ma
         assert final.content == "part one, part two"
         assert final.id is None
 
-    @pytest.mark.asyncio
     async def test_invoke_agent_chain_bare_output_dict_stays_text(self) -> None:
         """
         A chain result with no AIMessage, only an "output" key (the API-key
@@ -509,7 +502,6 @@ class TestRunContextRunnable(IsolatedAsyncioTestCase):  # pylint: disable=too-ma
         assert final.content == "Please set OPENAI_API_KEY"
         assert final.id is None
 
-    @pytest.mark.asyncio
     async def test_invoke_agent_chain_unwraps_agent_finish(self) -> None:
         """
         An AgentFinish result is unwrapped to its return_values, so a native
@@ -525,7 +517,6 @@ class TestRunContextRunnable(IsolatedAsyncioTestCase):  # pylint: disable=too-ma
         assert self._block_types(final) == ["reasoning", "text"]
         assert ContentUtils.flatten_to_text(final) == "the answer"
 
-    @pytest.mark.asyncio
     async def test_invoke_agent_chain_mixed_content_falls_back_to_text(self) -> None:
         """
         When normalizing would lose text (langchain's provider translators skip
@@ -546,7 +537,6 @@ class TestRunContextRunnable(IsolatedAsyncioTestCase):  # pylint: disable=too-ma
         final: BaseMessage = written[-1]
         assert final.content == "hello world"
 
-    @pytest.mark.asyncio
     async def test_invoke_agent_chain_chunk_answer_is_journaled_as_message(self) -> None:
         """
         An AIMessageChunk answer (only a custom middleware could produce one)

--- a/tests/neuro_san/internals/run_context/langchain/core/test_run_context_runnable.py
+++ b/tests/neuro_san/internals/run_context/langchain/core/test_run_context_runnable.py
@@ -17,6 +17,8 @@
 
 from typing import Any
 from typing import Dict
+from typing import List
+from typing import Tuple
 
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import AsyncMock
@@ -27,6 +29,8 @@ import pytest
 
 from langchain_core.agents import AgentFinish
 from langchain_core.messages.ai import AIMessage
+from langchain_core.messages.ai import AIMessageChunk
+from langchain_core.messages.base import BaseMessage
 from langchain_core.messages.human import HumanMessage
 from langchain_core.outputs import LLMResult
 from langchain_core.outputs.chat_generation import ChatGeneration
@@ -36,11 +40,15 @@ from neuro_san.internals.run_context.langchain.journaling.journaling_callback_ha
 
 from neuro_san.internals.run_context.langchain.core.run_context_runnable import RunContextRunnable
 from neuro_san.message.types.agent_framework_message import AgentFrameworkMessage
+from neuro_san.message.utils.content_utils import ContentUtils
 
 from tests.neuro_san.message.content_fixtures import ContentFixtures
 
 
-class TestRunContextRunnable(IsolatedAsyncioTestCase):
+# One test module per class is the repo convention, and RunContextRunnable
+# has many independent branches to pin, so the test count exceeds pylint's
+# default of 20 public methods.
+class TestRunContextRunnable(IsolatedAsyncioTestCase):  # pylint: disable=too-many-public-methods
     """
     Tests for RunContextRunnable: the capture-side projection of list-form
     (block) content in parse_chain_result, and the surfacing of
@@ -54,6 +62,10 @@ class TestRunContextRunnable(IsolatedAsyncioTestCase):
     find_ai_message is the single place that locates the provider-native
     AIMessage inside a chain result (dict, AgentFinish or bare AIMessage);
     parse_chain_result keeps its exact behavior on top of it.
+
+    invoke_agent_chain journals the provider-native answer (normalized to
+    standard blocks) when it carries block content, and keeps the plain
+    text-only AIMessage shape for everything else.
     """
 
     @staticmethod
@@ -338,3 +350,226 @@ class TestRunContextRunnable(IsolatedAsyncioTestCase):
         assert "rate limited" in final.content
         # ...so the stale KeyError traceback from attempt 1 must not be logged.
         assert not any("Traceback" in str(call) for call in sensitive_logger.error.call_args_list)
+
+    @staticmethod
+    def _make_invoking_runnable(chain_result: Any,
+                                error_detector: MagicMock = None) -> Tuple[RunContextRunnable, List[BaseMessage]]:
+        """
+        Build a runnable whose agent chain returns the given result and whose
+        journal records every written message.
+
+        :param chain_result: What agent_chain.ainvoke should return
+        :param error_detector: Optional error detector; defaults to a pass-through
+        :return: The runnable and the list its journal appends written messages to
+        """
+        written: List[BaseMessage] = []
+        journal: MagicMock = MagicMock()
+        journal.write_message = AsyncMock(side_effect=lambda msg, *_a, **_k: written.append(msg))
+        agent_chain: MagicMock = MagicMock()
+        agent_chain.ainvoke = AsyncMock(return_value=chain_result)
+        if error_detector is None:
+            error_detector = MagicMock()
+            error_detector.handle_error = MagicMock(side_effect=lambda output: output)
+        sensitive_logger: MagicMock = MagicMock()
+        sensitive_logger.should_log = MagicMock(return_value=True)
+        runnable: RunContextRunnable = RunContextRunnable.model_construct(
+            journal=journal,
+            sensitive_logger=sensitive_logger,
+            agent_chain=agent_chain,
+            error_detector=error_detector,
+            logger=MagicMock(),
+        )
+        return runnable, written
+
+    @staticmethod
+    def _block_types(message: BaseMessage) -> List[str]:
+        """
+        :param message: A message whose content is a list of block dictionaries
+        :return: The "type" of each block, in order
+        """
+        block_types: List[str] = []
+        for block in message.content:
+            block_types.append(block["type"])
+        return block_types
+
+    @pytest.mark.asyncio
+    async def test_invoke_agent_chain_preserves_block_content_answer(self) -> None:
+        """
+        A thinking-first native answer is journaled as the native message with
+        its content normalized to standard blocks, not as a fresh text-only
+        AIMessage: the reasoning and the usage metadata survive into the
+        journal while the text it projects to is unchanged.
+        """
+        usage: Dict[str, int] = {"input_tokens": 5, "output_tokens": 7, "total_tokens": 12}
+        native: AIMessage = ContentFixtures.anthropic_thinking_first().model_copy(update={"usage_metadata": usage})
+        runnable, written = self._make_invoking_runnable({"messages": [HumanMessage(content="q"), native]})
+        await runnable.invoke_agent_chain(inputs={}, runnable_config={}, max_attempts=1)
+
+        final: BaseMessage = written[-1]
+        assert isinstance(final.content, list)
+        assert self._block_types(final) == ["reasoning", "text"]
+        assert ContentUtils.flatten_to_text(final) == "the answer"
+        assert final.response_metadata["output_version"] == "v1"
+        assert final.response_metadata["model_provider"] == "anthropic"
+        assert final.usage_metadata == usage
+
+    @pytest.mark.asyncio
+    async def test_invoke_agent_chain_keeps_text_only_answer_shape(self) -> None:
+        """
+        A plain-string native answer keeps the shape it has always had: a fresh
+        AIMessage carrying only the text, without the native message's provider
+        bookkeeping (id, metadata) that it never carried before.
+        """
+        native: AIMessage = AIMessage(content="the answer", id="msg_1",
+                                      response_metadata={"model_provider": "openai"},
+                                      usage_metadata={"input_tokens": 1, "output_tokens": 1, "total_tokens": 2})
+        runnable, written = self._make_invoking_runnable({"messages": [native]})
+        await runnable.invoke_agent_chain(inputs={}, runnable_config={}, max_attempts=1)
+
+        final: BaseMessage = written[-1]
+        assert isinstance(final, AIMessage)
+        assert final.content == "the answer"
+        assert final.id is None
+        assert final.response_metadata == {}
+        assert final.usage_metadata is None
+
+    @pytest.mark.asyncio
+    async def test_invoke_agent_chain_error_rewrite_wins_over_native_blocks(self) -> None:
+        """
+        When the ErrorDetector rewrites the answer text, the journaled message
+        carries the formatted error as plain text even though the native
+        message had block content: the client-visible answer is the error.
+        """
+        error_detector: MagicMock = MagicMock()
+        error_detector.handle_error = MagicMock(return_value="formatted error")
+        runnable, written = self._make_invoking_runnable(ContentFixtures.anthropic_thinking_first(), error_detector)
+        await runnable.invoke_agent_chain(inputs={}, runnable_config={}, max_attempts=1)
+
+        final: BaseMessage = written[-1]
+        assert final.content == "formatted error"
+
+    @pytest.mark.asyncio
+    async def test_invoke_agent_chain_preserved_answer_excludes_tool_call_blocks(self) -> None:
+        """
+        A preserved block-content answer that still carries a tool call (the
+        loop was cut short) keeps its reasoning and text blocks but no
+        tool_use block: tool calls are not message content.
+        """
+        native: AIMessage = AIMessage(
+            content=[
+                {"type": "thinking", "thinking": "hmm", "signature": "sig"},
+                {"type": "text", "text": "the answer"},
+                {"type": "tool_use", "id": "toolu_1", "name": "lookup", "input": {"q": "x"}},
+            ],
+            tool_calls=[{"name": "lookup", "args": {"q": "x"}, "id": "toolu_1", "type": "tool_call"}],
+            response_metadata={"model_provider": "anthropic"},
+        )
+        runnable, written = self._make_invoking_runnable(native)
+        await runnable.invoke_agent_chain(inputs={}, runnable_config={}, max_attempts=1)
+
+        final: BaseMessage = written[-1]
+        assert self._block_types(final) == ["reasoning", "text"]
+        assert ContentUtils.flatten_to_text(final) == "the answer"
+
+    @pytest.mark.asyncio
+    async def test_invoke_agent_chain_tool_use_turn_collapses_to_text(self) -> None:
+        """
+        A text + tool_use native answer (every Anthropic tool-calling turn
+        without reasoning) is text-only once tool calls are set aside, so it
+        keeps the fresh AIMessage shape: no id, no metadata, no tool calls.
+        """
+        runnable, written = self._make_invoking_runnable({"messages": [ContentFixtures.anthropic_tool_use()]})
+        await runnable.invoke_agent_chain(inputs={}, runnable_config={}, max_attempts=1)
+
+        final: BaseMessage = written[-1]
+        assert isinstance(final, AIMessage)
+        assert final.content == "Let me look that up."
+        assert final.id is None
+        assert final.response_metadata == {}
+        assert final.tool_calls == []
+
+    @pytest.mark.asyncio
+    async def test_invoke_agent_chain_list_of_str_answer_collapses_to_text(self) -> None:
+        """
+        List-of-strings native content carries no block structure, so it is
+        journaled as the joined plain text.
+        """
+        runnable, written = self._make_invoking_runnable({"messages": [ContentFixtures.list_of_str()]})
+        await runnable.invoke_agent_chain(inputs={}, runnable_config={}, max_attempts=1)
+
+        final: BaseMessage = written[-1]
+        assert final.content == "part one, part two"
+        assert final.id is None
+
+    @pytest.mark.asyncio
+    async def test_invoke_agent_chain_bare_output_dict_stays_text(self) -> None:
+        """
+        A chain result with no AIMessage, only an "output" key (the API-key
+        and output-parse error paths), is journaled as that text.
+        """
+        runnable, written = self._make_invoking_runnable({"output": "Please set OPENAI_API_KEY"})
+        await runnable.invoke_agent_chain(inputs={}, runnable_config={}, max_attempts=1)
+
+        final: BaseMessage = written[-1]
+        assert isinstance(final, AIMessage)
+        assert final.content == "Please set OPENAI_API_KEY"
+        assert final.id is None
+
+    @pytest.mark.asyncio
+    async def test_invoke_agent_chain_unwraps_agent_finish(self) -> None:
+        """
+        An AgentFinish result is unwrapped to its return_values, so a native
+        block-content answer inside it is preserved the same way.
+        """
+        finish: AgentFinish = AgentFinish(
+            return_values={"messages": [HumanMessage(content="q"), ContentFixtures.anthropic_thinking_first()]},
+            log="")
+        runnable, written = self._make_invoking_runnable(finish)
+        await runnable.invoke_agent_chain(inputs={}, runnable_config={}, max_attempts=1)
+
+        final: BaseMessage = written[-1]
+        assert self._block_types(final) == ["reasoning", "text"]
+        assert ContentUtils.flatten_to_text(final) == "the answer"
+
+    @pytest.mark.asyncio
+    async def test_invoke_agent_chain_mixed_content_falls_back_to_text(self) -> None:
+        """
+        When normalizing would lose text (langchain's provider translators skip
+        a bare string inside a block list), the answer is journaled as the
+        full parsed text rather than as lossy blocks.
+        """
+        native: AIMessage = AIMessage(
+            content=[
+                "hello ",
+                {"type": "thinking", "thinking": "hmm", "signature": "sig"},
+                {"type": "text", "text": "world"},
+            ],
+            response_metadata={"model_provider": "anthropic"},
+        )
+        runnable, written = self._make_invoking_runnable({"messages": [native]})
+        await runnable.invoke_agent_chain(inputs={}, runnable_config={}, max_attempts=1)
+
+        final: BaseMessage = written[-1]
+        assert final.content == "hello world"
+
+    @pytest.mark.asyncio
+    async def test_invoke_agent_chain_chunk_answer_is_journaled_as_message(self) -> None:
+        """
+        An AIMessageChunk answer (only a custom middleware could produce one)
+        is journaled as a complete AIMessage with its blocks preserved, so the
+        journaled answer keeps the AI wire type.
+        """
+        native: AIMessageChunk = AIMessageChunk(
+            content=[
+                {"type": "thinking", "thinking": "hmm", "signature": "sig"},
+                {"type": "text", "text": "the answer"},
+            ],
+            response_metadata={"model_provider": "anthropic"},
+        )
+        runnable, written = self._make_invoking_runnable({"messages": [native]})
+        await runnable.invoke_agent_chain(inputs={}, runnable_config={}, max_attempts=1)
+
+        final: BaseMessage = written[-1]
+        assert type(final) is AIMessage  # pylint: disable=unidiomatic-typecheck
+        assert self._block_types(final) == ["reasoning", "text"]
+        assert ContentUtils.flatten_to_text(final) == "the answer"


### PR DESCRIPTION
Last of the three PRs for the "preserve native messages" rung of #1222, after #1320 (tool boundaries, merged) and #1321 (`find_ai_message` refactor, merged).

## What changes

`RunContextRunnable.invoke_agent_chain` journaled a fresh `AIMessage(text)` for every answer, so Anthropic thinking and OpenAI Responses reasoning blocks were lost before they reached the journal. The new `build_return_message` decides between the model's own message and that plain copy. It defaults to the plain copy and keeps the model's message only when four checks pass, in this order:

1. `find_ai_message` found a native `AIMessage`. Otherwise (exception, API-key error, bare `{"output": ...}`) there is nothing to preserve.
2. The ErrorDetector did not rewrite the text. If it did, the client gets the formatted error, not the model's content.
3. After `ContentUtils.normalize_message` (standard v1 blocks plus the `output_version` stamp) the content is still a block list. Text-only content, including a single text block, list-of-str, and text plus tool_use, keeps today's exact `AIMessage(text)` shape with no provider ids or metadata.
4. The normalized blocks still flatten to the parsed text. Langchain's translators skip items they do not recognize, so this fails closed to the plain copy if any text would be lost.

An `AIMessageChunk` is converted to a complete `AIMessage` before normalizing, so a custom middleware returning a chunk cannot give the journaled answer an unknown wire type.

## What does not change

- The wire: the converter still emits only the flattened `text` in this phase, and `parse_chain_result` produces that text exactly as before.
- The chat history: the copy appended for a block-content answer is plain text under the rule merged in #1320, so what is handed to providers, fallbacks included, is unchanged.
- Text-only traffic at every layer: the journaled object for a plain-string answer is byte-for-byte what it was.

## Tests

10 new invoke-level tests: block answer preserved with `output_version` and `usage_metadata`; text-only shape kept; error rewrite wins; tool_use blocks excluded from content; tool_use turn and list-of-str collapse to text; bare output dict; AgentFinish; mixed-content fallback; chunk converted. The test class carries a `too-many-public-methods` disable with its reason, as four other test modules do. Full suite: 703 passed, 1 skipped (main alone: 693). pylint 10.00/10, flake8 clean.
