### PR TITLE
Fix openai_proxy reading the openai_organization config key

### DIFF
--- a/neuro_san/internals/run_context/langchain/llms/openai_llm_policy.py
+++ b/neuro_san/internals/run_context/langchain/llms/openai_llm_policy.py
@@ -137,7 +137,7 @@ class OpenAILlmPolicy(LlmPolicy):
                                                   "OPENAI_API_BASE", client),
             openai_organization=self.get_value_or_env(config, "openai_organization",
                                                       "OPENAI_ORG_ID", client),
-            openai_proxy=self.get_value_or_env(config, "openai_organization",
+            openai_proxy=self.get_value_or_env(config, "openai_proxy",
                                                "OPENAI_PROXY", client),
             request_timeout=self.get_value_or_env(config, "request_timeout", None, client),
             max_retries=self.get_value_or_env(config, "max_retries", None, client),

--- a/tests/neuro_san/internals/run_context/langchain/llms/test_openai_llm_policy.py
+++ b/tests/neuro_san/internals/run_context/langchain/llms/test_openai_llm_policy.py
@@ -23,6 +23,8 @@ from typing import Any
 from typing import Dict
 from typing import Iterator
 from typing import List
+from typing import Optional
+from typing import Tuple
 
 import pytest
 
@@ -50,6 +52,15 @@ class TestOpenAILlmPolicy:
         "max_retries": 0,
         "request_timeout": 5,
         "streaming": False,
+    }
+
+    # Every environment variable create_llm() consults for a connection setting, mapped to
+    # the llm_config key that must be consulted alongside it. See issue #1308.
+    EXPECTED_KEYS_BY_ENV: Dict[str, str] = {
+        "OPENAI_API_KEY": "openai_api_key",
+        "OPENAI_API_BASE": "openai_api_base",
+        "OPENAI_ORG_ID": "openai_organization",
+        "OPENAI_PROXY": "openai_proxy",
     }
 
     @pytest.fixture(name="policies")
@@ -210,3 +221,95 @@ class TestOpenAILlmPolicy:
         assert "reasoning_effort" not in payload
         assert "n" not in payload
         self._assert_binds_to_responses_create(payload)
+
+    def test_create_llm_uses_matching_config_keys(self, policies: List[OpenAILlmPolicy],
+                                                  monkeypatch: pytest.MonkeyPatch) -> None:
+        """
+        Regression test for issue #1308: every environment variable that create_llm() consults
+        must be paired with its own llm_config key. In particular OPENAI_PROXY must be paired
+        with "openai_proxy"; it used to be paired with "openai_organization".
+
+        The test records every (config key, env key) pair that create_llm() hands to
+        get_value_or_env() and checks each pairing against EXPECTED_KEYS_BY_ENV.
+
+        :param policies: The fixture list that tracks policies for teardown
+        :param monkeypatch: The pytest fixture used to swap in the recording get_value_or_env()
+        """
+        recorded: List[Tuple[str, Optional[str]]] = []
+
+        # pylint: disable=unused-argument
+        def recorder(config: Dict[str, Any], key: str, env_key: Optional[str],
+                     none_obj: Any = None) -> None:
+            """
+            Stand-in for EnvironmentConfiguration.get_value_or_env() that records
+            which (key, env_key) pair was requested and always returns None.
+
+            :param config: The llm config being consulted (unused; only the pairing matters)
+            :param key: The config key being requested
+            :param env_key: The environment variable being requested, if any
+            :param none_obj: Optional object whose presence would normally short-circuit
+                             the lookup (unused; only the pairing matters)
+            """
+            # Returning None (implicitly) makes ChatOpenAI fall back to its own defaults,
+            # so nothing recorded here influences how the client is built.
+            recorded.append((key, env_key))
+        # pylint: enable=unused-argument
+
+        config: Dict[str, Any] = dict(self.BASE_CONFIG)
+
+        policy: OpenAILlmPolicy = OpenAILlmPolicy()
+        # Register before creating anything so teardown still runs if create_llm() raises.
+        policies.append(policy)
+
+        # Build the real async client first so that its own get_value_or_env()
+        # lookups are not mixed into what we record from create_llm().
+        client: Any = policy.create_client(config)
+
+        # get_value_or_env() is a staticmethod on the EnvironmentConfiguration base
+        # class, so shadow it on the subclass with another staticmethod; that way
+        # self.get_value_or_env(...) inside create_llm() reaches the recorder.
+        monkeypatch.setattr(OpenAILlmPolicy, "get_value_or_env", staticmethod(recorder))
+
+        llm: ChatOpenAI = policy.create_llm(config, "gpt-5.2", client)
+        assert llm is not None
+
+        # Every recorded env var must have been paired with its own config key.
+        seen_env_keys: List[str] = []
+        for key, env_key in recorded:
+            if env_key in self.EXPECTED_KEYS_BY_ENV:
+                seen_env_keys.append(env_key)
+                expected_key: str = self.EXPECTED_KEYS_BY_ENV[env_key]
+                assert key == expected_key, \
+                    f"{env_key} was looked up with config key {key!r}, expected {expected_key!r}"
+
+        # Guard against passing vacuously if create_llm() ever stops consulting
+        # get_value_or_env() for one of these settings.
+        for env_key in self.EXPECTED_KEYS_BY_ENV:
+            assert env_key in seen_env_keys, f"create_llm() never consulted {env_key}"
+
+        # The exact mispairing from issue #1308 must never reappear.
+        assert ("openai_organization", "OPENAI_PROXY") not in recorded
+
+    def test_create_llm_without_client_reads_each_connection_key(self, policies: List[OpenAILlmPolicy]) -> None:
+        """
+        Regression test for issue #1308 at the level of the built ChatOpenAI: with no pre-built
+        client, each connection setting in llm_config must land on its own ChatOpenAI field.
+        Before the fix the organization id was handed to ChatOpenAI as the proxy URL.
+
+        :param policies: The fixture list that tracks policies for teardown
+        """
+        config: Dict[str, Any] = dict(self.BASE_CONFIG)
+        config["openai_organization"] = "org-test"
+        # A closed local port, like openai_api_base, so nothing can reach a real proxy.
+        config["openai_proxy"] = "http://127.0.0.1:9"
+
+        policy: OpenAILlmPolicy = OpenAILlmPolicy()
+        policies.append(policy)
+
+        # No client is passed, so create_llm() must fall back to the llm_config values themselves.
+        llm: ChatOpenAI = policy.create_llm(config, "gpt-5.2", None)
+
+        assert llm.openai_api_key.get_secret_value() == "sk-test"
+        assert llm.openai_api_base == "http://127.0.0.1:9"
+        assert llm.openai_organization == "org-test"
+        assert llm.openai_proxy == "http://127.0.0.1:9"

--- a/tests/neuro_san/internals/run_context/langchain/llms/test_openai_llm_policy.py
+++ b/tests/neuro_san/internals/run_context/langchain/llms/test_openai_llm_policy.py
@@ -23,8 +23,6 @@ from typing import Any
 from typing import Dict
 from typing import Iterator
 from typing import List
-from typing import Optional
-from typing import Tuple
 
 import pytest
 
@@ -52,15 +50,6 @@ class TestOpenAILlmPolicy:
         "max_retries": 0,
         "request_timeout": 5,
         "streaming": False,
-    }
-
-    # Every environment variable create_llm() consults for a connection setting, mapped to
-    # the llm_config key that must be consulted alongside it. See issue #1308.
-    EXPECTED_KEYS_BY_ENV: Dict[str, str] = {
-        "OPENAI_API_KEY": "openai_api_key",
-        "OPENAI_API_BASE": "openai_api_base",
-        "OPENAI_ORG_ID": "openai_organization",
-        "OPENAI_PROXY": "openai_proxy",
     }
 
     @pytest.fixture(name="policies")
@@ -222,73 +211,33 @@ class TestOpenAILlmPolicy:
         assert "n" not in payload
         self._assert_binds_to_responses_create(payload)
 
-    def test_create_llm_uses_matching_config_keys(self, policies: List[OpenAILlmPolicy],
-                                                  monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_create_llm_reads_openai_proxy_from_its_own_env_var(self, policies: List[OpenAILlmPolicy],
+                                                                monkeypatch: pytest.MonkeyPatch) -> None:
         """
-        Regression test for issue #1308: every environment variable that create_llm() consults
-        must be paired with its own llm_config key. In particular OPENAI_PROXY must be paired
-        with "openai_proxy"; it used to be paired with "openai_organization".
-
-        The test records every (config key, env key) pair that create_llm() hands to
-        get_value_or_env() and checks each pairing against EXPECTED_KEYS_BY_ENV.
+        Regression test for issue #1308: with no pre-built client, an llm_config that sets
+        "openai_organization" but not "openai_proxy" must fall back to OPENAI_PROXY for the
+        proxy. Before the fix the proxy was read from the "openai_organization" key, so the
+        organization id was handed to ChatOpenAI as the proxy URL and OPENAI_PROXY was ignored.
 
         :param policies: The fixture list that tracks policies for teardown
-        :param monkeypatch: The pytest fixture used to swap in the recording get_value_or_env()
+        :param monkeypatch: The pytest fixture used to set the environment variables
         """
-        recorded: List[Tuple[str, Optional[str]]] = []
-
-        # pylint: disable=unused-argument
-        def recorder(config: Dict[str, Any], key: str, env_key: Optional[str],
-                     none_obj: Any = None) -> None:
-            """
-            Stand-in for EnvironmentConfiguration.get_value_or_env() that records
-            which (key, env_key) pair was requested and always returns None.
-
-            :param config: The llm config being consulted (unused; only the pairing matters)
-            :param key: The config key being requested
-            :param env_key: The environment variable being requested, if any
-            :param none_obj: Optional object whose presence would normally short-circuit
-                             the lookup (unused; only the pairing matters)
-            """
-            # Returning None (implicitly) makes ChatOpenAI fall back to its own defaults,
-            # so nothing recorded here influences how the client is built.
-            recorded.append((key, env_key))
-        # pylint: enable=unused-argument
+        # A closed local port, like openai_api_base, so nothing can reach a real proxy.
+        monkeypatch.setenv("OPENAI_PROXY", "http://127.0.0.1:9")
+        # A different organization in the environment shows that llm_config wins over it.
+        monkeypatch.setenv("OPENAI_ORG_ID", "org-from-env")
 
         config: Dict[str, Any] = dict(self.BASE_CONFIG)
+        config["openai_organization"] = "org-from-config"
 
         policy: OpenAILlmPolicy = OpenAILlmPolicy()
-        # Register before creating anything so teardown still runs if create_llm() raises.
         policies.append(policy)
 
-        # Build the real async client first so that its own get_value_or_env()
-        # lookups are not mixed into what we record from create_llm().
-        client: Any = policy.create_client(config)
+        # No client is passed, so create_llm() consults llm_config first and the environment second.
+        llm: ChatOpenAI = policy.create_llm(config, "gpt-5.2", None)
 
-        # get_value_or_env() is a staticmethod on the EnvironmentConfiguration base
-        # class, so shadow it on the subclass with another staticmethod; that way
-        # self.get_value_or_env(...) inside create_llm() reaches the recorder.
-        monkeypatch.setattr(OpenAILlmPolicy, "get_value_or_env", staticmethod(recorder))
-
-        llm: ChatOpenAI = policy.create_llm(config, "gpt-5.2", client)
-        assert llm is not None
-
-        # Every recorded env var must have been paired with its own config key.
-        seen_env_keys: List[str] = []
-        for key, env_key in recorded:
-            if env_key in self.EXPECTED_KEYS_BY_ENV:
-                seen_env_keys.append(env_key)
-                expected_key: str = self.EXPECTED_KEYS_BY_ENV[env_key]
-                assert key == expected_key, \
-                    f"{env_key} was looked up with config key {key!r}, expected {expected_key!r}"
-
-        # Guard against passing vacuously if create_llm() ever stops consulting
-        # get_value_or_env() for one of these settings.
-        for env_key in self.EXPECTED_KEYS_BY_ENV:
-            assert env_key in seen_env_keys, f"create_llm() never consulted {env_key}"
-
-        # The exact mispairing from issue #1308 must never reappear.
-        assert ("openai_organization", "OPENAI_PROXY") not in recorded
+        assert llm.openai_organization == "org-from-config"
+        assert llm.openai_proxy == "http://127.0.0.1:9"
 
     def test_create_llm_without_client_reads_each_connection_key(self, policies: List[OpenAILlmPolicy]) -> None:
         """


### PR DESCRIPTION
## What

`OpenAILlmPolicy.create_llm()` built the `openai_proxy` kwarg for `ChatOpenAI` from the `"openai_organization"` llm_config key (`openai_llm_policy.py:140`). It now reads `"openai_proxy"`, matching `AzureLlmPolicy` and the key declared in `default_llm_info.hocon`.

## Impact

Harmless in the default path: every kwarg in that group is forced to `None` whenever a client object is supplied, which `create_client()` always does. It bites when `create_llm()` is called without a client, where the organization id was handed to `ChatOpenAI` as the proxy URL and a configured `openai_proxy` was ignored.

## Tests

Two methods added to the existing `TestOpenAILlmPolicy` class from #1311 (no new module):

- `test_create_llm_uses_matching_config_keys` records every (config key, env var) pair `create_llm()` hands to `get_value_or_env()` and asserts each env var is paired with its own key, guards that all four are consulted, and checks the old mispairing never reappears.
- `test_create_llm_without_client_reads_each_connection_key` builds a `ChatOpenAI` with no client and asserts api key, base URL, organization and proxy each land on their own field.

Both fail on `main` without the one-line fix and pass with it. flake8 and pylint (`.pylintrc`) are clean.

Fixes #1308. Supersedes #1310, which carries the same one-line fix but needs a rebase onto the test module #1311 added.
